### PR TITLE
Document unit test scenarios with PHPDoc annotations

### DIFF
--- a/tests/Convenience/CaptureDateResolverTest.php
+++ b/tests/Convenience/CaptureDateResolverTest.php
@@ -27,6 +27,10 @@ final class CaptureDateResolverTest extends TestCase
 {
     private const XMP_NAMESPACE = 'http://ns.adobe.com/xap/1.0/';
 
+    /**
+     * Uses only XMP metadata to confirm the resolver falls back to the CreateDate string and
+     * returns a DateTimeImmutable instance.
+     */
     #[Test]
     public function returnsXmpCreateDateWhenExifIsMissing(): void
     {
@@ -46,6 +50,10 @@ final class CaptureDateResolverTest extends TestCase
         self::assertSame('2024-03-30T12:34:56+00:00', $result->format(DATE_ATOM));
     }
 
+    /**
+     * Provides an invalid CreateDate value to ensure the resolver rejects non-ISO formatted
+     * strings and returns null.
+     */
     #[Test]
     public function ignoresNonIsoCreateDateValues(): void
     {
@@ -62,6 +70,10 @@ final class CaptureDateResolverTest extends TestCase
         self::assertNull(CaptureDateResolver::bestCaptureDateTime($metadata));
     }
 
+    /**
+     * Supplies multiple XMP CreateDate entries and checks that the first ISO-8601 value is
+     * accepted and converted to a DateTimeImmutable instance.
+     */
     #[Test]
     public function acceptsFirstArrayElementWhenIsoString(): void
     {

--- a/tests/Convenience/ExifConvenienceTest.php
+++ b/tests/Convenience/ExifConvenienceTest.php
@@ -26,6 +26,10 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(ExifConvenience::class)]
 final class ExifConvenienceTest extends TestCase
 {
+    /**
+     * Provides both modern and legacy ISO sensitivity tags to ensure the helper prefers the
+     * EXIF-specific entry and falls back when absent.
+     */
     #[Test]
     public function isoPrefersModernTagAndFallsBackToLegacy(): void
     {
@@ -46,6 +50,10 @@ final class ExifConvenienceTest extends TestCase
         self::assertSame(200, ExifConvenience::iso($docWithLegacy));
     }
 
+    /**
+     * Ensures the ISO helper returns the first value from array-based entries rather than the raw
+     * array.
+     */
     #[Test]
     public function isoExtractsFirstEntryFromArray(): void
     {
@@ -58,6 +66,10 @@ final class ExifConvenienceTest extends TestCase
         self::assertSame(100, ExifConvenience::iso($doc));
     }
 
+    /**
+     * Reads capture timestamp tags and verifies the helper delegates to the document parser to
+     * return a timezone-aware DateTime.
+     */
     #[Test]
     public function captureDateTimeDelegatesToDocument(): void
     {
@@ -75,6 +87,10 @@ final class ExifConvenienceTest extends TestCase
         self::assertSame('2024-05-01T12:34:56+02:00', $captured->format(DATE_ATOM));
     }
 
+    /**
+     * Confirms null is returned when neither the IFD0 nor EXIF IFD provide capture date
+     * information.
+     */
     #[Test]
     public function captureDateTimeReturnsNullWhenMissing(): void
     {
@@ -83,6 +99,10 @@ final class ExifConvenienceTest extends TestCase
         self::assertNull(ExifConvenience::captureDateTime($doc));
     }
 
+    /**
+     * Supplies an incomplete timestamp string to ensure the helper refuses values lacking time
+     * components.
+     */
     #[Test]
     public function captureDateTimeReturnsNullForShortTimestamp(): void
     {

--- a/tests/Core/MemoryBuffer/MemoryBufferTest.php
+++ b/tests/Core/MemoryBuffer/MemoryBufferTest.php
@@ -40,6 +40,12 @@ namespace MagicSunday\ImageMeta\Tests\Core\MemoryBuffer {
 
         /**
          * Delegates to the global \substr implementation while allowing tests to force short reads.
+         *
+         * @param string   $string Source string to slice.
+         * @param int      $offset Starting offset to read from.
+         * @param int|null $length Optional maximum number of bytes to read.
+         *
+         * @return string Portion of the input string returned by \substr.
          */
         public static function invokeSubstrProxy(string $string, int $offset, ?int $length = null): string
         {
@@ -58,12 +64,19 @@ namespace MagicSunday\ImageMeta\Tests\Core\MemoryBuffer {
             return \substr($string, $offset, $length);
         }
 
+        /**
+         * Resets the short-read override flag after each test to avoid cross-test leakage.
+         */
         #[After]
         protected function resetOverrides(): void
         {
             self::$forceShortRead = false;
         }
 
+        /**
+         * Seeks to a position inside the buffer and verifies that the cursor reflects the move and
+         * subsequent reads advance it as expected.
+         */
         #[Test]
         public function testSeekMovesCursorWithinBounds(): void
         {
@@ -75,6 +88,9 @@ namespace MagicSunday\ImageMeta\Tests\Core\MemoryBuffer {
             self::assertSame(5, $buffer->tell());
         }
 
+        /**
+         * Attempts to seek beyond the available bytes to ensure a BoundsError is raised.
+         */
         #[Test]
         public function testSeekThrowsBoundsErrorOutsideBuffer(): void
         {
@@ -84,6 +100,10 @@ namespace MagicSunday\ImageMeta\Tests\Core\MemoryBuffer {
             $buffer->seek(4);
         }
 
+        /**
+         * Reads sequential slices and confirms both the returned data and cursor position match the
+         * requested byte count.
+         */
         #[Test]
         public function testReadReturnsRequestedBytes(): void
         {
@@ -95,6 +115,9 @@ namespace MagicSunday\ImageMeta\Tests\Core\MemoryBuffer {
             self::assertSame(11, $buffer->tell());
         }
 
+        /**
+         * Ensures that reading past the end of the buffer throws a BoundsError.
+         */
         #[Test]
         public function testReadThrowsBoundsErrorWhenLengthTooLarge(): void
         {
@@ -106,6 +129,10 @@ namespace MagicSunday\ImageMeta\Tests\Core\MemoryBuffer {
             $buffer->read(1);
         }
 
+        /**
+         * Forces the proxy \substr implementation to perform a short read so MemoryBuffer raises a
+         * ParseError as expected for truncated data.
+         */
         #[Test]
         public function testReadThrowsParseErrorOnShortRead(): void
         {
@@ -117,6 +144,10 @@ namespace MagicSunday\ImageMeta\Tests\Core\MemoryBuffer {
             $buffer->read(2);
         }
 
+        /**
+         * Reads unsigned integers of varying widths to confirm endian-specific helpers decode the
+         * packed payload and advance the cursor correctly.
+         */
         #[Test]
         public function testReadUnsignedIntegersRespectEndianness(): void
         {

--- a/tests/Core/StreamWindow/StreamWindowTest.php
+++ b/tests/Core/StreamWindow/StreamWindowTest.php
@@ -28,6 +28,9 @@ use function strlen;
  */
 final class StreamWindowTest extends TestCase
 {
+    /**
+     * Verifies that the window reports its configured length and initial cursor position.
+     */
     #[Test]
     public function testSizeReportsConfiguredLengthAndCursorStartsAtZero(): void
     {
@@ -37,6 +40,10 @@ final class StreamWindowTest extends TestCase
         self::assertSame(0, $window->tell());
     }
 
+    /**
+     * Seeks around inside the configured span and ensures the cursor reflects the requested
+     * positions.
+     */
     #[Test]
     public function testSeekMovesCursorWithinWindowBounds(): void
     {
@@ -49,6 +56,9 @@ final class StreamWindowTest extends TestCase
         self::assertSame(6, $window->tell());
     }
 
+    /**
+     * Attempts to seek beyond the window size to confirm a BoundsError is thrown.
+     */
     #[Test]
     public function testSeekThrowsBoundsErrorOutsideWindow(): void
     {
@@ -58,6 +68,9 @@ final class StreamWindowTest extends TestCase
         $window->seek(5);
     }
 
+    /**
+     * Reads bytes through the window and checks both the returned data and cursor advancement.
+     */
     #[Test]
     public function testReadReturnsRequestedBytesAndAdvancesCursor(): void
     {
@@ -67,6 +80,9 @@ final class StreamWindowTest extends TestCase
         self::assertSame(6, $window->tell());
     }
 
+    /**
+     * Ensures that read requests crossing the end of the window trigger a BoundsError.
+     */
     #[Test]
     public function testReadThrowsBoundsErrorWhenRequestCrossesEnd(): void
     {
@@ -76,6 +92,10 @@ final class StreamWindowTest extends TestCase
         $window->read(3);
     }
 
+    /**
+     * Reads sequential unsigned integers to verify the helpers decode packed big-endian values and
+     * advance the cursor appropriately.
+     */
     #[Test]
     public function testUnsignedIntegerHelpersReadSequentially(): void
     {
@@ -93,6 +113,9 @@ final class StreamWindowTest extends TestCase
         self::assertSame(strlen($payload), $window->tell());
     }
 
+    /**
+     * Confirms that insufficient remaining bytes cause the integer helper to raise a BoundsError.
+     */
     #[Test]
     public function testUnsignedIntegerHelpersThrowBoundsErrorOnShortData(): void
     {
@@ -110,7 +133,7 @@ final class StreamWindowTest extends TestCase
      *
      * @param string $payload Bytes to insert into the temporary stream.
      *
-     * @return Stream
+     * @return Stream Stream that exposes the payload for windowed reads.
      */
     private function createStream(string $payload): Stream
     {


### PR DESCRIPTION
## Summary
- add scenario-focused PHPDoc blocks to MemoryBuffer and StreamWindow unit tests
- document CaptureDateResolver and ExifConvenience tests with expected outcomes
- describe helper parameters and return values to align with project documentation standards

## Testing
- composer ci:test:php:unit

------
https://chatgpt.com/codex/tasks/task_e_68f9e50346448323afde6e2124d4b971