### PR TITLE
Fix XMP reader mixed content concatenation

### DIFF
--- a/src/Core/Stream.php
+++ b/src/Core/Stream.php
@@ -1,4 +1,12 @@
 <?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace MagicSunday\ImageMeta\Core;
@@ -27,7 +35,8 @@ final class Stream
             throw new ParseError("Cannot open: $path");
         }
         $stat = fstat($fh);
-        $size = (int)($stat['size'] ?? 0);
+        $size = (int) ($stat['size'] ?? 0);
+
         return new self($fh, $size);
     }
 
@@ -39,7 +48,7 @@ final class Stream
      */
     public function __construct($fh, int $size)
     {
-        $this->fh = $fh;
+        $this->fh   = $fh;
         $this->size = $size;
     }
 
@@ -48,14 +57,20 @@ final class Stream
      *
      * @return int
      */
-    public function size(): int { return $this->size; }
+    public function size(): int
+    {
+        return $this->size;
+    }
 
     /**
      * Returns the current cursor position relative to the start of the stream.
      *
      * @return int
      */
-    public function tell(): int { return $this->pos; }
+    public function tell(): int
+    {
+        return $this->pos;
+    }
 
     /**
      * Moves the read cursor to an absolute offset within the stream.
@@ -88,6 +103,7 @@ final class Stream
             throw new ParseError('short read');
         }
         $this->pos += $len;
+
         return $data;
     }
 
@@ -96,21 +112,30 @@ final class Stream
      *
      * @return int
      */
-    public function readU8(): int   { return ord($this->read(1)); }
+    public function readU8(): int
+    {
+        return ord($this->read(1));
+    }
 
     /**
      * Reads an unsigned 16-bit big-endian integer from the stream.
      *
      * @return int
      */
-    public function readU16BE(): int { return unpack('n', $this->read(2))[1]; }
+    public function readU16BE(): int
+    {
+        return unpack('n', $this->read(2))[1];
+    }
 
     /**
      * Reads an unsigned 32-bit big-endian integer from the stream.
      *
      * @return int
      */
-    public function readU32BE(): int { return unpack('N', $this->read(4))[1]; }
+    public function readU32BE(): int
+    {
+        return unpack('N', $this->read(4))[1];
+    }
 
     /**
      * Reads an unsigned 64-bit big-endian integer from the stream.
@@ -121,6 +146,7 @@ final class Stream
     {
         $hi = $this->readU32BE();
         $lo = $this->readU32BE();
+
         return ($hi << 32) | $lo;
     }
 
@@ -135,6 +161,7 @@ final class Stream
         if ($offset < 0 || $length < 0 || $offset + $length > $this->size) {
             throw new BoundsError('window out of range');
         }
+
         return new StreamWindow($this, $offset, $length);
     }
 }

--- a/src/Core/StreamWindow.php
+++ b/src/Core/StreamWindow.php
@@ -1,4 +1,12 @@
 <?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace MagicSunday\ImageMeta\Core;
@@ -20,22 +28,29 @@ final class StreamWindow
     public function __construct(
         private readonly Stream $base,
         private readonly int $offset,
-        private readonly int $length
-    ) {}
+        private readonly int $length,
+    ) {
+    }
 
     /**
      * Returns the number of bytes exposed through this window.
      *
      * @return int
      */
-    public function size(): int { return $this->length; }
+    public function size(): int
+    {
+        return $this->length;
+    }
 
     /**
      * Returns the cursor position relative to the start of the window.
      *
      * @return int
      */
-    public function tell(): int { return $this->cursor; }
+    public function tell(): int
+    {
+        return $this->cursor;
+    }
 
     /**
      * Repositions the window cursor to an absolute offset inside the window.
@@ -65,6 +80,7 @@ final class StreamWindow
         $this->base->seek($this->offset + $this->cursor);
         $data = $this->base->read($len);
         $this->cursor += $len;
+
         return $data;
     }
 
@@ -73,21 +89,30 @@ final class StreamWindow
      *
      * @return int
      */
-    public function readU8(): int     { return ord($this->read(1)); }
+    public function readU8(): int
+    {
+        return ord($this->read(1));
+    }
 
     /**
      * Reads an unsigned 16-bit big-endian integer from the window.
      *
      * @return int
      */
-    public function readU16BE(): int  { return unpack('n', $this->read(2))[1]; }
+    public function readU16BE(): int
+    {
+        return unpack('n', $this->read(2))[1];
+    }
 
     /**
      * Reads an unsigned 32-bit big-endian integer from the window.
      *
      * @return int
      */
-    public function readU32BE(): int  { return unpack('N', $this->read(4))[1]; }
+    public function readU32BE(): int
+    {
+        return unpack('N', $this->read(4))[1];
+    }
 
     /**
      * Reads an unsigned 64-bit big-endian integer from the window.
@@ -98,6 +123,7 @@ final class StreamWindow
     {
         $hi = $this->readU32BE();
         $lo = $this->readU32BE();
+
         return ($hi << 32) | $lo;
     }
 }

--- a/src/MetadataReader.php
+++ b/src/MetadataReader.php
@@ -1,4 +1,12 @@
 <?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace MagicSunday\ImageMeta;
@@ -7,8 +15,8 @@ use MagicSunday\ImageMeta\Core\Stream;
 use MagicSunday\ImageMeta\Detect\ContainerType;
 use MagicSunday\ImageMeta\Detect\FormatDetector;
 use MagicSunday\ImageMeta\Model\Metadata;
-use MagicSunday\ImageMeta\Parse\Jpeg\JpegExtractor;
 use MagicSunday\ImageMeta\Parse\IsoBmff\IsoBmffExtractor;
+use MagicSunday\ImageMeta\Parse\Jpeg\JpegExtractor;
 use MagicSunday\ImageMeta\Parse\Tiff\TiffExifReader;
 use MagicSunday\ImageMeta\Parse\Xmp\XmpReader;
 
@@ -27,7 +35,7 @@ final class MetadataReader
     public function read(string $path): Metadata
     {
         $stream = Stream::fromPath($path);
-        $type = FormatDetector::detect($stream);
+        $type   = FormatDetector::detect($stream);
 
         return match ($type) {
             ContainerType::JPEG    => $this->fromJpeg($stream),
@@ -44,13 +52,18 @@ final class MetadataReader
      */
     private function fromJpeg(Stream $stream): Metadata
     {
-        $jpeg = new JpegExtractor($stream);
+        $jpeg      = new JpegExtractor($stream);
         $exifBlobs = $jpeg->extractExifBlobs();
         $xmpBlobs  = $jpeg->extractXmpPackets();
 
-        $exifDoc = null; $xmpDoc = null;
-        if ($exifBlobs !== []) { $exifDoc = (new TiffExifReader())->parseFromBlob($exifBlobs[0]); }
-        if ($xmpBlobs !== [])  { $xmpDoc  = (new XmpReader())->parse($xmpBlobs[0]); }
+        $exifDoc = null;
+        $xmpDoc  = null;
+        if ($exifBlobs !== []) {
+            $exifDoc = (new TiffExifReader())->parseFromBlob($exifBlobs[0]);
+        }
+        if ($xmpBlobs !== []) {
+            $xmpDoc = (new XmpReader())->parse($xmpBlobs[0]);
+        }
 
         return new Metadata($exifBlobs, null, $exifDoc, $xmpBlobs, $xmpDoc);
     }
@@ -66,9 +79,14 @@ final class MetadataReader
     {
         [$exifBlobs, $xmpBlobs, $qt] = (new IsoBmffExtractor($stream))->extract();
 
-        $exifDoc = null; $xmpDoc = null;
-        if ($exifBlobs !== []) { $exifDoc = (new TiffExifReader())->parseFromBlob($exifBlobs[0]); }
-        if ($xmpBlobs !== [])  { $xmpDoc  = (new XmpReader())->parse($xmpBlobs[0]); }
+        $exifDoc = null;
+        $xmpDoc  = null;
+        if ($exifBlobs !== []) {
+            $exifDoc = (new TiffExifReader())->parseFromBlob($exifBlobs[0]);
+        }
+        if ($xmpBlobs !== []) {
+            $xmpDoc = (new XmpReader())->parse($xmpBlobs[0]);
+        }
 
         return new Metadata($exifBlobs, $qt, $exifDoc, $xmpBlobs, $xmpDoc);
     }

--- a/src/Model/Exif/ExifDocument.php
+++ b/src/Model/Exif/ExifDocument.php
@@ -1,4 +1,12 @@
 <?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace MagicSunday\ImageMeta\Model\Exif;
@@ -12,8 +20,9 @@ final class IfdEntry
         public readonly int $tag,
         public readonly int $type,
         public readonly int $count,
-        public readonly mixed $value
-    ) {}
+        public readonly mixed $value,
+    ) {
+    }
 }
 
 final class Ifd
@@ -21,10 +30,14 @@ final class Ifd
     /** @param array<int, IfdEntry> $entries */
     public function __construct(
         public readonly array $entries,
-        public readonly ?int $nextIfdOffset = null
-    ) {}
+        public readonly ?int $nextIfdOffset = null,
+    ) {
+    }
 
-    public function get(int $tag): ?IfdEntry { return $this->entries[$tag] ?? null; }
+    public function get(int $tag): ?IfdEntry
+    {
+        return $this->entries[$tag] ?? null;
+    }
 }
 
 final class ExifDocument
@@ -34,14 +47,30 @@ final class ExifDocument
         public readonly ?Ifd $exifIfd,
         public readonly ?Ifd $gpsIfd,
         public readonly ?Ifd $interopIfd,
-        public readonly ?Ifd $ifd1
-    ) {}
+        public readonly ?Ifd $ifd1,
+    ) {
+    }
 
     // ---- Convenience (Strings/Numbers)
