### PR TITLE
refactor: centralize EXIF tag constants

### DIFF
--- a/src/Convenience/ExifConvenience.php
+++ b/src/Convenience/ExifConvenience.php
@@ -13,6 +13,7 @@ namespace MagicSunday\ImageMeta\Convenience;
 
 use DateTimeImmutable;
 use MagicSunday\ImageMeta\Model\Exif\ExifDocument;
+use MagicSunday\ImageMeta\Model\Exif\ExifTag;
 use MagicSunday\ImageMeta\Model\Exif\IfdEntry;
 use Throwable;
 
@@ -91,7 +92,7 @@ final class ExifConvenience
      */
     public static function exposureTime(ExifDocument $doc): ?float
     {
-        $e = self::find($doc, 0x829A); // ExposureTime (rational)
+        $e = self::find($doc, ExifTag::EXPOSURE_TIME); // ExposureTime (rational)
 
         return self::rationalToFloat($e?->value);
     }
@@ -105,7 +106,7 @@ final class ExifConvenience
      */
     public static function fNumber(ExifDocument $doc): ?float
     {
-        $e = self::find($doc, 0x829D); // FNumber (rational)
+        $e = self::find($doc, ExifTag::F_NUMBER); // FNumber (rational)
 
         return self::rationalToFloat($e?->value);
     }
@@ -119,7 +120,7 @@ final class ExifConvenience
      */
     public static function focalLength(ExifDocument $doc): ?float
     {
-        $e = self::find($doc, 0x920A); // FocalLength (rational)
+        $e = self::find($doc, ExifTag::FOCAL_LENGTH); // FocalLength (rational)
 
         return self::rationalToFloat($e?->value);
     }
