### PR TITLE
Add StreamWindow tests and adjust MemoryBuffer import

### DIFF
--- a/src/Core/MemoryBuffer.php
+++ b/src/Core/MemoryBuffer.php
@@ -13,7 +13,6 @@ namespace MagicSunday\ImageMeta\Core;
 
 use function ord;
 use function strlen;
-use function substr;
 use function unpack;
 
 /**

--- a/tests/Core/StreamWindow/StreamWindowTest.php
+++ b/tests/Core/StreamWindow/StreamWindowTest.php
@@ -1,0 +1,123 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\ImageMeta\Tests\Core\StreamWindow;
+
+use MagicSunday\ImageMeta\Core\BoundsError;
+use MagicSunday\ImageMeta\Core\Stream;
+use MagicSunday\ImageMeta\Core\StreamWindow;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+use function fopen;
+use function fwrite;
+use function pack;
+use function rewind;
+use function strlen;
+
+/**
+ * Unit tests covering the stream window cursor, bounds checks, and integer helpers.
+ */
+final class StreamWindowTest extends TestCase
+{
+    #[Test]
+    public function testSizeReportsConfiguredLengthAndCursorStartsAtZero(): void
+    {
+        $window = new StreamWindow($this->createStream('0123456789'), 2, 5);
+
+        self::assertSame(5, $window->size());
+        self::assertSame(0, $window->tell());
+    }
+
+    #[Test]
+    public function testSeekMovesCursorWithinWindowBounds(): void
+    {
+        $window = new StreamWindow($this->createStream('abcdefghij'), 1, 6);
+
+        $window->seek(3);
+        self::assertSame(3, $window->tell());
+
+        $window->seek(6);
+        self::assertSame(6, $window->tell());
+    }
+
+    #[Test]
+    public function testSeekThrowsBoundsErrorOutsideWindow(): void
+    {
+        $window = new StreamWindow($this->createStream('abcdefghij'), 0, 4);
+
+        $this->expectException(BoundsError::class);
+        $window->seek(5);
+    }
+
+    #[Test]
+    public function testReadReturnsRequestedBytesAndAdvancesCursor(): void
+    {
+        $window = new StreamWindow($this->createStream('MagicSunday'), 5, 6);
+
+        self::assertSame('Sunday', $window->read(6));
+        self::assertSame(6, $window->tell());
+    }
+
+    #[Test]
+    public function testReadThrowsBoundsErrorWhenRequestCrossesEnd(): void
+    {
+        $window = new StreamWindow($this->createStream('Meta'), 1, 2);
+
+        $this->expectException(BoundsError::class);
+        $window->read(3);
+    }
+
+    #[Test]
+    public function testUnsignedIntegerHelpersReadSequentially(): void
+    {
+        $payload = pack('C', 0xAA)
+            . pack('n', 0xBEEF)
+            . pack('N', 0x01020304)
+            . pack('N2', 0x01234567, 0x89ABCDEF);
+
+        $window = new StreamWindow($this->createStream($payload), 0, strlen($payload));
+
+        self::assertSame(0xAA, $window->readU8());
+        self::assertSame(0xBEEF, $window->readU16BE());
+        self::assertSame(0x01020304, $window->readU32BE());
+        self::assertSame(0x0123456789ABCDEF, $window->readU64BE());
+        self::assertSame(strlen($payload), $window->tell());
+    }
+
+    #[Test]
+    public function testUnsignedIntegerHelpersThrowBoundsErrorOnShortData(): void
+    {
+        $payload = pack('C', 0x01) . pack('n', 0x0203);
+        $window  = new StreamWindow($this->createStream($payload), 0, strlen($payload));
+
+        $window->readU8();
+
+        $this->expectException(BoundsError::class);
+        $window->readU64BE();
+    }
+
+    /**
+     * Creates a Stream instance populated with the provided payload.
+     *
+     * @param string $payload Bytes to insert into the temporary stream.
+     *
+     * @return Stream
+     */
+    private function createStream(string $payload): Stream
+    {
+        $handle = fopen('php://temp', 'r+b');
+        fwrite($handle, $payload);
+        rewind($handle);
+
+        return new Stream($handle, strlen($payload));
+    }
+}

--- a/tests/Parse/Tiff/TiffExifReaderTest.php
+++ b/tests/Parse/Tiff/TiffExifReaderTest.php
@@ -268,10 +268,10 @@ final class TiffExifReaderTest extends TestCase
     /**
      * Packs a Classic TIFF directory entry.
      *
-     * @param int $tag            TIFF tag identifier.
-     * @param int $type           TIFF field type code.
-     * @param int $count          Number of values represented.
-     * @param int $valueOrOffset  Inline value or data offset.
+     * @param int $tag           TIFF tag identifier.
+     * @param int $type          TIFF field type code.
+     * @param int $count         Number of values represented.
+     * @param int $valueOrOffset Inline value or data offset.
      */
     private static function packClassicEntry(int $tag, int $type, int $count, int $valueOrOffset): string
     {
@@ -284,10 +284,10 @@ final class TiffExifReaderTest extends TestCase
     /**
      * Packs a BigTIFF directory entry in little-endian order.
      *
-     * @param int $tag            TIFF tag identifier.
-     * @param int $type           TIFF field type code.
-     * @param int $count          Number of values represented.
-     * @param int $valueOrOffset  Inline value or data offset.
+     * @param int $tag           TIFF tag identifier.
+     * @param int $type          TIFF field type code.
+     * @param int $count         Number of values represented.
+     * @param int $valueOrOffset Inline value or data offset.
      */
     private static function packBigTiffEntry(int $tag, int $type, int $count, int $valueOrOffset): string
     {


### PR DESCRIPTION
## Summary
- add PHPUnit coverage for the StreamWindow cursor, bounds, and unsigned integer helpers
- drop the explicit substr import in MemoryBuffer so the test hook for short reads can operate
- realign existing TIFF helper PHPDoc parameters after running the coding standards fixer

## Testing
- composer ci:test:php:unit
- composer ci:test:php:unit:coverage *(fails: No code coverage driver available)*
- composer ci:test:php:phpstan *(fails: existing baseline errors)*
- composer ci:cgl

------
https://chatgpt.com/codex/tasks/task_e_68f9dbe628e0832397f862eaed348396