### PR TITLE
test: add phpdoc summaries to XmpDocument tests

### DIFF
--- a/tests/Xmp/XmpDocumentTest.php
+++ b/tests/Xmp/XmpDocumentTest.php
@@ -26,6 +26,9 @@ final class XmpDocumentTest extends TestCase
     private const EXIF_NAMESPACE = 'http://ns.adobe.com/exif/1.0/';
 
     #[Test]
+    /**
+     * Ensures accessor methods expose values parsed by the XMP reader.
+     */
     public function testDocumentAccessorsWithReaderData(): void
     {
         $xml = <<<XML
@@ -54,6 +57,9 @@ XML;
     }
 
     #[Test]
+    /**
+     * Confirms parser-fed documents yield expected accessor results.
+     */
     public function testDocumentAccessorsWithParserData(): void
     {
         $xml = <<<XML
@@ -86,6 +92,9 @@ XML;
     }
 
     #[Test]
+    /**
+     * Validates external entity bag entries are ignored for safety.
+     */
     public function testExternalEntityBagIsIgnored(): void
     {
         $xml = <<<XML


### PR DESCRIPTION
## Summary
- add concise PHPDoc summaries to the XMP document accessor tests
- clarify the security expectation for ignored external entity bags

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f9ee62ad988323b372295425015b45