### PR TITLE
fix: safely resolve XMP capture dates

### DIFF
--- a/src/Convenience/CaptureDateResolver.php
+++ b/src/Convenience/CaptureDateResolver.php
@@ -13,6 +13,7 @@ namespace MagicSunday\ImageMeta\Convenience;
 
 use DateTimeImmutable;
 use MagicSunday\ImageMeta\Model\Metadata;
+use MagicSunday\ImageMeta\Model\Xmp\XmpDocument;
 use Throwable;
 
 /**
@@ -43,9 +44,9 @@ final class CaptureDateResolver
         }
 
         if ($metadata->xmpDoc !== null) {
-            $createDate = $metadata->xmpDoc->createDate();
+            $createDate = self::readXmpCreateDate($metadata->xmpDoc);
 
-            if (is_string($createDate) && $createDate !== '') {
+            if ($createDate !== null) {
                 try {
                     // XMP createDate is already ISO 8601, so we can consume it directly.
                     return new DateTimeImmutable($createDate);
@@ -56,5 +57,36 @@ final class CaptureDateResolver
         }
 
         return null;
+    }
+
+    /**
+     * Extracts the ISO 8601 create date from the XMP document.
+     */
+    private static function readXmpCreateDate(XmpDocument $document): ?string
+    {
+        $value = $document->get('http://ns.adobe.com/xap/1.0/', 'CreateDate');
+
+        if (is_array($value)) {
+            $value = $value[0] ?? null;
+        }
+
+        if (!is_string($value)) {
+            return null;
+        }
+
+        $value = trim($value);
+
+        if ($value === '') {
+            return null;
+        }
+
+        if (preg_match(
+            '/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+\-]\d{2}:?\d{2})$/',
+            $value
+        ) !== 1) {
+            return null;
+        }
+
+        return $value;
     }
 }

--- a/tests/Convenience/CaptureDateResolverTest.php
+++ b/tests/Convenience/CaptureDateResolverTest.php
@@ -1,0 +1,86 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\ImageMeta\Tests\Convenience;
+
+use DateTimeImmutable;
+use MagicSunday\ImageMeta\Convenience\CaptureDateResolver;
+use MagicSunday\ImageMeta\Model\Metadata;
+use MagicSunday\ImageMeta\Model\Xmp\XmpDocument;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \MagicSunday\ImageMeta\Convenience\CaptureDateResolver
+ */
+#[CoversClass(CaptureDateResolver::class)]
+final class CaptureDateResolverTest extends TestCase
+{
+    private const XMP_NAMESPACE = 'http://ns.adobe.com/xap/1.0/';
+
+    #[Test]
+    public function returnsXmpCreateDateWhenExifIsMissing(): void
+    {
+        $metadata = new Metadata(
+            exifBlobs: [],
+            quickTime: null,
+            exifDoc: null,
+            xmpBlobs: [],
+            xmpDoc: new XmpDocument([
+                '{' . self::XMP_NAMESPACE . '}CreateDate' => '2024-03-30T12:34:56Z',
+            ]),
+        );
+
+        $result = CaptureDateResolver::bestCaptureDateTime($metadata);
+
+        self::assertInstanceOf(DateTimeImmutable::class, $result);
+        self::assertSame('2024-03-30T12:34:56+00:00', $result->format(DATE_ATOM));
+    }
+
+    #[Test]
+    public function ignoresNonIsoCreateDateValues(): void
+    {
+        $metadata = new Metadata(
+            exifBlobs: [],
+            quickTime: null,
+            exifDoc: null,
+            xmpBlobs: [],
+            xmpDoc: new XmpDocument([
+                '{' . self::XMP_NAMESPACE . '}CreateDate' => 'not-a-date',
+            ]),
+        );
+
+        self::assertNull(CaptureDateResolver::bestCaptureDateTime($metadata));
+    }
+
+    #[Test]
+    public function acceptsFirstArrayElementWhenIsoString(): void
+    {
+        $metadata = new Metadata(
+            exifBlobs: [],
+            quickTime: null,
+            exifDoc: null,
+            xmpBlobs: [],
+            xmpDoc: new XmpDocument([
+                '{' . self::XMP_NAMESPACE . '}CreateDate' => [
+                    '2024-03-30T12:34:56Z',
+                    '2024-03-30T12:34:56+01:00',
+                ],
+            ]),
+        );
+
+        $result = CaptureDateResolver::bestCaptureDateTime($metadata);
+
+        self::assertInstanceOf(DateTimeImmutable::class, $result);
+        self::assertSame('2024-03-30T12:34:56+00:00', $result->format(DATE_ATOM));
+    }
+}


### PR DESCRIPTION
## Summary
- use the XMP document getter to retrieve CreateDate and validate its ISO 8601 format
- ignore malformed or empty XMP timestamps while still accepting list values
- cover the XMP fallback path in the capture date resolver with dedicated tests

## Testing
- composer ci:test:php:unit

------
https://chatgpt.com/codex/tasks/task_e_68f9cd37add88323aeecb94e23a39e26