### PR TITLE
Add guard coverage for bounds and parse errors

### DIFF
--- a/src/Core/MemoryBuffer.php
+++ b/src/Core/MemoryBuffer.php
@@ -13,7 +13,6 @@ namespace MagicSunday\ImageMeta\Core;
 
 use function ord;
 use function strlen;
-use function substr;
 use function unpack;
 
 /**

--- a/tests/Core/BoundsError/BoundsErrorTest.php
+++ b/tests/Core/BoundsError/BoundsErrorTest.php
@@ -1,0 +1,64 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\ImageMeta\Tests\Core\BoundsError;
+
+use MagicSunday\ImageMeta\Core\BoundsError;
+use MagicSunday\ImageMeta\Core\Stream;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+use function fopen;
+use function fwrite;
+use function rewind;
+use function strlen;
+
+/**
+ * Dedicated unit tests asserting that guard rails raise informative BoundsError messages.
+ */
+final class BoundsErrorTest extends TestCase
+{
+    /**
+     * Attempts to read beyond the declared stream length to ensure the guard throws a descriptive BoundsError.
+     */
+    #[Test]
+    public function testStreamReadBeyondEndReportsContextInBoundsError(): void
+    {
+        $payload = 'meta';
+
+        $fh = fopen('php://temp', 'r+b');
+        fwrite($fh, $payload);
+        rewind($fh);
+
+        $stream = new Stream($fh, strlen($payload));
+
+        $stream->read(4);
+
+        $this->expectException(BoundsError::class);
+        $this->expectExceptionMessage('read beyond EOF: 4+1 > 4');
+
+        $stream->read(1);
+    }
+
+    /**
+     * Seeks outside the memory buffer to verify the resulting BoundsError contains the attempted offset.
+     */
+    #[Test]
+    public function testMemoryBufferSeekOutsideRangeReportsAttemptedOffset(): void
+    {
+        $buffer = new \MagicSunday\ImageMeta\Core\MemoryBuffer('guard');
+
+        $this->expectException(BoundsError::class);
+        $this->expectExceptionMessage('MemoryBuffer seek out of range: 6');
+
+        $buffer->seek(6);
+    }
+}

--- a/tests/Core/ParseError/ParseErrorTest.php
+++ b/tests/Core/ParseError/ParseErrorTest.php
@@ -1,0 +1,80 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\ImageMeta\Tests\Core\ParseError;
+
+use MagicSunday\ImageMeta\Core\ParseError;
+use MagicSunday\ImageMeta\Core\Stream;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+use function fopen;
+use function fwrite;
+use function restore_error_handler;
+use function rewind;
+use function set_error_handler;
+use function str_contains;
+use function sys_get_temp_dir;
+use function uniqid;
+
+/**
+ * Tests covering the ParseError exception raised by stream guard failures.
+ */
+final class ParseErrorTest extends TestCase
+{
+    /**
+     * Declares a stream size larger than the written payload to force a short read ParseError.
+     */
+    #[Test]
+    public function testStreamReadThrowsParseErrorOnShortRead(): void
+    {
+        $fh = fopen('php://temp', 'r+b');
+        fwrite($fh, 'A');
+        rewind($fh);
+
+        $stream = new Stream($fh, 2);
+
+        $this->expectException(ParseError::class);
+        $this->expectExceptionMessage('short read');
+
+        $stream->read(2);
+    }
+
+    /**
+     * Attempts to open a non-existent file path using Stream::fromPath to verify the error message.
+     */
+    #[Test]
+    public function testStreamFromPathThrowsParseErrorWhenFileMissing(): void
+    {
+        $path = sys_get_temp_dir() . '/imagemeta-missing-' . uniqid('', true);
+
+        $this->expectException(ParseError::class);
+        $this->expectExceptionMessage("Cannot open: {$path}");
+
+        $previousHandler = set_error_handler(static function (int $errno, string $errstr) use ($path, &$previousHandler): bool {
+            if (str_contains($errstr, $path)) {
+                return true;
+            }
+
+            if ($previousHandler !== null) {
+                return (bool) $previousHandler($errno, $errstr);
+            }
+
+            return false;
+        });
+
+        try {
+            Stream::fromPath($path);
+        } finally {
+            restore_error_handler();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add PHPUnit coverage that asserts the BoundsError guard messages for stream and memory buffer operations
- exercise Stream::read and Stream::fromPath parse-error paths with targeted synthetic inputs while suppressing spurious warnings
- drop the unused substr import from MemoryBuffer so the short-read guard can be exercised through the existing test shim

## Testing
- `composer ci:test:php:unit`
- `composer ci:test:php:unit:coverage` *(fails: no code coverage driver available in environment)*
- `composer ci:test:php:phpstan` *(fails: pre-existing static analysis findings covered by project baseline)*
- `composer ci:cgl`

------
https://chatgpt.com/codex/tasks/task_e_68f9e8ccacd0832390e42124150a4364