### PR TITLE
Fix ParseError for truncated TIFF values

### DIFF
--- a/src/Parse/Tiff/TiffExifReader.php
+++ b/src/Parse/Tiff/TiffExifReader.php
@@ -23,6 +23,8 @@ use function chr;
 use function ord;
 use function pack;
 use function rtrim;
+use function sprintf;
+use function strlen;
 use function substr;
 use function unpack;
 
@@ -155,15 +157,7 @@ final class TiffExifReader
      */
     private function decodeValue(int $type, int $count, int $valueOrOffset): mixed
     {
-        $unitSize = match ($type) {
-            1, 2, 6, 7 => 1,           // BYTE, ASCII, SBYTE, UNDEFINED
-            3, 8 => 2,           // SHORT, SSHORT
-            4, 9 => 4,           // LONG, SLONG
-            5, 10 => 8,           // RATIONAL, SRATIONAL (two LONGs)
-            11      => 4,           // FLOAT
-            12      => 8,           // DOUBLE
-            default => throw new ParseError("Unsupported TIFF type: $type"),
-        };
+        $unitSize         = $this->bytesPerComponent($type);
         $dataSize        = $unitSize * $count;
         $inlineThreshold = $this->bigTiff ? 8 : 4;
 
@@ -196,6 +190,21 @@ final class TiffExifReader
      */
     private function decodeBytes(int $type, int $count, string $bytes): mixed
     {
+        $componentSize = $this->bytesPerComponent($type);
+        $bytesLength   = strlen($bytes);
+        $expectedBytes = $componentSize * $count;
+
+        if ($bytesLength < $expectedBytes) {
+            throw new ParseError(
+                sprintf(
+                    'Truncated value for TIFF type %d (expected %d bytes, got %d)',
+                    $type,
+                    $expectedBytes,
+                    $bytesLength,
+                ),
+            );
+        }
+
         if ($type === 2) { // ASCII
             return rtrim($bytes, "\0");
         }
@@ -225,16 +234,28 @@ final class TiffExifReader
                 12      => $this->unpackDouble(substr($bytes, $cursor, 8)),    // DOUBLE
                 default => throw new ParseError("Unsupported type in decodeBytes: $type"),
             };
-            $cursor += match ($type) {
-                1,6,7 => 1,
-                3,8 => 2,
-                4,9,11 => 4,
-                12      => 8,
-                default => 0,
-            };
+            $cursor += $componentSize;
         }
 
         return $count === 1 ? $vals[0] : $vals;
+    }
+
+    /**
+     * Returns the number of bytes used per component for a TIFF field type.
+     *
+     * @param int $type TIFF field type code.
+     *
+     * @return int
+     */
+    private function bytesPerComponent(int $type): int
+    {
+        return match ($type) {
+            1, 2, 6, 7 => 1,           // BYTE, ASCII, SBYTE, UNDEFINED
+            3, 8 => 2,           // SHORT, SSHORT
+            4, 9, 11 => 4,           // LONG, SLONG, FLOAT
+            5, 10, 12 => 8,           // RATIONAL, SRATIONAL, DOUBLE
+            default => throw new ParseError("Unsupported TIFF type: $type"),
+        };
     }
 
     /**

--- a/tests/Parse/Tiff/TiffExifReaderTest.php
+++ b/tests/Parse/Tiff/TiffExifReaderTest.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 namespace MagicSunday\ImageMeta\Tests\Parse\Tiff;
 
 use MagicSunday\ImageMeta\Core\BoundsError;
+use MagicSunday\ImageMeta\Core\Endian;
 use MagicSunday\ImageMeta\Core\ParseError;
 use MagicSunday\ImageMeta\Model\Exif\ExifDocument;
 use MagicSunday\ImageMeta\Model\Exif\ExifTag;
@@ -113,6 +114,28 @@ final class TiffExifReaderTest extends TestCase
         $entry = $document->ifd0->get(ExifTag::GPS_ALTITUDE_REF);
         self::assertNotNull($entry);
         self::assertSame([1, 2, 3], $entry->value);
+    }
+
+    /**
+     * Ensures truncated byte payloads are converted into parse errors instead of PHP notices.
+     */
+    #[Test]
+    public function rejectsTruncatedBytePayload(): void
+    {
+        $reader = new TiffExifReader();
+
+        $refClass = new \ReflectionClass($reader);
+        $boProp   = $refClass->getProperty('bo');
+        $boProp->setAccessible(true);
+        $boProp->setValue($reader, Endian::Little);
+
+        $decodeBytes = $refClass->getMethod('decodeBytes');
+        $decodeBytes->setAccessible(true);
+
+        $this->expectException(ParseError::class);
+        $this->expectExceptionMessage('Truncated value for TIFF type 1');
+
+        $decodeBytes->invoke($reader, 1, 2, "\x01");
     }
 
     /**


### PR DESCRIPTION
## Summary
- add byte-length validation when decoding TIFF values to raise a ParseError on truncated data
- cover the regression with a TIFF EXIF reader test exercising truncated byte payloads

## Testing
- composer ci:test:php:unit

------
https://chatgpt.com/codex/tasks/task_e_68f9f0211180832397d23eecfea21011