### PR TITLE
docs: document phpdoc annotations

### DIFF
--- a/src/Convenience/CaptureDateResolver.php
+++ b/src/Convenience/CaptureDateResolver.php
@@ -61,6 +61,10 @@ final class CaptureDateResolver
 
     /**
      * Extracts the ISO 8601 create date from the XMP document.
+     *
+     * @param XmpDocument $document XMP document holding metadata properties.
+     *
+     * @return string|null ISO 8601 timestamp or null when unavailable.
      */
     private static function readXmpCreateDate(XmpDocument $document): ?string
     {

--- a/src/Model/Exif/ValueConverters.php
+++ b/src/Model/Exif/ValueConverters.php
@@ -68,6 +68,8 @@ final readonly class ValueConverters
      *
      * @param string|null $ref Direction reference (N/E/S/W).
      * @param mixed       $val Rational triplet describing the coordinate.
+     *
+     * @return float|null
      */
     private static function dmsToFloat(?string $ref, mixed $val): ?float
     {

--- a/src/Model/QuickTimeMeta.php
+++ b/src/Model/QuickTimeMeta.php
@@ -27,6 +27,8 @@ final readonly class QuickTimeMeta
 
     /**
      * Returns the QuickTime content identifier value when available.
+     *
+     * @return string|null
      */
     public function contentIdentifier(): ?string
     {

--- a/src/Model/Xmp/XmpDocument.php
+++ b/src/Model/Xmp/XmpDocument.php
@@ -33,6 +33,9 @@ final readonly class XmpDocument
     /**
      * Looks up a property by namespace URI and local name.
      *
+     * @param string $namespaceUri Namespace URI that scopes the property.
+     * @param string $localName    Local property name to retrieve.
+     *
      * @return array<int, string>|string|null
      */
     public function get(string $namespaceUri, string $localName): array|string|null
@@ -45,6 +48,8 @@ final readonly class XmpDocument
 
     /**
      * Finds the first property with the given local name independent of the namespace.
+     *
+     * @param string $localName Local property name to search for.
      *
      * @return array<int, string>|string|null
      */

--- a/src/Parse/Xmp/XmpReader.php
+++ b/src/Parse/Xmp/XmpReader.php
@@ -32,6 +32,10 @@ final class XmpReader
      *
      * The resulting document stores values keyed by Clark notation ("{namespace}local") and
      * flattens RDF containers (Bag/Seq/Alt) into PHP lists.
+     *
+     * @param string $xml The raw XML payload containing the XMP packet.
+     *
+     * @return XmpDocument Parsed XMP representation.
      */
     public function parse(string $xml): XmpDocument
     {
@@ -120,6 +124,8 @@ final class XmpReader
      * Finalises the collected container/list data for the current element.
      *
      * @param array<int, string> $items
+     *
+     * @return array|string|null
      */
     private function finalizeValue(array $items, string $text): array|string|null
     {


### PR DESCRIPTION
## Summary
- add missing parameter and return annotations to the XMP reader and document helpers
- document the QuickTime content identifier accessor and EXIF coordinate conversion return types
- clarify the capture date resolver's XMP create date contract

## Testing
- composer ci:test:php:cgl *(fails: existing binary_operator_spaces issues in test fixtures)*

------
https://chatgpt.com/codex/tasks/task_e_68f9e0d9786c832396df7d0cd307dcd6