### PR TITLE
style: qualify global helper calls

### DIFF
--- a/src/Convenience/ExifConvenience.php
+++ b/src/Convenience/ExifConvenience.php
@@ -17,6 +17,9 @@ use MagicSunday\ImageMeta\Model\Exif\ExifTag;
 use MagicSunday\ImageMeta\Model\Exif\IfdEntry;
 use Throwable;
 
+use function is_string;
+use function strlen;
+
 /**
  * Helper routines that extract frequently-used EXIF values in a safe manner.
  */

--- a/src/Core/MemoryBuffer.php
+++ b/src/Core/MemoryBuffer.php
@@ -11,6 +11,11 @@ declare(strict_types=1);
 
 namespace MagicSunday\ImageMeta\Core;
 
+use function ord;
+use function strlen;
+use function substr;
+use function unpack;
+
 /**
  * Provides a simple, bounds-checked in-memory buffer abstraction.
  *

--- a/src/Core/StreamWindow.php
+++ b/src/Core/StreamWindow.php
@@ -11,6 +11,9 @@ declare(strict_types=1);
 
 namespace MagicSunday\ImageMeta\Core;
 
+use function ord;
+use function unpack;
+
 /**
  * Represents a bounded view into a parent stream with an independent cursor.
  */

--- a/src/MakerNotes/AppleDecoder.php
+++ b/src/MakerNotes/AppleDecoder.php
@@ -11,6 +11,9 @@ declare(strict_types=1);
 
 namespace MagicSunday\ImageMeta\MakerNotes;
 
+use function sha1;
+use function strlen;
+
 /**
  * Decoder that returns basic metadata about the raw maker notes produced by Apple devices.
  */

--- a/src/MakerNotes/Registry.php
+++ b/src/MakerNotes/Registry.php
@@ -11,6 +11,10 @@ declare(strict_types=1);
 
 namespace MagicSunday\ImageMeta\MakerNotes;
 
+use function array_find;
+use function str_starts_with;
+use function strtolower;
+
 /**
  * Registry that stores maker note decoders by vendor prefixes and allows lookups.
  */
@@ -40,6 +44,7 @@ final class Registry
     public function find(string $make): ?MakerNotesDecoderInterface
     {
         $make = strtolower($make);
+
         return array_find(
             $this->decoders,
             fn (MakerNotesDecoderInterface $decoder, int|string $prefix): bool => $prefix !== ''

--- a/src/Model/Exif/ExifDocument.php
+++ b/src/Model/Exif/ExifDocument.php
@@ -14,6 +14,11 @@ namespace MagicSunday\ImageMeta\Model\Exif;
 use DateTimeImmutable;
 use DateTimeZone;
 
+use function is_string;
+use function rtrim;
+use function str_replace;
+use function substr;
+
 /**
  * Represents a parsed EXIF payload and exposes convenience accessors.
  */

--- a/src/Model/Xmp/XmpDocument.php
+++ b/src/Model/Xmp/XmpDocument.php
@@ -11,6 +11,13 @@ declare(strict_types=1);
 
 namespace MagicSunday\ImageMeta\Model\Xmp;
 
+use function array_find;
+use function is_array;
+use function is_string;
+use function sprintf;
+use function strpos;
+use function substr;
+
 /**
  * Immutable representation of an extracted XMP document keyed by Clark notation.
  */

--- a/src/Parse/Tiff/TiffExifReader.php
+++ b/src/Parse/Tiff/TiffExifReader.php
@@ -19,6 +19,13 @@ use MagicSunday\ImageMeta\Model\Exif\ExifTag;
 use MagicSunday\ImageMeta\Model\Exif\Ifd;
 use MagicSunday\ImageMeta\Model\Exif\IfdEntry;
 
+use function chr;
+use function ord;
+use function pack;
+use function rtrim;
+use function substr;
+use function unpack;
+
 /**
  * Parses classic TIFF and BigTIFF structures embedded in EXIF payloads.
  */

--- a/tests/Convenience/ExifConvenienceTest.php
+++ b/tests/Convenience/ExifConvenienceTest.php
@@ -68,7 +68,7 @@ final class ExifConvenienceTest extends TestCase
             ExifTag::OFFSET_TIME_ORIGINAL => new IfdEntry(ExifTag::OFFSET_TIME_ORIGINAL, 2, 1, '+02:00'),
         ]);
 
-        $doc     = new ExifDocument($ifd0, $exifIfd, null, null, null);
+        $doc      = new ExifDocument($ifd0, $exifIfd, null, null, null);
         $captured = ExifConvenience::captureDateTime($doc);
 
         self::assertNotNull($captured);


### PR DESCRIPTION
## Summary
- import frequently used global helpers via `use function` across core, model, and maker-note components
- keep stream and buffer utilities consistent with leading namespace-qualified function usage
- align tests with cs fixer formatting expectations

## Testing
- composer ci:cgl
- composer ci:test:php:phpstan *(fails: existing 193 errors in baseline)*
- composer ci:test:php:unit

------
https://chatgpt.com/codex/tasks/task_e_68f9d47ff8f88323b5cde7df9c34bf17