@@ -133,8 +134,8 @@ final class ExifConvenience
      */
     public static function iso(ExifDocument $doc): ?int
     {
-        // ISO can be ExifIFD tag 0x8827 (old) or PhotographicSensitivity 0x8833
-        $entry = self::find($doc, 0x8833) ?? self::find($doc, 0x8827);
+        // ISO can be ExifIFD tag ExifTag::PHOTOGRAPHIC_SENSITIVITY or the newer ExifTag::ISO_SPEED
+        $entry = self::find($doc, ExifTag::ISO_SPEED) ?? self::find($doc, ExifTag::PHOTOGRAPHIC_SENSITIVITY);
 
         if ($entry === null) {
             return null;

--- a/src/Model/Exif/ExifDocument.php
+++ b/src/Model/Exif/ExifDocument.php
@@ -42,7 +42,7 @@ final class ExifDocument
      */
     public function cameraMake(): ?string
     {
-        return $this->str($this->ifd0, 0x010F);
+        return $this->str($this->ifd0, ExifTag::MAKE);
     }
 
     /**
@@ -52,7 +52,7 @@ final class ExifDocument
      */
     public function cameraModel(): ?string
     {
-        return $this->str($this->ifd0, 0x0110);
+        return $this->str($this->ifd0, ExifTag::MODEL);
     }
 
     /**
@@ -62,7 +62,7 @@ final class ExifDocument
      */
     public function lensModel(): ?string
     {
-        return $this->str($this->exifIfd, 0xA434);
+        return $this->str($this->exifIfd, ExifTag::LENS_MODEL);
     }
 
     /**
@@ -72,7 +72,7 @@ final class ExifDocument
      */
     public function orientation(): ?int
     {
-        return $this->int($this->ifd0, 0x0112);
+        return $this->int($this->ifd0, ExifTag::ORIENTATION);
     }
 
     /**
@@ -82,8 +82,8 @@ final class ExifDocument
      */
     public function iso(): ?int
     {
-        // EXIF ISO tag (PhotographicSensitivity) 0x8827
-        return $this->int($this->exifIfd, 0x8827);
+        // EXIF ISO tag (PhotographicSensitivity)
+        return $this->int($this->exifIfd, ExifTag::PHOTOGRAPHIC_SENSITIVITY);
     }
 
     /**
@@ -93,8 +93,8 @@ final class ExifDocument
      */
     public function exposureTime(): ?float
     {
-        // Tag 0x829A RATIONAL
-        $v = $this->exifIfd?->get(0x829A)?->value ?? null;
+        // Tag ExifTag::EXPOSURE_TIME (RATIONAL)
+        $v = $this->exifIfd?->get(ExifTag::EXPOSURE_TIME)?->value ?? null;
 
         return ValueConverters::rationalToFloat($v);
     }
@@ -106,8 +106,8 @@ final class ExifDocument
      */
     public function fNumber(): ?float
     {
-        // Tag 0x829D RATIONAL
-        $v = $this->exifIfd?->get(0x829D)?->value ?? null;
+        // Tag ExifTag::F_NUMBER (RATIONAL)
+        $v = $this->exifIfd?->get(ExifTag::F_NUMBER)?->value ?? null;
 
         return ValueConverters::rationalToFloat($v);
     }
@@ -119,8 +119,8 @@ final class ExifDocument
      */
     public function focalLengthMm(): ?float
     {
-        // Tag 0x920A RATIONAL
-        $v = $this->exifIfd?->get(0x920A)?->value ?? null;
+        // Tag ExifTag::FOCAL_LENGTH (RATIONAL)
+        $v = $this->exifIfd?->get(ExifTag::FOCAL_LENGTH)?->value ?? null;
 
         return ValueConverters::rationalToFloat($v);
     }
@@ -132,7 +132,7 @@ final class ExifDocument
      */
     public function dateTimeOriginalRaw(): ?string
     {
-        return $this->str($this->exifIfd, 0x9003);
+        return $this->str($this->exifIfd, ExifTag::DATETIME_ORIGINAL);
     }
 
     /**
@@ -142,7 +142,7 @@ final class ExifDocument
      */
     public function offsetTimeOriginalRaw(): ?string
     {
-        return $this->str($this->exifIfd, 0x9011);
+        return $this->str($this->exifIfd, ExifTag::OFFSET_TIME_ORIGINAL);
     }
 
     /**

--- a/src/Model/Exif/ExifTag.php
+++ b/src/Model/Exif/ExifTag.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\ImageMeta\Model\Exif;
+
+/**
+ * Centralised list of EXIF tag identifiers used throughout the library.
+ */
+final class ExifTag
+{
+    // Image file directory (IFD0)
+    public const MAKE        = 0x010F;
+    public const MODEL       = 0x0110;
+    public const ORIENTATION = 0x0112;
+
+    // Pointer tags
+    public const EXIF_IFD_POINTER             = 0x8769;
+    public const GPS_IFD_POINTER              = 0x8825;
+    public const INTEROPERABILITY_IFD_POINTER = 0xA005;
+
+    // EXIF sub IFD
+    public const EXPOSURE_TIME            = 0x829A;
+    public const F_NUMBER                 = 0x829D;
+    public const PHOTOGRAPHIC_SENSITIVITY = 0x8827;
+    public const ISO_SPEED                = 0x8833;
+    public const DATETIME_ORIGINAL        = 0x9003;
+    public const OFFSET_TIME_ORIGINAL     = 0x9011;
+    public const FOCAL_LENGTH             = 0x920A;
+    public const LENS_MODEL               = 0xA434;
+
+    // GPS sub IFD
+    public const GPS_LATITUDE_REF  = 0x0001;
+    public const GPS_LATITUDE      = 0x0002;
+    public const GPS_LONGITUDE_REF = 0x0003;
+    public const GPS_LONGITUDE     = 0x0004;
+    public const GPS_ALTITUDE_REF  = 0x0005;
+    public const GPS_ALTITUDE      = 0x0006;
+
+    private function __construct()
+    {
+    }
+}

--- a/src/Model/Exif/ValueConverters.php
+++ b/src/Model/Exif/ValueConverters.php
@@ -44,18 +44,18 @@ final class ValueConverters
      */
     public static function gpsFromIfd(Ifd $gps): array
     {
-        $latRef = $gps->get(0x0001)?->value ?? null;
-        $latVal = $gps->get(0x0002)?->value ?? null;
-        $lonRef = $gps->get(0x0003)?->value ?? null;
-        $lonVal = $gps->get(0x0004)?->value ?? null;
+        $latRef = $gps->get(ExifTag::GPS_LATITUDE_REF)?->value ?? null;
+        $latVal = $gps->get(ExifTag::GPS_LATITUDE)?->value ?? null;
+        $lonRef = $gps->get(ExifTag::GPS_LONGITUDE_REF)?->value ?? null;
+        $lonVal = $gps->get(ExifTag::GPS_LONGITUDE)?->value ?? null;
 
         $lat = self::dmsToFloat($latRef, $latVal);
         $lon = self::dmsToFloat($lonRef, $lonVal);
 
         $alt = null;
-        if (($e = $gps->get(0x0006)) && is_array($e->value) && count($e->value) === 2 && (int) $e->value[1] !== 0) {
+        if (($e = $gps->get(ExifTag::GPS_ALTITUDE)) && is_array($e->value) && count($e->value) === 2 && (int) $e->value[1] !== 0) {
             $alt = $e->value[0] / $e->value[1];
-            if (($ref = $gps->get(0x0005)) && (int) ($ref->value ?? 0) === 1) {
+            if (($ref = $gps->get(ExifTag::GPS_ALTITUDE_REF)) && (int) ($ref->value ?? 0) === 1) {
                 $alt = -$alt;
             }
         }

--- a/src/Parse/Tiff/TiffExifReader.php
+++ b/src/Parse/Tiff/TiffExifReader.php
@@ -15,6 +15,7 @@ use MagicSunday\ImageMeta\Core\Endian;
 use MagicSunday\ImageMeta\Core\MemoryBuffer;
 use MagicSunday\ImageMeta\Core\ParseError;
 use MagicSunday\ImageMeta\Model\Exif\ExifDocument;
+use MagicSunday\ImageMeta\Model\Exif\ExifTag;
 use MagicSunday\ImageMeta\Model\Exif\Ifd;
 use MagicSunday\ImageMeta\Model\Exif\IfdEntry;
 
@@ -66,13 +67,13 @@ final class TiffExifReader
         $gpsIfd     = null;
         $interopIfd = null;
         $ifd1       = null;
-        if ($e = $ifd0->get(0x8769)) { // ExifIFDPointer
+        if ($e = $ifd0->get(ExifTag::EXIF_IFD_POINTER)) { // ExifIFDPointer
             $exifIfd = $this->readIfd((int) $e->value);
-            if ($e2 = $exifIfd->get(0xA005)) { // Interop IFD
+            if ($e2 = $exifIfd->get(ExifTag::INTEROPERABILITY_IFD_POINTER)) { // Interop IFD
                 $interopIfd = $this->readIfd((int) $e2->value);
             }
         }
-        if ($g = $ifd0->get(0x8825)) { // GPSInfoIFDPointer
+        if ($g = $ifd0->get(ExifTag::GPS_IFD_POINTER)) { // GPSInfoIFDPointer
             $gpsIfd = $this->readIfd((int) $g->value);
         }
         if ($ifd0->nextIfdOffset) {

--- a/tests/Convenience/ExifConvenienceTest.php
+++ b/tests/Convenience/ExifConvenienceTest.php
@@ -1,0 +1,60 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\ImageMeta\Tests\Convenience;
+
+use MagicSunday\ImageMeta\Convenience\ExifConvenience;
+use MagicSunday\ImageMeta\Model\Exif\ExifDocument;
+use MagicSunday\ImageMeta\Model\Exif\ExifTag;
+use MagicSunday\ImageMeta\Model\Exif\Ifd;
+use MagicSunday\ImageMeta\Model\Exif\IfdEntry;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \MagicSunday\ImageMeta\Convenience\ExifConvenience
+ */
+#[CoversClass(ExifConvenience::class)]
+final class ExifConvenienceTest extends TestCase
+{
+    #[Test]
+    public function isoPrefersModernTagAndFallsBackToLegacy(): void
+    {
+        $ifd0 = new Ifd([
+            ExifTag::PHOTOGRAPHIC_SENSITIVITY => new IfdEntry(ExifTag::PHOTOGRAPHIC_SENSITIVITY, 3, 1, 200),
+        ]);
+
+        $exifIfd = new Ifd([
+            ExifTag::ISO_SPEED => new IfdEntry(ExifTag::ISO_SPEED, 3, 1, 320),
+        ]);
+
+        $doc = new ExifDocument($ifd0, $exifIfd, null, null, null);
+
+        self::assertSame(320, ExifConvenience::iso($doc));
+
+        $docWithLegacy = new ExifDocument($ifd0, null, null, null, null);
+
+        self::assertSame(200, ExifConvenience::iso($docWithLegacy));
+    }
+
+    #[Test]
+    public function isoExtractsFirstEntryFromArray(): void
+    {
+        $ifd0 = new Ifd([
+            ExifTag::PHOTOGRAPHIC_SENSITIVITY => new IfdEntry(ExifTag::PHOTOGRAPHIC_SENSITIVITY, 3, 3, [100, 200, 400]),
+        ]);
+
+        $doc = new ExifDocument($ifd0, null, null, null, null);
+
+        self::assertSame(100, ExifConvenience::iso($doc));
+    }
+}

--- a/tests/Model/Exif/ExifDocumentTest.php
+++ b/tests/Model/Exif/ExifDocumentTest.php
@@ -1,0 +1,78 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\ImageMeta\Tests\Model\Exif;
+
+use MagicSunday\ImageMeta\Model\Exif\ExifDocument;
+use MagicSunday\ImageMeta\Model\Exif\ExifTag;
+use MagicSunday\ImageMeta\Model\Exif\Ifd;
+use MagicSunday\ImageMeta\Model\Exif\IfdEntry;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \MagicSunday\ImageMeta\Model\Exif\ExifDocument
+ */
+#[CoversClass(ExifDocument::class)]
+final class ExifDocumentTest extends TestCase
+{
+    #[Test]
+    public function exposesRepresentativeExifValues(): void
+    {
+        $ifd0 = new Ifd([
+            ExifTag::MAKE        => new IfdEntry(ExifTag::MAKE, 2, 1, "Canon\0"),
+            ExifTag::MODEL       => new IfdEntry(ExifTag::MODEL, 2, 1, 'EOS R5'),
+            ExifTag::ORIENTATION => new IfdEntry(ExifTag::ORIENTATION, 3, 1, 6),
+        ]);
+
+        $exifIfd = new Ifd([
+            ExifTag::PHOTOGRAPHIC_SENSITIVITY => new IfdEntry(ExifTag::PHOTOGRAPHIC_SENSITIVITY, 3, 1, 200),
+            ExifTag::EXPOSURE_TIME            => new IfdEntry(ExifTag::EXPOSURE_TIME, 5, 1, [1, 125]),
+            ExifTag::F_NUMBER                 => new IfdEntry(ExifTag::F_NUMBER, 5, 1, [28, 10]),
+            ExifTag::FOCAL_LENGTH             => new IfdEntry(ExifTag::FOCAL_LENGTH, 5, 1, [50, 1]),
+            ExifTag::LENS_MODEL               => new IfdEntry(ExifTag::LENS_MODEL, 2, 1, 'RF50mm F1.2L USM'),
+            ExifTag::DATETIME_ORIGINAL        => new IfdEntry(ExifTag::DATETIME_ORIGINAL, 2, 1, '2024:05:01 12:34:56'),
+            ExifTag::OFFSET_TIME_ORIGINAL     => new IfdEntry(ExifTag::OFFSET_TIME_ORIGINAL, 2, 1, '+02:00'),
+        ]);
+
+        $gpsIfd = new Ifd([
+            ExifTag::GPS_LATITUDE_REF  => new IfdEntry(ExifTag::GPS_LATITUDE_REF, 2, 2, 'N'),
+            ExifTag::GPS_LATITUDE      => new IfdEntry(ExifTag::GPS_LATITUDE, 5, 3, [[40, 1], [26, 1], [3000, 100]]),
+            ExifTag::GPS_LONGITUDE_REF => new IfdEntry(ExifTag::GPS_LONGITUDE_REF, 2, 2, 'E'),
+            ExifTag::GPS_LONGITUDE     => new IfdEntry(ExifTag::GPS_LONGITUDE, 5, 3, [[79, 1], [58, 1], [6000, 100]]),
+            ExifTag::GPS_ALTITUDE_REF  => new IfdEntry(ExifTag::GPS_ALTITUDE_REF, 1, 1, 0),
+            ExifTag::GPS_ALTITUDE      => new IfdEntry(ExifTag::GPS_ALTITUDE, 5, 1, [123, 1]),
+        ]);
+
+        $doc = new ExifDocument($ifd0, $exifIfd, $gpsIfd, null, null);
+
+        self::assertSame('Canon', $doc->cameraMake());
+        self::assertSame('EOS R5', $doc->cameraModel());
+        self::assertSame('RF50mm F1.2L USM', $doc->lensModel());
+        self::assertSame(6, $doc->orientation());
+        self::assertSame(200, $doc->iso());
+        self::assertSame(0.008, $doc->exposureTime());
+        self::assertSame(2.8, $doc->fNumber());
+        self::assertSame(50.0, $doc->focalLengthMm());
+        self::assertSame('2024:05:01 12:34:56', $doc->dateTimeOriginalRaw());
+        self::assertSame('+02:00', $doc->offsetTimeOriginalRaw());
+
+        $capture = $doc->captureDateTime();
+        self::assertNotNull($capture);
+        self::assertSame('2024-05-01T12:34:56+02:00', $capture->format(DATE_ATOM));
+
+        $gps = $doc->gps();
+        self::assertEqualsWithDelta(40.441666, $gps['lat'], 0.000001);
+        self::assertEqualsWithDelta(79.983333, $gps['lon'], 0.000001);
+        self::assertEquals(123.0, $gps['alt']);
+    }
+}


### PR DESCRIPTION
## Summary
- add a dedicated `ExifTag` constants holder for tag ids used by the EXIF model
- refactor EXIF document, convenience helpers, and TIFF reader to reference the new constants
- add regression tests covering representative EXIF accessors and ISO handling

## Testing
- composer ci:cgl
- composer ci:test:php:unit

------
https://chatgpt.com/codex/tasks/task_e_68f9c36d520c83238a8abd4bc604a395