### PR TITLE
docs: add maker notes documentation

### DIFF
--- a/src/MakerNotes/AppleDecoder.php
+++ b/src/MakerNotes/AppleDecoder.php
@@ -1,10 +1,30 @@
 <?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace MagicSunday\ImageMeta\MakerNotes;
 
+/**
+ * Decoder that returns basic metadata about the raw maker notes produced by Apple devices.
+ */
 final class AppleDecoder implements MakerNotesDecoderInterface
 {
+    /**
+     * Creates a metadata map describing the Apple maker note payload.
+     *
+     * @param string      $raw   Raw maker note data stream.
+     * @param string      $make  Reported camera make string.
+     * @param string|null $model Optional camera model identifier.
+     *
+     * @return array<string, mixed> Normalised metadata describing the vendor, payload length, and hash.
+     */
     public function decode(string $raw, string $make, ?string $model): array
     {
         return [

--- a/src/MakerNotes/MakerNotesDecoderInterface.php
+++ b/src/MakerNotes/MakerNotesDecoderInterface.php
@@ -1,10 +1,29 @@
 <?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace MagicSunday\ImageMeta\MakerNotes;
 
+/**
+ * Describes a decoder that can interpret manufacturer-specific maker note metadata.
+ */
 interface MakerNotesDecoderInterface
 {
-    /** @return array<string, mixed> decoded map; may be partial */
+    /**
+     * Decodes a maker note payload for a specific camera make and model.
+     *
+     * @param string      $raw   Raw maker note byte sequence.
+     * @param string      $make  Camera make identifier associated with the payload.
+     * @param string|null $model Optional camera model identifier when available.
+     *
+     * @return array<string, mixed> Decoded metadata map; may be partial depending on decoder coverage.
+     */
     public function decode(string $raw, string $make, ?string $model): array;
 }

--- a/src/MakerNotes/Registry.php
+++ b/src/MakerNotes/Registry.php
@@ -1,18 +1,42 @@
 <?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace MagicSunday\ImageMeta\MakerNotes;
 
+/**
+ * Registry that stores maker note decoders by vendor prefixes and allows lookups.
+ */
 final class Registry
 {
     /** @var array<string, MakerNotesDecoderInterface> make prefix => decoder */
     private array $decoders = [];
 
+    /**
+     * Registers a decoder instance for the given case-insensitive make prefix.
+     *
+     * @param string                     $makePrefix Prefix of the camera make used to select the decoder.
+     * @param MakerNotesDecoderInterface $decoder    Decoder responsible for handling maker note metadata.
+     */
     public function register(string $makePrefix, MakerNotesDecoderInterface $decoder): void
     {
         $this->decoders[strtolower($makePrefix)] = $decoder;
     }
 
+    /**
+     * Finds the first decoder whose registered prefix matches the provided make string.
+     *
+     * @param string $make The camera make string from the metadata.
+     *
+     * @return MakerNotesDecoderInterface|null The matching decoder or null when no decoder is registered for the make.
+     */
     public function find(string $make): ?MakerNotesDecoderInterface
     {
         $make = strtolower($make);
@@ -21,6 +45,7 @@ final class Registry
                 return $dec;
             }
         }
+
         return null;
     }
 }


### PR DESCRIPTION
## Summary
- document the maker notes registry class and its public API
- describe the Apple maker notes decoder and interface contract in PHPDoc blocks

## Testing
- composer ci:cgl

------
https://chatgpt.com/codex/tasks/task_e_68f95e5fbc7c8323a04e702f521b28f9