### PR TITLE
Add explicit global function imports to test fixtures

### DIFF
--- a/tests/Jpeg/JpegExtractorTest.php
+++ b/tests/Jpeg/JpegExtractorTest.php
@@ -18,6 +18,15 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
+use function chr;
+use function fopen;
+use function fwrite;
+use function implode;
+use function pack;
+use function rewind;
+use function str_repeat;
+use function strlen;
+
 /**
  * Exercises the JPEG extractor using synthetic marker segments.
  *

--- a/tests/Parse/IsoBmff/IsoBmffExtractorTest.php
+++ b/tests/Parse/IsoBmff/IsoBmffExtractorTest.php
@@ -18,6 +18,15 @@ use MagicSunday\ImageMeta\Parse\IsoBmff\IsoBmffExtractor;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
+use function chr;
+use function fopen;
+use function fwrite;
+use function hex2bin;
+use function pack;
+use function rewind;
+use function strlen;
+use function substr;
+
 /**
  * Exercises the ISO BMFF extractor against synthetic container layouts.
  *


### PR DESCRIPTION
## Summary
- add explicit `use function` imports for the JPEG extractor test helpers
- add missing `use function` imports for the ISO BMFF extractor test fixtures

## Testing
- `composer ci:test:php:unit` *(fails: MagicSunday\\ImageMeta\\Tests\\Core\\MemoryBuffer\\MemoryBufferTest::testReadThrowsParseErrorOnShortRead)*
- `composer ci:test:php:unit:coverage` *(fails: No code coverage driver available)*
- `composer ci:test:php:phpstan` *(fails with existing baseline violations)*
- `composer ci:cgl`


------
https://chatgpt.com/codex/tasks/task_e_68f9eae488b08323b15e921e07dc126e