### PR TITLE
fix: drop redundant readonly on promoted props

### DIFF
--- a/src/Model/Exif/ExifDocument.php
+++ b/src/Model/Exif/ExifDocument.php
@@ -32,11 +32,11 @@ final readonly class ExifDocument
      * @param Ifd|null $ifd1       Optional next IFD, typically thumbnails.
      */
     public function __construct(
-        public readonly Ifd $ifd0,
-        public readonly ?Ifd $exifIfd,
-        public readonly ?Ifd $gpsIfd,
-        public readonly ?Ifd $interopIfd,
-        public readonly ?Ifd $ifd1,
+        public Ifd $ifd0,
+        public ?Ifd $exifIfd,
+        public ?Ifd $gpsIfd,
+        public ?Ifd $interopIfd,
+        public ?Ifd $ifd1,
     ) {
     }
 

--- a/src/Model/Exif/Ifd.php
+++ b/src/Model/Exif/Ifd.php
@@ -21,8 +21,8 @@ final readonly class Ifd
      * @param int|null             $nextIfdOffset Optional offset to the next directory.
      */
     public function __construct(
-        public readonly array $entries,
-        public readonly ?int $nextIfdOffset = null,
+        public array $entries,
+        public ?int $nextIfdOffset = null,
     ) {
     }
 

--- a/src/Model/Exif/IfdEntry.php
+++ b/src/Model/Exif/IfdEntry.php
@@ -23,10 +23,10 @@ final readonly class IfdEntry
      * @param mixed $value The raw value or values decoded from the IFD.
      */
     public function __construct(
-        public readonly int $tag,
-        public readonly int $type,
-        public readonly int $count,
-        public readonly mixed $value,
+        public int $tag,
+        public int $type,
+        public int $count,
+        public mixed $value,
     ) {
     }
 }

--- a/src/Model/Metadata.php
+++ b/src/Model/Metadata.php
@@ -27,11 +27,11 @@ final readonly class Metadata
      * @param XmpDocument|null   $xmpDoc    Parsed representation of the primary XMP packet.
      */
     public function __construct(
-        public readonly array $exifBlobs,
-        public readonly ?QuickTimeMeta $quickTime,
-        public readonly ?ExifDocument $exifDoc = null,
-        public readonly array $xmpBlobs = [],
-        public readonly ?XmpDocument $xmpDoc = null,
+        public array $exifBlobs,
+        public ?QuickTimeMeta $quickTime,
+        public ?ExifDocument $exifDoc = null,
+        public array $xmpBlobs = [],
+        public ?XmpDocument $xmpDoc = null,
     ) {
     }
 }

--- a/src/Model/QuickTimeMeta.php
+++ b/src/Model/QuickTimeMeta.php
@@ -21,7 +21,7 @@ final readonly class QuickTimeMeta
      *
      * @param array<string, string|int|float|bool> $keys Map of QuickTime metadata keys and their values.
      */
-    public function __construct(public readonly array $keys)
+    public function __construct(public array $keys)
     {
     }
 

--- a/src/Model/Xmp/XmpDocument.php
+++ b/src/Model/Xmp/XmpDocument.php
@@ -26,7 +26,7 @@ final readonly class XmpDocument
     /**
      * @param array<string, string|array<int, string>> $data Map of Clark notation => value
      */
-    public function __construct(public readonly array $data)
+    public function __construct(public array $data)
     {
     }
 


### PR DESCRIPTION
## Summary
- remove redundant readonly modifier from promoted properties in readonly model classes

## Testing
- composer ci:cgl
- composer ci:test:php:unit
- composer ci:test:php:unit:coverage
- composer ci:test:php:phpstan

------
https://chatgpt.com/codex/tasks/task_e_68f9ee3e1ccc832381706ba88dfa3026