### PR TITLE
refactor: replace JPEG APP marker magic numbers

### DIFF
--- a/src/Parse/Jpeg/JpegExtractor.php
+++ b/src/Parse/Jpeg/JpegExtractor.php
@@ -36,6 +36,16 @@ final class JpegExtractor
     private const int MAX_APP_SEGMENT_SIZE = 4_194_304; // 4 MiB payload limit
 
     /**
+     * APP marker codes carrying metadata of interest.
+     *
+     * APP1  (0xE1) exposes EXIF and XMP metadata, APP2 (0xE2) carries ICC
+     * profile fragments, and APP13 (0xED) contains IPTC/Photoshop resources.
+     */
+    private const int MARKER_APP1  = 0xE1;
+    private const int MARKER_APP2  = 0xE2;
+    private const int MARKER_APP13 = 0xED;
+
+    /**
      * Signatures identifying metadata-bearing APP segments.
      */
     private const string EXIF_SIGNATURE = "Exif\0\0";
@@ -174,11 +184,11 @@ final class JpegExtractor
             $payloadLength = $segmentLength - 2;
             $payload       = $this->readSegmentPayload($marker, $offset, $payloadLength);
 
-            if ($marker === 0xE1) {
+            if ($marker === self::MARKER_APP1) {
                 $this->handleApp1($payload);
-            } elseif ($marker === 0xE2) {
+            } elseif ($marker === self::MARKER_APP2) {
                 $this->handleApp2($payload, $offset);
-            } elseif ($marker === 0xED) {
+            } elseif ($marker === self::MARKER_APP13) {
                 $this->handleApp13($payload);
             }
         }

--- a/tests/Jpeg/JpegExtractorTest.php
+++ b/tests/Jpeg/JpegExtractorTest.php
@@ -30,6 +30,10 @@ final class JpegExtractorTest extends TestCase
     private const ICC_SIGNATURE  = "ICC_PROFILE\0";
     private const IPTC_SIGNATURE = "Photoshop 3.0\0";
 
