### PR TITLE
Add function imports to metadata reader test

### DIFF
--- a/tests/MetadataReader/MetadataReaderTest.php
+++ b/tests/MetadataReader/MetadataReaderTest.php
@@ -19,6 +19,14 @@ use MagicSunday\ImageMeta\Model\Xmp\XmpDocument;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
+use function chr;
+use function file_put_contents;
+use function pack;
+use function strlen;
+use function sys_get_temp_dir;
+use function tempnam;
+use function unlink;
+
 /**
  * Integration coverage for the convenience metadata reader.
  *


### PR DESCRIPTION
## Summary
- add explicit use-function imports for global helpers used in MetadataReaderTest

## Testing
- composer ci:cgl

------
https://chatgpt.com/codex/tasks/task_e_68f9e8c02720832394b91fb45147af05