### PR TITLE
Mark IsoBmffExtractor as readonly

### DIFF
--- a/src/Parse/IsoBmff/IsoBmffExtractor.php
+++ b/src/Parse/IsoBmff/IsoBmffExtractor.php
@@ -33,7 +33,7 @@ use function unpack;
  * Streaming ISOBMFF reader for HEIC/AVIF/MP4/MOV.
  * Extracts EXIF/XMP payloads and QuickTime metadata.
  */
-final class IsoBmffExtractor
+final readonly class IsoBmffExtractor
 {
     /**
      * UUID identifying XMP payload boxes within ISO BMFF containers.


### PR DESCRIPTION
## Summary
- declare `IsoBmffExtractor` as a `final readonly` class to reflect its immutable design

## Testing
- `composer ci:test:php:unit` *(fails: MemoryBuffer short-read expectation not met, existing failure)*
- `composer ci:test:php:unit:coverage` *(fails: No code coverage driver available in environment)*
- `composer ci:test:php:phpstan` *(fails: pre-existing static analysis violations)*
- `composer ci:cgl`

------
https://chatgpt.com/codex/tasks/task_e_68f9dbcc45008323bd772df640d744b1