+    private const int MARKER_APP1  = 0xE1;
+    private const int MARKER_APP2  = 0xE2;
+    private const int MARKER_APP13 = 0xED;
+
     /**
      * Verifies APP1 segments yield EXIF and XMP payloads regardless of ordering.
      *
@@ -59,21 +63,21 @@ final class JpegExtractorTest extends TestCase
         $xmpXml      = '<x:xmpmeta xmlns:x="adobe:ns:meta/">One</x:xmpmeta>';
 
         yield 'only-exif' => [
-            [self::segment(0xE1, self::EXIF_SIGNATURE . $exifPayload)],
+            [self::segment(self::MARKER_APP1, self::EXIF_SIGNATURE . $exifPayload)],
             [$exifPayload],
             [],
         ];
 
         yield 'only-xmp' => [
-            [self::segment(0xE1, self::XMP_SIGNATURE . $xmpXml)],
+            [self::segment(self::MARKER_APP1, self::XMP_SIGNATURE . $xmpXml)],
             [],
             [$xmpXml],
         ];
 
         yield 'xmp-before-exif' => [
             [
-                self::segment(0xE1, self::XMP_SIGNATURE . $xmpXml),
-                self::segment(0xE1, self::EXIF_SIGNATURE . $exifPayload),
+                self::segment(self::MARKER_APP1, self::XMP_SIGNATURE . $xmpXml),
+                self::segment(self::MARKER_APP1, self::EXIF_SIGNATURE . $exifPayload),
             ],
             [$exifPayload],
             [$xmpXml],
@@ -81,8 +85,8 @@ final class JpegExtractorTest extends TestCase
 
         yield 'exif-before-xmp' => [
             [
-                self::segment(0xE1, self::EXIF_SIGNATURE . $exifPayload),
-                self::segment(0xE1, self::XMP_SIGNATURE . $xmpXml),
+                self::segment(self::MARKER_APP1, self::EXIF_SIGNATURE . $exifPayload),
+                self::segment(self::MARKER_APP1, self::XMP_SIGNATURE . $xmpXml),
             ],
             [$exifPayload],
             [$xmpXml],
@@ -100,9 +104,9 @@ final class JpegExtractorTest extends TestCase
         $xmpXml     = '<x:xmpmeta xmlns:x="adobe:ns:meta/">Large</x:xmpmeta>';
 
         $jpeg = self::jpeg(
-            self::segment(0xE1, self::EXIF_SIGNATURE . $firstBlob),
-            self::segment(0xE1, self::EXIF_SIGNATURE . $secondBlob),
-            self::segment(0xE1, self::XMP_SIGNATURE . $xmpXml),
+            self::segment(self::MARKER_APP1, self::EXIF_SIGNATURE . $firstBlob),
+            self::segment(self::MARKER_APP1, self::EXIF_SIGNATURE . $secondBlob),
+            self::segment(self::MARKER_APP1, self::XMP_SIGNATURE . $xmpXml),
         );
 
         $extractor = $this->createExtractor($jpeg);
@@ -123,8 +127,8 @@ final class JpegExtractorTest extends TestCase
         $segment2Payload = self::ICC_SIGNATURE . "\x02\x02" . $iccPart2;
 
         $jpeg = self::jpeg(
-            self::segment(0xE2, $segment1Payload),
-            self::segment(0xE2, $segment2Payload),
+            self::segment(self::MARKER_APP2, $segment1Payload),
+            self::segment(self::MARKER_APP2, $segment2Payload),
         );
 
         $extractor = $this->createExtractor($jpeg);
@@ -143,8 +147,8 @@ final class JpegExtractorTest extends TestCase
         $iptcTwo = self::IPTC_SIGNATURE . 'payload-two';
 
         $jpeg = self::jpeg(
-            self::segment(0xED, $iptcOne),
-            self::segment(0xED, $iptcTwo),
+            self::segment(self::MARKER_APP13, $iptcOne),
+            self::segment(self::MARKER_APP13, $iptcTwo),
         );
 
         $extractor = $this->createExtractor($jpeg);
@@ -195,12 +199,14 @@ final class JpegExtractorTest extends TestCase
         $ignoredExif = 'ignored-after-sos';
 
         $jpeg = "\xFF\xD8"
-            . self::segment(0xE1, self::EXIF_SIGNATURE . $primaryExif)
-            . self::segment(0xE1, self::XMP_SIGNATURE . $xmpXml)
+            . self::segment(self::MARKER_APP1, self::EXIF_SIGNATURE . $primaryExif)
+            . self::segment(self::MARKER_APP1, self::XMP_SIGNATURE . $xmpXml)
             . "\xFF\xDA" . pack('n', 8) . "\x03\x01\x00\x02\x11\x03"
             . "\xFF\x00" . 'A'
             . "\xFF\xD0"
-            . "\xFF\xE1" . pack('n', strlen(self::EXIF_SIGNATURE . $ignoredExif) + 2) . self::EXIF_SIGNATURE . $ignoredExif
+            . "\xFF" . chr(self::MARKER_APP1)
+            . pack('n', strlen(self::EXIF_SIGNATURE . $ignoredExif) + 2)
+            . self::EXIF_SIGNATURE . $ignoredExif
             . "\xFF\xD9";
 
         $extractor = $this->createExtractor($jpeg);

--- a/tests/MetadataReader/MetadataReaderTest.php
+++ b/tests/MetadataReader/MetadataReaderTest.php
@@ -29,6 +29,8 @@ final class MetadataReaderTest extends TestCase
     private const EXIF_SIGNATURE = "Exif\0\0";
     private const XMP_SIGNATURE  = "http://ns.adobe.com/xap/1.0/\0";
 
+    private const int MARKER_APP1 = 0xE1;
+
     /**
      * Ensures JPEG detection extracts EXIF and XMP payloads with parsed documents.
      */
@@ -43,8 +45,8 @@ final class MetadataReaderTest extends TestCase
             . '</x:xmpmeta>';
 
         $jpeg = "\xFF\xD8"
-            . self::segment(0xE1, self::EXIF_SIGNATURE . $tiff)
-            . self::segment(0xE1, self::XMP_SIGNATURE . $xmp)
+            . self::segment(self::MARKER_APP1, self::EXIF_SIGNATURE . $tiff)
+            . self::segment(self::MARKER_APP1, self::XMP_SIGNATURE . $xmp)
             . "\xFF\xD9";
 
         $path = $this->writeTempFile($jpeg);


### PR DESCRIPTION
## Summary
- document the APP marker codes used by the JPEG extractor and reuse them instead of magic numbers
- align JPEG-related test fixtures to reference the same marker constants for clarity

## Testing
- .build/bin/phpunit --configuration .build/phpunit.xml tests/Jpeg/JpegExtractorTest.php

------
https://chatgpt.com/codex/tasks/task_e_68f9de83ea908323a9bd1ff8dc2f364a