### PR TITLE
Add PHPUnit coverage for detectors and metadata helpers

### DIFF
--- a/tests/Detect/FormatDetector/FormatDetectorTest.php
+++ b/tests/Detect/FormatDetector/FormatDetectorTest.php
@@ -11,9 +11,11 @@ declare(strict_types=1);
 
 namespace MagicSunday\ImageMeta\Tests\Detect\FormatDetector;
 
+use MagicSunday\ImageMeta\Core\BoundsError;
 use MagicSunday\ImageMeta\Core\Stream;
 use MagicSunday\ImageMeta\Detect\ContainerType;
 use MagicSunday\ImageMeta\Detect\FormatDetector;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
@@ -31,59 +33,70 @@ use function strlen;
 final class FormatDetectorTest extends TestCase
 {
     /**
-     * Ensures the JPEG magic number at the beginning of the stream is detected.
+     * Ensures known signatures resolve to the expected container types.
+     *
+     * @param string        $payload  Synthetic payload written to an in-memory stream.
+     * @param ContainerType $expected Container type that should be detected for the payload.
      */
     #[Test]
-    public function detectsJpegMagicNumber(): void
+    #[DataProvider('provideSuccessfulSignatures')]
+    public function detectReturnsExpectedContainerType(string $payload, ContainerType $expected): void
     {
-        $payload = "\xFF\xD8\xFF\xE0";
-
-        $fh = fopen('php://temp', 'r+b');
-        fwrite($fh, $payload);
-        rewind($fh);
-
-        $stream = new Stream($fh, strlen($payload));
+        $stream = $this->createStream($payload);
 
         $detected = FormatDetector::detect($stream);
 
-        self::assertSame(ContainerType::JPEG, $detected);
+        self::assertSame($expected, $detected);
     }
 
     /**
-     * Ensures an ISO base media file brand at offset four is detected as ISOBMFF.
+     * Ensures unknown signatures raise the configured runtime exception and truncated payloads fail with bounds errors.
+     *
+     * @param string $payload         Payload that should trigger an exception.
+     * @param class-string<\Throwable> $expectedException Expected exception class.
      */
     #[Test]
-    public function detectsIsoBmffBrand(): void
+    #[DataProvider('provideUnsupportedSignatures')]
+    public function detectThrowsForUnsupportedSignature(string $payload, string $expectedException): void
     {
-        $payload = "\x00\x00\x00\x00ftypisom";
+        $stream = $this->createStream($payload);
 
-        $fh = fopen('php://temp', 'r+b');
-        fwrite($fh, $payload);
-        rewind($fh);
-
-        $stream = new Stream($fh, strlen($payload));
-
-        $detected = FormatDetector::detect($stream);
-
-        self::assertSame(ContainerType::ISOBMFF, $detected);
-    }
-
-    /**
-     * Ensures unsupported signatures raise a runtime exception.
-     */
-    #[Test]
-    public function throwsWhenSignatureIsUnknown(): void
-    {
-        $payload = "\x00\x11\x22\x33bad!";
-
-        $fh = fopen('php://temp', 'r+b');
-        fwrite($fh, $payload);
-        rewind($fh);
-
-        $stream = new Stream($fh, strlen($payload));
-
-        $this->expectException(RuntimeException::class);
+        $this->expectException($expectedException);
 
         FormatDetector::detect($stream);
+    }
+
+    /**
+     * Builds a stream instance backed by php://memory for the provided payload.
+     */
+    private function createStream(string $payload): Stream
+    {
+        $handle = fopen('php://memory', 'r+b');
+        fwrite($handle, $payload);
+        rewind($handle);
+
+        return new Stream($handle, strlen($payload));
+    }
+
+    /**
+     * Provides known container signatures that should result in successful detection.
+     *
+     * @return iterable<string, array{0: string, 1: ContainerType}>
+     */
+    public static function provideSuccessfulSignatures(): iterable
+    {
+        yield 'jpeg' => ["\xFF\xD8\xFF\xE0", ContainerType::JPEG];
+        yield 'iso-base-media brand' => ["\x00\x00\x00\x18ftypisom", ContainerType::ISOBMFF];
+    }
+
+    /**
+     * Provides payloads that should not match any supported signature.
+     *
+     * @return iterable<string, array{0: string, 1: class-string<\Throwable>}>
+     */
+    public static function provideUnsupportedSignatures(): iterable
+    {
+        yield 'unknown bytes' => ["\x00\x11\x22\x33bad!", RuntimeException::class];
+        yield 'truncated stream' => ["\xFF", BoundsError::class];
     }
 }

