### PR TITLE
Move JPEG extractor test into Parse namespace

### DIFF
--- a/src/Parse/IsoBmff/IsoBmffExtractor.php
+++ b/src/Parse/IsoBmff/IsoBmffExtractor.php
@@ -429,6 +429,7 @@ final readonly class IsoBmffExtractor
      * Strips redundant EXIF signatures so downstream parsers accept the blob.
      *
      * @param string $blob Raw EXIF payload that may still include the "Exif\0\0" signature prefix.
+     *
      * @return string EXIF payload trimmed to the TIFF header when a redundant signature is detected.
      */
     private function normalizeExifBlob(string $blob): string

--- a/tests/Model/QuickTimeMeta/QuickTimeMetaTest.php
+++ b/tests/Model/QuickTimeMeta/QuickTimeMetaTest.php
@@ -29,7 +29,7 @@ final class QuickTimeMetaTest extends TestCase
     public function returnsStoredContentIdentifier(): void
     {
         $identifier = 'abc-123';
-        $keys = [
+        $keys       = [
             'com.apple.quicktime.content.identifier' => $identifier,
             'com.apple.quicktime.location.ISO6709'   => '+12.345-067.890/',
         ];

--- a/tests/Parse/Jpeg/JpegExtractorTest.php
+++ b/tests/Parse/Jpeg/JpegExtractorTest.php
@@ -9,7 +9,7 @@
 
 declare(strict_types=1);
 
-namespace MagicSunday\ImageMeta\Tests\Jpeg;
+namespace MagicSunday\ImageMeta\Tests\Parse\Jpeg;
 
 use MagicSunday\ImageMeta\Core\ParseError;
 use MagicSunday\ImageMeta\Core\Stream;

--- a/tests/Parse/Tiff/TiffExifReaderTest.php
+++ b/tests/Parse/Tiff/TiffExifReaderTest.php
@@ -357,7 +357,7 @@ final class TiffExifReaderTest extends TestCase
      * Packs raw bytes into an inline integer value for Classic TIFF entries.
      *
      * @param array<int, int> $values Byte values to encode.
-     * @param int              $width Inline storage width.
+     * @param int             $width  Inline storage width.
      */
     private static function inlineBytes(array $values, int $width): int
     {

--- a/tests/Parse/Xmp/XmpParser/XmpParserTest.php
+++ b/tests/Parse/Xmp/XmpParser/XmpParserTest.php
@@ -93,6 +93,6 @@ XML;
     public static function provideInvalidXmpFragments(): iterable
     {
         yield 'broken xml declaration' => ['<?xml version="1.0"?><rdf:RDF'];
-        yield 'unsupported namespace'  => ['<root xmlns="urn:example"><value>ignored</value></root>'];
+        yield 'unsupported namespace' => ['<root xmlns="urn:example"><value>ignored</value></root>'];
     }
 }


### PR DESCRIPTION
## Summary
- move the JPEG extractor test into the Parse/Jpeg namespace
- update the namespace declaration after relocating the test
- apply php-cs-fixer formatting updates produced by `composer ci:cgl`

## Testing
- composer dump-autoload
- composer ci:test:php:unit
- composer ci:test:php:unit:coverage *(fails: No code coverage driver available)*
- composer ci:test:php:phpstan *(fails: existing analysis errors in the codebase)*
- composer ci:cgl

------
https://chatgpt.com/codex/tasks/task_e_68f9ef8d47208323b1e83c92a5593a69