### PR TITLE
feat: normalize XMP document structure

### DIFF
--- a/src/Model/Xmp/XmpDocument.php
+++ b/src/Model/Xmp/XmpDocument.php
@@ -13,31 +13,62 @@ namespace MagicSunday\ImageMeta\Model\Xmp;
 
 final class XmpDocument
 {
-    /** @param array<string, array<string, mixed>> $data nsUri => [prop => value] */
+    /**
+     * @param array<string, string|array<int, string>> $data Map of Clark notation => value
+     */
     public function __construct(public readonly array $data)
     {
     }
 
-    /** Convenient flat lookup: nsUri + prop */
-    public function get(string $nsUri, string $prop): mixed
+    /**
+     * Looks up a property by namespace URI and local name.
+     *
+     * @return array<int, string>|string|null
+     */
+    public function get(string $namespaceUri, string $localName): array|string|null
     {
-        return $this->data[$nsUri][$prop] ?? null;
+        $key   = $this->buildClarkName($namespaceUri, $localName);
+        $value = $this->data[$key] ?? null;
+
+        return is_string($value) || is_array($value) ? $value : null;
     }
 
-    /** Namespace‑agnostic helper (first match by local name) */
-    public function find(string $localName): mixed
+    /**
+     * Finds the first property with the given local name independent of the namespace.
+     *
+     * @return array<int, string>|string|null
+     */
+    public function find(string $localName): array|string|null
     {
-        foreach ($this->data as $ns => $props) {
-            foreach ($props as $k => $v) {
-                if (str_contains($k, ':')) {
-                    [$prefix, $ln] = explode(':', $k, 2);
-                    if ($ln === $localName) {
-                        return $v;
-                    }
-                }
+        foreach ($this->data as $key => $value) {
+            if ($this->matchesLocalName($key, $localName) && (is_string($value) || is_array($value))) {
+                return $value;
             }
         }
 
         return null;
+    }
+
+    private function buildClarkName(string $namespaceUri, string $localName): string
+    {
+        return $namespaceUri !== ''
+            ? sprintf('{%s}%s', $namespaceUri, $localName)
+            : $localName;
+    }
+
+    private function matchesLocalName(string $clark, string $localName): bool
+    {
+        if ($clark === $localName) {
+            return true;
+        }
+
+        if ($clark !== '' && $clark[0] === '{') {
+            $pos = strpos($clark, '}');
+            if ($pos !== false) {
+                return substr($clark, $pos + 1) === $localName;
+            }
+        }
+
+        return false;
     }
 }

--- a/src/Parse/Xmp/XmpParser.php
+++ b/src/Parse/Xmp/XmpParser.php
@@ -21,62 +21,99 @@ use XMLReader;
  */
 final class XmpParser
 {
+    private const RDF_NAMESPACE  = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#';
+    private const DC_NAMESPACE   = 'http://purl.org/dc/elements/1.1/';
+    private const XMP_NAMESPACE  = 'http://ns.adobe.com/xap/1.0/';
+    private const EXIF_NAMESPACE = 'http://ns.adobe.com/exif/1.0/';
+
+    /**
+     * Parses a subset of XMP data and returns values keyed by Clark notation.
+     */
     public function parse(string $xmpXml): XmpDocument
     {
-        $xr = new XMLReader();
-        $xr->XML($xmpXml, encoding: 'UTF-8', options: XMLReader::SUBST_ENTITIES);
+        $reader = new XMLReader();
+        if (!$reader->XML($xmpXml, 'UTF-8', LIBXML_NONET | LIBXML_NOERROR | LIBXML_NOWARNING)) {
+            return new XmpDocument([]);
+        }
 
-        $props = [];
+        $properties = [];
+        /** @var array{string, string}|null $pendingBag */
+        $pendingBag = null;
 
-        while ($xr->read()) {
-            if ($xr->nodeType !== XMLReader::ELEMENT) {
+        while ($reader->read()) {
+            if ($reader->nodeType === XMLReader::END_ELEMENT) {
+                if ($pendingBag !== null && $this->matchesElement($reader, $pendingBag[0], $pendingBag[1])) {
+                    $pendingBag = null;
+                }
+
                 continue;
             }
 
-            $qname = $this->qname($xr);
-            if ($qname === 'rdf:Bag' && isset($props['_last_dc_subject'])) {
-                // parse list items into dc:subject
-                $props['dc:subject'] = $this->readBag($xr);
-                unset($props['_last_dc_subject']);
+            if ($reader->nodeType !== XMLReader::ELEMENT) {
                 continue;
             }
 
-            // capture strings for common props
-            if (in_array($qname, [
-                'xmp:CreateDate', 'xmp:ModifyDate',
-                'exif:DateTimeOriginal', 'exif:OffsetTimeOriginal',
-            ], true)) {
-                $props[$qname] = $this->readElementText($xr);
+            $namespace = $reader->namespaceURI ?? '';
+            $localName = $reader->localName;
+
+            if ($namespace === self::RDF_NAMESPACE && $localName === 'Bag' && $pendingBag !== null) {
+                $bag = $this->readBag($reader);
+                if ($bag !== []) {
+                    [$bagNs, $bagLocal]                                   = $pendingBag;
+                    $properties[$this->buildClarkName($bagNs, $bagLocal)] = $bag;
+                }
+                continue;
             }
 
-            if ($qname === 'dc:subject') {
-                // the actual strings live in nested rdf:Bag/rdf:li
-                $props['_last_dc_subject'] = true;
+            if ($namespace === self::DC_NAMESPACE && $localName === 'subject') {
+                $pendingBag = $reader->isEmptyElement ? null : [$namespace, $localName];
+                continue;
+            }
+
+            if ($this->isStringProperty($namespace, $localName)) {
+                $text = $this->readElementText($reader);
+                if ($text !== '') {
+                    $properties[$this->buildClarkName($namespace, $localName)] = $text;
+                }
             }
         }
 
-        $xr->close();
+        $reader->close();
 
-        return new XmpDocument($props);
+        return new XmpDocument($properties);
     }
 
-    private function qname(XMLReader $xr): string
+    private function isStringProperty(string $namespace, string $localName): bool
     {
-        $prefix = $xr->prefix ? $xr->prefix . ':' : '';
-
-        return $prefix . $xr->localName;
+        return ($namespace === self::XMP_NAMESPACE && in_array($localName, ['CreateDate', 'ModifyDate'], true))
+            || ($namespace === self::EXIF_NAMESPACE && in_array($localName, ['DateTimeOriginal', 'OffsetTimeOriginal'], true));
     }
 
-    private function readElementText(XMLReader $xr): string
+    private function matchesElement(XMLReader $reader, string $namespace, string $localName): bool
+    {
+        return ($reader->namespaceURI ?? '') === $namespace && $reader->localName === $localName;
+    }
+
+    private function buildClarkName(string $namespaceUri, string $localName): string
+    {
+        return $namespaceUri !== ''
+            ? sprintf('{%s}%s', $namespaceUri, $localName)
+            : $localName;
+    }
+
+    private function readElementText(XMLReader $reader): string
     {
         $text = '';
-        if (!$xr->isEmptyElement) {
-            while ($xr->read()) {
-                if ($xr->nodeType === XMLReader::TEXT || $xr->nodeType === XMLReader::CDATA) {
-                    $text .= $xr->value;
-                } elseif ($xr->nodeType === XMLReader::END_ELEMENT) {
-                    break;
-                }
+        if ($reader->isEmptyElement) {
+            return $text;
+        }
+
+        $depth = $reader->depth;
+        while ($reader->read()) {
+            if ($reader->nodeType === XMLReader::TEXT || $reader->nodeType === XMLReader::CDATA) {
+                $text .= $reader->value;
+            } elseif ($reader->nodeType === XMLReader::END_ELEMENT && $reader->depth === $depth) {
+                break;
             }
         }
 
@@ -84,23 +121,30 @@ final class XmpParser
     }
 
     /** @return list<string> */
-    private function readBag(XMLReader $xr): array
+    private function readBag(XMLReader $reader): array
     {
         $items = [];
-        if ($xr->isEmptyElement) {
+        if ($reader->isEmptyElement) {
             return $items;
         }
 
-        $depth = $xr->depth;
-        while ($xr->read()) {
-            if ($xr->nodeType === XMLReader::END_ELEMENT && $xr->depth === $depth && $xr->localName === 'Bag') {
+        $depth = $reader->depth;
+        while ($reader->read()) {
+            if ($reader->nodeType === XMLReader::END_ELEMENT && $reader->depth === $depth) {
                 break;
             }
-            if ($xr->nodeType === XMLReader::ELEMENT && $xr->localName === 'li') {
-                $items[] = $this->readElementText($xr);
+
+            if ($reader->nodeType === XMLReader::ELEMENT
+                && ($reader->namespaceURI ?? '') === self::RDF_NAMESPACE
+                && $reader->localName === 'li'
+            ) {
+                $value = $this->readElementText($reader);
+                if ($value !== '') {
+                    $items[] = $value;
+                }
             }
         }
 
-        return array_values(array_filter($items, fn ($s) => $s !== ''));
+        return $items;
     }
 }

--- a/src/Parse/Xmp/XmpReader.php
+++ b/src/Parse/Xmp/XmpReader.php
@@ -19,86 +19,118 @@ use XMLReader;
  */
 final class XmpReader
 {
+    private const RDF_NAMESPACE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#';
+
     /**
      * Parses an XMP packet and returns a document containing discovered properties.
      *
-     * @param string $xml Raw XMP packet contents.
-     *
-     * @return XmpDocument
+     * The resulting document stores values keyed by Clark notation ("{namespace}local") and
+     * flattens RDF containers (Bag/Seq/Alt) into PHP lists.
      */
     public function parse(string $xml): XmpDocument
     {
-        $xr = new XMLReader();
-        if (!$xr->XML($xml, null, LIBXML_NONET | LIBXML_NOERROR | LIBXML_NOWARNING)) {
+        $reader = new XMLReader();
+        if (!$reader->XML($xml, null, LIBXML_NONET | LIBXML_NOERROR | LIBXML_NOWARNING)) {
             return new XmpDocument([]);
         }
-        $props = [];
-        $stack = [];
-        while ($xr->read()) {
-            if ($xr->nodeType === XMLReader::ELEMENT) {
-                $stack[] = $this->qname($xr);
-                // Simple property with text content
-                if (!$xr->isEmptyElement) {
-                    $text = $this->readText($xr);
-                    if ($text !== null) {
-                        $props[end($stack)] = $text;
+
+        $data        = [];
+        $elementPath = [];
+        $textBuffers = [];
+        $listBuffers = [];
+
+        while ($reader->read()) {
+            switch ($reader->nodeType) {
+                case XMLReader::ELEMENT:
+                    $depth     = $reader->depth;
+                    $namespace = $reader->namespaceURI ?? '';
+                    $localName = $reader->localName;
+
+                    $elementPath[$depth] = [$namespace, $localName];
+                    $textBuffers[$depth] = '';
+
+                    if ($namespace !== self::RDF_NAMESPACE) {
+                        $listBuffers[$depth] = [];
                     }
-                } else {
-                    // Empty element: could be a bag/seq container; keep marker if needed
-                    $props[end($stack)] ??= null;
-                }
-            } elseif ($xr->nodeType === XMLReader::END_ELEMENT) {
-                array_pop($stack);
+
+                    if ($reader->isEmptyElement) {
+                        if ($namespace !== self::RDF_NAMESPACE) {
+                            $value = $this->finalizeValue($listBuffers[$depth] ?? [], $textBuffers[$depth] ?? '');
+                            if ($value !== null) {
+                                $data[$this->buildClarkName($namespace, $localName)] = $value;
+                            }
+                        }
+
+                        unset($elementPath[$depth], $textBuffers[$depth], $listBuffers[$depth]);
+                    }
+                    break;
+
+                case XMLReader::TEXT:
+                case XMLReader::WHITESPACE:
+                case XMLReader::SIGNIFICANT_WHITESPACE:
+                case XMLReader::CDATA:
+                    $depth = $reader->depth - 1;
+                    if ($depth >= 0 && array_key_exists($depth, $textBuffers)) {
+                        $textBuffers[$depth] .= $reader->value;
+                    }
+                    break;
+
+                case XMLReader::END_ELEMENT:
+                    $depth = $reader->depth;
+                    $info  = $elementPath[$depth] ?? null;
+                    if ($info === null) {
+                        break;
+                    }
+
+                    [$namespace, $localName] = $info;
+                    if ($namespace === self::RDF_NAMESPACE && $localName === 'li') {
+                        $text = trim($textBuffers[$depth] ?? '');
+                        if ($text !== '') {
+                            for ($parentDepth = $depth - 1; $parentDepth >= 0; --$parentDepth) {
+                                if (isset($listBuffers[$parentDepth])) {
+                                    $listBuffers[$parentDepth][] = $text;
+                                    break;
+                                }
+                            }
+                        }
+                    } elseif ($namespace !== self::RDF_NAMESPACE) {
+                        $value = $this->finalizeValue($listBuffers[$depth] ?? [], $textBuffers[$depth] ?? '');
+                        if ($value !== null) {
+                            $data[$this->buildClarkName($namespace, $localName)] = $value;
+                        }
+                    }
+
+                    unset($elementPath[$depth], $textBuffers[$depth], $listBuffers[$depth]);
+                    break;
             }
         }
-        $xr->close();
 
-        return new XmpDocument($props);
+        $reader->close();
+
+        return new XmpDocument($data);
     }
 
     /**
-     * Builds the fully-qualified name for the current XML element.
+     * Finalises the collected container/list data for the current element.
      *
-     * @param XMLReader $xr Active XML reader instance.
-     *
-     * @return string
+     * @param array<int, string> $items
      */
-    private function qname(XMLReader $xr): string
+    private function finalizeValue(array $items, string $text): array|string|null
     {
-        $prefix = $xr->prefix !== '' ? $xr->prefix . ':' : '';
+        $items = array_values(array_filter($items, static fn (string $value): bool => $value !== ''));
+        if ($items !== []) {
+            return $items;
+        }
 
-        return $prefix . $xr->localName;
+        $text = trim($text);
+
+        return $text === '' ? null : $text;
     }
 
-    /**
-     * Reads text content of the current element, flattening simple RDF containers.
-     *
-     * @param XMLReader $xr Active XML reader instance positioned on an element.
-     *
-     * @return string|null
-     */
-    private function readText(XMLReader $xr): ?string
+    private function buildClarkName(string $namespaceUri, string $localName): string
     {
-        $depth = $xr->depth;
-        $txt   = '';
-        while ($xr->read()) {
-            if ($xr->nodeType === XMLReader::TEXT || $xr->nodeType === XMLReader::CDATA) {
-                $txt .= $xr->value;
-            } elseif ($xr->nodeType === XMLReader::END_ELEMENT && $xr->depth === $depth) {
-                break;
-            } elseif ($xr->nodeType === XMLReader::ELEMENT) {
-                // For simple containers (rdf:Alt/Bag/Seq with rdf:li children)
-                $name = $this->qname($xr);
-                if (str_ends_with($name, 'li') && !$xr->isEmptyElement) {
-                    $li = $this->readText($xr);
-                    if ($li !== null) {
-                        $txt .= ($txt !== '' ? ';' : '') . $li; // naive concat
-                    }
-                }
-            }
-        }
-        $txt = trim($txt);
-
-        return $txt === '' ? null : $txt;
+        return $namespaceUri !== ''
+            ? sprintf('{%s}%s', $namespaceUri, $localName)
+            : $localName;
     }
 }

--- a/tests/Xmp/XmpDocumentTest.php
+++ b/tests/Xmp/XmpDocumentTest.php
@@ -1,0 +1,87 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\ImageMeta\Tests\Xmp;
+
+use MagicSunday\ImageMeta\Parse\Xmp\XmpParser;
+use MagicSunday\ImageMeta\Parse\Xmp\XmpReader;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Integration-level tests for XmpDocument accessors fed by different parsers.
+ */
+final class XmpDocumentTest extends TestCase
+{
+    private const DC_NAMESPACE   = 'http://purl.org/dc/elements/1.1/';
+    private const XMP_NAMESPACE  = 'http://ns.adobe.com/xap/1.0/';
+    private const EXIF_NAMESPACE = 'http://ns.adobe.com/exif/1.0/';
+
+    #[Test]
+    public function testDocumentAccessorsWithReaderData(): void
+    {
+        $xml = <<<XML
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+         xmlns:dc="http://purl.org/dc/elements/1.1/"
+         xmlns:xmp="http://ns.adobe.com/xap/1.0/">
+  <rdf:Description>
+    <xmp:CreateDate>2024-03-30T12:34:56Z</xmp:CreateDate>
+    <dc:subject>
+      <rdf:Bag>
+        <rdf:li>First</rdf:li>
+        <rdf:li>Second</rdf:li>
+      </rdf:Bag>
+    </dc:subject>
+  </rdf:Description>
+</rdf:RDF>
+XML;
+
+        $document = (new XmpReader())->parse($xml);
+
+        self::assertSame('2024-03-30T12:34:56Z', $document->get(self::XMP_NAMESPACE, 'CreateDate'));
+        self::assertSame('2024-03-30T12:34:56Z', $document->find('CreateDate'));
+        self::assertSame(['First', 'Second'], $document->get(self::DC_NAMESPACE, 'subject'));
+        self::assertSame(['First', 'Second'], $document->find('subject'));
+        self::assertNull($document->get(self::DC_NAMESPACE, 'title'));
+    }
+
+    #[Test]
+    public function testDocumentAccessorsWithParserData(): void
+    {
+        $xml = <<<XML
+<x:xmpmeta xmlns:x="adobe:ns:meta/"
+           xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+           xmlns:xmp="http://ns.adobe.com/xap/1.0/"
+           xmlns:exif="http://ns.adobe.com/exif/1.0/"
+           xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <rdf:RDF>
+    <rdf:Description>
+      <xmp:ModifyDate>2024-03-30T12:34:56Z</xmp:ModifyDate>
+      <exif:DateTimeOriginal>2024-03-29T09:08:07Z</exif:DateTimeOriginal>
+      <dc:subject>
+        <rdf:Bag>
+          <rdf:li>First</rdf:li>
+          <rdf:li>Second</rdf:li>
+        </rdf:Bag>
+      </dc:subject>
+    </rdf:Description>
+  </rdf:RDF>
+</x:xmpmeta>
+XML;
+
+        $document = (new XmpParser())->parse($xml);
+
+        self::assertSame('2024-03-30T12:34:56Z', $document->get(self::XMP_NAMESPACE, 'ModifyDate'));
+        self::assertSame('2024-03-29T09:08:07Z', $document->get(self::EXIF_NAMESPACE, 'DateTimeOriginal'));
+        self::assertSame('2024-03-29T09:08:07Z', $document->find('DateTimeOriginal'));
+        self::assertSame(['First', 'Second'], $document->find('subject'));
+    }
+}

--- a/tests/Xmp/XmpReaderTest.php
+++ b/tests/Xmp/XmpReaderTest.php
@@ -22,6 +22,8 @@ use PHPUnit\Framework\TestCase;
  */
 final class XmpReaderTest extends TestCase
 {
+    private const DC_NAMESPACE = 'http://purl.org/dc/elements/1.1/';
+
     /**
      * Ensures mixed text and CDATA nodes are concatenated verbatim.
      */
@@ -35,7 +37,10 @@ final class XmpReaderTest extends TestCase
         $reader   = new XmpReader();
         $document = $reader->parse($xml);
 
-        self::assertArrayHasKey('dc:title', $document->data);
-        self::assertSame('Prefix <tag> & middle suffix', $document->data['dc:title']);
+        $key = '{' . self::DC_NAMESPACE . '}title';
+        self::assertArrayHasKey($key, $document->data);
+        self::assertSame('Prefix <tag> & middle suffix', $document->data[$key]);
+        self::assertSame('Prefix <tag> & middle suffix', $document->get(self::DC_NAMESPACE, 'title'));
+        self::assertSame('Prefix <tag> & middle suffix', $document->find('title'));
     }
 }


### PR DESCRIPTION
## Summary
- normalize the XMP document storage around Clark-notation keys and improve lookup helpers
- update the XMP reader and parser to emit the unified structure and keep RDF container values as lists
- add PHPUnit coverage exercising XmpDocument::get()/find() with data from both parsers

## Testing
- composer ci:test:php:unit
- composer ci:cgl

------
https://chatgpt.com/codex/tasks/task_e_68f9be16248483238ea776171c8de10c