### PR TITLE
Add explicit global function imports in test fixtures

### DIFF
--- a/tests/Jpeg/JpegExtractorTest.php
+++ b/tests/Jpeg/JpegExtractorTest.php
@@ -18,6 +18,15 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
+use function chr;
+use function fopen;
+use function fwrite;
+use function implode;
+use function pack;
+use function rewind;
+use function str_repeat;
+use function strlen;
+
 /**
  * Exercises the JPEG extractor using synthetic marker segments.
  *

--- a/tests/MakerNotes/AppleDecoder/AppleDecoderTest.php
+++ b/tests/MakerNotes/AppleDecoder/AppleDecoderTest.php
@@ -15,6 +15,9 @@ use MagicSunday\ImageMeta\MakerNotes\AppleDecoder;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
+use function sha1;
+use function strlen;
+
 /**
  * Validates the Apple maker notes decoder implementation.
  *

--- a/tests/Parse/IsoBmff/IsoBmffExtractorTest.php
+++ b/tests/Parse/IsoBmff/IsoBmffExtractorTest.php
@@ -18,6 +18,15 @@ use MagicSunday\ImageMeta\Parse\IsoBmff\IsoBmffExtractor;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
+use function chr;
+use function fopen;
+use function fwrite;
+use function hex2bin;
+use function pack;
+use function rewind;
+use function strlen;
+use function substr;
+
 /**
  * Exercises the ISO BMFF extractor against synthetic container layouts.
  *

--- a/tests/Parse/Tiff/TiffExifReaderTest.php
+++ b/tests/Parse/Tiff/TiffExifReaderTest.php
@@ -20,6 +20,15 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
+use function call_user_func;
+use function count;
+use function implode;
+use function ord;
+use function pack;
+use function str_pad;
+use function str_repeat;
+use function strlen;
+
 /**
  * Exercises the TIFF EXIF reader with synthetic Classic TIFF and BigTIFF payloads.
  */


### PR DESCRIPTION
## Summary
- add explicit `use function` imports for global helpers in the ISO BMFF, JPEG, TIFF, and Apple decoder tests to clarify dependencies on PHP built-ins

## Testing
- `composer ci:test:php:unit` *(fails: MagicSunday\ImageMeta\Tests\Core\MemoryBuffer\MemoryBufferTest::testReadThrowsParseErrorOnShortRead)*
- `composer ci:test:php:unit:coverage` *(fails: No code coverage driver available)*
- `composer ci:test:php:phpstan` *(fails: pre-existing static analysis findings in the codebase)*
- `composer ci:cgl`


------
https://chatgpt.com/codex/tasks/task_e_68f9ea015c688323a92016ba3a718176