### PR TITLE
refactor: delegate metadata lookups to array_find

### DIFF
--- a/src/MakerNotes/Registry.php
+++ b/src/MakerNotes/Registry.php
@@ -40,12 +40,10 @@ final class Registry
     public function find(string $make): ?MakerNotesDecoderInterface
     {
         $make = strtolower($make);
-        foreach ($this->decoders as $pref => $dec) {
-            if ($pref !== '' && str_starts_with($make, $pref)) {
-                return $dec;
-            }
-        }
-
-        return null;
+        return array_find(
+            $this->decoders,
+            fn (MakerNotesDecoderInterface $decoder, int|string $prefix): bool => $prefix !== ''
+                && str_starts_with($make, (string) $prefix)
+        );
     }
 }

--- a/src/Model/Xmp/XmpDocument.php
+++ b/src/Model/Xmp/XmpDocument.php
@@ -40,13 +40,11 @@ final class XmpDocument
      */
     public function find(string $localName): array|string|null
     {
-        foreach ($this->data as $key => $value) {
-            if ($this->matchesLocalName($key, $localName) && (is_string($value) || is_array($value))) {
-                return $value;
-            }
-        }
-
-        return null;
+        return array_find(
+            $this->data,
+            fn (mixed $value, int|string $key): bool => $this->matchesLocalName((string) $key, $localName)
+                && (is_string($value) || is_array($value))
+        );
     }
 
     private function buildClarkName(string $namespaceUri, string $localName): string


### PR DESCRIPTION
## Summary
- refactor XMP document lookups to use the built-in array_find helper while preserving the existing predicate guards
- update the maker notes registry to reuse array_find for prefix matching of decoder registrations

## Testing
- composer ci:test:php:unit

------
https://chatgpt.com/codex/tasks/task_e_68f9cd490e548323b83abdde6a2a316c