### PR TITLE
docs: clarify EXIF normalization phpdoc

### DIFF
--- a/src/Parse/IsoBmff/IsoBmffExtractor.php
+++ b/src/Parse/IsoBmff/IsoBmffExtractor.php
@@ -427,6 +427,9 @@ final readonly class IsoBmffExtractor
 
     /**
      * Strips redundant EXIF signatures so downstream parsers accept the blob.
+     *
+     * @param string $blob Raw EXIF payload that may still include the "Exif\0\0" signature prefix.
+     * @return string EXIF payload trimmed to the TIFF header when a redundant signature is detected.
      */
     private function normalizeExifBlob(string $blob): string
     {


### PR DESCRIPTION
## Summary
- document the EXIF normalization helper with explicit parameter and return descriptions

## Testing
- composer ci:test:php:phpstan *(fails: existing phpstan errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68f9e7d2e8d883238fa833884c51c56e