-    public function cameraMake(): ?string  { return $this->str($this->ifd0, 0x010F); }
-    public function cameraModel(): ?string { return $this->str($this->ifd0, 0x0110); }
-    public function lensModel(): ?string   { return $this->str($this->exifIfd, 0xA434); }
-    public function orientation(): ?int    { return $this->int($this->ifd0, 0x0112); }
+    public function cameraMake(): ?string
+    {
+        return $this->str($this->ifd0, 0x010F);
+    }
+
+    public function cameraModel(): ?string
+    {
+        return $this->str($this->ifd0, 0x0110);
+    }
+
+    public function lensModel(): ?string
+    {
+        return $this->str($this->exifIfd, 0xA434);
+    }
+
+    public function orientation(): ?int
+    {
+        return $this->int($this->ifd0, 0x0112);
+    }
 
     public function iso(): ?int
     {
@@ -53,6 +82,7 @@ final class ExifDocument
     {
         // Tag 0x829A RATIONAL
         $v = $this->exifIfd?->get(0x829A)?->value ?? null;
+
         return ValueConverters::rationalToFloat($v);
     }
 
@@ -60,6 +90,7 @@ final class ExifDocument
     {
         // Tag 0x829D RATIONAL
         $v = $this->exifIfd?->get(0x829D)?->value ?? null;
+
         return ValueConverters::rationalToFloat($v);
     }
 
@@ -67,16 +98,27 @@ final class ExifDocument
     {
         // Tag 0x920A RATIONAL
         $v = $this->exifIfd?->get(0x920A)?->value ?? null;
+
         return ValueConverters::rationalToFloat($v);
     }
 
-    public function dateTimeOriginalRaw(): ?string  { return $this->str($this->exifIfd, 0x9003); }
-    public function offsetTimeOriginalRaw(): ?string { return $this->str($this->exifIfd, 0x9011); }
+    public function dateTimeOriginalRaw(): ?string
+    {
+        return $this->str($this->exifIfd, 0x9003);
+    }
+
+    public function offsetTimeOriginalRaw(): ?string
+    {
+        return $this->str($this->exifIfd, 0x9011);
+    }
 
     /** @return array{lat:?float, lon:?float, alt:?float} */
     public function gps(): array
     {
-        if (!$this->gpsIfd) return ['lat'=>null,'lon'=>null,'alt'=>null];
+        if (!$this->gpsIfd) {
+            return ['lat' => null, 'lon' => null, 'alt' => null];
+        }
+
         return ValueConverters::gpsFromIfd($this->gpsIfd);
     }
 
@@ -84,25 +126,31 @@ final class ExifDocument
     public function captureDateTime(): ?DateTimeImmutable
     {
         $raw = $this->dateTimeOriginalRaw();
-        if (!$raw) return null;
+        if (!$raw) {
+            return null;
+        }
         $offset = $this->offsetTimeOriginalRaw(); // like "+01:00"
-        $tz = $offset ? new DateTimeZone($offset) : new DateTimeZone('UTC');
+        $tz     = $offset ? new DateTimeZone($offset) : new DateTimeZone('UTC');
 
         // EXIF uses "YYYY:MM:DD HH:MM:SS"
         $normalized = str_replace(':', '-', substr($raw, 0, 10)) . substr($raw, 10); // YYYY-MM-DD HH:MM:SS
-        $dt = DateTimeImmutable::createFromFormat('Y-m-d H:i:s', $normalized, $tz);
+        $dt         = DateTimeImmutable::createFromFormat('Y-m-d H:i:s', $normalized, $tz);
+
         return $dt ?: null;
     }
 
     private function str(?Ifd $ifd, int $tag): ?string
     {
         $e = $ifd?->get($tag);
+
         return is_string($e?->value) ? rtrim($e->value, "\0") : null;
     }
+
     private function int(?Ifd $ifd, int $tag): ?int
     {
         $v = $ifd?->get($tag)?->value ?? null;
-        return is_int($v) ? $v : (is_float($v) ? (int)$v : null);
+
+        return is_int($v) ? $v : (is_float($v) ? (int) $v : null);
     }
 }
 
@@ -110,10 +158,13 @@ final class ValueConverters
 {
     public static function rationalToFloat(mixed $v): ?float
     {
-        if (is_array($v) && count($v) === 2 && (int)$v[1] !== 0) {
-            return (float)$v[0] / (float)$v[1];
+        if (is_array($v) && count($v) === 2 && (int) $v[1] !== 0) {
+            return (float) $v[0] / (float) $v[1];
         }
-        if (is_int($v) || is_float($v)) return (float)$v;
+        if (is_int($v) || is_float($v)) {
+            return (float) $v;
+        }
+
         return null;
     }
 
@@ -129,24 +180,30 @@ final class ValueConverters
         $lon = self::dmsToFloat($lonRef, $lonVal);
 
         $alt = null;
-        if (($e = $gps->get(0x0006)) && is_array($e->value) && count($e->value) === 2 && (int)$e->value[1] !== 0) {
+        if (($e = $gps->get(0x0006)) && is_array($e->value) && count($e->value) === 2 && (int) $e->value[1] !== 0) {
             $alt = $e->value[0] / $e->value[1];
-            if (($ref = $gps->get(0x0005)) && (int)($ref->value ?? 0) === 1) {
+            if (($ref = $gps->get(0x0005)) && (int) ($ref->value ?? 0) === 1) {
                 $alt = -$alt;
             }
         }
-        return ['lat'=>$lat,'lon'=>$lon,'alt'=>$alt];
+
+        return ['lat' => $lat, 'lon' => $lon, 'alt' => $alt];
     }
 
     private static function dmsToFloat(?string $ref, mixed $val): ?float
     {
-        if (!is_string($ref) || !is_array($val) || count($val) < 3) return null;
+        if (!is_string($ref) || !is_array($val) || count($val) < 3) {
+            return null;
+        }
         $deg = self::rationalToFloat($val[0] ?? null);
         $min = self::rationalToFloat($val[1] ?? null);
         $sec = self::rationalToFloat($val[2] ?? null);
-        if ($deg === null || $min === null || $sec === null) return null;
+        if ($deg === null || $min === null || $sec === null) {
+            return null;
+        }
 
         $sign = ($ref === 'S' || $ref === 'W') ? -1.0 : 1.0;
-        return $sign * ($deg + $min/60.0 + $sec/3600.0);
+
+        return $sign * ($deg + $min / 60.0 + $sec / 3600.0);
     }
 }

--- a/src/Model/Metadata.php
+++ b/src/Model/Metadata.php
@@ -1,4 +1,12 @@
 <?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace MagicSunday\ImageMeta\Model;
@@ -12,17 +20,18 @@ use MagicSunday\ImageMeta\Model\Xmp\XmpDocument;
 final class Metadata
 {
     /**
-     * @param list<string> $exifBlobs   TIFF‑EXIF blobs (first is primary)
+     * @param list<string>       $exifBlobs TIFF‑EXIF blobs (first is primary)
      * @param QuickTimeMeta|null $quickTime QuickTime metadata extracted from ISO BMFF containers.
-     * @param list<string> $xmpBlobs    XMP packets (RDF/XML), first is primary
-     * @param ExifDocument|null $exifDoc Parsed representation of the primary EXIF document.
-     * @param XmpDocument|null  $xmpDoc  Parsed representation of the primary XMP packet.
+     * @param list<string>       $xmpBlobs  XMP packets (RDF/XML), first is primary
+     * @param ExifDocument|null  $exifDoc   Parsed representation of the primary EXIF document.
+     * @param XmpDocument|null   $xmpDoc    Parsed representation of the primary XMP packet.
      */
     public function __construct(
         public readonly array $exifBlobs,
         public readonly ?QuickTimeMeta $quickTime,
         public readonly ?ExifDocument $exifDoc = null,
         public readonly array $xmpBlobs = [],
-        public readonly ?XmpDocument $xmpDoc = null
-    ) {}
+        public readonly ?XmpDocument $xmpDoc = null,
+    ) {
+    }
 }

--- a/src/Model/QuickTimeMeta.php
+++ b/src/Model/QuickTimeMeta.php
@@ -1,4 +1,12 @@
 <?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace MagicSunday\ImageMeta\Model;
@@ -6,12 +14,15 @@ namespace MagicSunday\ImageMeta\Model;
 final class QuickTimeMeta
 {
     /** @param array<string, string|int|float|bool> $keys */
-    public function __construct(public readonly array $keys) {}
+    public function __construct(public readonly array $keys)
+    {
+    }
 
     public function contentIdentifier(): ?string
     {
         $k1 = 'com.apple.quicktime.content.identifier';
         $k2 = 'com.apple.quicktime.live-photo.still-image-display-time'; // Beispiel, weitere Keys möglich
-        return isset($this->keys[$k1]) ? (string)$this->keys[$k1] : null;
+
+        return isset($this->keys[$k1]) ? (string) $this->keys[$k1] : null;
     }
 }

--- a/src/Model/Xmp/XmpDocument.php
+++ b/src/Model/Xmp/XmpDocument.php
@@ -1,22 +1,28 @@
 <?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
-
 namespace MagicSunday\ImageMeta\Model\Xmp;
-
 
 final class XmpDocument
 {
     /** @param array<string, array<string, mixed>> $data nsUri => [prop => value] */
-    public function __construct(public readonly array $data) {}
-
+    public function __construct(public readonly array $data)
+    {
+    }
 
     /** Convenient flat lookup: nsUri + prop */
     public function get(string $nsUri, string $prop): mixed
     {
         return $this->data[$nsUri][$prop] ?? null;
     }
-
 
     /** Namespace‑agnostic helper (first match by local name) */
     public function find(string $localName): mixed
@@ -25,10 +31,13 @@ final class XmpDocument
             foreach ($props as $k => $v) {
                 if (str_contains($k, ':')) {
                     [$prefix, $ln] = explode(':', $k, 2);
-                    if ($ln === $localName) return $v;
+                    if ($ln === $localName) {
+                        return $v;
+                    }
                 }
             }
         }
+
         return null;
     }
 }

--- a/src/Parse/IsoBmff/IsoBmffExtractor.php
+++ b/src/Parse/IsoBmff/IsoBmffExtractor.php
@@ -1,4 +1,12 @@
 <?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace MagicSunday\ImageMeta\Parse\IsoBmff;
