### PR TITLE
Add missing PHPDoc parameter to XmpReader finalizeValue

### DIFF
--- a/src/Parse/Xmp/XmpReader.php
+++ b/src/Parse/Xmp/XmpReader.php
@@ -124,6 +124,7 @@ final class XmpReader
      * Finalises the collected container/list data for the current element.
      *
      * @param array<int, string> $items
+     * @param string             $text
      *
      * @return array|string|null
      */


### PR DESCRIPTION
## Summary
- document the `$text` argument in `XmpReader::finalizeValue()` to keep PHPDoc complete

## Testing
- `composer ci:test:php:phpstan` *(fails: existing baseline issues in the project)*

------
https://chatgpt.com/codex/tasks/task_e_68f9e7da400883238f3106fefe035997