### PR TITLE
docs: enhance metadata helper phpdoc coverage

### DIFF
--- a/src/Convenience/CaptureDateResolver.php
+++ b/src/Convenience/CaptureDateResolver.php
@@ -1,22 +1,60 @@
 <?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace MagicSunday\ImageMeta\Convenience;
 
 use DateTimeImmutable;
 use MagicSunday\ImageMeta\Model\Metadata;
+use Throwable;
 
+/**
+ * Resolves the best available capture timestamp for an image asset.
+ *
+ * The resolver prefers EXIF information as it typically offers the most
+ * accurate capture metadata, but it can fall back to XMP when EXIF data is
+ * missing or incomplete.
+ */
 final class CaptureDateResolver
 {
-    public static function bestCaptureDateTime(Metadata $m): ?DateTimeImmutable
+    /**
+     * Determines the most precise capture timestamp contained in the metadata.
+     *
+     * @param Metadata $metadata structured metadata extracted from the asset
+     *
+     * @return DateTimeImmutable|null a normalised timestamp or null when no usable
+     *                                value is available
+     */
+    public static function bestCaptureDateTime(Metadata $metadata): ?DateTimeImmutable
     {
-        if ($m->exifDoc) {
-            $dt = ExifConvenience::captureDateTime($m->exifDoc);
-            if ($dt) return $dt;
+        if ($metadata->exifDoc !== null) {
+            $dateTime = ExifConvenience::captureDateTime($metadata->exifDoc);
+
+            if ($dateTime instanceof DateTimeImmutable) {
+                return $dateTime;
+            }
         }
-        if ($m->xmpDoc && ($iso = $m->xmpDoc->createDate())) {
-            try { return new DateTimeImmutable($iso); } catch (\Throwable) {}
+
+        if ($metadata->xmpDoc !== null) {
+            $createDate = $metadata->xmpDoc->createDate();
+
+            if (is_string($createDate) && $createDate !== '') {
+                try {
+                    // XMP createDate is already ISO 8601, so we can consume it directly.
+                    return new DateTimeImmutable($createDate);
+                } catch (Throwable) {
+                    // Ignore malformed timestamps and continue searching for fallbacks.
+                }
+            }
         }
+
         return null;
     }
 }

--- a/src/Convenience/ExifConvenience.php
+++ b/src/Convenience/ExifConvenience.php
@@ -1,4 +1,12 @@
 <?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace MagicSunday\ImageMeta\Convenience;
@@ -6,9 +14,20 @@ namespace MagicSunday\ImageMeta\Convenience;
 use DateTimeImmutable;
 use MagicSunday\ImageMeta\Model\Exif\ExifDocument;
 use MagicSunday\ImageMeta\Model\Exif\IfdEntry;
+use Throwable;
 
+/**
+ * Helper routines that extract frequently-used EXIF values in a safe manner.
+ */
 final class ExifConvenience
 {
+    /**
+     * Extracts camera identification details from the EXIF document.
+     *
+     * @param ExifDocument $doc parsed EXIF metadata
+     *
+     * @return array{make: ?string, model: ?string, lens: ?string} camera details ready for display
+     */
     public static function camera(ExifDocument $doc): array
     {
         return [
@@ -18,96 +37,190 @@ final class ExifConvenience
         ];
     }
 
+    /**
+     * Normalises the capture timestamp by combining the EXIF datetime and offset.
+     *
+     * @param ExifDocument $doc parsed EXIF metadata
+     *
+     * @return DateTimeImmutable|null the capture timestamp or null when unavailable
+     */
     public static function captureDateTime(ExifDocument $doc): ?DateTimeImmutable
     {
-        $dt = $doc->dateTimeOriginal();          // "YYYY:MM:DD HH:MM:SS"
-        if ($dt === null || $dt === '') {
+        $rawDateTime = $doc->dateTimeOriginal(); // "YYYY:MM:DD HH:MM:SS"
+
+        if (!is_string($rawDateTime) || $rawDateTime === '') {
             return null;
         }
-        $off = $doc->offsetTimeOriginal();       // e.g. "+01:00" or "-05:30"
-        // Normalize EXIF date format to ISO 8601
-        $iso = str_replace(':', '-', substr($dt, 0, 10)) . ' ' . substr($dt, 11);
-        $tz  = $off !== null && $off !== '' ? $off : '+00:00';
+
+        // Ensure that the timestamp contains both a date and a time component.
+        if (strlen($rawDateTime) < 19) {
+            return null;
+        }
+
+        $rawOffset = $doc->offsetTimeOriginal(); // e.g. "+01:00" or "-05:30"
+
+        $datePart       = str_replace(':', '-', substr($rawDateTime, 0, 10));
+        $timePart       = substr($rawDateTime, 11, 8);
+        $timeZoneOffset = $rawOffset !== null && $rawOffset !== '' ? $rawOffset : '+00:00';
+
         try {
-            return new DateTimeImmutable($iso . $tz);
-        } catch (\Throwable) {
+            return new DateTimeImmutable(sprintf('%s %s%s', $datePart, $timePart, $timeZoneOffset));
+        } catch (Throwable) {
             return null;
         }
     }
 
+    /**
+     * Returns the GPS coordinates extracted from the EXIF document.
+     *
+     * @param ExifDocument $doc parsed EXIF metadata
+     *
+     * @return array{lat: ?float, lon: ?float, alt: ?float} geographic coordinates
+     */
     public static function gps(ExifDocument $doc): array
     {
         return $doc->gps(); // ['lat'=>?float,'lon'=>?float,'alt'=>?float]
     }
 
+    /**
+     * Converts the exposure time rational to seconds.
+     *
+     * @param ExifDocument $doc parsed EXIF metadata
+     *
+     * @return float|null exposure duration in seconds
+     */
     public static function exposureTime(ExifDocument $doc): ?float
     {
         $e = self::find($doc, 0x829A); // ExposureTime (rational)
+
         return self::rationalToFloat($e?->value);
     }
 
+    /**
+     * Retrieves the aperture (f-number) from the EXIF data.
+     *
+     * @param ExifDocument $doc parsed EXIF metadata
+     *
+     * @return float|null aperture value
+     */
     public static function fNumber(ExifDocument $doc): ?float
     {
         $e = self::find($doc, 0x829D); // FNumber (rational)
+
         return self::rationalToFloat($e?->value);
     }
 
+    /**
+     * Retrieves the focal length from the EXIF data in millimetres.
+     *
+     * @param ExifDocument $doc parsed EXIF metadata
+     *
+     * @return float|null focal length in millimetres
+     */
     public static function focalLength(ExifDocument $doc): ?float
     {
         $e = self::find($doc, 0x920A); // FocalLength (rational)
+
         return self::rationalToFloat($e?->value);
     }
 
+    /**
+     * Determines the ISO sensitivity from either the modern or legacy tag.
+     *
+     * @param ExifDocument $doc parsed EXIF metadata
+     *
+     * @return int|null ISO value when available
+     */
     public static function iso(ExifDocument $doc): ?int
     {
         // ISO can be ExifIFD tag 0x8827 (old) or PhotographicSensitivity 0x8833
-        $e = self::find($doc, 0x8833) ?? self::find($doc, 0x8827);
-        if (!$e) return null;
-        $v = $e->value;
-        if (is_array($v)) {
-            $v = $v[0] ?? null;
+        $entry = self::find($doc, 0x8833) ?? self::find($doc, 0x8827);
+
+        if ($entry === null) {
+            return null;
         }
-        return is_int($v) ? $v : (is_float($v) ? (int)$v : null);
+
+        $value = $entry->value;
+
+        if (is_array($value)) {
+            // Some cameras store ISO as a list, keep the first element.
+            $value = $value[0] ?? null;
+        }
+
+        if (is_int($value)) {
+            return $value;
+        }
+
+        if (is_float($value)) {
+            return (int) $value;
+        }
+
+        return null;
     }
 
-    /** Unified associative array (handy for DB ingest) */
+    /**
+     * Provides a flattened associative representation of common EXIF values.
+     *
+     * @param ExifDocument $doc parsed EXIF metadata
+     *
+     * @return array<string, mixed> normalised metadata values
+     */
     public static function toArray(ExifDocument $doc): array
     {
-        $dt = self::captureDateTime($doc);
+        $dt  = self::captureDateTime($doc);
         $gps = $doc->gps();
+
         return [
-            'make'         => $doc->cameraMake(),
-            'model'        => $doc->cameraModel(),
-            'lens'         => $doc->lensModel(),
-            'orientation'  => $doc->orientation(),
-            'captured_at'  => $dt?->format(DATE_ATOM),
-            'exposure_s'   => self::exposureTime($doc),
-            'fnumber'      => self::fNumber($doc),
-            'focal_mm'     => self::focalLength($doc),
-            'iso'          => self::iso($doc),
-            'gps_lat'      => $gps['lat'],
-            'gps_lon'      => $gps['lon'],
-            'gps_alt'      => $gps['alt'],
+            'make'        => $doc->cameraMake(),
+            'model'       => $doc->cameraModel(),
+            'lens'        => $doc->lensModel(),
+            'orientation' => $doc->orientation(),
+            'captured_at' => $dt?->format(DATE_ATOM),
+            'exposure_s'  => self::exposureTime($doc),
+            'fnumber'     => self::fNumber($doc),
+            'focal_mm'    => self::focalLength($doc),
+            'iso'         => self::iso($doc),
+            'gps_lat'     => $gps['lat'],
+            'gps_lon'     => $gps['lon'],
+            'gps_alt'     => $gps['alt'],
         ];
     }
 
+    /**
+     * Finds a tag either within the EXIF IFD or as a fallback in IFD0.
+     *
+     * @param ExifDocument $doc parsed EXIF metadata
+     * @param int          $tag tag identifier to search for
+     *
+     * @return IfdEntry|null matching tag entry when present
+     */
     private static function find(ExifDocument $doc, int $tag): ?IfdEntry
     {
         return $doc->exifIfd?->get($tag) ?? $doc->ifd0->get($tag) ?? null;
     }
 
+    /**
+     * Converts EXIF rational values (or lists of rationals) into a float.
+     *
+     * @param mixed $v scalar, rational pair or list of rational pairs from an EXIF tag
+     *
+     * @return float|null normalised scalar value
+     */
     private static function rationalToFloat(mixed $v): ?float
     {
         if (is_array($v)) {
             // [num, den] or list of rationals
-            if (count($v) === 2 && is_numeric($v[0] ?? null) && is_numeric($v[1] ?? null) && (int)$v[1] !== 0) {
-                return (float)$v[0] / (float)$v[1];
+            if (count($v) === 2 && is_numeric($v[0] ?? null) && is_numeric($v[1] ?? null) && (int) $v[1] !== 0) {
+                return (float) $v[0] / (float) $v[1];
             }
             if (isset($v[0]) && is_array($v[0]) && count($v[0]) === 2) {
-                $n = $v[0][0] ?? 0; $d = $v[0][1] ?? 1;
-                return (int)$d !== 0 ? (float)$n / (float)$d : null;
+                $n = $v[0][0] ?? 0;
+                $d = $v[0][1] ?? 1;
+
+                return (int) $d !== 0 ? (float) $n / (float) $d : null;
             }
         }
-        return is_int($v) || is_float($v) ? (float)$v : null;
+
+        return is_int($v) || is_float($v) ? (float) $v : null;
     }
 }

--- a/src/Core/Endian.php
+++ b/src/Core/Endian.php
@@ -1,10 +1,23 @@
 <?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace MagicSunday\ImageMeta\Core;
 
+/**
+ * Represents the byte ordering identifiers used inside TIFF and EXIF headers.
+ */
 enum Endian: string
 {
+    /** Little-endian ordering ("II"). */
     case Little = 'II';
+    /** Big-endian ordering ("MM"). */
     case Big = 'MM';
 }

--- a/src/Core/MemoryBuffer.php
+++ b/src/Core/MemoryBuffer.php
@@ -1,18 +1,62 @@
 <?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace MagicSunday\ImageMeta\Core;
 
+/**
+ * Provides a simple, bounds-checked in-memory buffer abstraction.
+ *
+ * The buffer exposes random-access read operations that mimic the stream API
+ * used throughout the project, ensuring that parser code can rely on
+ * consistent guard rails even when the input data originates from a string.
+ */
 final class MemoryBuffer
 {
+    /**
+     * @param string $data raw binary payload to expose as a seekable buffer
+     * @param int    $pos  initial read position within the buffer
+     */
     public function __construct(
         private readonly string $data,
-        private int $pos = 0
-    ) {}
+        private int $pos = 0,
+    ) {
+    }
 
-    public function size(): int { return strlen($this->data); }
-    public function tell(): int { return $this->pos; }
+    /**
+     * Returns the total size of the backing buffer in bytes.
+     *
+     * @return int number of available bytes
+     */
+    public function size(): int
+    {
+        return strlen($this->data);
+    }
 
+    /**
+     * Reports the current read offset within the buffer.
+     *
+     * @return int current cursor position
+     */
+    public function tell(): int
+    {
+        return $this->pos;
+    }
+
+    /**
+     * Moves the read cursor to an absolute offset within the buffer.
+     *
+     * @param int $offset absolute position in bytes
+     *
+     * @throws BoundsError when the requested offset is outside the buffer
+     */
     public function seek(int $offset): void
     {
         if ($offset < 0 || $offset > $this->size()) {
@@ -21,36 +65,106 @@ final class MemoryBuffer
         $this->pos = $offset;
     }
 
-    public function read(int $len): string
+    /**
+     * Reads a fixed-length chunk from the current position.
+     *
+     * The cursor advances by the number of requested bytes.
+     *
+     * @param int $length number of bytes to consume
+     *
+     * @return string raw binary data with the requested length
+     *
+     * @throws BoundsError when the requested length exceeds the buffer
+     * @throws ParseError  when the read returns fewer bytes than requested
+     */
+    public function read(int $length): string
     {
-        $end = $this->pos + $len;
-        if ($len < 0 || $end > $this->size()) {
-            throw new BoundsError("MemoryBuffer read out of range: {$this->pos}+{$len}");
+        $end = $this->pos + $length;
+        if ($length < 0 || $end > $this->size()) {
+            throw new BoundsError("MemoryBuffer read out of range: {$this->pos}+{$length}");
         }
-        $chunk = substr($this->data, $this->pos, $len);
-        if (strlen($chunk) !== $len) {
+        $chunk = substr($this->data, $this->pos, $length);
+        if (strlen($chunk) !== $length) {
             throw new ParseError('MemoryBuffer short read');
         }
         $this->pos = $end;
+
         return $chunk;
     }
 
-    public function readU8(): int     { return ord($this->read(1)); }
-    public function readU16LE(): int  { return unpack('v', $this->read(2))[1]; }
-    public function readU16BE(): int  { return unpack('n', $this->read(2))[1]; }
-    public function readU32LE(): int  { return unpack('V', $this->read(4))[1]; }
-    public function readU32BE(): int  { return unpack('N', $this->read(4))[1]; }
+    /**
+     * Reads an unsigned 8-bit integer from the buffer.
+     *
+     * @return int unsigned 8-bit integer
+     */
+    public function readU8(): int
+    {
+        return ord($this->read(1));
+    }
 
+    /**
+     * Reads an unsigned 16-bit integer using little-endian byte order.
+     *
+     * @return int unsigned 16-bit integer
+     */
+    public function readU16LE(): int
+    {
+        return unpack('v', $this->read(2))[1];
+    }
+
+    /**
+     * Reads an unsigned 16-bit integer using big-endian byte order.
+     *
+     * @return int unsigned 16-bit integer
+     */
+    public function readU16BE(): int
+    {
+        return unpack('n', $this->read(2))[1];
+    }
+
+    /**
+     * Reads an unsigned 32-bit integer using little-endian byte order.
+     *
+     * @return int unsigned 32-bit integer
+     */
+    public function readU32LE(): int
+    {
+        return unpack('V', $this->read(4))[1];
+    }
+
+    /**
+     * Reads an unsigned 32-bit integer using big-endian byte order.
+     *
+     * @return int unsigned 32-bit integer
+     */
+    public function readU32BE(): int
+    {
+        return unpack('N', $this->read(4))[1];
+    }
+
+    /**
+     * Reads an unsigned 64-bit integer using little-endian byte order.
+     *
+     * @return int unsigned 64-bit integer
+     */
     public function readU64LE(): int
     {
         $lo = $this->readU32LE();
         $hi = $this->readU32LE();
+
         return ($hi << 32) | $lo;
     }
+
+    /**
+     * Reads an unsigned 64-bit integer using big-endian byte order.
+     *
+     * @return int unsigned 64-bit integer
+     */
     public function readU64BE(): int
     {
         $hi = $this->readU32BE();
         $lo = $this->readU32BE();
+
         return ($hi << 32) | $lo;
     }
 }

--- a/src/Detect/ContainerType.php
+++ b/src/Detect/ContainerType.php
@@ -1,10 +1,23 @@
 <?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace MagicSunday\ImageMeta\Detect;
 
+/**
+ * Enumerates supported top-level container formats for image metadata extraction.
+ */
 enum ContainerType
 {
+    /** JPEG file interchange format. */
     case JPEG;
-    case ISOBMFF; // HEIC/AVIF/MP4/MOV
+    /** ISO Base Media File Format such as HEIC, AVIF, MP4, or MOV. */
+    case ISOBMFF;
 }

--- a/src/Detect/FormatDetector.php
+++ b/src/Detect/FormatDetector.php
@@ -1,25 +1,46 @@
 <?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace MagicSunday\ImageMeta\Detect;
 
 use MagicSunday\ImageMeta\Core\Stream;
+use RuntimeException;
 
+/**
+ * Detects the container type of a binary stream based on magic numbers.
+ */
 final class FormatDetector
 {
-    public static function detect(Stream $s): ContainerType
+    /**
+     * Inspects the leading bytes of the stream and returns the detected container type.
+     *
+     * @param Stream $stream seekable stream positioned at an arbitrary offset
+     *
+     * @return ContainerType detected container format
+     *
+     * @throws RuntimeException when the signature does not match a known container
+     */
+    public static function detect(Stream $stream): ContainerType
     {
-        $s->seek(0);
-        $magic2 = $s->read(2);
+        $stream->seek(0);
+        $magic2 = $stream->read(2);
         if ($magic2 === "\xFF\xD8") {
             return ContainerType::JPEG;
         }
-        $s->seek(4);
-        $brand = $s->read(4); // 'ftyp'
+        $stream->seek(4);
+        $brand = $stream->read(4); // 'ftyp'
         if ($brand === 'ftyp') {
             return ContainerType::ISOBMFF;
         }
         // a few HEIC files may start with 0 size+ftyp; we already cover 'ftyp' at [4..8]
-        throw new \RuntimeException('Unsupported or unknown container');
+        throw new RuntimeException('Unsupported or unknown container');
     }
 }


### PR DESCRIPTION
## Summary
- add file headers and PHPDoc blocks for MemoryBuffer, Endian, ContainerType, and FormatDetector
- document metadata convenience helpers and clarify capture-date resolution logic
- expand EXIF convenience method documentation for common accessors

## Testing
- composer ci:cgl -- --dry-run *(fails: existing repository coding-style violations outside the touched files)*

------
https://chatgpt.com/codex/tasks/task_e_68f95b18a87483238f3c04a2829c521d