### PR TITLE
docs: expand phpdoc coverage for xmp utilities

### DIFF
--- a/src/Model/Xmp/XmpDocument.php
+++ b/src/Model/Xmp/XmpDocument.php
@@ -11,6 +11,9 @@ declare(strict_types=1);
 
 namespace MagicSunday\ImageMeta\Model\Xmp;
 
+/**
+ * Immutable representation of an extracted XMP document keyed by Clark notation.
+ */
 final readonly class XmpDocument
 {
     /**
@@ -47,6 +50,14 @@ final readonly class XmpDocument
         );
     }
 
+    /**
+     * Builds a Clark notation key for the given namespace/local name pair.
+     *
+     * @param string $namespaceUri Namespace URI that qualifies the property.
+     * @param string $localName    Local property name as declared in the document.
+     *
+     * @return string Fully-qualified Clark notation value.
+     */
     private function buildClarkName(string $namespaceUri, string $localName): string
     {
         return $namespaceUri !== ''
@@ -54,6 +65,14 @@ final readonly class XmpDocument
             : $localName;
     }
 
+    /**
+     * Checks whether the provided Clark notation belongs to the given local name.
+     *
+     * @param string $clark     Property key expressed in Clark notation.
+     * @param string $localName Local property name to compare against.
+     *
+     * @return bool True when the local name part of the key matches the provided name.
+     */
     private function matchesLocalName(string $clark, string $localName): bool
     {
         if ($clark === $localName) {

--- a/src/Parse/IsoBmff/IsoBmffExtractor.php
+++ b/src/Parse/IsoBmff/IsoBmffExtractor.php
@@ -24,6 +24,11 @@ final class IsoBmffExtractor
 {
     private const XMP_UUID = "\xBE\x7A\xCF\xCB\x97\xA9\x42\xE8\x9C\x71\x99\x94\x91\xE3\xAF\xAC";
 
+    /**
+     * Initialises the extractor with the source stream that contains the ISO BMFF structure.
+     *
+     * @param Stream $stream Stream positioned at the beginning of the media file to parse.
+     */
     public function __construct(private readonly Stream $stream)
     {
     }

--- a/src/Parse/Xmp/XmpParser.php
+++ b/src/Parse/Xmp/XmpParser.php
@@ -87,12 +87,29 @@ final class XmpParser
         return new XmpDocument($properties);
     }
 
+    /**
+     * Determines whether the current element should be captured as a scalar string property.
+     *
+     * @param string $namespace Namespace URI associated with the element.
+     * @param string $localName Local element name as read from the stream.
+     *
+     * @return bool True when the element maps to a scalar value in the resulting document.
+     */
     private function isStringProperty(string $namespace, string $localName): bool
     {
         return ($namespace === self::XMP_NAMESPACE && in_array($localName, ['CreateDate', 'ModifyDate'], true))
             || ($namespace === self::EXIF_NAMESPACE && in_array($localName, ['DateTimeOriginal', 'OffsetTimeOriginal'], true));
     }
 
+    /**
+     * Checks whether the current reader position matches the provided qualified name.
+     *
+     * @param XMLReader $reader    XML reader currently positioned on an element.
+     * @param string    $namespace Expected namespace URI.
+     * @param string    $localName Expected local element name.
+     *
+     * @return bool True when the reader points at an element with the provided name.
+     */
     private function matchesElement(XMLReader $reader, string $namespace, string $localName): bool
     {
         return ($reader->namespaceURI ?? '') === $namespace && $reader->localName === $localName;

--- a/src/Parse/Xmp/XmpReader.php
+++ b/src/Parse/Xmp/XmpReader.php
@@ -127,6 +127,14 @@ final class XmpReader
         return $text === '' ? null : $text;
     }
 
+    /**
+     * Combines namespace URI and local name into a Clark notation key.
+     *
+     * @param string $namespaceUri Namespace URI assigned to the element.
+     * @param string $localName    Element name without namespace prefix.
+     *
+     * @return string Clark notation string representing the element.
+     */
     private function buildClarkName(string $namespaceUri, string $localName): string
     {
         return $namespaceUri !== ''


### PR DESCRIPTION
## Summary
- add constructor PHPDoc describing the ISO BMFF stream dependency
- document the XMP document model and helper methods
- add PHPDoc coverage for XMP reader and parser helpers

## Testing
- composer ci:test:php:cgl *(fails: existing style violations in Registry.php and ExifConvenienceTest.php)*

------
https://chatgpt.com/codex/tasks/task_e_68f9d1448b348323bcfe5cb21066f2d4