### PR TITLE
fix: clarify iloc item id parsing logic

### DIFF
--- a/src/Parse/IsoBmff/IsoBmffExtractor.php
+++ b/src/Parse/IsoBmff/IsoBmffExtractor.php
@@ -599,7 +599,15 @@ final readonly class IsoBmffExtractor
         $locations = [];
 
         for ($i = 0; $i < $itemCount; ++$i) {
-            $itemId             = $version < 2 ? $win->readU16BE() : (($flags & 0x0001) !== 0 ? $win->readU32BE() : $win->readU16BE());
+            if ($version < 2) {
+                $itemId = $win->readU16BE();
+            } else {
+                if (($flags & 0x0001) !== 0) {
+                    $itemId = $win->readU32BE();
+                } else {
+                    $itemId = $win->readU16BE();
+                }
+            }
             $constructionMethod = 0;
             if ($version === 1 || $version === 2) {
                 $tmp                = $win->readU16BE();


### PR DESCRIPTION
## Summary
- replace the nested ternary used for `iloc` item identifier parsing with explicit branching

## Testing
- composer ci:test:php:unit *(fails: `MemoryBufferTest::testReadThrowsParseErrorOnShortRead` was expected to raise a `ParseError` but none was thrown)*
- composer ci:test:php:unit:coverage *(fails: no code coverage driver is available in the environment)*
- composer ci:test:php:phpstan *(fails: existing baseline contains numerous reported issues)*
- composer ci:cgl

------
https://chatgpt.com/codex/tasks/task_e_68f9e8dd3f008323aedc8d7e1a3595d0