### PR TITLE
Qualify global function calls in metadata utilities

### DIFF
--- a/.build/.php-cs-fixer.dist.php
+++ b/.build/.php-cs-fixer.dist.php
@@ -78,7 +78,7 @@ return (new PhpCsFixer\Config())
         'global_namespace_import'         => [
             'import_classes'   => true,
             'import_constants' => true,
-            'import_functions' => true,
+            'import_functions' => false,
         ],
         'function_declaration'            => [
             'closure_function_spacing' => 'one',

--- a/src/Convenience/ExifConvenience.php
+++ b/src/Convenience/ExifConvenience.php
@@ -49,23 +49,23 @@ final class ExifConvenience
     {
         $rawDateTime = $doc->dateTimeOriginal(); // "YYYY:MM:DD HH:MM:SS"
 
-        if (!is_string($rawDateTime) || $rawDateTime === '') {
+        if (!\is_string($rawDateTime) || $rawDateTime === '') {
             return null;
         }
 
         // Ensure that the timestamp contains both a date and a time component.
-        if (strlen($rawDateTime) < 19) {
+        if (\strlen($rawDateTime) < 19) {
             return null;
         }
 
         $rawOffset = $doc->offsetTimeOriginal(); // e.g. "+01:00" or "-05:30"
 
-        $datePart       = str_replace(':', '-', substr($rawDateTime, 0, 10));
-        $timePart       = substr($rawDateTime, 11, 8);
+        $datePart       = \str_replace(':', '-', \substr($rawDateTime, 0, 10));
+        $timePart       = \substr($rawDateTime, 11, 8);
         $timeZoneOffset = $rawOffset !== null && $rawOffset !== '' ? $rawOffset : '+00:00';
 
         try {
-            return new DateTimeImmutable(sprintf('%s %s%s', $datePart, $timePart, $timeZoneOffset));
+            return new DateTimeImmutable(\sprintf('%s %s%s', $datePart, $timePart, $timeZoneOffset));
         } catch (Throwable) {
             return null;
         }
@@ -143,16 +143,16 @@ final class ExifConvenience
 
         $value = $entry->value;
 
-        if (is_array($value)) {
+        if (\is_array($value)) {
             // Some cameras store ISO as a list, keep the first element.
             $value = $value[0] ?? null;
         }
 
-        if (is_int($value)) {
+        if (\is_int($value)) {
             return $value;
         }
 
-        if (is_float($value)) {
+        if (\is_float($value)) {
             return (int) $value;
         }
 
@@ -209,12 +209,12 @@ final class ExifConvenience
      */
     private static function rationalToFloat(mixed $v): ?float
     {
-        if (is_array($v)) {
+        if (\is_array($v)) {
             // [num, den] or list of rationals
-            if (count($v) === 2 && is_numeric($v[0] ?? null) && is_numeric($v[1] ?? null) && (int) $v[1] !== 0) {
+            if (\count($v) === 2 && \is_numeric($v[0] ?? null) && \is_numeric($v[1] ?? null) && (int) $v[1] !== 0) {
                 return (float) $v[0] / (float) $v[1];
             }
-            if (isset($v[0]) && is_array($v[0]) && count($v[0]) === 2) {
+            if (isset($v[0]) && \is_array($v[0]) && \count($v[0]) === 2) {
                 $n = $v[0][0] ?? 0;
                 $d = $v[0][1] ?? 1;
 
@@ -222,6 +222,6 @@ final class ExifConvenience
             }
         }
 
-        return is_int($v) || is_float($v) ? (float) $v : null;
+        return \is_int($v) || \is_float($v) ? (float) $v : null;
     }
 }

--- a/src/Core/MemoryBuffer.php
+++ b/src/Core/MemoryBuffer.php
@@ -37,7 +37,7 @@ final class MemoryBuffer
      */
     public function size(): int
     {
-        return strlen($this->data);
+        return \strlen($this->data);
     }
 
     /**
@@ -83,8 +83,8 @@ final class MemoryBuffer
         if ($length < 0 || $end > $this->size()) {
             throw new BoundsError("MemoryBuffer read out of range: {$this->pos}+{$length}");
         }
-        $chunk = substr($this->data, $this->pos, $length);
-        if (strlen($chunk) !== $length) {
+        $chunk = \substr($this->data, $this->pos, $length);
+        if (\strlen($chunk) !== $length) {
             throw new ParseError('MemoryBuffer short read');
         }
         $this->pos = $end;
@@ -99,7 +99,7 @@ final class MemoryBuffer
      */
     public function readU8(): int
     {
-        return ord($this->read(1));
+        return \ord($this->read(1));
     }
 
     /**
@@ -109,7 +109,7 @@ final class MemoryBuffer
      */
     public function readU16LE(): int
     {
-        return unpack('v', $this->read(2))[1];
+        return \unpack('v', $this->read(2))[1];
     }
 
     /**
@@ -119,7 +119,7 @@ final class MemoryBuffer
      */
     public function readU16BE(): int
     {
-        return unpack('n', $this->read(2))[1];
+        return \unpack('n', $this->read(2))[1];
     }
 
     /**
@@ -129,7 +129,7 @@ final class MemoryBuffer
      */
     public function readU32LE(): int
     {
-        return unpack('V', $this->read(4))[1];
+        return \unpack('V', $this->read(4))[1];
     }
 
     /**
@@ -139,7 +139,7 @@ final class MemoryBuffer
      */
     public function readU32BE(): int
     {
-        return unpack('N', $this->read(4))[1];
+        return \unpack('N', $this->read(4))[1];
     }
 
     /**

--- a/src/Core/Stream.php
+++ b/src/Core/Stream.php
@@ -30,11 +30,11 @@ final class Stream
      */
     public static function fromPath(string $path): self
     {
-        $fh = fopen($path, 'rb');
+        $fh = \fopen($path, 'rb');
         if ($fh === false) {
             throw new ParseError("Cannot open: $path");
         }
-        $stat = fstat($fh);
+        $stat = \fstat($fh);
         $size = (int) ($stat['size'] ?? 0);
 
         return new self($fh, $size);
@@ -82,7 +82,7 @@ final class Stream
         if ($offset < 0 || $offset > $this->size) {
             throw new BoundsError("seek out of range: $offset");
         }
-        fseek($this->fh, $offset);
+        \fseek($this->fh, $offset);
         $this->pos = $offset;
     }
 
@@ -98,8 +98,8 @@ final class Stream
         if ($len < 0 || $this->pos + $len > $this->size) {
             throw new BoundsError("read beyond EOF: {$this->pos}+{$len} > {$this->size}");
         }
-        $data = fread($this->fh, $len);
-        if ($data === false || strlen($data) !== $len) {
+        $data = \fread($this->fh, $len);
+        if ($data === false || \strlen($data) !== $len) {
             throw new ParseError('short read');
         }
         $this->pos += $len;
@@ -114,7 +114,7 @@ final class Stream
      */
     public function readU8(): int
     {
-        return ord($this->read(1));
+        return \ord($this->read(1));
     }
 
     /**
@@ -124,7 +124,7 @@ final class Stream
      */
     public function readU16BE(): int
     {
-        return unpack('n', $this->read(2))[1];
+        return \unpack('n', $this->read(2))[1];
     }
 
     /**
@@ -134,7 +134,7 @@ final class Stream
      */
     public function readU32BE(): int
     {
-        return unpack('N', $this->read(4))[1];
+        return \unpack('N', $this->read(4))[1];
     }
 
     /**

--- a/src/MakerNotes/AppleDecoder.php
+++ b/src/MakerNotes/AppleDecoder.php
@@ -29,8 +29,8 @@ final class AppleDecoder implements MakerNotesDecoderInterface
     {
         return [
             '_vendor' => 'Apple',
-            '_length' => strlen($raw),
-            '_sha1'   => sha1($raw, false),
+            '_length' => \strlen($raw),
+            '_sha1'   => \sha1($raw, false),
         ];
     }
 }

--- a/src/Model/Exif/ValueConverters.php
+++ b/src/Model/Exif/ValueConverters.php
@@ -25,10 +25,10 @@ final class ValueConverters
      */
     public static function rationalToFloat(mixed $v): ?float
     {
-        if (is_array($v) && count($v) === 2 && (int) $v[1] !== 0) {
+        if (\is_array($v) && \count($v) === 2 && (int) $v[1] !== 0) {
             return (float) $v[0] / (float) $v[1];
         }
-        if (is_int($v) || is_float($v)) {
+        if (\is_int($v) || \is_float($v)) {
             return (float) $v;
         }
 
@@ -53,7 +53,7 @@ final class ValueConverters
         $lon = self::dmsToFloat($lonRef, $lonVal);
 
         $alt = null;
-        if (($e = $gps->get(ExifTag::GPS_ALTITUDE)) && is_array($e->value) && count($e->value) === 2 && (int) $e->value[1] !== 0) {
+        if (($e = $gps->get(ExifTag::GPS_ALTITUDE)) && \is_array($e->value) && \count($e->value) === 2 && (int) $e->value[1] !== 0) {
             $alt = $e->value[0] / $e->value[1];
             if (($ref = $gps->get(ExifTag::GPS_ALTITUDE_REF)) && (int) ($ref->value ?? 0) === 1) {
                 $alt = -$alt;
@@ -71,7 +71,7 @@ final class ValueConverters
      */
     private static function dmsToFloat(?string $ref, mixed $val): ?float
     {
-        if (!is_string($ref) || !is_array($val) || count($val) < 3) {
+        if (!\is_string($ref) || !\is_array($val) || \count($val) < 3) {
             return null;
         }
         $deg = self::rationalToFloat($val[0] ?? null);

--- a/src/Parse/IsoBmff/IsoBmffExtractor.php
+++ b/src/Parse/IsoBmff/IsoBmffExtractor.php
@@ -51,7 +51,7 @@ final class IsoBmffExtractor
         }
 
         if ($queuedUuidXmp !== []) {
-            $xmpBlobs = array_merge($xmpBlobs, $queuedUuidXmp);
+            $xmpBlobs = \array_merge($xmpBlobs, $queuedUuidXmp);
         }
 
         $qt = $qtKeys === [] ? null : new QuickTimeMeta($qtKeys);
@@ -248,13 +248,13 @@ final class IsoBmffExtractor
         }
 
         // Deduplicate while preserving encounter order to avoid processing the same item twice.
-        $exifItemIds = array_values(array_unique($exifItemIds));
-        $xmpItemIds  = array_values(array_unique($xmpItemIds));
+        $exifItemIds = \array_values(\array_unique($exifItemIds));
+        $xmpItemIds  = \array_values(\array_unique($xmpItemIds));
 
         if ($primaryItemId !== null) {
             // Ensure the declared primary item is considered first for XMP resolution.
-            array_unshift($xmpItemIds, $primaryItemId);
-            $xmpItemIds = array_values(array_unique($xmpItemIds));
+            \array_unshift($xmpItemIds, $primaryItemId);
+            $xmpItemIds = \array_values(\array_unique($xmpItemIds));
         }
 
         return [$exifItemIds, $xmpItemIds];
@@ -314,7 +314,7 @@ final class IsoBmffExtractor
      */
     private function normalizeExifBlob(string $blob): string
     {
-        return str_starts_with($blob, "Exif\0\0") ? substr($blob, 6) : $blob;
+        return \str_starts_with($blob, "Exif\0\0") ? \substr($blob, 6) : $blob;
     }
 
     /**
@@ -421,7 +421,7 @@ final class IsoBmffExtractor
             $win->readU16BE(); // protection index
             $remaining = $infe->contentSize - $win->tell();
             $payload   = $remaining > 0 ? $win->read($remaining) : '';
-            $parts     = $payload === '' ? [] : explode("\0", $payload);
+            $parts     = $payload === '' ? [] : \explode("\0", $payload);
 
             $name        = $parts[0] ?? null;
             $contentType = isset($parts[1]) && $parts[1] !== '' ? $parts[1] : null;
@@ -439,7 +439,7 @@ final class IsoBmffExtractor
         $itemType    = $win->read(4);
         $remaining   = $infe->contentSize - $win->tell();
         $payload     = $remaining > 0 ? $win->read($remaining) : '';
-        $parts       = $payload === '' ? [] : explode("\0", $payload);
+        $parts       = $payload === '' ? [] : \explode("\0", $payload);
         $name        = $parts[0] ?? null;
         $contentType = isset($parts[1]) && $parts[1] !== '' ? $parts[1] : null;
 
@@ -651,7 +651,7 @@ final class IsoBmffExtractor
         $payload     = $payloadSize > 0 ? $win->read($payloadSize) : '';
 
         if ($type === 1 || $type === 2 || $type === 7) {
-            return trim($payload, "\0");
+            return \trim($payload, "\0");
         }
 
         return $payload;
@@ -681,14 +681,14 @@ final class IsoBmffExtractor
      */
     private function isExifItem(array $info): bool
     {
-        if (isset($info['itemType']) && strcasecmp((string) $info['itemType'], 'Exif') === 0) {
+        if (isset($info['itemType']) && \strcasecmp((string) $info['itemType'], 'Exif') === 0) {
             return true;
         }
-        if (isset($info['name']) && strcasecmp((string) $info['name'], 'Exif') === 0) {
+        if (isset($info['name']) && \strcasecmp((string) $info['name'], 'Exif') === 0) {
             return true;
         }
         if (isset($info['contentType'])) {
-            $ct = strtolower((string) $info['contentType']);
+            $ct = \strtolower((string) $info['contentType']);
 
             return $ct === 'application/exif' || $ct === 'image/tiff';
         }
@@ -707,7 +707,7 @@ final class IsoBmffExtractor
             return false;
         }
 
-        return strtolower((string) $info['contentType']) === 'application/rdf+xml';
+        return \strtolower((string) $info['contentType']) === 'application/rdf+xml';
     }
 
     /**
@@ -751,7 +751,7 @@ final class IsoBmffExtractor
             0       => 0,
             1       => $window->readU8(),
             2       => $window->readU16BE(),
-            3       => unpack('N', "\0" . $window->read(3))[1],
+            3       => \unpack('N', "\0" . $window->read(3))[1],
             4       => $window->readU32BE(),
             8       => $window->readU64BE(),
             default => throw new ParseError("unsupported integer size $bytes"),
@@ -783,7 +783,7 @@ final class IsoBmffExtractor
      */
     private function isPrintableFourcc(string $fourcc): bool
     {
-        return strlen($fourcc) === 4 && preg_match('/^[\x20-\x7E]{4}$/', $fourcc) === 1;
+        return \strlen($fourcc) === 4 && \preg_match('/^[\x20-\x7E]{4}$/', $fourcc) === 1;
     }
 
     /**
@@ -795,11 +795,11 @@ final class IsoBmffExtractor
      */
     private function fourccToIndex(string $fourcc): ?int
     {
-        if (strlen($fourcc) !== 4) {
+        if (\strlen($fourcc) !== 4) {
             return null;
         }
 
-        $value = unpack('N', $fourcc)[1];
+        $value = \unpack('N', $fourcc)[1];
 
         return $value > 0 ? $value : null;
     }

--- a/src/Parse/Jpeg/JpegExtractor.php
+++ b/src/Parse/Jpeg/JpegExtractor.php
@@ -163,14 +163,14 @@ final class JpegExtractor
         }
 
         if ($this->iccExpectedCount !== null && $this->iccExpectedCount > 0) {
-            if (count($this->iccSequence) === $this->iccExpectedCount) {
-                $expectedSequence = range(1, $this->iccExpectedCount);
-                $presentSequence  = array_keys($this->iccSequence);
-                sort($presentSequence);
+            if (\count($this->iccSequence) === $this->iccExpectedCount) {
+                $expectedSequence = \range(1, $this->iccExpectedCount);
+                $presentSequence  = \array_keys($this->iccSequence);
+                \sort($presentSequence);
 
                 if ($presentSequence === $expectedSequence) {
-                    ksort($this->iccSequence);
-                    $this->iccProfile = implode('', $this->iccSequence);
+                    \ksort($this->iccSequence);
+                    $this->iccProfile = \implode('', $this->iccSequence);
                 }
             }
         }
@@ -201,7 +201,7 @@ final class JpegExtractor
                 continue; // stuffed byte inside scan data
             }
 
-            return [ord($code), $markerOffset];
+            return [\ord($code), $markerOffset];
         }
     }
 
@@ -220,7 +220,7 @@ final class JpegExtractor
 
         if ($length < 2) {
             throw new ParseError(
-                sprintf('Segment length %d for marker 0x%02X at offset %d is invalid', $length, $marker, $offset)
+                \sprintf('Segment length %d for marker 0x%02X at offset %d is invalid', $length, $marker, $offset)
             );
         }
 
@@ -228,7 +228,7 @@ final class JpegExtractor
             $payloadLength = $length - 2;
             if ($payloadLength > self::MAX_APP_SEGMENT_SIZE) {
                 throw new ParseError(
-                    sprintf(
+                    \sprintf(
                         'APP segment 0x%02X at offset %d exceeds maximum payload of %d bytes',
                         $marker,
                         $offset,
@@ -260,7 +260,7 @@ final class JpegExtractor
             return $this->s->read($length);
         } catch (BoundsError $exception) {
             throw new ParseError(
-                sprintf('Truncated segment for marker 0x%02X at offset %d', $marker, $offset),
+                \sprintf('Truncated segment for marker 0x%02X at offset %d', $marker, $offset),
                 0,
                 $exception
             );
@@ -274,14 +274,14 @@ final class JpegExtractor
      */
     private function handleApp1(string $payload): void
     {
-        if (str_starts_with($payload, self::EXIF_SIGNATURE)) {
-            $this->exifBlobs[] = substr($payload, strlen(self::EXIF_SIGNATURE));
+        if (\str_starts_with($payload, self::EXIF_SIGNATURE)) {
+            $this->exifBlobs[] = \substr($payload, \strlen(self::EXIF_SIGNATURE));
 
             return;
         }
 
-        if (str_starts_with($payload, self::XMP_SIGNATURE)) {
-            $this->xmpPackets[] = substr($payload, strlen(self::XMP_SIGNATURE));
+        if (\str_starts_with($payload, self::XMP_SIGNATURE)) {
+            $this->xmpPackets[] = \substr($payload, \strlen(self::XMP_SIGNATURE));
         }
     }
 
@@ -293,18 +293,18 @@ final class JpegExtractor
      */
     private function handleApp2(string $payload, int $offset): void
     {
-        if (!str_starts_with($payload, self::ICC_SIGNATURE)) {
+        if (!\str_starts_with($payload, self::ICC_SIGNATURE)) {
             return;
         }
 
-        $signatureLength = strlen(self::ICC_SIGNATURE);
-        if (strlen($payload) < $signatureLength + 2) {
-            throw new ParseError(sprintf('ICC segment at offset %d is too short', $offset));
+        $signatureLength = \strlen(self::ICC_SIGNATURE);
+        if (\strlen($payload) < $signatureLength + 2) {
+            throw new ParseError(\sprintf('ICC segment at offset %d is too short', $offset));
         }
 
-        $sequenceNumber = ord($payload[$signatureLength]);
-        $sequenceCount  = ord($payload[$signatureLength + 1]);
-        $iccData        = substr($payload, $signatureLength + 2);
+        $sequenceNumber = \ord($payload[$signatureLength]);
+        $sequenceCount  = \ord($payload[$signatureLength + 1]);
+        $iccData        = \substr($payload, $signatureLength + 2);
 
         $this->iccSegments[] = $payload;
 
@@ -322,7 +322,7 @@ final class JpegExtractor
             return;
         }
 
-        if (!array_key_exists($sequenceNumber, $this->iccSequence)) {
+        if (!\array_key_exists($sequenceNumber, $this->iccSequence)) {
             $this->iccSequence[$sequenceNumber] = $iccData;
         }
     }
@@ -334,7 +334,7 @@ final class JpegExtractor
      */
     private function handleApp13(string $payload): void
     {
-        if (str_starts_with($payload, self::IPTC_SIGNATURE)) {
+        if (\str_starts_with($payload, self::IPTC_SIGNATURE)) {
             $this->iptcPayloads[] = $payload;
         }
     }


### PR DESCRIPTION
## Summary
- keep php-cs-fixer from importing global functions so explicit namespace qualification persists
- prefix PHP built-ins with backslashes in the EXIF convenience helpers, core buffer/stream classes, and the Apple maker-note decoder
- update the JPEG and ISOBMFF extractors to consistently use fully-qualified global functions

## Testing
- composer ci:cgl
- composer ci:test:php:phpstan *(fails: existing analysis violations reported in the current codebase)*

------
https://chatgpt.com/codex/tasks/task_e_68f9c7b8b9148323adfff8e9daa5e78f