### PR TITLE
Simplify memory buffer and stream error messages

### DIFF
--- a/src/Core/MemoryBuffer.php
+++ b/src/Core/MemoryBuffer.php
@@ -65,7 +65,7 @@ final class MemoryBuffer
     public function seek(int $offset): void
     {
         if ($offset < 0 || $offset > $this->size()) {
-            throw new BoundsError("MemoryBuffer seek out of range: {$offset}");
+            throw new BoundsError("MemoryBuffer seek out of range: $offset");
         }
         $this->pos = $offset;
     }
@@ -86,7 +86,7 @@ final class MemoryBuffer
     {
         $end = $this->pos + $length;
         if ($length < 0 || $end > $this->size()) {
-            throw new BoundsError("MemoryBuffer read out of range: {$this->pos}+{$length}");
+            throw new BoundsError('MemoryBuffer read out of range: ' . $this->pos . '+' . $length);
         }
         $chunk = substr($this->data, $this->pos, $length);
         if (strlen($chunk) !== $length) {

--- a/src/Core/Stream.php
+++ b/src/Core/Stream.php
@@ -104,7 +104,7 @@ final class Stream
     public function read(int $len): string
     {
         if ($len < 0 || $this->pos + $len > $this->size) {
-            throw new BoundsError("read beyond EOF: {$this->pos}+{$len} > {$this->size}");
+            throw new BoundsError('read beyond EOF: ' . $this->pos . '+' . $len . ' > ' . $this->size);
         }
         $data = fread($this->fh, $len);
         if ($data === false || strlen($data) !== $len) {


### PR DESCRIPTION
## Summary
- adjust MemoryBuffer bounds error strings to drop brace-based interpolation
- update Stream EOF guard message to match the simpler formatting

## Testing
- `composer ci:test:php:unit` *(fails: MagicSunday\ImageMeta\Tests\Core\MemoryBuffer\MemoryBufferTest::testReadThrowsParseErrorOnShortRead)*
- `composer ci:test:php:unit:coverage` *(fails: No code coverage driver available)*
- `composer ci:test:php:phpstan` *(fails: existing baseline errors)*
- `composer ci:cgl`


------
https://chatgpt.com/codex/tasks/task_e_68f9e8d029b48323be27259fe13bdf16