--- a/tests/MakerNotes/AppleDecoder/AppleDecoderTest.php
+++ b/tests/MakerNotes/AppleDecoder/AppleDecoderTest.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\ImageMeta\Tests\MakerNotes\AppleDecoder;
+
+use MagicSunday\ImageMeta\MakerNotes\AppleDecoder;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Validates the Apple maker notes decoder implementation.
+ *
+ * @covers \MagicSunday\ImageMeta\MakerNotes\AppleDecoder
+ */
+final class AppleDecoderTest extends TestCase
+{
+    /**
+     * Ensures the decoder returns the expected metadata map including vendor, length, and SHA1 hash.
+     */
+    #[Test]
+    public function decodeReturnsExpectedMetadata(): void
+    {
+        $raw     = "\x01\x02example";
+        $decoder = new AppleDecoder();
+
+        $metadata = $decoder->decode($raw, 'Apple', 'iPhone');
+
+        self::assertSame('Apple', $metadata['_vendor']);
+        self::assertSame(strlen($raw), $metadata['_length']);
+        self::assertSame(40, strlen($metadata['_sha1']));
+        self::assertSame(sha1($raw), $metadata['_sha1']);
+    }
+}

--- a/tests/MakerNotes/Registry/RegistryTest.php
+++ b/tests/MakerNotes/Registry/RegistryTest.php
@@ -1,0 +1,56 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\ImageMeta\Tests\MakerNotes\Registry;
+
+use MagicSunday\ImageMeta\MakerNotes\MakerNotesDecoderInterface;
+use MagicSunday\ImageMeta\MakerNotes\Registry;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Exercises the maker notes decoder registry.
+ *
+ * @covers \MagicSunday\ImageMeta\MakerNotes\Registry
+ */
+final class RegistryTest extends TestCase
+{
+    /**
+     * Ensures decoders can be registered and retrieved via case-insensitive prefix matching.
+     */
+    #[Test]
+    public function findsDecoderByMakePrefix(): void
+    {
+        $decoder  = new class implements MakerNotesDecoderInterface {
+            public function decode(string $raw, string $make, ?string $model): array
+            {
+                return ['decoder' => 'apple'];
+            }
+        };
+        $registry = new Registry();
+        $registry->register('Apple', $decoder);
+
+        $match = $registry->find('APPLE iPhone 15 Pro');
+
+        self::assertSame($decoder, $match);
+    }
+
+    /**
+     * Ensures null is returned when no decoder prefix matches the make string.
+     */
+    #[Test]
+    public function returnsNullWhenNoDecoderMatches(): void
+    {
+        $registry = new Registry();
+
+        self::assertNull($registry->find('Unknown Manufacturer'));
+    }
+}

--- a/tests/Model/QuickTimeMeta/QuickTimeMetaTest.php
+++ b/tests/Model/QuickTimeMeta/QuickTimeMetaTest.php
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\ImageMeta\Tests\Model\QuickTimeMeta;
+
+use MagicSunday\ImageMeta\Model\QuickTimeMeta;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Verifies the behaviour of the QuickTime metadata container model.
+ *
+ * @covers \MagicSunday\ImageMeta\Model\QuickTimeMeta
+ */
+final class QuickTimeMetaTest extends TestCase
+{
+    /**
+     * Ensures the constructor stores the provided metadata map and the identifier is accessible.
+     */
+    #[Test]
+    public function returnsConfiguredContentIdentifier(): void
+    {
+        $keys = [
+            'com.apple.quicktime.content.identifier' => 'abc-123',
+            'com.apple.quicktime.location.ISO6709'   => '+12.345-067.890/',
+        ];
+
+        $meta = new QuickTimeMeta($keys);
+
+        self::assertSame($keys, $meta->keys);
+        self::assertSame('abc-123', $meta->contentIdentifier());
+    }
+
+    /**
+     * Ensures null is returned when the identifier key is missing.
+     */
+    #[Test]
+    public function returnsNullWhenIdentifierIsMissing(): void
+    {
+        $meta = new QuickTimeMeta([
+            'com.apple.quicktime.location.ISO6709' => '+12.345-067.890/',
+        ]);
+
+        self::assertNull($meta->contentIdentifier());
+    }
+}

