### PR TITLE
style: import substr helper

### DIFF
--- a/src/Core/MemoryBuffer.php
+++ b/src/Core/MemoryBuffer.php
@@ -13,6 +13,7 @@ namespace MagicSunday\ImageMeta\Core;
 
 use function ord;
 use function strlen;
+use function substr;
 use function unpack;
 
 /**


### PR DESCRIPTION
## Summary
- include substr in MemoryBuffer function imports to comply with alphabetical ordering guidance

## Testing
- composer ci:test:php:cgl *(fails: existing style violations in test fixtures)*

------
https://chatgpt.com/codex/tasks/task_e_68f9e7fad07c832387bc1099e50a6882