### PR TITLE
refactor: add integer types to EXIF tag constants

### DIFF
--- a/src/Model/Exif/ExifTag.php
+++ b/src/Model/Exif/ExifTag.php
@@ -17,32 +17,32 @@ namespace MagicSunday\ImageMeta\Model\Exif;
 final class ExifTag
 {
     // Image file directory (IFD0)
-    public const MAKE        = 0x010F;
-    public const MODEL       = 0x0110;
-    public const ORIENTATION = 0x0112;
+    public const int MAKE        = 0x010F;
+    public const int MODEL       = 0x0110;
+    public const int ORIENTATION = 0x0112;
 
     // Pointer tags
-    public const EXIF_IFD_POINTER             = 0x8769;
-    public const GPS_IFD_POINTER              = 0x8825;
-    public const INTEROPERABILITY_IFD_POINTER = 0xA005;
+    public const int EXIF_IFD_POINTER             = 0x8769;
+    public const int GPS_IFD_POINTER              = 0x8825;
+    public const int INTEROPERABILITY_IFD_POINTER = 0xA005;
 
     // EXIF sub IFD
-    public const EXPOSURE_TIME            = 0x829A;
-    public const F_NUMBER                 = 0x829D;
-    public const PHOTOGRAPHIC_SENSITIVITY = 0x8827;
-    public const ISO_SPEED                = 0x8833;
-    public const DATETIME_ORIGINAL        = 0x9003;
-    public const OFFSET_TIME_ORIGINAL     = 0x9011;
-    public const FOCAL_LENGTH             = 0x920A;
-    public const LENS_MODEL               = 0xA434;
+    public const int EXPOSURE_TIME            = 0x829A;
+    public const int F_NUMBER                 = 0x829D;
+    public const int PHOTOGRAPHIC_SENSITIVITY = 0x8827;
+    public const int ISO_SPEED                = 0x8833;
+    public const int DATETIME_ORIGINAL        = 0x9003;
+    public const int OFFSET_TIME_ORIGINAL     = 0x9011;
+    public const int FOCAL_LENGTH             = 0x920A;
+    public const int LENS_MODEL               = 0xA434;
 
     // GPS sub IFD
-    public const GPS_LATITUDE_REF  = 0x0001;
-    public const GPS_LATITUDE      = 0x0002;
-    public const GPS_LONGITUDE_REF = 0x0003;
-    public const GPS_LONGITUDE     = 0x0004;
-    public const GPS_ALTITUDE_REF  = 0x0005;
-    public const GPS_ALTITUDE      = 0x0006;
+    public const int GPS_LATITUDE_REF  = 0x0001;
+    public const int GPS_LATITUDE      = 0x0002;
+    public const int GPS_LONGITUDE_REF = 0x0003;
+    public const int GPS_LONGITUDE     = 0x0004;
+    public const int GPS_ALTITUDE_REF  = 0x0005;
+    public const int GPS_ALTITUDE      = 0x0006;
 
     private function __construct()
     {


### PR DESCRIPTION
## Summary
- declare each EXIF tag constant in `ExifTag` with an explicit `int` type declaration

## Testing
- composer ci:cgl
- composer ci:test:php:phpstan *(fails: existing PHPStan issues unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68f9c7a9735883239e405b77af3b237e