### PR TITLE
Move ISO BMFF extractor test into Parse suite

### DIFF
--- a/tests/Parse/IsoBmff/IsoBmffExtractorTest.php
+++ b/tests/Parse/IsoBmff/IsoBmffExtractorTest.php
@@ -9,7 +9,7 @@
 
 declare(strict_types=1);
 
-namespace MagicSunday\ImageMeta\Tests\IsoBmff;
+namespace MagicSunday\ImageMeta\Tests\Parse\IsoBmff;
 
 use MagicSunday\ImageMeta\Core\ParseError;
 use MagicSunday\ImageMeta\Core\Stream;


### PR DESCRIPTION
## Summary
- relocate the ISO BMFF extractor PHPUnit suite beneath tests/Parse
- update the test namespace to reflect the new directory structure

## Testing
- ❌ `composer ci:test:php:unit` *(fails: existing MemoryBufferTest expectation unmet)*
- ❌ `composer ci:test:php:unit:coverage` *(fails: no code coverage driver available)*
- ❌ `composer ci:test:php:phpstan` *(fails: pre-existing PHPStan violations across the codebase)*
- ✅ `composer ci:cgl`


------
https://chatgpt.com/codex/tasks/task_e_68f9dbdb650883238d930954aec3aa67