### PR TITLE
fix: throw parse error for unknown container

### DIFF
--- a/src/Detect/FormatDetector.php
+++ b/src/Detect/FormatDetector.php
@@ -11,8 +11,8 @@ declare(strict_types=1);
 
 namespace MagicSunday\ImageMeta\Detect;
 
+use MagicSunday\ImageMeta\Core\ParseError;
 use MagicSunday\ImageMeta\Core\Stream;
-use RuntimeException;
 
 /**
  * Detects the container type of a binary stream based on magic numbers.
@@ -26,7 +26,7 @@ final class FormatDetector
      *
      * @return ContainerType detected container format
      *
-     * @throws RuntimeException when the signature does not match a known container
+     * @throws ParseError when the signature does not match a known container
      */
     public static function detect(Stream $stream): ContainerType
     {
@@ -41,6 +41,6 @@ final class FormatDetector
             return ContainerType::ISOBMFF;
         }
         // a few HEIC files may start with 0 size+ftyp; we already cover 'ftyp' at [4..8]
-        throw new RuntimeException('Unsupported or unknown container');
+        throw new ParseError('Unsupported or unknown container');
     }
 }

--- a/tests/Detect/FormatDetector/FormatDetectorTest.php
+++ b/tests/Detect/FormatDetector/FormatDetectorTest.php
@@ -11,12 +11,12 @@ declare(strict_types=1);
 
 namespace MagicSunday\ImageMeta\Tests\Detect\FormatDetector;
 
+use MagicSunday\ImageMeta\Core\ParseError;
 use MagicSunday\ImageMeta\Core\Stream;
 use MagicSunday\ImageMeta\Detect\ContainerType;
 use MagicSunday\ImageMeta\Detect\FormatDetector;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
-use RuntimeException;
 
 use function fopen;
 use function fwrite;
@@ -57,14 +57,14 @@ final class FormatDetectorTest extends TestCase
     }
 
     /**
-     * Ensures that an unsupported signature results in a runtime exception.
+     * Ensures that an unsupported signature results in a parse error.
      */
     #[Test]
     public function detectThrowsForUnsupportedSignature(): void
     {
         $stream = $this->createStream('UNSUPPORTED');
 
-        $this->expectException(RuntimeException::class);
+        $this->expectException(ParseError::class);
 
         FormatDetector::detect($stream);
     }


### PR DESCRIPTION
## Summary
- adjust `FormatDetector` to raise `ParseError` for unsupported signatures
- update phpdoc and tests to expect the new exception type

## Testing
- composer ci:test:php:unit

------
https://chatgpt.com/codex/tasks/task_e_68f9e0d54e2883239a6f2148e12313f3