@@ -16,7 +24,9 @@ final class IsoBmffExtractor
 {
     private const XMP_UUID = "\xBE\x7A\xCF\xCB\x97\xA9\x42\xE8\x9C\x71\x99\x94\x91\xE3\xAF\xAC";
 
-    public function __construct(private readonly Stream $stream) {}
+    public function __construct(private readonly Stream $stream)
+    {
+    }
 
     /**
      * Extracts EXIF blobs, XMP packets, and QuickTime metadata from the stream.
@@ -25,9 +35,9 @@ final class IsoBmffExtractor
      */
     public function extract(): array
     {
-        $exifBlobs = [];
-        $xmpBlobs = [];
-        $qtKeys = [];
+        $exifBlobs     = [];
+        $xmpBlobs      = [];
+        $qtKeys        = [];
         $queuedUuidXmp = [];
 
         foreach ($this->walkTopLevelBoxes() as $box) {
@@ -57,7 +67,7 @@ final class IsoBmffExtractor
     private function walkTopLevelBoxes(): iterable
     {
         $fileSize = $this->stream->size();
-        $offset = 0;
+        $offset   = 0;
 
         while ($offset + 8 <= $fileSize) {
             $box = $this->readBoxAt($offset, $fileSize);
@@ -73,7 +83,7 @@ final class IsoBmffExtractor
     /**
      * Parses the `moov` box, collecting nested metadata boxes of interest.
      *
-     * @param object             $moov      Box descriptor for the movie box.
+     * @param object                $moov      Box descriptor for the movie box.
      * @param list<string>          $exifBlobs
      * @param list<string>          $xmpBlobs
      * @param array<string, string> $qtKeys
@@ -92,7 +102,7 @@ final class IsoBmffExtractor
     /**
      * Parses the `udta` user data box for embedded metadata containers.
      *
-     * @param object             $udta      Box descriptor for the user data box.
+     * @param object                $udta      Box descriptor for the user data box.
      * @param list<string>          $exifBlobs
      * @param list<string>          $xmpBlobs
      * @param array<string, string> $qtKeys
@@ -109,7 +119,7 @@ final class IsoBmffExtractor
     /**
      * Parses the ISO BMFF metadata box and resolves payload references.
      *
-     * @param object             $meta      Box descriptor for the metadata box.
+     * @param object                $meta      Box descriptor for the metadata box.
      * @param list<string>          $exifBlobs
      * @param list<string>          $xmpBlobs
      * @param array<string, string> $qtKeys
@@ -162,19 +172,19 @@ final class IsoBmffExtractor
      */
     private function collectDirectPayloads(object $meta): array
     {
-        $itemInfos = [];
-        $locations = [];
+        $itemInfos     = [];
+        $locations     = [];
         $primaryItemId = null;
-        $directXmp = [];
-        $uuidXmp = [];
-        $directExif = [];
-        $keysMaps = [];
-        $ilstBoxes = [];
+        $directXmp     = [];
+        $uuidXmp       = [];
+        $directExif    = [];
+        $keysMaps      = [];
+        $ilstBoxes     = [];
 
         foreach ($this->walkChildren($meta, 4) as $child) {
             switch ($child->type) {
                 case 'Exif':
-                    $blob = $this->readAll($child->window);
+                    $blob         = $this->readAll($child->window);
                     $directExif[] = $this->normalizeExifBlob($blob);
                     break;
                 case 'iinf':
@@ -206,25 +216,26 @@ final class IsoBmffExtractor
         }
 
         return [
-            'itemInfos' => $itemInfos,
-            'locations' => $locations,
+            'itemInfos'     => $itemInfos,
+            'locations'     => $locations,
             'primaryItemId' => $primaryItemId,
-            'directXmp' => $directXmp,
-            'uuidXmp' => $uuidXmp,
-            'directExif' => $directExif,
-            'keysMaps' => $keysMaps,
-            'ilstBoxes' => $ilstBoxes,
+            'directXmp'     => $directXmp,
+            'uuidXmp'       => $uuidXmp,
+            'directExif'    => $directExif,
+            'keysMaps'      => $keysMaps,
+            'ilstBoxes'     => $ilstBoxes,
         ];
     }
 
     /**
      * @param array<int, array{id: int, itemType: ?string, name: ?string, contentType: ?string}> $itemInfos
+     *
      * @return array{0: list<int>, 1: list<int>}
      */
     private function gatherItemIds(array $itemInfos, ?int $primaryItemId): array
     {
         $exifItemIds = [];
-        $xmpItemIds = [];
+        $xmpItemIds  = [];
 
         // Collect item IDs that advertise EXIF/XMP payloads via their metadata descriptors.
         foreach ($itemInfos as $info) {
@@ -238,7 +249,7 @@ final class IsoBmffExtractor
 
         // Deduplicate while preserving encounter order to avoid processing the same item twice.
         $exifItemIds = array_values(array_unique($exifItemIds));
-        $xmpItemIds = array_values(array_unique($xmpItemIds));
+        $xmpItemIds  = array_values(array_unique($xmpItemIds));
 
         if ($primaryItemId !== null) {
             // Ensure the declared primary item is considered first for XMP resolution.
@@ -250,9 +261,10 @@ final class IsoBmffExtractor
     }
 
     /**
-     * @param list<int> $itemIds
+     * @param list<int>                                                                                                                     $itemIds
      * @param array<int, array{dataReferenceIndex:int, constructionMethod:int, baseOffset:int, extents:list<array{offset:int,length:int}>}> $locations
-     * @param (callable(string):string)|null $transform
+     * @param (callable(string):string)|null                                                                                                $transform
+     *
      * @return list<string>
      */
     private function resolveQueuedItems(array $itemIds, array $locations, ?callable $transform): array
@@ -272,9 +284,10 @@ final class IsoBmffExtractor
     }
 
     /**
-     * @param array<string, string> $existing
+     * @param array<string, string>    $existing
      * @param list<array<int, string>> $keysMaps
-     * @param list<object> $ilstBoxes
+     * @param list<object>             $ilstBoxes
+     *
      * @return array<string, string>
      */
     private function mergeQuickTimeKeys(array $existing, array $keysMaps, array $ilstBoxes): array
@@ -307,7 +320,7 @@ final class IsoBmffExtractor
     /**
      * Resolves metadata item references described by an `iloc` box.
      *
-     * @param int   $itemId    Identifier of the item to resolve.
+     * @param int                                                                                                                           $itemId    Identifier of the item to resolve.
      * @param array<int, array{dataReferenceIndex:int, constructionMethod:int, baseOffset:int, extents:list<array{offset:int,length:int}>}> $locations
      *
      * @return string|null
@@ -326,7 +339,7 @@ final class IsoBmffExtractor
             return null;
         }
 
-        $blob = '';
+        $blob  = '';
         $total = 0;
         foreach ($location['extents'] as $extent) {
             $length = $extent['length'];
@@ -338,7 +351,7 @@ final class IsoBmffExtractor
                 throw new ParseError('iloc extent length exceeds file size');
             }
 
-            $baseOffset = $location['baseOffset'];
+            $baseOffset   = $location['baseOffset'];
             $extentOffset = $extent['offset'];
             if ($baseOffset < 0 || $extentOffset < 0) {
                 throw new ParseError('iloc negative offset');
@@ -372,15 +385,15 @@ final class IsoBmffExtractor
         $this->readUInt24($win); // flags
 
         $entryCount = $version === 0 ? $win->readU16BE() : $win->readU32BE();
-        $start = $win->tell();
-        $items = [];
-        $index = 0;
+        $start      = $win->tell();
+        $items      = [];
+        $index      = 0;
         foreach ($this->walkChildren($iinf, $start) as $child) {
             if ($child->type !== 'infe') {
                 continue;
             }
             $items[] = $this->parseInfe($child);
-            $index++;
+            ++$index;
             if ($index >= $entryCount) {
                 break;
             }
@@ -401,39 +414,39 @@ final class IsoBmffExtractor
         $win = $infe->window;
         $win->seek(0);
         $version = $win->readU8();
-        $flags = $this->readUInt24($win);
+        $flags   = $this->readUInt24($win);
 
         if ($version === 0 || $version === 1) {
             $itemId = $win->readU16BE();
             $win->readU16BE(); // protection index
             $remaining = $infe->contentSize - $win->tell();
-            $payload = $remaining > 0 ? $win->read($remaining) : '';
-            $parts = $payload === '' ? [] : explode("\0", $payload);
+            $payload   = $remaining > 0 ? $win->read($remaining) : '';
+            $parts     = $payload === '' ? [] : explode("\0", $payload);
 
-            $name = $parts[0] ?? null;
+            $name        = $parts[0] ?? null;
             $contentType = isset($parts[1]) && $parts[1] !== '' ? $parts[1] : null;
 
             return [
-                'id' => $itemId,
-                'itemType' => null,
-                'name' => $name !== '' ? $name : null,
+                'id'          => $itemId,
+                'itemType'    => null,
+                'name'        => $name !== '' ? $name : null,
                 'contentType' => $contentType,
             ];
         }
 
         $id = ($flags & 0x0001) !== 0 ? $win->readU32BE() : $win->readU16BE();
         $win->readU16BE(); // protection index
-        $itemType = $win->read(4);
-        $remaining = $infe->contentSize - $win->tell();
-        $payload = $remaining > 0 ? $win->read($remaining) : '';
-        $parts = $payload === '' ? [] : explode("\0", $payload);
-        $name = $parts[0] ?? null;
+        $itemType    = $win->read(4);
+        $remaining   = $infe->contentSize - $win->tell();
+        $payload     = $remaining > 0 ? $win->read($remaining) : '';
+        $parts       = $payload === '' ? [] : explode("\0", $payload);
+        $name        = $parts[0] ?? null;
         $contentType = isset($parts[1]) && $parts[1] !== '' ? $parts[1] : null;
 
         return [
-            'id' => $id,
-            'itemType' => $itemType !== '' ? $itemType : null,
-            'name' => $name !== '' ? $name : null,
+            'id'          => $id,
+            'itemType'    => $itemType !== '' ? $itemType : null,
+            'name'        => $name !== '' ? $name : null,
             'contentType' => $contentType,
         ];
     }
@@ -450,15 +463,15 @@ final class IsoBmffExtractor
         $win = $iloc->window;
         $win->seek(0);
         $version = $win->readU8();
-        $flags = $this->readUInt24($win);
+        $flags   = $this->readUInt24($win);
 
         $offsetLengthSizes = $win->readU8();
-        $offsetSize = $this->validateSizeNibble(($offsetLengthSizes >> 4) & 0x0F);
-        $lengthSize = $this->validateSizeNibble($offsetLengthSizes & 0x0F);
+        $offsetSize        = $this->validateSizeNibble(($offsetLengthSizes >> 4) & 0x0F);
+        $lengthSize        = $this->validateSizeNibble($offsetLengthSizes & 0x0F);
 
-        $baseField = $win->readU8();
+        $baseField      = $win->readU8();
         $baseOffsetSize = $this->validateSizeNibble(($baseField >> 4) & 0x0F);
-        $indexSize = 0;
+        $indexSize      = 0;
         if ($version === 1 || $version === 2) {
             $indexSize = $this->validateSizeNibble($win->readU8() & 0x0F);
         }
@@ -466,32 +479,32 @@ final class IsoBmffExtractor
         $itemCount = $version < 2 ? $win->readU16BE() : $win->readU32BE();
         $locations = [];
 
-        for ($i = 0; $i < $itemCount; $i++) {
-            $itemId = $version < 2 ? $win->readU16BE() : (($flags & 0x0001) !== 0 ? $win->readU32BE() : $win->readU16BE());
+        for ($i = 0; $i < $itemCount; ++$i) {
+            $itemId             = $version < 2 ? $win->readU16BE() : (($flags & 0x0001) !== 0 ? $win->readU32BE() : $win->readU16BE());
             $constructionMethod = 0;
             if ($version === 1 || $version === 2) {
-                $tmp = $win->readU16BE();
+                $tmp                = $win->readU16BE();
                 $constructionMethod = ($tmp >> 12) & 0x0F;
             }
             $dataReferenceIndex = $win->readU16BE();
-            $baseOffset = $baseOffsetSize > 0 ? $this->readUInt($win, $baseOffsetSize) : 0;
-            $extentCount = $win->readU16BE();
-            $extents = [];
+            $baseOffset         = $baseOffsetSize > 0 ? $this->readUInt($win, $baseOffsetSize) : 0;
+            $extentCount        = $win->readU16BE();
+            $extents            = [];
 
-            for ($j = 0; $j < $extentCount; $j++) {
+            for ($j = 0; $j < $extentCount; ++$j) {
                 if ($indexSize > 0) {
                     $this->readUInt($win, $indexSize); // extent_index, ignored
                 }
                 $extentOffset = $offsetSize > 0 ? $this->readUInt($win, $offsetSize) : 0;
                 $extentLength = $lengthSize > 0 ? $this->readUInt($win, $lengthSize) : 0;
-                $extents[] = ['offset' => $extentOffset, 'length' => $extentLength];
+                $extents[]    = ['offset' => $extentOffset, 'length' => $extentLength];
             }
 
             $locations[$itemId] = [
                 'dataReferenceIndex' => $dataReferenceIndex,
                 'constructionMethod' => $constructionMethod,
-                'baseOffset' => $baseOffset,
-                'extents' => $extents,
+                'baseOffset'         => $baseOffset,
+                'extents'            => $extents,
             ];
         }
 
@@ -528,20 +541,20 @@ final class IsoBmffExtractor
         $win->seek(0);
         $win->read(4); // version/flags
         $entryCount = $win->readU32BE();
-        $map = [];
-        $pos = $win->tell();
+        $map        = [];
+        $pos        = $win->tell();
 
-        for ($i = 1; $i <= $entryCount; $i++) {
+        for ($i = 1; $i <= $entryCount; ++$i) {
             if ($pos + 8 > $keys->contentSize) {
                 throw new ParseError('keys entry truncated');
             }
             $win->seek($pos);
-            $size = $win->readU32BE();
+            $size      = $win->readU32BE();
             $namespace = $win->read(4);
             if ($size < 8 || $pos + $size > $keys->contentSize) {
                 throw new ParseError('invalid keys entry size');
             }
-            $name = $win->read($size - 8);
+            $name    = $win->read($size - 8);
             $map[$i] = $name;
             $pos += $size;
         }
@@ -566,7 +579,7 @@ final class IsoBmffExtractor
         $result = [];
         foreach ($this->walkChildren($ilst) as $entry) {
             $keyName = null;
-            $index = $this->fourccToIndex($entry->type);
+            $index   = $this->fourccToIndex($entry->type);
             if ($index !== null && isset($keyIndex[$index])) {
                 $keyName = $keyIndex[$index];
             } elseif ($entry->type === '----') {
@@ -635,7 +648,7 @@ final class IsoBmffExtractor
         $type = $win->readU32BE();
         $win->readU32BE(); // locale
         $payloadSize = $data->contentSize - 8;
-        $payload = $payloadSize > 0 ? $win->read($payloadSize) : '';
+        $payload     = $payloadSize > 0 ? $win->read($payloadSize) : '';
 
         if ($type === 1 || $type === 2 || $type === 7) {
             return trim($payload, "\0");
@@ -668,14 +681,15 @@ final class IsoBmffExtractor
      */
     private function isExifItem(array $info): bool
     {
-        if (isset($info['itemType']) && strcasecmp((string)$info['itemType'], 'Exif') === 0) {
+        if (isset($info['itemType']) && strcasecmp((string) $info['itemType'], 'Exif') === 0) {
             return true;
         }
-        if (isset($info['name']) && strcasecmp((string)$info['name'], 'Exif') === 0) {
+        if (isset($info['name']) && strcasecmp((string) $info['name'], 'Exif') === 0) {
             return true;
         }
         if (isset($info['contentType'])) {
-            $ct = strtolower((string)$info['contentType']);
+            $ct = strtolower((string) $info['contentType']);
+
             return $ct === 'application/exif' || $ct === 'image/tiff';
         }
 
@@ -693,7 +707,7 @@ final class IsoBmffExtractor
             return false;
         }
 
-        return strtolower((string)$info['contentType']) === 'application/rdf+xml';
+        return strtolower((string) $info['contentType']) === 'application/rdf+xml';
     }
 
     /**
@@ -707,6 +721,7 @@ final class IsoBmffExtractor
     {
         $window->seek(0);
         $size = $window->size();
+
         return $size > 0 ? $window->read($size) : '';
     }
 
@@ -733,12 +748,12 @@ final class IsoBmffExtractor
     private function readUInt(StreamWindow $window, int $bytes): int
     {
         return match ($bytes) {
-            0 => 0,
-            1 => $window->readU8(),
-            2 => $window->readU16BE(),
-            3 => unpack('N', "\0" . $window->read(3))[1],
-            4 => $window->readU32BE(),
-            8 => $window->readU64BE(),
+            0       => 0,
+            1       => $window->readU8(),
+            2       => $window->readU16BE(),
+            3       => unpack('N', "\0" . $window->read(3))[1],
+            4       => $window->readU32BE(),
+            8       => $window->readU64BE(),
             default => throw new ParseError("unsupported integer size $bytes"),
         };
     }
@@ -785,6 +800,7 @@ final class IsoBmffExtractor
         }
 
         $value = unpack('N', $fourcc)[1];
+
         return $value > 0 ? $value : null;
     }
 
@@ -802,9 +818,9 @@ final class IsoBmffExtractor
             throw new ParseError('child offset outside container');
         }
 
-        $limit = $parent->contentOffset + $parent->contentSize;
+        $limit  = $parent->contentOffset + $parent->contentSize;
         $cursor = $parent->contentOffset + $offset;
-        $end = $parent->contentOffset + $parent->contentSize;
+        $end    = $parent->contentOffset + $parent->contentSize;
 
         while ($cursor + 8 <= $end) {
             $box = $this->readBoxAt($cursor, $limit);
@@ -832,10 +848,10 @@ final class IsoBmffExtractor
         }
 
         $this->stream->seek($offset);
-        $size32 = $this->stream->readU32BE();
-        $type = $this->stream->read(4);
+        $size32     = $this->stream->readU32BE();
+        $type       = $this->stream->read(4);
         $headerSize = 8;
-        $size = $size32;
+        $size       = $size32;
 
         if ($size32 === 0) {
             $size = $limit - $offset;
@@ -858,17 +874,17 @@ final class IsoBmffExtractor
         }
 
         $contentOffset = $offset + $headerSize;
-        $contentSize = $size - $headerSize;
-        $window = $this->stream->window($contentOffset, $contentSize);
+        $contentSize   = $size - $headerSize;
+        $window        = $this->stream->window($contentOffset, $contentSize);
 
         return (object) [
-            'type' => $type,
-            'size' => $size,
-            'offset' => $offset,
+            'type'          => $type,
+            'size'          => $size,
+            'offset'        => $offset,
             'contentOffset' => $contentOffset,
-            'contentSize' => $contentSize,
-            'window' => $window,
-            'userType' => $userType,
+            'contentSize'   => $contentSize,
+            'window'        => $window,
+            'userType'      => $userType,
         ];
     }
 }

--- a/src/Parse/Jpeg/JpegExtractor.php
+++ b/src/Parse/Jpeg/JpegExtractor.php
@@ -1,4 +1,12 @@
 <?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace MagicSunday\ImageMeta\Parse\Jpeg;
@@ -13,12 +21,12 @@ use MagicSunday\ImageMeta\Core\Stream;
 final class JpegExtractor
 {
     private const MAX_APP_SEGMENT_SIZE = 4_194_304; // 4 MiB payload limit
-    private const EXIF_SIGNATURE = "Exif\0\0";
-    private const XMP_SIGNATURE = "http://ns.adobe.com/xap/1.0/\0";
-    private const ICC_SIGNATURE = "ICC_PROFILE\0";
-    private const IPTC_SIGNATURE = "Photoshop 3.0\0";
-    private const MARKER_SOS = 0xDA;
-    private const MARKER_EOI = 0xD9;
+    private const EXIF_SIGNATURE       = "Exif\0\0";
+    private const XMP_SIGNATURE        = "http://ns.adobe.com/xap/1.0/\0";
+    private const ICC_SIGNATURE        = "ICC_PROFILE\0";
+    private const IPTC_SIGNATURE       = "Photoshop 3.0\0";
+    private const MARKER_SOS           = 0xDA;
+    private const MARKER_EOI           = 0xD9;
 
     private bool $parsed = false;
     /** @var list<string> */
@@ -28,9 +36,9 @@ final class JpegExtractor
     /** @var list<string> */
     private array $iccSegments = [];
     /** @var array<int, string> */
-    private array $iccSequence = [];
+    private array $iccSequence     = [];
     private ?int $iccExpectedCount = null;
-    private ?string $iccProfile = null;
+    private ?string $iccProfile    = null;
     /** @var list<string> */
     private array $iptcPayloads = [];
 
@@ -39,7 +47,9 @@ final class JpegExtractor
      *
      * @param Stream $s Stream representing the JPEG binary.
      */
-    public function __construct(private readonly Stream $s) {}
+    public function __construct(private readonly Stream $s)
+    {
+    }
 
     /**
      * Returns all discovered EXIF payloads in the order they appeared.
@@ -115,13 +125,13 @@ final class JpegExtractor
             throw new ParseError('Not a JPEG (missing SOI marker)');
         }
 
-        $this->exifBlobs = [];
-        $this->xmpPackets = [];
-        $this->iccSegments = [];
-        $this->iccSequence = [];
+        $this->exifBlobs        = [];
+        $this->xmpPackets       = [];
+        $this->iccSegments      = [];
+        $this->iccSequence      = [];
         $this->iccExpectedCount = null;
-        $this->iccProfile = null;
-        $this->iptcPayloads = [];
+        $this->iccProfile       = null;
+        $this->iptcPayloads     = [];
 
         while (true) {
             [$marker, $offset] = $this->nextMarkerWithOffset();
@@ -138,10 +148,10 @@ final class JpegExtractor
                 continue; // markers without payload
             }
 
-            $isAppSegment = $marker >= 0xE0 && $marker <= 0xEF;
+            $isAppSegment  = $marker >= 0xE0 && $marker <= 0xEF;
             $segmentLength = $this->readSegmentLength($marker, $offset, $isAppSegment);
             $payloadLength = $segmentLength - 2;
-            $payload = $this->readSegmentPayload($marker, $offset, $payloadLength);
+            $payload       = $this->readSegmentPayload($marker, $offset, $payloadLength);
 
             if ($marker === 0xE1) {
                 $this->handleApp1($payload);
@@ -155,7 +165,7 @@ final class JpegExtractor
         if ($this->iccExpectedCount !== null && $this->iccExpectedCount > 0) {
             if (count($this->iccSequence) === $this->iccExpectedCount) {
                 $expectedSequence = range(1, $this->iccExpectedCount);
-                $presentSequence = array_keys($this->iccSequence);
+                $presentSequence  = array_keys($this->iccSequence);
                 sort($presentSequence);
 
                 if ($presentSequence === $expectedSequence) {
@@ -293,8 +303,8 @@ final class JpegExtractor
         }
 
         $sequenceNumber = ord($payload[$signatureLength]);
-        $sequenceCount = ord($payload[$signatureLength + 1]);
-        $iccData = substr($payload, $signatureLength + 2);
+        $sequenceCount  = ord($payload[$signatureLength + 1]);
+        $iccData        = substr($payload, $signatureLength + 2);
 
         $this->iccSegments[] = $payload;
 

--- a/src/Parse/Tiff/TiffExifReader.php
+++ b/src/Parse/Tiff/TiffExifReader.php
@@ -1,4 +1,12 @@
 <?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace MagicSunday\ImageMeta\Parse\Tiff;
@@ -32,10 +40,10 @@ final class TiffExifReader
         $this->buf->seek(0);
 
         // byte order
-        $boSig = $this->buf->read(2);
+        $boSig    = $this->buf->read(2);
         $this->bo = match ($boSig) {
-            'II' => Endian::Little,
-            'MM' => Endian::Big,
+            'II'    => Endian::Little,
+            'MM'    => Endian::Big,
             default => throw new ParseError('Bad TIFF byte order'),
         };
 
@@ -44,25 +52,28 @@ final class TiffExifReader
             $this->bigTiff = true;
             $this->parseBigTiffHeader();
             $firstIfd = $this->readU64();
-            $ifd0 = $this->readIfd($firstIfd);
+            $ifd0     = $this->readIfd($firstIfd);
         } elseif ($magic === 0x2A) {
             $this->bigTiff = false;
-            $firstIfd = $this->readU32();
-            $ifd0 = $this->readIfd($firstIfd);
+            $firstIfd      = $this->readU32();
+            $ifd0          = $this->readIfd($firstIfd);
         } else {
             throw new ParseError('Unknown TIFF magic (expected 0x002A or 0x002B)');
         }
 
         // follow pointers
-        $exifIfd = null; $gpsIfd = null; $interopIfd = null; $ifd1 = null;
+        $exifIfd    = null;
+        $gpsIfd     = null;
+        $interopIfd = null;
+        $ifd1       = null;
         if ($e = $ifd0->get(0x8769)) { // ExifIFDPointer
-            $exifIfd = $this->readIfd((int)$e->value);
+            $exifIfd = $this->readIfd((int) $e->value);
             if ($e2 = $exifIfd->get(0xA005)) { // Interop IFD
-                $interopIfd = $this->readIfd((int)$e2->value);
+                $interopIfd = $this->readIfd((int) $e2->value);
             }
         }
         if ($g = $ifd0->get(0x8825)) { // GPSInfoIFDPointer
-            $gpsIfd = $this->readIfd((int)$g->value);
+            $gpsIfd = $this->readIfd((int) $g->value);
         }
         if ($ifd0->nextIfdOffset) {
             $ifd1 = $this->readIfd($ifd0->nextIfdOffset);
@@ -99,11 +110,12 @@ final class TiffExifReader
         }
         $this->buf->seek($offset);
         $entryCount = $this->bigTiff ? $this->readU64() : $this->readU16();
-        $entries = [];
-        for ($i = 0; $i < $entryCount; $i++) {
+        $entries    = [];
+        for ($i = 0; $i < $entryCount; ++$i) {
             $entries += $this->readDirEntry();
         }
         $next = $this->bigTiff ? $this->readU64() : $this->readU32();
+
         return new Ifd($entries, $next > 0 ? $next : null);
     }
 
@@ -114,13 +126,14 @@ final class TiffExifReader
      */
     private function readDirEntry(): array
     {
-        $tag  = $this->readU16();
-        $type = $this->readU16();
-        $cnt  = $this->bigTiff ? $this->readU64() : $this->readU32();
+        $tag      = $this->readU16();
+        $type     = $this->readU16();
+        $cnt      = $this->bigTiff ? $this->readU64() : $this->readU32();
         $valOrOff = $this->bigTiff ? $this->readU64() : $this->readU32();
 
         $value = $this->decodeValue($type, $cnt, $valOrOff);
-        return [$tag => new IfdEntry($tag, $type, (int)$cnt, $value)];
+
+        return [$tag => new IfdEntry($tag, $type, (int) $cnt, $value)];
     }
 
     /**
@@ -136,20 +149,21 @@ final class TiffExifReader
     {
         $unitSize = match ($type) {
             1, 2, 6, 7 => 1,           // BYTE, ASCII, SBYTE, UNDEFINED
-            3, 8       => 2,           // SHORT, SSHORT
-            4, 9       => 4,           // LONG, SLONG
-            5, 10      => 8,           // RATIONAL, SRATIONAL (two LONGs)
-            11         => 4,           // FLOAT
-            12         => 8,           // DOUBLE
-            default    => throw new ParseError("Unsupported TIFF type: $type"),
+            3, 8 => 2,           // SHORT, SSHORT
+            4, 9 => 4,           // LONG, SLONG
+            5, 10 => 8,           // RATIONAL, SRATIONAL (two LONGs)
+            11      => 4,           // FLOAT
+            12      => 8,           // DOUBLE
+            default => throw new ParseError("Unsupported TIFF type: $type"),
         };
-        $dataSize = $unitSize * $count;
+        $dataSize        = $unitSize * $count;
         $inlineThreshold = $this->bigTiff ? 8 : 4;
 
         if ($dataSize <= $inlineThreshold) {
             // valueOrOffset is inline value area
-            $raw = $this->uXToBytes($valueOrOffset, $inlineThreshold);
+            $raw   = $this->uXToBytes($valueOrOffset, $inlineThreshold);
             $bytes = substr($raw, 0, $dataSize);
+
             return $this->decodeBytes($type, $count, $bytes);
         }
 
@@ -159,6 +173,7 @@ final class TiffExifReader
         $this->buf->seek($off);
         $bytes = $this->buf->read($dataSize);
         $this->buf->seek($cur);
+
         return $this->decodeBytes($type, $count, $bytes);
     }
 
@@ -178,37 +193,39 @@ final class TiffExifReader
         }
         if ($type === 5 || $type === 10) { // RATIONAL / SRATIONAL
             $out = [];
-            for ($i = 0; $i < $count; $i++) {
-                $num = $this->read32FromBytes($bytes, $i * 8 + 0, $type === 10);
-                $den = $this->read32FromBytes($bytes, $i * 8 + 4, $type === 10);
+            for ($i = 0; $i < $count; ++$i) {
+                $num   = $this->read32FromBytes($bytes, $i * 8 + 0, $type === 10);
+                $den   = $this->read32FromBytes($bytes, $i * 8 + 4, $type === 10);
                 $out[] = [$num, $den];
             }
+
             return $count === 1 ? $out[0] : $out;
         }
 
-        $vals = [];
+        $vals   = [];
         $cursor = 0;
-        for ($i = 0; $i < $count; $i++) {
+        for ($i = 0; $i < $count; ++$i) {
             $vals[] = match ($type) {
-                1 => ord($bytes[$cursor++]),                              // BYTE
-                6 => self::toSigned(ord($bytes[$cursor++] ), 8),          // SBYTE
-                7 => ord($bytes[$cursor++]),                              // UNDEFINED → return as byte
-                3 => $this->unpackU16(substr($bytes, $cursor, 2)),        // SHORT
-                8 => $this->unpackS16(substr($bytes, $cursor, 2)),        // SSHORT
-                4 => $this->unpackU32(substr($bytes, $cursor, 4)),        // LONG
-                9 => $this->unpackS32(substr($bytes, $cursor, 4)),        // SLONG
-                11 => $this->unpackFloat(substr($bytes, $cursor, 4)),     // FLOAT
-                12 => $this->unpackDouble(substr($bytes, $cursor, 8)),    // DOUBLE
+                1       => ord($bytes[$cursor++]),                              // BYTE
+                6       => self::toSigned(ord($bytes[$cursor++]), 8),          // SBYTE
+                7       => ord($bytes[$cursor++]),                              // UNDEFINED → return as byte
+                3       => $this->unpackU16(substr($bytes, $cursor, 2)),        // SHORT
+                8       => $this->unpackS16(substr($bytes, $cursor, 2)),        // SSHORT
+                4       => $this->unpackU32(substr($bytes, $cursor, 4)),        // LONG
+                9       => $this->unpackS32(substr($bytes, $cursor, 4)),        // SLONG
+                11      => $this->unpackFloat(substr($bytes, $cursor, 4)),     // FLOAT
+                12      => $this->unpackDouble(substr($bytes, $cursor, 8)),    // DOUBLE
                 default => throw new ParseError("Unsupported type in decodeBytes: $type"),
             };
             $cursor += match ($type) {
                 1,6,7 => 1,
-                3,8   => 2,
+                3,8 => 2,
                 4,9,11 => 4,
-                12    => 8,
+                12      => 8,
                 default => 0,
             };
         }
+
         return $count === 1 ? $vals[0] : $vals;
     }
 
@@ -257,14 +274,17 @@ final class TiffExifReader
             return $this->bo === Endian::Little ? pack('V', $v) : pack('N', $v);
         }
         if ($bytes === 8) {
-            $hi = ($v >> 32) & 0xFFFFFFFF; $lo = $v & 0xFFFFFFFF;
+            $hi = ($v >> 32) & 0xFFFFFFFF;
+            $lo = $v & 0xFFFFFFFF;
+
             return $this->bo === Endian::Little ? pack('V2', $lo, $hi) : pack('N2', $hi, $lo);
         }
         // fallback (shouldn't happen here)
         $bin = '';
-        for ($i = 0; $i < $bytes; $i++) {
-            $bin = chr(($v >> ($this->bo === Endian::Little ? ($i*8) : (($bytes-1-$i)*8))) & 0xFF) . $bin;
+        for ($i = 0; $i < $bytes; ++$i) {
+            $bin = chr(($v >> ($this->bo === Endian::Little ? ($i * 8) : (($bytes - 1 - $i) * 8))) & 0xFF) . $bin;
         }
+
         return $bin;
     }
 
@@ -280,6 +300,7 @@ final class TiffExifReader
     private function read32FromBytes(string $bytes, int $offset, bool $signed): int
     {
         $chunk = substr($bytes, $offset, 4);
+
         return $signed ? $this->unpackS32($chunk) : $this->unpackU32($chunk);
     }
 
@@ -305,6 +326,7 @@ final class TiffExifReader
     private function unpackS16(string $b): int
     {
         $u = $this->unpackU16($b);
+
         return $u >= 0x8000 ? $u - 0x10000 : $u;
     }
 
@@ -330,6 +352,7 @@ final class TiffExifReader
     private function unpackS32(string $b): int
     {
         $u = $this->unpackU32($b);
+
         return ($u & 0x80000000) ? -((~$u & 0xFFFFFFFF) + 1) : $u;
     }
 
@@ -342,7 +365,7 @@ final class TiffExifReader
      */
     private function unpackFloat(string $b): float
     {
-        return (float)($this->bo === Endian::Little ? unpack('g', $b)[1] : unpack('G', $b)[1]);
+        return (float) ($this->bo === Endian::Little ? unpack('g', $b)[1] : unpack('G', $b)[1]);
     }
 
     /**
@@ -354,7 +377,7 @@ final class TiffExifReader
      */
     private function unpackDouble(string $b): float
     {
-        return (float)($this->bo === Endian::Little ? unpack('e', $b)[1] : unpack('E', $b)[1]);
+        return (float) ($this->bo === Endian::Little ? unpack('e', $b)[1] : unpack('E', $b)[1]);
     }
 
     /**
@@ -368,6 +391,7 @@ final class TiffExifReader
     private static function toSigned(int $u, int $bits): int
     {
         $sign = 1 << ($bits - 1);
+
         return ($u & $sign) ? $u - (1 << $bits) : $u;
     }
 }

--- a/src/Parse/Xmp/XmpParser.php
+++ b/src/Parse/Xmp/XmpParser.php
@@ -1,4 +1,12 @@
 <?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace MagicSunday\ImageMeta\Parse\Xmp;
@@ -9,7 +17,7 @@ use XMLReader;
 /**
  * Lightweight streaming XMP (RDF/XML) parser via XMLReader.
  * - extrahiert gängige Properties (xmp:CreateDate, exif:DateTimeOriginal, dc:subject (Bag))
- * - belässt unbekannte Props als einfache textuelle Werte (Best-Effort)
+ * - belässt unbekannte Props als einfache textuelle Werte (Best-Effort).
  */
 final class XmpParser
 {
@@ -21,7 +29,9 @@ final class XmpParser
         $props = [];
 
         while ($xr->read()) {
-            if ($xr->nodeType !== XMLReader::ELEMENT) continue;
+            if ($xr->nodeType !== XMLReader::ELEMENT) {
+                continue;
+            }
 
             $qname = $this->qname($xr);
             if ($qname === 'rdf:Bag' && isset($props['_last_dc_subject'])) {
@@ -33,8 +43,8 @@ final class XmpParser
 
             // capture strings for common props
             if (in_array($qname, [
-                'xmp:CreateDate','xmp:ModifyDate',
-                'exif:DateTimeOriginal','exif:OffsetTimeOriginal'
+                'xmp:CreateDate', 'xmp:ModifyDate',
+                'exif:DateTimeOriginal', 'exif:OffsetTimeOriginal',
             ], true)) {
                 $props[$qname] = $this->readElementText($xr);
             }
@@ -46,12 +56,14 @@ final class XmpParser
         }
 
         $xr->close();
+
         return new XmpDocument($props);
     }
 
     private function qname(XMLReader $xr): string
     {
         $prefix = $xr->prefix ? $xr->prefix . ':' : '';
+
         return $prefix . $xr->localName;
     }
 
@@ -67,6 +79,7 @@ final class XmpParser
                 }
             }
         }
+
         return trim($text);
     }
 
@@ -74,7 +87,9 @@ final class XmpParser
     private function readBag(XMLReader $xr): array
     {
         $items = [];
-        if ($xr->isEmptyElement) return $items;
+        if ($xr->isEmptyElement) {
+            return $items;
+        }
 
         $depth = $xr->depth;
         while ($xr->read()) {
@@ -85,6 +100,7 @@ final class XmpParser
                 $items[] = $this->readElementText($xr);
             }
         }
-        return array_values(array_filter($items, fn($s) => $s !== ''));
+
+        return array_values(array_filter($items, fn ($s) => $s !== ''));
     }
 }

--- a/src/Parse/Xmp/XmpReader.php
+++ b/src/Parse/Xmp/XmpReader.php
@@ -1,9 +1,18 @@
 <?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace MagicSunday\ImageMeta\Parse\Xmp;
 
 use MagicSunday\ImageMeta\Model\Xmp\XmpDocument;
+use XMLReader;
 
 /**
  * Performs a lightweight XMP RDF/XML pass using \XMLReader to capture simple properties.
@@ -19,14 +28,14 @@ final class XmpReader
      */
     public function parse(string $xml): XmpDocument
     {
-        $xr = new \XMLReader();
+        $xr = new XMLReader();
         if (!$xr->XML($xml, null, LIBXML_NONET | LIBXML_NOERROR | LIBXML_NOWARNING)) {
             return new XmpDocument([]);
         }
         $props = [];
         $stack = [];
         while ($xr->read()) {
-            if ($xr->nodeType === \XMLReader::ELEMENT) {
+            if ($xr->nodeType === XMLReader::ELEMENT) {
                 $stack[] = $this->qname($xr);
                 // Simple property with text content
                 if (!$xr->isEmptyElement) {
@@ -38,44 +47,46 @@ final class XmpReader
                     // Empty element: could be a bag/seq container; keep marker if needed
                     $props[end($stack)] ??= null;
                 }
-            } elseif ($xr->nodeType === \XMLReader::END_ELEMENT) {
+            } elseif ($xr->nodeType === XMLReader::END_ELEMENT) {
                 array_pop($stack);
             }
         }
         $xr->close();
+
         return new XmpDocument($props);
     }
 
     /**
      * Builds the fully-qualified name for the current XML element.
      *
-     * @param \XMLReader $xr Active XML reader instance.
+     * @param XMLReader $xr Active XML reader instance.
      *
      * @return string
      */
-    private function qname(\XMLReader $xr): string
+    private function qname(XMLReader $xr): string
     {
         $prefix = $xr->prefix !== '' ? $xr->prefix . ':' : '';
+
         return $prefix . $xr->localName;
     }
 
     /**
      * Reads text content of the current element, flattening simple RDF containers.
      *
-     * @param \XMLReader $xr Active XML reader instance positioned on an element.
+     * @param XMLReader $xr Active XML reader instance positioned on an element.
      *
      * @return string|null
      */
-    private function readText(\XMLReader $xr): ?string
+    private function readText(XMLReader $xr): ?string
     {
         $depth = $xr->depth;
-        $txt = '';
+        $txt   = '';
         while ($xr->read()) {
-            if ($xr->nodeType === \XMLReader::TEXT || $xr->nodeType === \XMLReader::CDATA) {
-                $txt += $xr->value;
-            } elseif ($xr->nodeType === \XMLReader::END_ELEMENT && $xr->depth === $depth) {
+            if ($xr->nodeType === XMLReader::TEXT || $xr->nodeType === XMLReader::CDATA) {
+                $txt .= $xr->value;
+            } elseif ($xr->nodeType === XMLReader::END_ELEMENT && $xr->depth === $depth) {
                 break;
-            } elseif ($xr->nodeType === \XMLReader::ELEMENT) {
+            } elseif ($xr->nodeType === XMLReader::ELEMENT) {
                 // For simple containers (rdf:Alt/Bag/Seq with rdf:li children)
                 $name = $this->qname($xr);
                 if (str_ends_with($name, 'li') && !$xr->isEmptyElement) {
@@ -87,6 +98,7 @@ final class XmpReader
             }
         }
         $txt = trim($txt);
+
         return $txt === '' ? null : $txt;
     }
 }

--- a/tests/IsoBmff/IsoBmffExtractorTest.php
+++ b/tests/IsoBmff/IsoBmffExtractorTest.php
@@ -1,5 +1,12 @@
 <?php
 
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace MagicSunday\ImageMeta\Tests\IsoBmff;
@@ -25,11 +32,11 @@ final class IsoBmffExtractorTest extends TestCase
     public function testExtractExifFromExifBox(): void
     {
         $exifPayload = "Exif\0\0primary-exif";
-        $meta = self::fullBox('meta', self::box('Exif', $exifPayload));
-        $ftyp = self::box('ftyp', 'isom');
-        $data = $ftyp . $meta;
+        $meta        = self::fullBox('meta', self::box('Exif', $exifPayload));
+        $ftyp        = self::box('ftyp', 'isom');
+        $data        = $ftyp . $meta;
 
-        $extractor = $this->createExtractor($data);
+        $extractor           = $this->createExtractor($data);
         [$exifs, $xmps, $qt] = $extractor->extract();
 
         self::assertSame(['primary-exif'], $exifs);
@@ -43,12 +50,12 @@ final class IsoBmffExtractorTest extends TestCase
     #[Test]
     public function testResolveIlocMultiExtent(): void
     {
-        $exifBlob = "Exif\0\0" . 'segment-one' . 'segment-two';
-        $part1 = substr($exifBlob, 0, 10);
-        $part2 = substr($exifBlob, 10);
+        $exifBlob = "Exif\0\0" . 'segment-onesegment-two';
+        $part1    = substr($exifBlob, 0, 10);
+        $part2    = substr($exifBlob, 10);
 
         $infePayload = "\x02\0\0\0" . pack('n', 1) . pack('n', 0) . 'Exif' . "\0" . 'application/octet-stream' . "\0\0";
-        $infe = self::box('infe', $infePayload);
+        $infe        = self::box('infe', $infePayload);
         $iinfPayload = "\0\0\0\0" . pack('n', 1) . $infe;
 
         $ilocBuilder = function (int $offset1, int $offset2, int $len1, int $len2): string {
@@ -61,6 +68,7 @@ final class IsoBmffExtractorTest extends TestCase
             $payload .= pack('n', 2); // extent count
             $payload .= pack('N', $offset1) . pack('N', $len1);
             $payload .= pack('N', $offset2) . pack('N', $len2);
+
             return self::box('iloc', $payload);
         };
 
@@ -68,20 +76,20 @@ final class IsoBmffExtractorTest extends TestCase
 
         // Build once to compute offsets
         $metaPayload = $iinf . $ilocBuilder(0, 0, strlen($part1), strlen($part2));
-        $meta = self::fullBox('meta', $metaPayload);
-        $ftyp = self::box('ftyp', 'isom');
+        $meta        = self::fullBox('meta', $metaPayload);
+        $ftyp        = self::box('ftyp', 'isom');
         $mdatPayload = $part1 . $part2;
-        $mdat = self::box('mdat', $mdatPayload);
+        $mdat        = self::box('mdat', $mdatPayload);
 
         $offsetBase = strlen($ftyp) + strlen($meta) + 8; // mdat payload offset
-        $iloc = $ilocBuilder($offsetBase, $offsetBase + strlen($part1), strlen($part1), strlen($part2));
-        $meta = self::fullBox('meta', $iinf . $iloc);
-        $data = $ftyp . $meta . $mdat;
+        $iloc       = $ilocBuilder($offsetBase, $offsetBase + strlen($part1), strlen($part1), strlen($part2));
+        $meta       = self::fullBox('meta', $iinf . $iloc);
+        $data       = $ftyp . $meta . $mdat;
 
         $extractor = $this->createExtractor($data);
-        [$exifs] = $extractor->extract();
+        [$exifs]   = $extractor->extract();
 
-        self::assertSame(['segment-one' . 'segment-two'], $exifs);
+        self::assertSame(['segment-onesegment-two'], $exifs);
     }
 
     /**
@@ -90,20 +98,20 @@ final class IsoBmffExtractorTest extends TestCase
     #[Test]
     public function testExtractXmpFromUuidAndItem(): void
     {
-        $uuidGuid = hex2bin('be7acfcb97a942e89c71999491e3afac');
-        $uuidXmp = '<x:xmpmeta xmlns:x="adobe:ns:meta/">uuid</x:xmpmeta>';
+        $uuidGuid  = hex2bin('be7acfcb97a942e89c71999491e3afac');
+        $uuidXmp   = '<x:xmpmeta xmlns:x="adobe:ns:meta/">uuid</x:xmpmeta>';
         $directXmp = '<x:xmpmeta xmlns:x="adobe:ns:meta/">direct</x:xmpmeta>';
-        $itemXmp = '<x:xmpmeta xmlns:x="adobe:ns:meta/">item</x:xmpmeta>';
+        $itemXmp   = '<x:xmpmeta xmlns:x="adobe:ns:meta/">item</x:xmpmeta>';
 
         $uuidBox = self::box('uuid', $uuidGuid . $uuidXmp);
 
         $infePayload = "\x02\0\0\0" . pack('n', 2) . pack('n', 0) . 'xmp' . "\0" . 'application/rdf+xml' . "\0\0";
-        $infe = self::box('infe', $infePayload);
+        $infe        = self::box('infe', $infePayload);
         $iinfPayload = "\0\0\0\0" . pack('n', 1) . $infe;
-        $iinf = self::box('iinf', $iinfPayload);
+        $iinf        = self::box('iinf', $iinfPayload);
 
         $pitmPayload = "\0\0\0\0" . pack('n', 2);
-        $pitm = self::box('pitm', $pitmPayload);
+        $pitm        = self::box('pitm', $pitmPayload);
 
         $ilocBuilder = function (int $offset, int $length): string {
             $payload = "\0\0\0\0";
@@ -114,22 +122,23 @@ final class IsoBmffExtractorTest extends TestCase
             $payload .= pack('n', 0);
             $payload .= pack('n', 1);
             $payload .= pack('N', $offset) . pack('N', $length);
+
             return self::box('iloc', $payload);
         };
 
-        $xmpData = $itemXmp;
+        $xmpData     = $itemXmp;
         $metaPayload = $pitm . $iinf . $ilocBuilder(0, strlen($xmpData)) . self::box('XMP ', $directXmp);
-        $meta = self::fullBox('meta', $metaPayload);
-        $ftyp = self::box('ftyp', 'isom');
-        $mdat = self::box('mdat', $xmpData);
+        $meta        = self::fullBox('meta', $metaPayload);
+        $ftyp        = self::box('ftyp', 'isom');
+        $mdat        = self::box('mdat', $xmpData);
 
         $offsetBase = strlen($ftyp) + strlen($uuidBox) + strlen($meta) + 8;
-        $iloc = $ilocBuilder($offsetBase, strlen($xmpData));
-        $meta = self::fullBox('meta', $pitm . $iinf . $iloc . self::box('XMP ', $directXmp));
-        $data = $ftyp . $uuidBox . $meta . $mdat;
+        $iloc       = $ilocBuilder($offsetBase, strlen($xmpData));
+        $meta       = self::fullBox('meta', $pitm . $iinf . $iloc . self::box('XMP ', $directXmp));
+        $data       = $ftyp . $uuidBox . $meta . $mdat;
 
         $extractor = $this->createExtractor($data);
-        [, $xmps] = $extractor->extract();
+        [, $xmps]  = $extractor->extract();
 
         self::assertSame([$itemXmp, $directXmp, $uuidXmp], $xmps);
     }
@@ -143,15 +152,15 @@ final class IsoBmffExtractorTest extends TestCase
         $keysValue = 'id-from-keys';
         $mdtaValue = 'id-from-mdta';
 
-        $keysFile = $this->createFileWithQuickTimeKeys($keysValue);
-        $keysExtractor = $this->createExtractor($keysFile);
+        $keysFile       = $this->createFileWithQuickTimeKeys($keysValue);
+        $keysExtractor  = $this->createExtractor($keysFile);
         [, , $keysMeta] = $keysExtractor->extract();
 
         self::assertInstanceOf(QuickTimeMeta::class, $keysMeta);
         self::assertSame($keysValue, $keysMeta->contentIdentifier());
 
-        $mdtaFile = $this->createFileWithMdtaIdentifier($mdtaValue);
-        $mdtaExtractor = $this->createExtractor($mdtaFile);
+        $mdtaFile       = $this->createFileWithMdtaIdentifier($mdtaValue);
+        $mdtaExtractor  = $this->createExtractor($mdtaFile);
         [, , $mdtaMeta] = $mdtaExtractor->extract();
 
         self::assertInstanceOf(QuickTimeMeta::class, $mdtaMeta);
@@ -165,9 +174,9 @@ final class IsoBmffExtractorTest extends TestCase
     public function testSkipDataRefIndexNotZero(): void
     {
         $infePayload = "\x02\0\0\0" . pack('n', 1) . pack('n', 0) . 'Exif' . "\0\0\0";
-        $infe = self::box('infe', $infePayload);
+        $infe        = self::box('infe', $infePayload);
         $iinfPayload = "\0\0\0\0" . pack('n', 1) . $infe;
-        $iinf = self::box('iinf', $iinfPayload);
+        $iinf        = self::box('iinf', $iinfPayload);
 
         $payload = "\0\0\0\0";
         $payload .= "\x44";
@@ -185,7 +194,7 @@ final class IsoBmffExtractorTest extends TestCase
         $data = $ftyp . $meta . $mdat;
 
         $extractor = $this->createExtractor($data);
-        [$exifs] = $extractor->extract();
+        [$exifs]   = $extractor->extract();
 
         self::assertSame([], $exifs);
     }
@@ -197,7 +206,7 @@ final class IsoBmffExtractorTest extends TestCase
     public function testInvalidBoxSizesThrowParseError(): void
     {
         $infePayload = "\x02\0\0\0" . pack('n', 1) . pack('n', 0) . 'Exif' . "\0\0\0";
-        $iinf = self::box('iinf', "\0\0\0\0" . pack('n', 1) . self::box('infe', $infePayload));
+        $iinf        = self::box('iinf', "\0\0\0\0" . pack('n', 1) . self::box('infe', $infePayload));
 
         $ilocPayload = "\0\0\0\0";
         $ilocPayload .= "\x44";
@@ -234,13 +243,13 @@ final class IsoBmffExtractorTest extends TestCase
             . 'com.apple.quicktime.content.identifier';
         $keys = self::box('keys', "\0\0\0\0" . pack('N', 1) . $keysEntry);
 
-        $dataBox = self::box('data', pack('N', 1) . pack('N', 0) . $value);
+        $dataBox   = self::box('data', pack('N', 1) . pack('N', 0) . $value);
         $ilstEntry = self::box(pack('N', 1), $dataBox);
-        $ilst = self::box('ilst', $ilstEntry);
+        $ilst      = self::box('ilst', $ilstEntry);
 
         $metaPayload = "\0\0\0\0" . $keys . $ilst;
-        $meta = self::box('meta', $metaPayload);
-        $moov = self::box('moov', self::box('udta', $meta));
+        $meta        = self::box('meta', $metaPayload);
+        $moov        = self::box('moov', self::box('udta', $meta));
 
         return self::box('ftyp', 'isom') . $moov;
     }
@@ -252,15 +261,15 @@ final class IsoBmffExtractorTest extends TestCase
      */
     private function createFileWithMdtaIdentifier(string $value): string
     {
-        $mean = self::box('mean', pack('N', 1) . pack('N', 0) . 'com.apple.quicktime');
-        $name = self::box('name', pack('N', 1) . pack('N', 0) . 'content.identifier');
-        $data = self::box('data', pack('N', 1) . pack('N', 0) . $value);
+        $mean     = self::box('mean', pack('N', 1) . pack('N', 0) . 'com.apple.quicktime');
+        $name     = self::box('name', pack('N', 1) . pack('N', 0) . 'content.identifier');
+        $data     = self::box('data', pack('N', 1) . pack('N', 0) . $value);
         $freeform = self::box('----', $mean . $name . $data);
-        $ilst = self::box('ilst', $freeform);
+        $ilst     = self::box('ilst', $freeform);
 
         $metaPayload = "\0\0\0\0" . $ilst;
-        $meta = self::box('meta', $metaPayload);
-        $moov = self::box('moov', $meta);
+        $meta        = self::box('meta', $metaPayload);
+        $moov        = self::box('moov', $meta);
 
         return self::box('ftyp', 'isom') . $moov;
     }
@@ -288,6 +297,7 @@ final class IsoBmffExtractorTest extends TestCase
     private static function box(string $type, string $payload): string
     {
         $size = 8 + strlen($payload);
+
         return pack('N', $size) . $type . $payload;
     }
 
@@ -302,6 +312,7 @@ final class IsoBmffExtractorTest extends TestCase
     private static function fullBox(string $type, string $payload, int $version = 0, int $flags = 0): string
     {
         $header = chr($version) . chr(($flags >> 16) & 0xFF) . chr(($flags >> 8) & 0xFF) . chr($flags & 0xFF);
+
         return self::box($type, $header . $payload);
     }
 }

--- a/tests/Jpeg/JpegExtractorTest.php
+++ b/tests/Jpeg/JpegExtractorTest.php
@@ -1,5 +1,12 @@
 <?php
 
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace MagicSunday\ImageMeta\Tests\Jpeg;
@@ -19,8 +26,8 @@ use PHPUnit\Framework\TestCase;
 final class JpegExtractorTest extends TestCase
 {
     private const EXIF_SIGNATURE = "Exif\0\0";
-    private const XMP_SIGNATURE = "http://ns.adobe.com/xap/1.0/\0";
-    private const ICC_SIGNATURE = "ICC_PROFILE\0";
+    private const XMP_SIGNATURE  = "http://ns.adobe.com/xap/1.0/\0";
+    private const ICC_SIGNATURE  = "ICC_PROFILE\0";
     private const IPTC_SIGNATURE = "Photoshop 3.0\0";
 
     /**
@@ -34,7 +41,7 @@ final class JpegExtractorTest extends TestCase
     #[DataProvider('provideApp1Variants')]
     public function extractsExifAndXmpInAnyOrder(array $segments, array $expectedExif, array $expectedXmp): void
     {
-        $jpeg = self::jpeg(...$segments);
+        $jpeg      = self::jpeg(...$segments);
         $extractor = $this->createExtractor($jpeg);
 
         self::assertSame($expectedExif, $extractor->extractExifBlobs());
@@ -49,7 +56,7 @@ final class JpegExtractorTest extends TestCase
     public static function provideApp1Variants(): iterable
     {
         $exifPayload = 'primary-exif';
-        $xmpXml = '<x:xmpmeta xmlns:x="adobe:ns:meta/">One</x:xmpmeta>';
+        $xmpXml      = '<x:xmpmeta xmlns:x="adobe:ns:meta/">One</x:xmpmeta>';
 
         yield 'only-exif' => [
             [self::segment(0xE1, self::EXIF_SIGNATURE . $exifPayload)],
@@ -88,9 +95,9 @@ final class JpegExtractorTest extends TestCase
     #[Test]
     public function testLargeExifOver64KBIsHandled(): void
     {
-        $firstBlob = str_repeat('A', 40_000);
+        $firstBlob  = str_repeat('A', 40_000);
         $secondBlob = str_repeat('B', 30_000);
-        $xmpXml = '<x:xmpmeta xmlns:x="adobe:ns:meta/">Large</x:xmpmeta>';
+        $xmpXml     = '<x:xmpmeta xmlns:x="adobe:ns:meta/">Large</x:xmpmeta>';
 
         $jpeg = self::jpeg(
             self::segment(0xE1, self::EXIF_SIGNATURE . $firstBlob),
@@ -110,8 +117,8 @@ final class JpegExtractorTest extends TestCase
     #[Test]
     public function testIccProfileSegmentsAreMerged(): void
     {
-        $iccPart1 = 'icc-part-one';
-        $iccPart2 = 'icc-part-two';
+        $iccPart1        = 'icc-part-one';
+        $iccPart2        = 'icc-part-two';
         $segment1Payload = self::ICC_SIGNATURE . "\x01\x02" . $iccPart1;
         $segment2Payload = self::ICC_SIGNATURE . "\x02\x02" . $iccPart2;
 
@@ -152,8 +159,8 @@ final class JpegExtractorTest extends TestCase
      */
     public static function provideInvalidSegments(): iterable
     {
-        $lengthTooSmall = "\xFF\xD8" . "\xFF\xE1\x00\x01" . "\xFF\xD9";
-        $truncatedPayload = "\xFF\xD8" . "\xFF\xE1" . pack('n', 10) . 'abcde' . "\xFF\xD9";
+        $lengthTooSmall   = "\xFF\xD8\xFF\xE1\x00\x01\xFF\xD9";
+        $truncatedPayload = "\xFF\xD8\xFF\xE1" . pack('n', 10) . 'abcde' . "\xFF\xD9";
 
         yield 'length-smaller-than-two' => [$lengthTooSmall, '/length/i'];
         yield 'truncated-payload' => [$truncatedPayload, '/truncated/i'];
@@ -164,8 +171,8 @@ final class JpegExtractorTest extends TestCase
     /**
      * Ensures invalid segment lengths and truncated payloads raise ParseError.
      *
-     * @param string $jpeg            Binary JPEG fixture provided by the data set.
-     * @param string $messagePattern  Regular expression expected in the error message.
+     * @param string $jpeg           Binary JPEG fixture provided by the data set.
+     * @param string $messagePattern Regular expression expected in the error message.
      */
     public function testInvalidLengthsAndUnexpectedEoiThrowParseError(string $jpeg, string $messagePattern): void
     {
@@ -184,7 +191,7 @@ final class JpegExtractorTest extends TestCase
     public function testStopsAtSosIgnoresRestartMarkers(): void
     {
         $primaryExif = 'primary-before-sos';
-        $xmpXml = '<x:xmpmeta xmlns:x="adobe:ns:meta/">BeforeSOS</x:xmpmeta>';
+        $xmpXml      = '<x:xmpmeta xmlns:x="adobe:ns:meta/">BeforeSOS</x:xmpmeta>';
         $ignoredExif = 'ignored-after-sos';
 
         $jpeg = "\xFF\xD8"

--- a/tests/Xmp/XmpReaderTest.php
+++ b/tests/Xmp/XmpReaderTest.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\ImageMeta\Tests\Xmp;
+
+use MagicSunday\ImageMeta\Parse\Xmp\XmpReader;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Validates the XMP reader behaviour.
+ *
+ * @covers \MagicSunday\ImageMeta\Parse\Xmp\XmpReader
+ */
+final class XmpReaderTest extends TestCase
+{
+    /**
+     * Ensures mixed text and CDATA nodes are concatenated verbatim.
+     */
+    #[Test]
+    public function testMixedContentIsPreserved(): void
+    {
+        $xml = '<dc:title xmlns:dc="http://purl.org/dc/elements/1.1/">'
+            . 'Prefix <![CDATA[<tag> & middle]]> suffix'
+            . '</dc:title>';
+
+        $reader   = new XmpReader();
+        $document = $reader->parse($xml);
+
+        self::assertArrayHasKey('dc:title', $document->data);
+        self::assertSame('Prefix <tag> & middle suffix', $document->data['dc:title']);
+    }
+}


### PR DESCRIPTION
## Summary
- ensure `XmpReader::readText` concatenates text segments with string-safe `.=` logic
- add PHPUnit coverage for mixed text and CDATA content in the XMP reader
- apply the project coding style fixes via `composer ci:cgl`

## Testing
- composer ci:test:php:unit
- composer ci:cgl

------
https://chatgpt.com/codex/tasks/task_e_68f9bb732a248323a87a3e81f2e9bc4d