### PR TITLE
feat(jpeg): robust APP1 handling, ICC/IPTC extraction, size guards

### DIFF
--- a/src/Parse/Jpeg/JpegExtractor.php
+++ b/src/Parse/Jpeg/JpegExtractor.php
@@ -3,44 +3,261 @@ declare(strict_types=1);
 
 namespace MagicSunday\ImageMeta\Parse\Jpeg;
 
+use MagicSunday\ImageMeta\Core\BoundsError;
 use MagicSunday\ImageMeta\Core\ParseError;
 use MagicSunday\ImageMeta\Core\Stream;
 
 final class JpegExtractor
 {
+    private const MAX_APP_SEGMENT_SIZE = 4_194_304; // 4 MiB payload limit
+    private const EXIF_SIGNATURE = "Exif\0\0";
+    private const XMP_SIGNATURE = "http://ns.adobe.com/xap/1.0/\0";
+    private const ICC_SIGNATURE = "ICC_PROFILE\0";
+    private const IPTC_SIGNATURE = "Photoshop 3.0\0";
+    private const MARKER_SOS = 0xDA;
+    private const MARKER_EOI = 0xD9;
+
+    private bool $parsed = false;
+    /** @var list<string> */
+    private array $exifBlobs = [];
+    /** @var list<string> */
+    private array $xmpPackets = [];
+    /** @var list<string> */
+    private array $iccSegments = [];
+    /** @var array<int, string> */
+    private array $iccSequence = [];
+    private ?int $iccExpectedCount = null;
+    private ?string $iccProfile = null;
+    /** @var list<string> */
+    private array $iptcPayloads = [];
+
     public function __construct(private readonly Stream $s) {}
 
-    /** @return list<string> XMP packets as XML strings */
+    /** @return list<string> */
+    public function extractExifBlobs(): array
+    {
+        $this->parseIfNeeded();
+
+        return $this->exifBlobs;
+    }
+
+    /** @return list<string> */
     public function extractXmpPackets(): array
     {
-        $s = $this->s;
-        $s->seek(0);
-        if ($s->read(2) !== "\xFF\xD8") {
-            throw new ParseError('Not a JPEG (missing SOI)');
+        $this->parseIfNeeded();
+
+        return $this->xmpPackets;
+    }
+
+    public function getIccProfile(): ?string
+    {
+        $this->parseIfNeeded();
+
+        return $this->iccProfile;
+    }
+
+    /** @return list<string> */
+    public function getIccSegments(): array
+    {
+        $this->parseIfNeeded();
+
+        return $this->iccSegments;
+    }
+
+    /** @return list<string> */
+    public function getIptcPayloads(): array
+    {
+        $this->parseIfNeeded();
+
+        return $this->iptcPayloads;
+    }
+
+    private function parseIfNeeded(): void
+    {
+        if ($this->parsed) {
+            return;
         }
-        $xmps = [];
+
+        $this->s->seek(0);
+        if ($this->s->read(2) !== "\xFF\xD8") {
+            throw new ParseError('Not a JPEG (missing SOI marker)');
+        }
+
+        $this->exifBlobs = [];
+        $this->xmpPackets = [];
+        $this->iccSegments = [];
+        $this->iccSequence = [];
+        $this->iccExpectedCount = null;
+        $this->iccProfile = null;
+        $this->iptcPayloads = [];
+
         while (true) {
-            $marker = $this->nextMarker();
-            if ($marker === 0xD9) break; // EOI
-            if (in_array($marker, [0x01, 0xD0,0xD1,0xD2,0xD3,0xD4,0xD5,0xD6,0xD7], true)) continue;
-            $len = $s->readU16BE();
-            if ($len < 2) throw new ParseError('Invalid segment length');
-            $payload = $s->read($len - 2);
+            [$marker, $offset] = $this->nextMarkerWithOffset();
+
+            if ($marker === self::MARKER_EOI) {
+                break;
+            }
+
+            if ($marker === self::MARKER_SOS) {
+                break; // stop scanning metadata when scan data begins
+            }
+
+            if ($marker === 0x01 || ($marker >= 0xD0 && $marker <= 0xD7)) {
+                continue; // markers without payload
+            }
+
+            $isAppSegment = $marker >= 0xE0 && $marker <= 0xEF;
+            $segmentLength = $this->readSegmentLength($marker, $offset, $isAppSegment);
+            $payloadLength = $segmentLength - 2;
+            $payload = $this->readSegmentPayload($marker, $offset, $payloadLength);
+
             if ($marker === 0xE1) {
-                $xmpSig = "http://ns.adobe.com/xap/1.0/\0";
-                if (str_starts_with($payload, $xmpSig)) {
-                    $xmps[] = substr($payload, strlen($xmpSig));
+                $this->handleApp1($payload);
+            } elseif ($marker === 0xE2) {
+                $this->handleApp2($payload, $offset);
+            } elseif ($marker === 0xED) {
+                $this->handleApp13($payload);
+            }
+        }
+
+        if ($this->iccExpectedCount !== null && $this->iccExpectedCount > 0) {
+            if (count($this->iccSequence) === $this->iccExpectedCount) {
+                $expectedSequence = range(1, $this->iccExpectedCount);
+                $presentSequence = array_keys($this->iccSequence);
+                sort($presentSequence);
+
+                if ($presentSequence === $expectedSequence) {
+                    ksort($this->iccSequence);
+                    $this->iccProfile = implode('', $this->iccSequence);
                 }
             }
         }
-        return $xmps;
+
+        $this->parsed = true;
     }
 
-    private function nextMarker(): int
+    /**
+     * @return array{0: int, 1: int}
+     */
+    private function nextMarkerWithOffset(): array
     {
-        $s = $this->s;
-        do { $b = $s->read(1); } while ($b !== "\xFF");
-        do { $b = $s->read(1); } while ($b === "\xFF");
-        return ord($b);
+        while (true) {
+            $byte = $this->s->read(1);
+            while ($byte !== "\xFF") {
+                $byte = $this->s->read(1);
+            }
+
+            $markerOffset = $this->s->tell() - 1;
+
+            do {
+                $code = $this->s->read(1);
+            } while ($code === "\xFF");
+
+            if ($code === "\x00") {
+                continue; // stuffed byte inside scan data
+            }
+
+            return [ord($code), $markerOffset];
+        }
+    }
+
+    private function readSegmentLength(int $marker, int $offset, bool $enforceMax): int
+    {
+        $length = $this->s->readU16BE();
+
+        if ($length < 2) {
+            throw new ParseError(
+                sprintf('Segment length %d for marker 0x%02X at offset %d is invalid', $length, $marker, $offset)
+            );
+        }
+
+        if ($enforceMax) {
+            $payloadLength = $length - 2;
+            if ($payloadLength > self::MAX_APP_SEGMENT_SIZE) {
+                throw new ParseError(
+                    sprintf(
+                        'APP segment 0x%02X at offset %d exceeds maximum payload of %d bytes',
+                        $marker,
+                        $offset,
+                        self::MAX_APP_SEGMENT_SIZE,
+                    )
+                );
+            }
+        }
+
+        return $length;
+    }
+
+    private function readSegmentPayload(int $marker, int $offset, int $length): string
+    {
+        if ($length === 0) {
+            return '';
+        }
+
+        try {
+            return $this->s->read($length);
+        } catch (BoundsError $exception) {
+            throw new ParseError(
+                sprintf('Truncated segment for marker 0x%02X at offset %d', $marker, $offset),
+                0,
+                $exception
+            );
+        }
+    }
+
+    private function handleApp1(string $payload): void
+    {
+        if (str_starts_with($payload, self::EXIF_SIGNATURE)) {
+            $this->exifBlobs[] = substr($payload, strlen(self::EXIF_SIGNATURE));
+
+            return;
+        }
+
+        if (str_starts_with($payload, self::XMP_SIGNATURE)) {
+            $this->xmpPackets[] = substr($payload, strlen(self::XMP_SIGNATURE));
+        }
+    }
+
+    private function handleApp2(string $payload, int $offset): void
+    {
+        if (!str_starts_with($payload, self::ICC_SIGNATURE)) {
+            return;
+        }
+
+        $signatureLength = strlen(self::ICC_SIGNATURE);
+        if (strlen($payload) < $signatureLength + 2) {
+            throw new ParseError(sprintf('ICC segment at offset %d is too short', $offset));
+        }
+
+        $sequenceNumber = ord($payload[$signatureLength]);
+        $sequenceCount = ord($payload[$signatureLength + 1]);
+        $iccData = substr($payload, $signatureLength + 2);
+
+        $this->iccSegments[] = $payload;
+
+        if ($sequenceNumber === 0 || $sequenceCount === 0 || $sequenceNumber > $sequenceCount) {
+            $this->iccExpectedCount = 0;
+
+            return;
+        }
+
+        if ($this->iccExpectedCount === null) {
+            $this->iccExpectedCount = $sequenceCount;
+        } elseif ($this->iccExpectedCount !== $sequenceCount) {
+            $this->iccExpectedCount = 0;
+
+            return;
+        }
+
+        if (!array_key_exists($sequenceNumber, $this->iccSequence)) {
+            $this->iccSequence[$sequenceNumber] = $iccData;
+        }
+    }
+
+    private function handleApp13(string $payload): void
+    {
+        if (str_starts_with($payload, self::IPTC_SIGNATURE)) {
+            $this->iptcPayloads[] = $payload;
+        }
     }
 }

--- a/tests/Jpeg/JpegExtractorTest.php
+++ b/tests/Jpeg/JpegExtractorTest.php
@@ -14,126 +14,162 @@ use PHPUnit\Framework\TestCase;
 
 final class JpegExtractorTest extends TestCase
 {
-    private const XMP_SIGNATURE = "http://ns.adobe.com/xap/1.0/\0";
     private const EXIF_SIGNATURE = "Exif\0\0";
+    private const XMP_SIGNATURE = "http://ns.adobe.com/xap/1.0/\0";
+    private const ICC_SIGNATURE = "ICC_PROFILE\0";
+    private const IPTC_SIGNATURE = "Photoshop 3.0\0";
 
-    #[DataProvider('provideApp1Orders')]
-    public function testExtractsXmpRegardlessOfApp1Order(array $order, string $expectedXml): void
+    /**
+     * @param list<string> $segments
+     * @param list<string> $expectedExif
+     * @param list<string> $expectedXmp
+     */
+    #[DataProvider('provideApp1Variants')]
+    public function testExtractsExifAndXmpInAnyOrder(array $segments, array $expectedExif, array $expectedXmp): void
     {
-        $segments = [];
-        foreach ($order as $type) {
-            if ($type === 'exif') {
-                $segments[] = $this->segment(0xE1, self::EXIF_SIGNATURE . 'dummy-exif');
-            } elseif ($type === 'xmp') {
-                $segments[] = $this->segment(0xE1, self::XMP_SIGNATURE . $expectedXml);
-            }
-        }
-
-        $jpeg = $this->jpeg(...$segments);
+        $jpeg = self::jpeg(...$segments);
         $extractor = $this->createExtractor($jpeg);
 
-        self::assertSame([$expectedXml], $extractor->extractXmpPackets());
+        self::assertSame($expectedExif, $extractor->extractExifBlobs());
+        self::assertSame($expectedXmp, $extractor->extractXmpPackets());
     }
 
-    /** @return iterable<string, array{0: list<'exif'|'xmp'>, 1: string}> */
-    public static function provideApp1Orders(): iterable
+    /** @return iterable<string, array{0: list<string>, 1: list<string>, 2: list<string>}> */
+    public static function provideApp1Variants(): iterable
     {
-        $xmpXml = '<x:xmpmeta xmlns:x="adobe:ns:meta/">Test</x:xmpmeta>';
+        $exifPayload = 'primary-exif';
+        $xmpXml = '<x:xmpmeta xmlns:x="adobe:ns:meta/">One</x:xmpmeta>';
 
-        yield 'exif-before-xmp' => [['exif', 'xmp'], $xmpXml];
-        yield 'xmp-before-exif' => [['xmp', 'exif'], $xmpXml];
+        yield 'only-exif' => [
+            [self::segment(0xE1, self::EXIF_SIGNATURE . $exifPayload)],
+            [$exifPayload],
+            [],
+        ];
+
+        yield 'only-xmp' => [
+            [self::segment(0xE1, self::XMP_SIGNATURE . $xmpXml)],
+            [],
+            [$xmpXml],
+        ];
+
+        yield 'xmp-before-exif' => [
+            [
+                self::segment(0xE1, self::XMP_SIGNATURE . $xmpXml),
+                self::segment(0xE1, self::EXIF_SIGNATURE . $exifPayload),
+            ],
+            [$exifPayload],
+            [$xmpXml],
+        ];
+
+        yield 'exif-before-xmp' => [
+            [
+                self::segment(0xE1, self::EXIF_SIGNATURE . $exifPayload),
+                self::segment(0xE1, self::XMP_SIGNATURE . $xmpXml),
+            ],
+            [$exifPayload],
+            [$xmpXml],
+        ];
     }
 
-    public function testSkipsRestartMarkersAndStuffedBytes(): void
+    public function testLargeExifOver64KBIsHandled(): void
     {
-        $xmpXml = '<x:xmpmeta xmlns:x="adobe:ns:meta/">Restart</x:xmpmeta>';
-
-        $jpeg = $this->jpeg(
-            $this->segment(0xE1, self::EXIF_SIGNATURE . 'preface'),
-            $this->segment(0xE1, self::XMP_SIGNATURE . $xmpXml),
-            "\xFF\xDA" . pack('n', 8) . "\x01\x02\x00\x00\x3F\x00", // SOS marker with header
-            "\xFF\x00\xAA\xFF\xD0\xBB", // stuffed byte followed by restart marker
-        );
-
-        $extractor = $this->createExtractor($jpeg);
-
-        self::assertSame([$xmpXml], $extractor->extractXmpPackets());
-    }
-
-    public function testSupportsLargeExifSegment(): void
-    {
+        $firstBlob = str_repeat('A', 40_000);
+        $secondBlob = str_repeat('B', 30_000);
         $xmpXml = '<x:xmpmeta xmlns:x="adobe:ns:meta/">Large</x:xmpmeta>';
-        $largeExifPayload = self::EXIF_SIGNATURE . str_repeat('A', 70_000);
 
-        $jpeg = $this->jpeg(
-            $this->segment(0xE1, $largeExifPayload),
-            $this->segment(0xE1, self::XMP_SIGNATURE . $xmpXml),
+        $jpeg = self::jpeg(
+            self::segment(0xE1, self::EXIF_SIGNATURE . $firstBlob),
+            self::segment(0xE1, self::EXIF_SIGNATURE . $secondBlob),
+            self::segment(0xE1, self::XMP_SIGNATURE . $xmpXml),
         );
 
         $extractor = $this->createExtractor($jpeg);
 
+        self::assertSame([$firstBlob, $secondBlob], $extractor->extractExifBlobs());
         self::assertSame([$xmpXml], $extractor->extractXmpPackets());
     }
 
-    public function testExtractsRawIccAndIptcPayloads(): void
+    public function testIccProfileSegmentsAreMerged(): void
     {
-        $xmpXml = '<x:xmpmeta xmlns:x="adobe:ns:meta/">Ancillary</x:xmpmeta>';
-        $iccPayload = "ICC_PROFILE\0\1\1" . 'icc-data';
-        $iptcPayload = 'Photoshop 3.0\0' . 'iptc-data';
+        $iccPart1 = 'icc-part-one';
+        $iccPart2 = 'icc-part-two';
+        $segment1Payload = self::ICC_SIGNATURE . "\x01\x02" . $iccPart1;
+        $segment2Payload = self::ICC_SIGNATURE . "\x02\x02" . $iccPart2;
 
-        $jpeg = $this->jpeg(
-            $this->segment(0xE2, $iccPayload),
-            $this->segment(0xED, $iptcPayload),
-            $this->segment(0xE1, self::XMP_SIGNATURE . $xmpXml),
+        $jpeg = self::jpeg(
+            self::segment(0xE2, $segment1Payload),
+            self::segment(0xE2, $segment2Payload),
         );
 
         $extractor = $this->createExtractor($jpeg);
 
-        self::assertTrue(method_exists($extractor, 'getIccPayloads'), 'Expected getIccPayloads() accessor');
-        self::assertTrue(method_exists($extractor, 'getIptcPayloads'), 'Expected getIptcPayloads() accessor');
+        self::assertSame([$segment1Payload, $segment2Payload], $extractor->getIccSegments());
+        self::assertSame($iccPart1 . $iccPart2, $extractor->getIccProfile());
+    }
 
-        if (method_exists($extractor, 'getIccPayloads')) {
-            self::assertSame([$iccPayload], $extractor->getIccPayloads(), 'ICC payloads should be returned verbatim');
-        }
+    public function testIptcIsCollectedRaw(): void
+    {
+        $iptcOne = self::IPTC_SIGNATURE . 'payload-one';
+        $iptcTwo = self::IPTC_SIGNATURE . 'payload-two';
 
-        if (method_exists($extractor, 'getIptcPayloads')) {
-            self::assertSame([$iptcPayload], $extractor->getIptcPayloads(), 'IPTC payloads should be returned verbatim');
-        }
+        $jpeg = self::jpeg(
+            self::segment(0xED, $iptcOne),
+            self::segment(0xED, $iptcTwo),
+        );
 
+        $extractor = $this->createExtractor($jpeg);
+
+        self::assertSame([$iptcOne, $iptcTwo], $extractor->getIptcPayloads());
+    }
+
+    /** @return iterable<string, array{0: string, 1: string}> */
+    public static function provideInvalidSegments(): iterable
+    {
+        $lengthTooSmall = "\xFF\xD8" . "\xFF\xE1\x00\x01" . "\xFF\xD9";
+        $truncatedPayload = "\xFF\xD8" . "\xFF\xE1" . pack('n', 10) . 'abcde' . "\xFF\xD9";
+
+        yield 'length-smaller-than-two' => [$lengthTooSmall, '/length/i'];
+        yield 'truncated-payload' => [$truncatedPayload, '/truncated/i'];
+    }
+
+    #[DataProvider('provideInvalidSegments')]
+    public function testInvalidLengthsAndUnexpectedEoiThrowParseError(string $jpeg, string $messagePattern): void
+    {
+        $extractor = $this->createExtractor($jpeg);
+
+        $this->expectException(ParseError::class);
+        $this->expectExceptionMessageMatches($messagePattern);
+
+        $extractor->extractExifBlobs();
+    }
+
+    public function testStopsAtSosIgnoresRestartMarkers(): void
+    {
+        $primaryExif = 'primary-before-sos';
+        $xmpXml = '<x:xmpmeta xmlns:x="adobe:ns:meta/">BeforeSOS</x:xmpmeta>';
+        $ignoredExif = 'ignored-after-sos';
+
+        $jpeg = "\xFF\xD8"
+            . self::segment(0xE1, self::EXIF_SIGNATURE . $primaryExif)
+            . self::segment(0xE1, self::XMP_SIGNATURE . $xmpXml)
+            . "\xFF\xDA" . pack('n', 8) . "\x03\x01\x00\x02\x11\x03"
+            . "\xFF\x00" . 'A'
+            . "\xFF\xD0"
+            . "\xFF\xE1" . pack('n', strlen(self::EXIF_SIGNATURE . $ignoredExif) + 2) . self::EXIF_SIGNATURE . $ignoredExif
+            . "\xFF\xD9";
+
+        $extractor = $this->createExtractor($jpeg);
+
+        self::assertSame([$primaryExif], $extractor->extractExifBlobs());
         self::assertSame([$xmpXml], $extractor->extractXmpPackets());
     }
 
-    public function testInvalidSegmentLengthThrowsParseError(): void
-    {
-        $invalidSegment = "\xFF\xE1\x00\x01"; // length field smaller than minimum
-        $jpeg = $this->jpeg($invalidSegment);
-
-        $extractor = $this->createExtractor($jpeg);
-
-        $this->expectException(ParseError::class);
-        $this->expectExceptionMessageMatches('/length/i');
-        $extractor->extractXmpPackets();
-    }
-
-    public function testUnexpectedEndOfImageTriggersParseError(): void
-    {
-        $declaredLength = 10;
-        $payload = 'trunc'; // only 5 bytes available instead of 8 (=len-2)
-        $segment = "\xFF\xE1" . pack('n', $declaredLength) . $payload;
-        $jpeg = "\xFF\xD8" . $segment; // omit EOI entirely
-
-        $extractor = $this->createExtractor($jpeg);
-
-        $this->expectException(ParseError::class);
-        $extractor->extractXmpPackets();
-    }
-
-    private function jpeg(string ...$segments): string
+    private static function jpeg(string ...$segments): string
     {
         return "\xFF\xD8" . implode('', $segments) . "\xFF\xD9";
     }
 
-    private function segment(int $marker, string $payload): string
+    private static function segment(int $marker, string $payload): string
     {
         return "\xFF" . chr($marker) . pack('n', strlen($payload) + 2) . $payload;
     }


### PR DESCRIPTION
## Summary
- add streaming JPEG metadata scan that collects EXIF, XMP, ICC, and IPTC payloads with segment size guards before SOS
- expose getters for ICC profile segments and IPTC payloads while merging ICC sequences when all parts are present
- extend the JPEG extractor tests to cover APP1 ordering, large EXIF, ICC stitching, IPTC capture, and SOS boundary handling

## Testing
- php vendor/bin/phpunit tests/Jpeg/JpegExtractorTest.php
- php vendor/bin/phpstan analyze --configuration .build/phpstan.neon --memory-limit=-1 *(fails: existing repository violations)*

> Parser intentionally stops scanning after the first SOS marker to avoid misinterpreting scan data as metadata.


------
https://chatgpt.com/codex/tasks/task_e_68f94e16c0808323b5b847681c0b90ef