### PR TITLE
test: annotate extractor tests with attributes

### DIFF
--- a/tests/IsoBmff/IsoBmffExtractorTest.php
+++ b/tests/IsoBmff/IsoBmffExtractorTest.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace MagicSunday\ImageMeta\Tests\IsoBmff;
 
-require_once __DIR__ . '/../../src/Core/Exceptions.php';
-
 use MagicSunday\ImageMeta\Core\ParseError;
 use MagicSunday\ImageMeta\Core\Stream;
 use MagicSunday\ImageMeta\Model\QuickTimeMeta;
@@ -23,6 +21,7 @@ final class IsoBmffExtractorTest extends TestCase
     /**
      * Ensures EXIF blobs embedded directly in the meta box are returned.
      */
+    #[Test]
     public function testExtractExifFromExifBox(): void
     {
         $exifPayload = "Exif\0\0primary-exif";
@@ -41,6 +40,7 @@ final class IsoBmffExtractorTest extends TestCase
     /**
      * Verifies fragmented EXIF data referenced via iloc extents is reassembled.
      */
+    #[Test]
     public function testResolveIlocMultiExtent(): void
     {
         $exifBlob = "Exif\0\0" . 'segment-one' . 'segment-two';
@@ -87,6 +87,7 @@ final class IsoBmffExtractorTest extends TestCase
     /**
      * Ensures XMP payloads are collected from uuid boxes and item locations.
      */
+    #[Test]
     public function testExtractXmpFromUuidAndItem(): void
     {
         $uuidGuid = hex2bin('be7acfcb97a942e89c71999491e3afac');
@@ -136,6 +137,7 @@ final class IsoBmffExtractorTest extends TestCase
     /**
      * Confirms QuickTime identifiers are populated from keys and mdta boxes.
      */
+    #[Test]
     public function testReadContentIdentifierFromKeysOrMdta(): void
     {
         $keysValue = 'id-from-keys';
@@ -159,6 +161,7 @@ final class IsoBmffExtractorTest extends TestCase
     /**
      * Ensures items referencing external data are skipped.
      */
+    #[Test]
     public function testSkipDataRefIndexNotZero(): void
     {
         $infePayload = "\x02\0\0\0" . pack('n', 1) . pack('n', 0) . 'Exif' . "\0\0\0";
@@ -190,6 +193,7 @@ final class IsoBmffExtractorTest extends TestCase
     /**
      * Verifies invalid extent definitions trigger a parse error.
      */
+    #[Test]
     public function testInvalidBoxSizesThrowParseError(): void
     {
         $infePayload = "\x02\0\0\0" . pack('n', 1) . pack('n', 0) . 'Exif' . "\0\0\0";

--- a/tests/Jpeg/JpegExtractorTest.php
+++ b/tests/Jpeg/JpegExtractorTest.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace MagicSunday\ImageMeta\Tests\Jpeg;
 
-require_once __DIR__ . '/../../src/Core/Exceptions.php';
-
 use MagicSunday\ImageMeta\Core\ParseError;
 use MagicSunday\ImageMeta\Core\Stream;
 use MagicSunday\ImageMeta\Parse\Jpeg\JpegExtractor;
@@ -87,6 +85,7 @@ final class JpegExtractorTest extends TestCase
     /**
      * Ensures multiple EXIF segments larger than 64KB are collected as-is.
      */
+    #[Test]
     public function testLargeExifOver64KBIsHandled(): void
     {
         $firstBlob = str_repeat('A', 40_000);
@@ -108,6 +107,7 @@ final class JpegExtractorTest extends TestCase
     /**
      * Confirms ICC profile fragments are reordered and merged into a single profile.
      */
+    #[Test]
     public function testIccProfileSegmentsAreMerged(): void
     {
         $iccPart1 = 'icc-part-one';
@@ -129,6 +129,7 @@ final class JpegExtractorTest extends TestCase
     /**
      * Ensures APP13 segments with the Photoshop signature are stored verbatim.
      */
+    #[Test]
     public function testIptcIsCollectedRaw(): void
     {
         $iptcOne = self::IPTC_SIGNATURE . 'payload-one';
@@ -179,6 +180,7 @@ final class JpegExtractorTest extends TestCase
     /**
      * Verifies scanning stops at SOS and ignores restart markers during search.
      */
+    #[Test]
     public function testStopsAtSosIgnoresRestartMarkers(): void
     {
         $primaryExif = 'primary-before-sos';


### PR DESCRIPTION
## Summary
- annotate JPEG extractor tests with #[Test] attributes and drop the manual require_once include
- annotate ISO BMFF extractor tests with #[Test] attributes so discovery no longer depends on test* prefixes

## Testing
- composer ci:cgl *(fails: DirectoryNotFoundException: The "/workspace/imagemeta/.build/../test/" directory does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68f95b252f608323ae97008eba93178d