### PR TITLE
fix: guard EXIF capture date convenience

### DIFF
--- a/src/Convenience/ExifConvenience.php
+++ b/src/Convenience/ExifConvenience.php
@@ -47,7 +47,7 @@ final class ExifConvenience
      */
     public static function captureDateTime(ExifDocument $doc): ?DateTimeImmutable
     {
-        $rawDateTime = $doc->dateTimeOriginal(); // "YYYY:MM:DD HH:MM:SS"
+        $rawDateTime = $doc->dateTimeOriginalRaw(); // "YYYY:MM:DD HH:MM:SS"
 
         if (!is_string($rawDateTime) || $rawDateTime === '') {
             return null;
@@ -58,14 +58,8 @@ final class ExifConvenience
             return null;
         }
 
-        $rawOffset = $doc->offsetTimeOriginal(); // e.g. "+01:00" or "-05:30"
-
-        $datePart       = str_replace(':', '-', substr($rawDateTime, 0, 10));
-        $timePart       = substr($rawDateTime, 11, 8);
-        $timeZoneOffset = $rawOffset !== null && $rawOffset !== '' ? $rawOffset : '+00:00';
-
         try {
-            return new DateTimeImmutable(sprintf('%s %s%s', $datePart, $timePart, $timeZoneOffset));
+            return $doc->captureDateTime();
         } catch (Throwable) {
             return null;
         }

--- a/tests/Convenience/ExifConvenienceTest.php
+++ b/tests/Convenience/ExifConvenienceTest.php
@@ -57,4 +57,43 @@ final class ExifConvenienceTest extends TestCase
 
         self::assertSame(100, ExifConvenience::iso($doc));
     }
+
+    #[Test]
+    public function captureDateTimeDelegatesToDocument(): void
+    {
+        $ifd0 = new Ifd([]);
+
+        $exifIfd = new Ifd([
+            ExifTag::DATETIME_ORIGINAL    => new IfdEntry(ExifTag::DATETIME_ORIGINAL, 2, 1, '2024:05:01 12:34:56'),
+            ExifTag::OFFSET_TIME_ORIGINAL => new IfdEntry(ExifTag::OFFSET_TIME_ORIGINAL, 2, 1, '+02:00'),
+        ]);
+
+        $doc     = new ExifDocument($ifd0, $exifIfd, null, null, null);
+        $captured = ExifConvenience::captureDateTime($doc);
+
+        self::assertNotNull($captured);
+        self::assertSame('2024-05-01T12:34:56+02:00', $captured->format(DATE_ATOM));
+    }
+
+    #[Test]
+    public function captureDateTimeReturnsNullWhenMissing(): void
+    {
+        $doc = new ExifDocument(new Ifd([]), new Ifd([]), null, null, null);
+
+        self::assertNull(ExifConvenience::captureDateTime($doc));
+    }
+
+    #[Test]
+    public function captureDateTimeReturnsNullForShortTimestamp(): void
+    {
+        $ifd0 = new Ifd([]);
+
+        $exifIfd = new Ifd([
+            ExifTag::DATETIME_ORIGINAL => new IfdEntry(ExifTag::DATETIME_ORIGINAL, 2, 1, '2024:05:01'),
+        ]);
+
+        $doc = new ExifDocument($ifd0, $exifIfd, null, null, null);
+
+        self::assertNull(ExifConvenience::captureDateTime($doc));
+    }
 }


### PR DESCRIPTION
## Summary
- delegate `ExifConvenience::captureDateTime()` to the `ExifDocument` implementation while keeping the guard logic
- add unit coverage for the convenience timestamp handling to prevent regressions

## Testing
- composer ci:test:php:unit

------
https://chatgpt.com/codex/tasks/task_e_68f9cd2054448323a7badc292224cb80