### PR TITLE
Add unit tests for EXIF IFD models

### DIFF
--- a/tests/Model/Exif/Ifd/IfdTest.php
+++ b/tests/Model/Exif/Ifd/IfdTest.php
@@ -1,0 +1,78 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\ImageMeta\Tests\Model\Exif\Ifd;
+
+use MagicSunday\ImageMeta\Model\Exif\Ifd;
+use MagicSunday\ImageMeta\Model\Exif\IfdEntry;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for the {@see Ifd} model.
+ */
+final class IfdTest extends TestCase
+{
+    /**
+     * Ensures the constructor exposes the provided entries and optional next IFD offset.
+     */
+    #[Test]
+    public function testConstructorStoresEntriesAndNextOffset(): void
+    {
+        $entry = new IfdEntry(0x010F, 2, 1, 'MagicSunday');
+        $ifd = new Ifd([$entry->tag => $entry], 256);
+
+        self::assertSame([$entry->tag => $entry], $ifd->entries);
+        self::assertSame(256, $ifd->nextIfdOffset);
+    }
+
+    /**
+     * Verifies that the next IFD offset defaults to null when it is omitted.
+     */
+    #[Test]
+    public function testConstructorDefaultsNextOffsetToNull(): void
+    {
+        $entry = new IfdEntry(0x0110, 2, 1, 'Camera Model');
+        $ifd = new Ifd([$entry->tag => $entry]);
+
+        self::assertSame([$entry->tag => $entry], $ifd->entries);
+        self::assertNull($ifd->nextIfdOffset);
+    }
+
+    /**
+     * Ensures that get() returns the entry associated with a known tag identifier.
+     */
+    #[Test]
+    public function testGetReturnsEntryForKnownTag(): void
+    {
+        $cameraEntry = new IfdEntry(0x0110, 2, 1, 'Camera Model');
+        $artistEntry = new IfdEntry(0x013B, 2, 1, 'MagicSunday');
+
+        $ifd = new Ifd([
+            $cameraEntry->tag => $cameraEntry,
+            $artistEntry->tag => $artistEntry,
+        ]);
+
+        self::assertSame($artistEntry, $ifd->get(0x013B));
+    }
+
+    /**
+     * Ensures that get() returns null when the tag identifier is not present in the directory.
+     */
+    #[Test]
+    public function testGetReturnsNullForUnknownTag(): void
+    {
+        $cameraEntry = new IfdEntry(0x0110, 2, 1, 'Camera Model');
+        $ifd = new Ifd([$cameraEntry->tag => $cameraEntry]);
+
+        self::assertNull($ifd->get(0x010F));
+    }
+}

--- a/tests/Model/Exif/IfdEntry/IfdEntryTest.php
+++ b/tests/Model/Exif/IfdEntry/IfdEntryTest.php
@@ -1,0 +1,52 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\ImageMeta\Tests\Model\Exif\IfdEntry;
+
+use MagicSunday\ImageMeta\Model\Exif\IfdEntry;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for the {@see IfdEntry} model.
+ */
+final class IfdEntryTest extends TestCase
+{
+    /**
+     * Ensures the constructor assigns the provided scalar values to the exposed properties.
+     */
+    #[Test]
+    public function testConstructorAssignsScalarValues(): void
+    {
+        $entry = new IfdEntry(0x010F, 2, 1, 'MagicSunday');
+
+        self::assertSame(0x010F, $entry->tag);
+        self::assertSame(2, $entry->type);
+        self::assertSame(1, $entry->count);
+        self::assertSame('MagicSunday', $entry->value);
+    }
+
+    /**
+     * Verifies that complex values such as arrays are exposed unchanged.
+     */
+    #[Test]
+    public function testConstructorPreservesArrayValues(): void
+    {
+        $value = [1, 2, 3];
+
+        $entry = new IfdEntry(0x8769, 3, count($value), $value);
+
+        self::assertSame(0x8769, $entry->tag);
+        self::assertSame(3, $entry->type);
+        self::assertSame(3, $entry->count);
+        self::assertSame($value, $entry->value);
+    }
+}


### PR DESCRIPTION
## Summary
- add PHPUnit coverage for the IfdEntry model constructor and property exposure
- verify Ifd construction semantics and lookup behaviour, including null cases

## Testing
- composer ci:test:php:unit

------
https://chatgpt.com/codex/tasks/task_e_68f9f3f447fc832398747551cf41ac32