### PR TITLE
style: import global helper functions in CaptureDateResolver

### DIFF
--- a/src/Convenience/CaptureDateResolver.php
+++ b/src/Convenience/CaptureDateResolver.php
@@ -16,6 +16,11 @@ use MagicSunday\ImageMeta\Model\Metadata;
 use MagicSunday\ImageMeta\Model\Xmp\XmpDocument;
 use Throwable;
 
+use function is_array;
+use function is_string;
+use function preg_match;
+use function trim;
+
 /**
  * Resolves the best available capture timestamp for an image asset.
  *


### PR DESCRIPTION
## Summary
- add explicit `use function` imports for the global helpers consumed by `CaptureDateResolver`

## Testing
- composer ci:test:php:phpstan *(fails: existing phpstan baseline issues in unrelated files)*
- composer ci:test:php:cgl *(fails: coding standard violations in existing test files)*

------
https://chatgpt.com/codex/tasks/task_e_68f9e7f6feb48323a326083b1daee0a8