### PR TITLE
refactor: align IsoBmffExtractor with readonly class semantics

### DIFF
--- a/src/Parse/IsoBmff/IsoBmffExtractor.php
+++ b/src/Parse/IsoBmff/IsoBmffExtractor.php
@@ -125,7 +125,7 @@ final readonly class IsoBmffExtractor
      *
      * @param Stream $stream Stream positioned at the beginning of the media file to parse.
      */
-    public function __construct(private readonly Stream $stream)
+    public function __construct(private Stream $stream)
     {
     }
 


### PR DESCRIPTION
## Summary
- rely on the class-level readonly declaration of `IsoBmffExtractor`
- drop the redundant property-level readonly flag on the constructor-promoted stream dependency

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f9e0d6c16c8323a75d34011c781294