### PR TITLE
Add PHPUnit Test attributes to extractor tests

### DIFF
--- a/tests/IsoBmff/IsoBmffExtractorTest.php
+++ b/tests/IsoBmff/IsoBmffExtractorTest.php
@@ -10,11 +10,13 @@ use MagicSunday\ImageMeta\Core\ParseError;
 use MagicSunday\ImageMeta\Core\Stream;
 use MagicSunday\ImageMeta\Model\QuickTimeMeta;
 use MagicSunday\ImageMeta\Parse\IsoBmff\IsoBmffExtractor;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 final class IsoBmffExtractorTest extends TestCase
 {
-    public function testExtractExifFromExifBox(): void
+    #[Test]
+    public function extractExifFromExifBox(): void
     {
         $exifPayload = "Exif\0\0primary-exif";
         $meta = self::fullBox('meta', self::box('Exif', $exifPayload));
@@ -29,7 +31,8 @@ final class IsoBmffExtractorTest extends TestCase
         self::assertNull($qt);
     }
 
-    public function testResolveIlocMultiExtent(): void
+    #[Test]
+    public function resolveIlocMultiExtent(): void
     {
         $exifBlob = "Exif\0\0" . 'segment-one' . 'segment-two';
         $part1 = substr($exifBlob, 0, 10);
@@ -72,7 +75,8 @@ final class IsoBmffExtractorTest extends TestCase
         self::assertSame(['segment-one' . 'segment-two'], $exifs);
     }
 
-    public function testExtractXmpFromUuidAndItem(): void
+    #[Test]
+    public function extractXmpFromUuidAndItem(): void
     {
         $uuidGuid = hex2bin('be7acfcb97a942e89c71999491e3afac');
         $uuidXmp = '<x:xmpmeta xmlns:x="adobe:ns:meta/">uuid</x:xmpmeta>';
@@ -118,7 +122,8 @@ final class IsoBmffExtractorTest extends TestCase
         self::assertSame([$itemXmp, $directXmp, $uuidXmp], $xmps);
     }
 
-    public function testReadContentIdentifierFromKeysOrMdta(): void
+    #[Test]
+    public function readContentIdentifierFromKeysOrMdta(): void
     {
         $keysValue = 'id-from-keys';
         $mdtaValue = 'id-from-mdta';
@@ -138,7 +143,8 @@ final class IsoBmffExtractorTest extends TestCase
         self::assertSame($mdtaValue, $mdtaMeta->contentIdentifier());
     }
 
-    public function testSkipDataRefIndexNotZero(): void
+    #[Test]
+    public function skipDataRefIndexNotZero(): void
     {
         $infePayload = "\x02\0\0\0" . pack('n', 1) . pack('n', 0) . 'Exif' . "\0\0\0";
         $infe = self::box('infe', $infePayload);
@@ -166,7 +172,8 @@ final class IsoBmffExtractorTest extends TestCase
         self::assertSame([], $exifs);
     }
 
-    public function testInvalidBoxSizesThrowParseError(): void
+    #[Test]
+    public function invalidBoxSizesThrowParseError(): void
     {
         $infePayload = "\x02\0\0\0" . pack('n', 1) . pack('n', 0) . 'Exif' . "\0\0\0";
         $iinf = self::box('iinf', "\0\0\0\0" . pack('n', 1) . self::box('infe', $infePayload));

--- a/tests/Jpeg/JpegExtractorTest.php
+++ b/tests/Jpeg/JpegExtractorTest.php
@@ -10,6 +10,7 @@ use MagicSunday\ImageMeta\Core\ParseError;
 use MagicSunday\ImageMeta\Core\Stream;
 use MagicSunday\ImageMeta\Parse\Jpeg\JpegExtractor;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 final class JpegExtractorTest extends TestCase
@@ -24,8 +25,9 @@ final class JpegExtractorTest extends TestCase
      * @param list<string> $expectedExif
      * @param list<string> $expectedXmp
      */
+    #[Test]
     #[DataProvider('provideApp1Variants')]
-    public function testExtractsExifAndXmpInAnyOrder(array $segments, array $expectedExif, array $expectedXmp): void
+    public function extractsExifAndXmpInAnyOrder(array $segments, array $expectedExif, array $expectedXmp): void
     {
         $jpeg = self::jpeg(...$segments);
         $extractor = $this->createExtractor($jpeg);
@@ -71,7 +73,8 @@ final class JpegExtractorTest extends TestCase
         ];
     }
 
-    public function testLargeExifOver64KBIsHandled(): void
+    #[Test]
+    public function largeExifOver64KBIsHandled(): void
     {
         $firstBlob = str_repeat('A', 40_000);
         $secondBlob = str_repeat('B', 30_000);
@@ -89,7 +92,8 @@ final class JpegExtractorTest extends TestCase
         self::assertSame([$xmpXml], $extractor->extractXmpPackets());
     }
 
-    public function testIccProfileSegmentsAreMerged(): void
+    #[Test]
+    public function iccProfileSegmentsAreMerged(): void
     {
         $iccPart1 = 'icc-part-one';
         $iccPart2 = 'icc-part-two';
@@ -107,7 +111,8 @@ final class JpegExtractorTest extends TestCase
         self::assertSame($iccPart1 . $iccPart2, $extractor->getIccProfile());
     }
 
-    public function testIptcIsCollectedRaw(): void
+    #[Test]
+    public function iptcIsCollectedRaw(): void
     {
         $iptcOne = self::IPTC_SIGNATURE . 'payload-one';
         $iptcTwo = self::IPTC_SIGNATURE . 'payload-two';
@@ -132,8 +137,9 @@ final class JpegExtractorTest extends TestCase
         yield 'truncated-payload' => [$truncatedPayload, '/truncated/i'];
     }
 
+    #[Test]
     #[DataProvider('provideInvalidSegments')]
-    public function testInvalidLengthsAndUnexpectedEoiThrowParseError(string $jpeg, string $messagePattern): void
+    public function invalidLengthsAndUnexpectedEoiThrowParseError(string $jpeg, string $messagePattern): void
     {
         $extractor = $this->createExtractor($jpeg);
 
@@ -143,7 +149,8 @@ final class JpegExtractorTest extends TestCase
         $extractor->extractExifBlobs();
     }
 
-    public function testStopsAtSosIgnoresRestartMarkers(): void
+    #[Test]
+    public function stopsAtSosIgnoresRestartMarkers(): void
     {
         $primaryExif = 'primary-before-sos';
         $xmpXml = '<x:xmpmeta xmlns:x="adobe:ns:meta/">BeforeSOS</x:xmpmeta>';


### PR DESCRIPTION
## Summary
- import the PHPUnit Test attribute into the IsoBmff and Jpeg extractor tests
- replace test-prefixed method names with #[Test] attributes for discovery
- ensure data provider annotations remain alongside the new Test attributes

## Testing
- vendor/bin/phpunit -c .build/phpunit.xml --bootstrap vendor/autoload.php

------
https://chatgpt.com/codex/tasks/task_e_68f9581ed34083239b0500601c1715cd