### PR TITLE
refactor: mark immutable model classes readonly

### DIFF
--- a/src/Model/Exif/ExifDocument.php
+++ b/src/Model/Exif/ExifDocument.php
@@ -17,7 +17,7 @@ use DateTimeZone;
 /**
  * Represents a parsed EXIF payload and exposes convenience accessors.
  */
-final class ExifDocument
+final readonly class ExifDocument
 {
     /**
      * @param Ifd      $ifd0       Root IFD of the TIFF structure.

--- a/src/Model/Exif/ExifTag.php
+++ b/src/Model/Exif/ExifTag.php
@@ -14,7 +14,7 @@ namespace MagicSunday\ImageMeta\Model\Exif;
 /**
  * Centralised list of EXIF tag identifiers used throughout the library.
  */
-final class ExifTag
+final readonly class ExifTag
 {
     // Image file directory (IFD0)
     public const int MAKE        = 0x010F;

--- a/src/Model/Exif/Ifd.php
+++ b/src/Model/Exif/Ifd.php
@@ -14,7 +14,7 @@ namespace MagicSunday\ImageMeta\Model\Exif;
 /**
  * Represents an image file directory (IFD) containing EXIF entries.
  */
-final class Ifd
+final readonly class Ifd
 {
     /**
      * @param array<int, IfdEntry> $entries       Map of tag identifiers to entries.

--- a/src/Model/Exif/IfdEntry.php
+++ b/src/Model/Exif/IfdEntry.php
@@ -14,7 +14,7 @@ namespace MagicSunday\ImageMeta\Model\Exif;
 /**
  * Represents a single entry within an image file directory (IFD).
  */
-final class IfdEntry
+final readonly class IfdEntry
 {
     /**
      * @param int   $tag   The numeric identifier of the entry.

--- a/src/Model/Exif/ValueConverters.php
+++ b/src/Model/Exif/ValueConverters.php
@@ -14,7 +14,7 @@ namespace MagicSunday\ImageMeta\Model\Exif;
 /**
  * Helper methods that translate EXIF/TIFF values into PHP friendly scalars.
  */
-final class ValueConverters
+final readonly class ValueConverters
 {
     /**
      * Converts a TIFF RATIONAL or scalar value into a floating point value.

--- a/src/Model/Metadata.php
+++ b/src/Model/Metadata.php
@@ -17,7 +17,7 @@ use MagicSunday\ImageMeta\Model\Xmp\XmpDocument;
 /**
  * Aggregates extracted metadata blobs alongside parsed representations.
  */
-final class Metadata
+final readonly class Metadata
 {
     /**
      * @param list<string>       $exifBlobs TIFF‑EXIF blobs (first is primary)

--- a/src/Model/QuickTimeMeta.php
+++ b/src/Model/QuickTimeMeta.php
@@ -14,7 +14,7 @@ namespace MagicSunday\ImageMeta\Model;
 /**
  * Holds QuickTime metadata keys that are extracted from QuickTime containers.
  */
-final class QuickTimeMeta
+final readonly class QuickTimeMeta
 {
     /**
      * Creates a new instance of QuickTime metadata information.

--- a/src/Model/Xmp/XmpDocument.php
+++ b/src/Model/Xmp/XmpDocument.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
 
 namespace MagicSunday\ImageMeta\Model\Xmp;
 
-final class XmpDocument
+final readonly class XmpDocument
 {
     /**
      * @param array<string, string|array<int, string>> $data Map of Clark notation => value


### PR DESCRIPTION
## Summary
- mark metadata model value objects as readonly classes to lock down their state
- keep constructor-promoted readonly properties for EXIF, XMP, and QuickTime models immutable at the class level

## Testing
- composer ci:test:php:unit
- composer ci:test:php:phpstan *(fails: existing baseline issues reported in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68f9d065660c83239ba2f398bf0c0a4a