--- a/tests/Parse/Xmp/XmpParser/XmpParserTest.php
+++ b/tests/Parse/Xmp/XmpParser/XmpParserTest.php
@@ -1,0 +1,98 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\ImageMeta\Tests\Parse\Xmp\XmpParser;
+
+use MagicSunday\ImageMeta\Parse\Xmp\XmpParser;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Validates the lightweight streaming XMP parser implementation.
+ *
+ * @covers \MagicSunday\ImageMeta\Parse\Xmp\XmpParser
+ */
+final class XmpParserTest extends TestCase
+{
+    private const string XMP_NS  = 'http://ns.adobe.com/xap/1.0/';
+    private const string DC_NS   = 'http://purl.org/dc/elements/1.1/';
+    private const string EXIF_NS = 'http://ns.adobe.com/exif/1.0/';
+
+    /**
+     * Ensures scalar properties and rdf:Bag containers are extracted correctly.
+     */
+    #[Test]
+    public function parseExtractsScalarAndBagValues(): void
+    {
+        $xml = <<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<x:xmpmeta xmlns:x="adobe:ns:meta/">
+  <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+    <rdf:Description
+      xmlns:xmp="http://ns.adobe.com/xap/1.0/"
+      xmlns:dc="http://purl.org/dc/elements/1.1/"
+      xmlns:exif="http://ns.adobe.com/exif/1.0/"
+    >
+      <xmp:CreateDate>2024-02-18T12:34:56Z</xmp:CreateDate>
+      <exif:DateTimeOriginal>2024-02-18T12:34:56</exif:DateTimeOriginal>
+      <dc:subject>
+        <rdf:Bag>
+          <rdf:li>sunset</rdf:li>
+          <rdf:li>vacation</rdf:li>
+        </rdf:Bag>
+      </dc:subject>
+    </rdf:Description>
+  </rdf:RDF>
+</x:xmpmeta>
+XML;
+
+        $parser   = new XmpParser();
+        $document = $parser->parse($xml);
+
+        self::assertSame(
+            '2024-02-18T12:34:56Z',
+            $document->get(self::XMP_NS, 'CreateDate')
+        );
+        self::assertSame(
+            '2024-02-18T12:34:56',
+            $document->get(self::EXIF_NS, 'DateTimeOriginal')
+        );
+        self::assertSame(
+            ['sunset', 'vacation'],
+            $document->get(self::DC_NS, 'subject')
+        );
+    }
+
+    /**
+     * Ensures malformed or unsupported XML fragments result in an empty document.
+     */
+    #[Test]
+    #[DataProvider('provideInvalidXmpFragments')]
+    public function parseReturnsEmptyDocumentForInvalidXml(string $xml): void
+    {
+        $parser   = new XmpParser();
+        $document = $parser->parse($xml);
+
+        self::assertSame([], $document->data);
+    }
+
+    /**
+     * Provides malformed or unsupported XML fragments for negative parsing scenarios.
+     *
+     * @return iterable<string, array{0: string}>
+     */
+    public static function provideInvalidXmpFragments(): iterable
+    {
+        yield 'broken xml declaration' => ['<?xml version="1.0"?><rdf:RDF'];
+        yield 'unsupported namespace'  => ['<root xmlns="urn:example"><value>ignored</value></root>'];
+    }
+}


### PR DESCRIPTION
## Summary
- add data-provider driven tests for the format detector covering success and failure flows
- exercise the XMP parser against scalar, bag, and invalid XML payloads
- cover QuickTime metadata accessors plus maker note registry and Apple decoder helpers

## Testing
- `composer ci:test:php:unit`


------
https://chatgpt.com/codex/tasks/task_e_68f9de822f088323b352005519ce2531