### PR TITLE
style: document parser signature constants

### DIFF
--- a/src/MakerNotes/Registry.php
+++ b/src/MakerNotes/Registry.php
@@ -40,6 +40,7 @@ final class Registry
     public function find(string $make): ?MakerNotesDecoderInterface
     {
         $make = strtolower($make);
+
         return array_find(
             $this->decoders,
             fn (MakerNotesDecoderInterface $decoder, int|string $prefix): bool => $prefix !== ''

--- a/src/Parse/IsoBmff/IsoBmffExtractor.php
+++ b/src/Parse/IsoBmff/IsoBmffExtractor.php
@@ -35,6 +35,9 @@ use function unpack;
  */
 final class IsoBmffExtractor
 {
+    /**
+     * UUID identifying XMP payload boxes within ISO BMFF containers.
+     */
     private const string XMP_UUID = "\xBE\x7A\xCF\xCB\x97\xA9\x42\xE8\x9C\x71\x99\x94\x91\xE3\xAF\xAC";
 
     /**

--- a/src/Parse/Jpeg/JpegExtractor.php
+++ b/src/Parse/Jpeg/JpegExtractor.php
@@ -34,12 +34,20 @@ use function substr;
 final class JpegExtractor
 {
     private const int MAX_APP_SEGMENT_SIZE = 4_194_304; // 4 MiB payload limit
-    private const string EXIF_SIGNATURE    = "Exif\0\0";
-    private const string XMP_SIGNATURE     = "http://ns.adobe.com/xap/1.0/\0";
-    private const string ICC_SIGNATURE     = "ICC_PROFILE\0";
-    private const string IPTC_SIGNATURE    = "Photoshop 3.0\0";
-    private const int MARKER_SOS           = 0xDA;
-    private const int MARKER_EOI           = 0xD9;
+
+    /**
+     * Signatures identifying metadata-bearing APP segments.
+     */
+    private const string EXIF_SIGNATURE = "Exif\0\0";
+    private const string XMP_SIGNATURE  = "http://ns.adobe.com/xap/1.0/\0";
+    private const string ICC_SIGNATURE  = "ICC_PROFILE\0";
+    private const string IPTC_SIGNATURE = "Photoshop 3.0\0";
+
+    /**
+     * Scan and termination markers that end metadata scanning.
+     */
+    private const int MARKER_SOS = 0xDA;
+    private const int MARKER_EOI = 0xD9;
 
     private bool $parsed = false;
     /** @var list<string> */

--- a/tests/Convenience/ExifConvenienceTest.php
+++ b/tests/Convenience/ExifConvenienceTest.php
@@ -68,7 +68,7 @@ final class ExifConvenienceTest extends TestCase
             ExifTag::OFFSET_TIME_ORIGINAL => new IfdEntry(ExifTag::OFFSET_TIME_ORIGINAL, 2, 1, '+02:00'),
         ]);
 
-        $doc     = new ExifDocument($ifd0, $exifIfd, null, null, null);
+        $doc      = new ExifDocument($ifd0, $exifIfd, null, null, null);
         $captured = ExifConvenience::captureDateTime($doc);
 
         self::assertNotNull($captured);


### PR DESCRIPTION
## Summary
- add inline documentation for the JPEG APP metadata signatures and marker constants
- describe the ISO BMFF XMP UUID constant for clarity
- apply php-cs-fixer adjustments from `composer ci:cgl`

## Testing
- `composer ci:test:php:phpstan` *(fails: existing baseline issues reported by PHPStan)*
- `composer ci:test:php:unit`


------
https://chatgpt.com/codex/tasks/task_e_68f9d47f1d7c83238c117e30c0b41150