### PR TITLE
Add function imports for EXIF helpers

### DIFF
--- a/src/Convenience/ExifConvenience.php
+++ b/src/Convenience/ExifConvenience.php
@@ -17,6 +17,11 @@ use MagicSunday\ImageMeta\Model\Exif\ExifTag;
 use MagicSunday\ImageMeta\Model\Exif\IfdEntry;
 use Throwable;
 
+use function count;
+use function is_array;
+use function is_float;
+use function is_int;
+use function is_numeric;
 use function is_string;
 use function strlen;
 

--- a/src/Model/Exif/ValueConverters.php
+++ b/src/Model/Exif/ValueConverters.php
@@ -11,6 +11,12 @@ declare(strict_types=1);
 
 namespace MagicSunday\ImageMeta\Model\Exif;
 
+use function count;
+use function is_array;
+use function is_float;
+use function is_int;
+use function is_string;
+
 /**
  * Helper methods that translate EXIF/TIFF values into PHP friendly scalars.
  */


### PR DESCRIPTION
## Summary
- add explicit use function imports for global helpers used by ExifConvenience
- declare function imports for helpers referenced in ValueConverters

## Testing
- composer ci:test:php:cgl *(fails: existing style violations in unrelated test files)*
- composer ci:test:php:phpstan *(fails: existing analysis findings in unrelated modules)*

------
https://chatgpt.com/codex/tasks/task_e_68f9e7fa1e888323b63a18d0072dad11