### PR TITLE
Add ValueConverters EXIF conversion tests

### DIFF
--- a/src/Parse/IsoBmff/IsoBmffExtractor.php
+++ b/src/Parse/IsoBmff/IsoBmffExtractor.php
@@ -429,6 +429,7 @@ final readonly class IsoBmffExtractor
      * Strips redundant EXIF signatures so downstream parsers accept the blob.
      *
      * @param string $blob Raw EXIF payload that may still include the "Exif\0\0" signature prefix.
+     *
      * @return string EXIF payload trimmed to the TIFF header when a redundant signature is detected.
      */
     private function normalizeExifBlob(string $blob): string

--- a/tests/Model/Exif/ValueConvertersTest.php
+++ b/tests/Model/Exif/ValueConvertersTest.php
@@ -1,0 +1,153 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\ImageMeta\Tests\Model\Exif;
+
+use MagicSunday\ImageMeta\Model\Exif\ExifTag;
+use MagicSunday\ImageMeta\Model\Exif\Ifd;
+use MagicSunday\ImageMeta\Model\Exif\IfdEntry;
+use MagicSunday\ImageMeta\Model\Exif\ValueConverters;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \MagicSunday\ImageMeta\Model\Exif\ValueConverters
+ */
+#[CoversClass(ValueConverters::class)]
+final class ValueConvertersTest extends TestCase
+{
+    #[Test]
+    #[DataProvider('provideValidRationals')]
+    /**
+     * Ensures rational values represented as numerator/denominator pairs are converted to floats.
+     *
+     * @param array{0:int,1:int} $value
+     */
+    public function convertsRationalPairsToFloat(array $value, float $expected): void
+    {
+        self::assertSame($expected, ValueConverters::rationalToFloat($value));
+    }
+
+    /**
+     * @return iterable<string, array{array{0:int,1:int}, float}>
+     */
+    public static function provideValidRationals(): iterable
+    {
+        yield 'positive integer' => [[3, 1], 3.0];
+        yield 'fractional value' => [[5, 2], 2.5];
+    }
+
+    #[Test]
+    #[DataProvider('provideScalarInputs')]
+    /**
+     * Ensures scalar values fall back to float conversion when no rational pair is provided.
+     */
+    public function convertsScalarsToFloat(int|float $value, float $expected): void
+    {
+        self::assertSame($expected, ValueConverters::rationalToFloat($value));
+    }
+
+    /**
+     * @return iterable<string, array{int|float, float}>
+     */
+    public static function provideScalarInputs(): iterable
+    {
+        yield 'integer' => [42, 42.0];
+        yield 'float' => [3.1415, 3.1415];
+    }
+
+    #[Test]
+    #[DataProvider('provideInvalidInputs')]
+    /**
+     * Ensures invalid values cannot be converted and return null instead.
+     */
+    public function returnsNullForInvalidRationalInputs(mixed $value): void
+    {
+        self::assertNull(ValueConverters::rationalToFloat($value));
+    }
+
+    /**
+     * @return iterable<string, array{mixed}>
+     */
+    public static function provideInvalidInputs(): iterable
+    {
+        yield 'denominator zero' => [[[1, 0]]];
+        yield 'not enough elements' => [[[1]]];
+        yield 'string' => ['invalid'];
+        yield 'null' => [null];
+    }
+
+    #[Test]
+    /**
+     * Ensures GPS coordinates are converted to floats using degree-minute-second rationals with a positive altitude.
+     */
+    public function extractsGpsCoordinatesWithPositiveAltitude(): void
+    {
+        $gps = new Ifd([
+            ExifTag::GPS_LATITUDE_REF  => new IfdEntry(ExifTag::GPS_LATITUDE_REF, 2, 2, 'N'),
+            ExifTag::GPS_LATITUDE      => new IfdEntry(ExifTag::GPS_LATITUDE, 5, 3, [[51, 1], [30, 1], [0, 1]]),
+            ExifTag::GPS_LONGITUDE_REF => new IfdEntry(ExifTag::GPS_LONGITUDE_REF, 2, 2, 'E'),
+            ExifTag::GPS_LONGITUDE     => new IfdEntry(ExifTag::GPS_LONGITUDE, 5, 3, [[0, 1], [7, 1], [3000, 100]]),
+            ExifTag::GPS_ALTITUDE_REF  => new IfdEntry(ExifTag::GPS_ALTITUDE_REF, 1, 1, 0),
+            ExifTag::GPS_ALTITUDE      => new IfdEntry(ExifTag::GPS_ALTITUDE, 5, 1, [450, 10]),
+        ]);
+
+        $result = ValueConverters::gpsFromIfd($gps);
+
+        self::assertEqualsWithDelta(51.5, $result['lat'], 0.000001);
+        self::assertEqualsWithDelta(0.125, $result['lon'], 0.000001);
+        self::assertEqualsWithDelta(45.0, $result['alt'], 0.000001);
+    }
+
+    #[Test]
+    /**
+     * Ensures GPS coordinates honour southern and western references and invert the altitude when required.
+     */
+    public function extractsGpsCoordinatesWithNegativeHemisphereAndAltitude(): void
+    {
+        $gps = new Ifd([
+            ExifTag::GPS_LATITUDE_REF  => new IfdEntry(ExifTag::GPS_LATITUDE_REF, 2, 2, 'S'),
+            ExifTag::GPS_LATITUDE      => new IfdEntry(ExifTag::GPS_LATITUDE, 5, 3, [[33, 1], [15, 1], [1800, 100]]),
+            ExifTag::GPS_LONGITUDE_REF => new IfdEntry(ExifTag::GPS_LONGITUDE_REF, 2, 2, 'W'),
+            ExifTag::GPS_LONGITUDE     => new IfdEntry(ExifTag::GPS_LONGITUDE, 5, 3, [[70, 1], [45, 1], [0, 1]]),
+            ExifTag::GPS_ALTITUDE_REF  => new IfdEntry(ExifTag::GPS_ALTITUDE_REF, 1, 1, 1),
+            ExifTag::GPS_ALTITUDE      => new IfdEntry(ExifTag::GPS_ALTITUDE, 5, 1, [250, 2]),
+        ]);
+
+        $result = ValueConverters::gpsFromIfd($gps);
+
+        self::assertEqualsWithDelta(-33.255, $result['lat'], 0.000001);
+        self::assertEqualsWithDelta(-70.75, $result['lon'], 0.000001);
+        self::assertEqualsWithDelta(-125.0, $result['alt'], 0.000001);
+    }
+
+    #[Test]
+    /**
+     * Ensures missing altitude entries result in a null altitude while still returning latitude and longitude.
+     */
+    public function extractsGpsCoordinatesWithoutAltitude(): void
+    {
+        $gps = new Ifd([
+            ExifTag::GPS_LATITUDE_REF  => new IfdEntry(ExifTag::GPS_LATITUDE_REF, 2, 2, 'N'),
+            ExifTag::GPS_LATITUDE      => new IfdEntry(ExifTag::GPS_LATITUDE, 5, 3, [[10, 1], [0, 1], [0, 1]]),
+            ExifTag::GPS_LONGITUDE_REF => new IfdEntry(ExifTag::GPS_LONGITUDE_REF, 2, 2, 'E'),
+            ExifTag::GPS_LONGITUDE     => new IfdEntry(ExifTag::GPS_LONGITUDE, 5, 3, [[20, 1], [30, 1], [0, 1]]),
+        ]);
+
+        $result = ValueConverters::gpsFromIfd($gps);
+
+        self::assertEqualsWithDelta(10.0, $result['lat'], 0.000001);
+        self::assertEqualsWithDelta(20.5, $result['lon'], 0.000001);
+        self::assertNull($result['alt']);
+    }
+}

