### PR TITLE
refactor: simplify ExifDocument int accessor

### DIFF
--- a/src/Model/Exif/ExifDocument.php
+++ b/src/Model/Exif/ExifDocument.php
@@ -206,6 +206,14 @@ final readonly class ExifDocument
     {
         $v = $ifd?->get($tag)?->value ?? null;
 
-        return is_int($v) ? $v : (is_float($v) ? (int) $v : null);
+        if (is_int($v)) {
+            return $v;
+        }
+
+        if (is_float($v)) {
+            return (int) $v;
+        }
+
+        return null;
     }
 }


### PR DESCRIPTION
## Summary
- replace the nested ternary in `ExifDocument::int()` with sequential conditionals to handle ints, floats, and null cleanly

## Testing
- composer ci:test:php:unit *(fails: `MemoryBufferTest::testReadThrowsParseErrorOnShortRead` was not thrown)*
- composer ci:test:php:unit:coverage *(fails: no code coverage driver available in the environment)*
- composer ci:test:php:phpstan *(fails: existing analysis errors in the codebase)*
- composer ci:cgl


------
https://chatgpt.com/codex/tasks/task_e_68f9e8db2d14832394468378e6325224