### PR TITLE
Add scalar type declarations to parser constants

### DIFF
--- a/src/Parse/IsoBmff/IsoBmffExtractor.php
+++ b/src/Parse/IsoBmff/IsoBmffExtractor.php
@@ -22,7 +22,7 @@ use MagicSunday\ImageMeta\Model\QuickTimeMeta;
  */
 final class IsoBmffExtractor
 {
-    private const XMP_UUID = "\xBE\x7A\xCF\xCB\x97\xA9\x42\xE8\x9C\x71\x99\x94\x91\xE3\xAF\xAC";
+    private const string XMP_UUID = "\xBE\x7A\xCF\xCB\x97\xA9\x42\xE8\x9C\x71\x99\x94\x91\xE3\xAF\xAC";
 
     /**
      * Initialises the extractor with the source stream that contains the ISO BMFF structure.

--- a/src/Parse/Jpeg/JpegExtractor.php
+++ b/src/Parse/Jpeg/JpegExtractor.php
@@ -20,13 +20,13 @@ use MagicSunday\ImageMeta\Core\Stream;
  */
 final class JpegExtractor
 {
-    private const MAX_APP_SEGMENT_SIZE = 4_194_304; // 4 MiB payload limit
-    private const EXIF_SIGNATURE       = "Exif\0\0";
-    private const XMP_SIGNATURE        = "http://ns.adobe.com/xap/1.0/\0";
-    private const ICC_SIGNATURE        = "ICC_PROFILE\0";
-    private const IPTC_SIGNATURE       = "Photoshop 3.0\0";
-    private const MARKER_SOS           = 0xDA;
-    private const MARKER_EOI           = 0xD9;
+    private const int MAX_APP_SEGMENT_SIZE = 4_194_304; // 4 MiB payload limit
+    private const string EXIF_SIGNATURE    = "Exif\0\0";
+    private const string XMP_SIGNATURE     = "http://ns.adobe.com/xap/1.0/\0";
+    private const string ICC_SIGNATURE     = "ICC_PROFILE\0";
+    private const string IPTC_SIGNATURE    = "Photoshop 3.0\0";
+    private const int MARKER_SOS           = 0xDA;
+    private const int MARKER_EOI           = 0xD9;
 
     private bool $parsed = false;
     /** @var list<string> */

--- a/src/Parse/Xmp/XmpParser.php
+++ b/src/Parse/Xmp/XmpParser.php
@@ -21,10 +21,10 @@ use XMLReader;
  */
 final class XmpParser
 {
-    private const RDF_NAMESPACE  = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#';
-    private const DC_NAMESPACE   = 'http://purl.org/dc/elements/1.1/';
-    private const XMP_NAMESPACE  = 'http://ns.adobe.com/xap/1.0/';
-    private const EXIF_NAMESPACE = 'http://ns.adobe.com/exif/1.0/';
+    private const string RDF_NAMESPACE  = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#';
+    private const string DC_NAMESPACE   = 'http://purl.org/dc/elements/1.1/';
+    private const string XMP_NAMESPACE  = 'http://ns.adobe.com/xap/1.0/';
+    private const string EXIF_NAMESPACE = 'http://ns.adobe.com/exif/1.0/';
 
     /**
      * Parses the provided XMP payload into a document object.

--- a/src/Parse/Xmp/XmpReader.php
+++ b/src/Parse/Xmp/XmpReader.php
@@ -19,7 +19,7 @@ use XMLReader;
  */
 final class XmpReader
 {
-    private const RDF_NAMESPACE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#';
+    private const string RDF_NAMESPACE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#';
 
     /**
      * Parses an XMP packet and returns a document containing discovered properties.


### PR DESCRIPTION
## Summary
- add string typing to the ISO BMFF XMP UUID constant
- annotate JPEG extractor constants with explicit int and string types
- add string type declarations to XMP parser and reader namespaces

## Testing
- composer ci:test:php:unit
- composer ci:test:php:unit:coverage *(fails: No code coverage driver available in container)*
- composer ci:test:php:phpstan *(fails: existing baseline violations reported in repository)*
- composer ci:cgl

------
https://chatgpt.com/codex/tasks/task_e_68f9d33171f083238836d302f32324ea