### PR TITLE
fix: import global helper functions

### DIFF
--- a/src/Core/Stream.php
+++ b/src/Core/Stream.php
@@ -11,6 +11,14 @@ declare(strict_types=1);
 
 namespace MagicSunday\ImageMeta\Core;
 
+use function fopen;
+use function fread;
+use function fseek;
+use function fstat;
+use function ord;
+use function strlen;
+use function unpack;
+
 /**
  * Provides a bounds-checked streaming reader over a binary resource handle.
  */

--- a/src/Parse/IsoBmff/IsoBmffExtractor.php
+++ b/src/Parse/IsoBmff/IsoBmffExtractor.php
@@ -16,6 +16,19 @@ use MagicSunday\ImageMeta\Core\Stream;
 use MagicSunday\ImageMeta\Core\StreamWindow;
 use MagicSunday\ImageMeta\Model\QuickTimeMeta;
 
+use function array_merge;
+use function array_unique;
+use function array_unshift;
+use function array_values;
+use function explode;
+use function preg_match;
+use function str_starts_with;
+use function strcasecmp;
+use function strlen;
+use function strtolower;
+use function substr;
+use function unpack;
+
 /**
  * Streaming ISOBMFF reader for HEIC/AVIF/MP4/MOV.
  * Extracts EXIF/XMP payloads and QuickTime metadata.

--- a/src/Parse/Jpeg/JpegExtractor.php
+++ b/src/Parse/Jpeg/JpegExtractor.php
@@ -15,6 +15,19 @@ use MagicSunday\ImageMeta\Core\BoundsError;
 use MagicSunday\ImageMeta\Core\ParseError;
 use MagicSunday\ImageMeta\Core\Stream;
 
+use function array_key_exists;
+use function array_keys;
+use function count;
+use function implode;
+use function ksort;
+use function ord;
+use function range;
+use function sort;
+use function sprintf;
+use function str_starts_with;
+use function strlen;
+use function substr;
+
 /**
  * Parses JPEG streams to extract metadata-bearing APP segments.
  */

--- a/src/Parse/Xmp/XmpReader.php
+++ b/src/Parse/Xmp/XmpReader.php
@@ -14,6 +14,12 @@ namespace MagicSunday\ImageMeta\Parse\Xmp;
 use MagicSunday\ImageMeta\Model\Xmp\XmpDocument;
 use XMLReader;
 
+use function array_filter;
+use function array_key_exists;
+use function array_values;
+use function sprintf;
+use function trim;
+
 /**
  * Performs a lightweight XMP RDF/XML pass using \XMLReader to capture simple properties.
  */


### PR DESCRIPTION
## Summary
- import PHP built-in helper functions used by the core Stream implementation
- qualify global helper usage in the JPEG, ISO BMFF, and XMP parsing components

## Testing
- composer ci:test:php:unit
- composer ci:test:php:unit:coverage *(fails: No code coverage driver available in the environment)*
- composer ci:test:php:phpstan *(fails: pre-existing analysis findings outside the change scope)*
- composer ci:cgl

------
https://chatgpt.com/codex/tasks/task_e_68f9d31e3f1c8323ba71ab5912dbae4f