--- a/tests/Model/QuickTimeMeta/QuickTimeMetaTest.php
+++ b/tests/Model/QuickTimeMeta/QuickTimeMetaTest.php
@@ -29,7 +29,7 @@ final class QuickTimeMetaTest extends TestCase
     public function returnsStoredContentIdentifier(): void
     {
         $identifier = 'abc-123';
-        $keys = [
+        $keys       = [
             'com.apple.quicktime.content.identifier' => $identifier,
             'com.apple.quicktime.location.ISO6709'   => '+12.345-067.890/',
         ];

--- a/tests/Parse/Tiff/TiffExifReaderTest.php
+++ b/tests/Parse/Tiff/TiffExifReaderTest.php
@@ -357,7 +357,7 @@ final class TiffExifReaderTest extends TestCase
      * Packs raw bytes into an inline integer value for Classic TIFF entries.
      *
      * @param array<int, int> $values Byte values to encode.
-     * @param int              $width Inline storage width.
+     * @param int             $width  Inline storage width.
      */
     private static function inlineBytes(array $values, int $width): int
     {

--- a/tests/Parse/Xmp/XmpParser/XmpParserTest.php
+++ b/tests/Parse/Xmp/XmpParser/XmpParserTest.php
@@ -93,6 +93,6 @@ XML;
     public static function provideInvalidXmpFragments(): iterable
     {
         yield 'broken xml declaration' => ['<?xml version="1.0"?><rdf:RDF'];
-        yield 'unsupported namespace'  => ['<root xmlns="urn:example"><value>ignored</value></root>'];
+        yield 'unsupported namespace' => ['<root xmlns="urn:example"><value>ignored</value></root>'];
     }
 }


### PR DESCRIPTION
## Summary
- add dedicated unit tests for ValueConverters covering rational conversion paths and GPS coordinate handling
- apply coding-style adjustments produced by composer ci:cgl

## Testing
- composer ci:test:php:unit
- composer ci:test:php:unit:coverage *(fails: No code coverage driver available)*
- composer ci:test:php:phpstan *(fails: baseline reports 193 errors)*
- composer ci:cgl

------
https://chatgpt.com/codex/tasks/task_e_68f9ef8e395883239ae9df6739a4d75b