### PR TITLE
Document stream test scenarios

### DIFF
--- a/src/Core/MemoryBuffer.php
+++ b/src/Core/MemoryBuffer.php
@@ -13,7 +13,6 @@ namespace MagicSunday\ImageMeta\Core;
 
 use function ord;
 use function strlen;
-use function substr;
 use function unpack;
 
 /**

--- a/tests/Core/Stream/StreamTest.php
+++ b/tests/Core/Stream/StreamTest.php
@@ -16,11 +16,20 @@ use MagicSunday\ImageMeta\Core\Stream;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
+use function fopen;
+use function fwrite;
+use function pack;
+use function rewind;
+use function strlen;
+
 /**
  * Unit tests verifying the behaviour of the bounds-checked stream wrapper.
  */
 final class StreamTest extends TestCase
 {
+    /**
+     * Ensures sequential big-endian integer reads advance the cursor as expected.
+     */
     #[Test]
     public function testReadsUnsignedIntegersSequentially(): void
     {
@@ -43,6 +52,9 @@ final class StreamTest extends TestCase
         self::assertSame(14, $stream->tell());
     }
 
+    /**
+     * Verifies chunked reads return the requested bytes and update the position.
+     */
     #[Test]
     public function testReadReturnsRequestedBytesAndAdvancesCursor(): void
     {
@@ -64,6 +76,9 @@ final class StreamTest extends TestCase
         self::assertSame(11, $stream->tell());
     }
 
+    /**
+     * Checks that requesting bytes past the end raises a BoundsError exception.
+     */
     #[Test]
     public function testReadThrowsBoundsErrorWhenRequestCrossesEnd(): void
     {
@@ -81,6 +96,9 @@ final class StreamTest extends TestCase
         $stream->read(1);
     }
 
+    /**
+     * Asserts seeking beyond the declared length triggers a BoundsError exception.
+     */
     #[Test]
     public function testSeekThrowsBoundsErrorWhenOffsetIsOutsideStream(): void
     {

--- a/tests/Parse/Tiff/TiffExifReaderTest.php
+++ b/tests/Parse/Tiff/TiffExifReaderTest.php
@@ -268,10 +268,10 @@ final class TiffExifReaderTest extends TestCase
     /**
      * Packs a Classic TIFF directory entry.
      *
-     * @param int $tag            TIFF tag identifier.
-     * @param int $type           TIFF field type code.
-     * @param int $count          Number of values represented.
-     * @param int $valueOrOffset  Inline value or data offset.
+     * @param int $tag           TIFF tag identifier.
+     * @param int $type          TIFF field type code.
+     * @param int $count         Number of values represented.
+     * @param int $valueOrOffset Inline value or data offset.
      */
     private static function packClassicEntry(int $tag, int $type, int $count, int $valueOrOffset): string
     {
@@ -284,10 +284,10 @@ final class TiffExifReaderTest extends TestCase
     /**
      * Packs a BigTIFF directory entry in little-endian order.
      *
-     * @param int $tag            TIFF tag identifier.
-     * @param int $type           TIFF field type code.
-     * @param int $count          Number of values represented.
-     * @param int $valueOrOffset  Inline value or data offset.
+     * @param int $tag           TIFF tag identifier.
+     * @param int $type          TIFF field type code.
+     * @param int $count         Number of values represented.
+     * @param int $valueOrOffset Inline value or data offset.
      */
     private static function packBigTiffEntry(int $tag, int $type, int $count, int $valueOrOffset): string
     {


### PR DESCRIPTION
## Summary
- document each stream test scenario with dedicated PHPDoc blocks and import the global helpers they rely on
- allow the MemoryBuffer short-read test hook to intercept substr by relying on the namespaced resolution
- normalize TIFF helper PHPDoc alignment per php-cs-fixer

## Testing
- composer ci:cgl
- composer ci:test:php:unit
- composer ci:test:php:unit:coverage *(fails: No code coverage driver available)*
- composer ci:test:php:phpstan *(fails: existing phpstan findings)*

------
https://chatgpt.com/codex/tasks/task_e_68f9dbe472548323b1c7853eb7f4c09d