### PR TITLE
Align Metadata constructor docblock parameter order

### DIFF
--- a/src/Model/Metadata.php
+++ b/src/Model/Metadata.php
@@ -22,8 +22,8 @@ final readonly class Metadata
     /**
      * @param list<string>       $exifBlobs TIFF‑EXIF blobs (first is primary)
      * @param QuickTimeMeta|null $quickTime QuickTime metadata extracted from ISO BMFF containers.
-     * @param list<string>       $xmpBlobs  XMP packets (RDF/XML), first is primary
      * @param ExifDocument|null  $exifDoc   Parsed representation of the primary EXIF document.
+     * @param list<string>       $xmpBlobs  XMP packets (RDF/XML), first is primary
      * @param XmpDocument|null   $xmpDoc    Parsed representation of the primary XMP packet.
      */
     public function __construct(


### PR DESCRIPTION
## Summary
- reorder the Metadata constructor docblock parameters to match the signature
- clarify the `$exifDoc` description before the `$xmpBlobs` entry

## Testing
- composer ci:cgl

------
https://chatgpt.com/codex/tasks/task_e_68f9f3f401a08323948c854e817d0acc