### PR TITLE
refine exif value typing

### DIFF
--- a/src/Convenience/ExifConvenience.php
+++ b/src/Convenience/ExifConvenience.php
@@ -15,13 +15,13 @@ use DateTimeImmutable;
 use MagicSunday\ImageMeta\Model\Exif\ExifDocument;
 use MagicSunday\ImageMeta\Model\Exif\ExifTag;
 use MagicSunday\ImageMeta\Model\Exif\IfdEntry;
+use MagicSunday\ImageMeta\Model\Exif\ValueConverters;
 use Throwable;
 
-use function count;
+use function array_is_list;
 use function is_array;
 use function is_float;
 use function is_int;
-use function is_numeric;
 use function is_string;
 use function strlen;
 
@@ -96,7 +96,7 @@ final class ExifConvenience
     {
         $e = self::find($doc, ExifTag::EXPOSURE_TIME); // ExposureTime (rational)
 
-        return self::rationalToFloat($e?->value);
+        return ValueConverters::rationalToFloat($e?->value ?? null);
     }
 
     /**
@@ -110,7 +110,7 @@ final class ExifConvenience
     {
         $e = self::find($doc, ExifTag::F_NUMBER); // FNumber (rational)
 
-        return self::rationalToFloat($e?->value);
+        return ValueConverters::rationalToFloat($e?->value ?? null);
     }
 
     /**
@@ -124,7 +124,7 @@ final class ExifConvenience
     {
         $e = self::find($doc, ExifTag::FOCAL_LENGTH); // FocalLength (rational)
 
-        return self::rationalToFloat($e?->value);
+        return ValueConverters::rationalToFloat($e?->value ?? null);
     }
 
     /**
@@ -146,8 +146,20 @@ final class ExifConvenience
         $value = $entry->value;
 
         if (is_array($value)) {
-            // Some cameras store ISO as a list, keep the first element.
-            $value = $value[0] ?? null;
+            $first = self::firstNumericFromList($value);
+            if (is_int($first)) {
+                return $first;
+            }
+            if (is_float($first)) {
+                return (int) $first;
+            }
+
+            $rational = ValueConverters::rationalToFloat($value);
+            if ($rational !== null) {
+                return (int) $rational;
+            }
+
+            return null;
         }
 
         if (is_int($value)) {
@@ -203,27 +215,20 @@ final class ExifConvenience
     }
 
     /**
-     * Converts EXIF rational values (or lists of rationals) into a float.
+     * Extracts the first numeric value from a list of scalars.
      *
-     * @param mixed $v scalar, rational pair or list of rational pairs from an EXIF tag
+     * @param array<int, mixed> $value Potential list of numeric ISO values.
      *
-     * @return float|null normalised scalar value
+     * @return int|float|null
      */
-    private static function rationalToFloat(mixed $v): ?float
+    private static function firstNumericFromList(array $value): int|float|null
     {
-        if (is_array($v)) {
-            // [num, den] or list of rationals
-            if (count($v) === 2 && is_numeric($v[0] ?? null) && is_numeric($v[1] ?? null) && (int) $v[1] !== 0) {
-                return (float) $v[0] / (float) $v[1];
-            }
-            if (isset($v[0]) && is_array($v[0]) && count($v[0]) === 2) {
-                $n = $v[0][0] ?? 0;
-                $d = $v[0][1] ?? 1;
-
-                return (int) $d !== 0 ? (float) $n / (float) $d : null;
-            }
+        if (!array_is_list($value)) {
+            return null;
         }
 
-        return is_int($v) || is_float($v) ? (float) $v : null;
+        $first = $value[0] ?? null;
+
+        return is_int($first) || is_float($first) ? $first : null;
     }
 }

--- a/src/MakerNotes/AppleDecoder.php
+++ b/src/MakerNotes/AppleDecoder.php
@@ -26,7 +26,7 @@ final class AppleDecoder implements MakerNotesDecoderInterface
      * @param string      $make  Reported camera make string.
      * @param string|null $model Optional camera model identifier.
      *
-     * @return array<string, mixed> Normalised metadata describing the vendor, payload length, and hash.
+     * @return array{_vendor: string, _length: int, _sha1: string} Normalised metadata describing the vendor, payload length, and hash.
      */
     public function decode(string $raw, string $make, ?string $model): array
     {

--- a/src/MakerNotes/MakerNotesDecoderInterface.php
+++ b/src/MakerNotes/MakerNotesDecoderInterface.php
@@ -23,7 +23,7 @@ interface MakerNotesDecoderInterface
      * @param string      $make  Camera make identifier associated with the payload.
      * @param string|null $model Optional camera model identifier when available.
      *
-     * @return array<string, mixed> Decoded metadata map; may be partial depending on decoder coverage.
+     * @return array<string, int|float|string|bool|null> Decoded metadata map; may be partial depending on decoder coverage.
      */
     public function decode(string $raw, string $make, ?string $model): array;
 }

--- a/src/Model/Exif/IfdEntry.php
+++ b/src/Model/Exif/IfdEntry.php
@@ -13,6 +13,11 @@ namespace MagicSunday\ImageMeta\Model\Exif;
 
 /**
  * Represents a single entry within an image file directory (IFD).
+ *
+ * @phpstan-type ExifRational array{0:int,1:int}
+ * @phpstan-type ExifNumericList list<int|float>
+ * @phpstan-type ExifRationalList list<ExifRational>
+ * @phpstan-type ExifValue int|float|string|ExifRational|ExifRationalList|ExifNumericList
  */
 final readonly class IfdEntry
 {
@@ -20,13 +25,13 @@ final readonly class IfdEntry
      * @param int   $tag   The numeric identifier of the entry.
      * @param int   $type  The TIFF field type code.
      * @param int   $count The number of values stored in the entry.
-     * @param mixed $value The raw value or values decoded from the IFD.
+     * @param ExifValue $value The raw value or values decoded from the IFD.
      */
     public function __construct(
         public int $tag,
         public int $type,
         public int $count,
-        public mixed $value,
+        public int|float|string|array $value,
     ) {
     }
 }

--- a/src/Model/Exif/ValueConverters.php
+++ b/src/Model/Exif/ValueConverters.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace MagicSunday\ImageMeta\Model\Exif;
 
+use function array_is_list;
 use function count;
 use function is_array;
 use function is_float;
@@ -19,21 +20,36 @@ use function is_string;
 
 /**
  * Helper methods that translate EXIF/TIFF values into PHP friendly scalars.
+ *
+ * @phpstan-import-type ExifRational from IfdEntry
+ * @phpstan-import-type ExifRationalList from IfdEntry
+ * @phpstan-import-type ExifValue from IfdEntry
  */
 final readonly class ValueConverters
 {
     /**
      * Converts a TIFF RATIONAL or scalar value into a floating point value.
      *
-     * @param mixed $v The value to convert.
+     * @param ExifValue|null $v The value to convert.
      *
      * @return float|null
      */
-    public static function rationalToFloat(mixed $v): ?float
+    public static function rationalToFloat(int|float|string|array|null $v): ?float
     {
-        if (is_array($v) && count($v) === 2 && (int) $v[1] !== 0) {
-            return (float) $v[0] / (float) $v[1];
+        if (is_array($v)) {
+            $pair = self::normaliseRationalPair($v);
+            if ($pair !== null && $pair[1] !== 0) {
+                return (float) $pair[0] / (float) $pair[1];
+            }
+
+            $list = self::normaliseRationalList($v);
+            if ($list !== null && isset($list[0]) && $list[0][1] !== 0) {
+                return (float) $list[0][0] / (float) $list[0][1];
+            }
+
+            return null;
         }
+
         if (is_int($v) || is_float($v)) {
             return (float) $v;
         }
@@ -55,13 +71,19 @@ final readonly class ValueConverters
         $lonRef = $gps->get(ExifTag::GPS_LONGITUDE_REF)?->value ?? null;
         $lonVal = $gps->get(ExifTag::GPS_LONGITUDE)?->value ?? null;
 
-        $lat = self::dmsToFloat($latRef, $latVal);
-        $lon = self::dmsToFloat($lonRef, $lonVal);
+        $latPairs = is_array($latVal) ? self::normaliseRationalList($latVal) : null;
+        $lonPairs = is_array($lonVal) ? self::normaliseRationalList($lonVal) : null;
+
+        $lat = self::dmsToFloat($latRef, $latPairs);
+        $lon = self::dmsToFloat($lonRef, $lonPairs);
 
         $alt = null;
-        if (($e = $gps->get(ExifTag::GPS_ALTITUDE)) && is_array($e->value) && count($e->value) === 2 && (int) $e->value[1] !== 0) {
-            $alt = $e->value[0] / $e->value[1];
-            if (($ref = $gps->get(ExifTag::GPS_ALTITUDE_REF)) && (int) ($ref->value ?? 0) === 1) {
+        if (($e = $gps->get(ExifTag::GPS_ALTITUDE)) && is_array($e->value)) {
+            $altPair = self::normaliseRationalPair($e->value);
+            if ($altPair !== null && $altPair[1] !== 0) {
+                $alt = $altPair[0] / $altPair[1];
+            }
+            if ($alt !== null && ($ref = $gps->get(ExifTag::GPS_ALTITUDE_REF)) && (int) ($ref->value ?? 0) === 1) {
                 $alt = -$alt;
             }
         }
@@ -72,12 +94,12 @@ final readonly class ValueConverters
     /**
      * Converts EXIF GPS degrees/minutes/seconds to a float coordinate.
      *
-     * @param string|null $ref Direction reference (N/E/S/W).
-     * @param mixed       $val Rational triplet describing the coordinate.
+     * @param string|null        $ref   Direction reference (N/E/S/W).
+     * @param ExifRationalList|null $val Rational triplet describing the coordinate.
      *
      * @return float|null
      */
-    private static function dmsToFloat(?string $ref, mixed $val): ?float
+    private static function dmsToFloat(?string $ref, ?array $val): ?float
     {
         if (!is_string($ref) || !is_array($val) || count($val) < 3) {
             return null;
@@ -92,5 +114,58 @@ final readonly class ValueConverters
         $sign = ($ref === 'S' || $ref === 'W') ? -1.0 : 1.0;
 
         return $sign * ($deg + $min / 60.0 + $sec / 3600.0);
+    }
+
+    /**
+     * Normalises a potential rational pair into a strict two-element array.
+     *
+     * @param array<int, mixed> $value Candidate value from EXIF data.
+     *
+     * @return ExifRational|null
+     */
+    private static function normaliseRationalPair(array $value): ?array
+    {
+        if (!array_is_list($value) || count($value) !== 2) {
+            return null;
+        }
+
+        $num = $value[0] ?? null;
+        $den = $value[1] ?? null;
+
+        if (!is_int($num) || !is_int($den)) {
+            return null;
+        }
+
+        return [$num, $den];
+    }
+
+    /**
+     * Validates that the provided value is a list of rational pairs.
+     *
+     * @param array<int, mixed> $value Candidate value from EXIF data.
+     *
+     * @return ExifRationalList|null
+     */
+    private static function normaliseRationalList(array $value): ?array
+    {
+        if (!array_is_list($value)) {
+            return null;
+        }
+
+        $list = [];
+        foreach ($value as $item) {
+            if (!is_array($item)) {
+                return null;
+            }
+
+            $pair = self::normaliseRationalPair($item);
+            if ($pair === null) {
+                return null;
+            }
+
+            $list[] = $pair;
+        }
+
+        return $list;
     }
 }

--- a/src/Model/Xmp/XmpDocument.php
+++ b/src/Model/Xmp/XmpDocument.php
@@ -57,7 +57,10 @@ final readonly class XmpDocument
     {
         return array_find(
             $this->data,
-            fn (mixed $value, int|string $key): bool => $this->matchesLocalName((string) $key, $localName)
+            /**
+             * @param array<int, string>|string $value
+             */
+            fn (array|string $value, int|string $key): bool => $this->matchesLocalName((string) $key, $localName)
                 && (is_string($value) || is_array($value))
         );
     }

--- a/src/Parse/Tiff/TiffExifReader.php
+++ b/src/Parse/Tiff/TiffExifReader.php
@@ -30,6 +30,8 @@ use function unpack;
 
 /**
  * Parses classic TIFF and BigTIFF structures embedded in EXIF payloads.
+ *
+ * @phpstan-import-type ExifValue from IfdEntry
  */
 final class TiffExifReader
 {
@@ -153,9 +155,9 @@ final class TiffExifReader
      * @param int $count         Number of values represented.
      * @param int $valueOrOffset Inline value bytes or an offset into the blob.
      *
-     * @return mixed
+     * @return ExifValue
      */
-    private function decodeValue(int $type, int $count, int $valueOrOffset): mixed
+    private function decodeValue(int $type, int $count, int $valueOrOffset): int|float|string|array
     {
         $unitSize         = $this->bytesPerComponent($type);
         $dataSize        = $unitSize * $count;
@@ -186,9 +188,9 @@ final class TiffExifReader
      * @param int    $count Number of values represented.
      * @param string $bytes Raw value bytes read from the blob.
      *
-     * @return mixed
+     * @return ExifValue
      */
-    private function decodeBytes(int $type, int $count, string $bytes): mixed
+    private function decodeBytes(int $type, int $count, string $bytes): int|float|string|array
     {
         $componentSize = $this->bytesPerComponent($type);
         $bytesLength   = strlen($bytes);
@@ -209,14 +211,14 @@ final class TiffExifReader
             return rtrim($bytes, "\0");
         }
         if ($type === 5 || $type === 10) { // RATIONAL / SRATIONAL
-            $out = [];
+            $rationalValues = [];
             for ($i = 0; $i < $count; ++$i) {
-                $num   = $this->read32FromBytes($bytes, $i * 8 + 0, $type === 10);
-                $den   = $this->read32FromBytes($bytes, $i * 8 + 4, $type === 10);
-                $out[] = [$num, $den];
+                $num               = $this->read32FromBytes($bytes, $i * 8 + 0, $type === 10);
+                $den               = $this->read32FromBytes($bytes, $i * 8 + 4, $type === 10);
+                $rationalValues[] = [$num, $den];
             }
 
-            return $count === 1 ? $out[0] : $out;
+            return $count === 1 ? $rationalValues[0] : $rationalValues;
         }
 
         $vals   = [];

--- a/tests/Convenience/ExifConvenienceTest.php
+++ b/tests/Convenience/ExifConvenienceTest.php
@@ -67,6 +67,36 @@ final class ExifConvenienceTest extends TestCase
     }
 
     /**
+     * Ensures ISO values stored as floating point scalars are truncated to integers.
+     */
+    #[Test]
+    public function isoCastsFloatValuesToInteger(): void
+    {
+        $ifd0 = new Ifd([
+            ExifTag::PHOTOGRAPHIC_SENSITIVITY => new IfdEntry(ExifTag::PHOTOGRAPHIC_SENSITIVITY, 11, 2, [200.0, 400.0]),
+        ]);
+
+        $doc = new ExifDocument($ifd0, null, null, null, null);
+
+        self::assertSame(200, ExifConvenience::iso($doc));
+    }
+
+    /**
+     * Ensures ISO rational pairs are interpreted via their numerator/denominator representation.
+     */
+    #[Test]
+    public function isoDerivesValueFromRationalPair(): void
+    {
+        $ifd0 = new Ifd([
+            ExifTag::PHOTOGRAPHIC_SENSITIVITY => new IfdEntry(ExifTag::PHOTOGRAPHIC_SENSITIVITY, 5, 1, [320, 1]),
+        ]);
+
+        $doc = new ExifDocument($ifd0, null, null, null, null);
+
+        self::assertSame(320, ExifConvenience::iso($doc));
+    }
+
+    /**
      * Reads capture timestamp tags and verifies the helper delegates to the document parser to
      * return a timezone-aware DateTime.
      */

--- a/tests/MakerNotes/AppleDecoder/AppleDecoderTest.php
+++ b/tests/MakerNotes/AppleDecoder/AppleDecoderTest.php
@@ -36,6 +36,7 @@ final class AppleDecoderTest extends TestCase
 
         $metadata = $decoder->decode($raw, 'Apple', 'iPhone');
 
+        self::assertSame(['_vendor', '_length', '_sha1'], array_keys($metadata));
         self::assertSame('Apple', $metadata['_vendor']);
         self::assertSame(strlen($raw), $metadata['_length']);
         self::assertSame(40, strlen($metadata['_sha1']));

--- a/tests/Model/Exif/ValueConvertersTest.php
+++ b/tests/Model/Exif/ValueConvertersTest.php
@@ -29,9 +29,9 @@ final class ValueConvertersTest extends TestCase
     #[Test]
     #[DataProvider('provideValidRationals')]
     /**
-     * Ensures rational values represented as numerator/denominator pairs are converted to floats.
+     * Ensures rational values represented as numerator/denominator pairs or lists are converted to floats.
      *
-     * @param array{0:int,1:int} $value
+     * @param array{0:int,1:int}|list<array{0:int,1:int}> $value
      */
     public function convertsRationalPairsToFloat(array $value, float $expected): void
     {
@@ -39,12 +39,13 @@ final class ValueConvertersTest extends TestCase
     }
 
     /**
-     * @return iterable<string, array{array{0:int,1:int}, float}>
+     * @return iterable<string, array{array{0:int,1:int}|list<array{0:int,1:int}>, float}>
      */
     public static function provideValidRationals(): iterable
     {
         yield 'positive integer' => [[3, 1], 3.0];
         yield 'fractional value' => [[5, 2], 2.5];
+        yield 'list of rationals' => [[[5, 2], [3, 1]], 2.5];
     }
 
     #[Test]
@@ -83,6 +84,7 @@ final class ValueConvertersTest extends TestCase
     {
         yield 'denominator zero' => [[[1, 0]]];
         yield 'not enough elements' => [[[1]]];
+        yield 'non rational list' => [[[1, 2, 3]]];
         yield 'string' => ['invalid'];
         yield 'null' => [null];
     }

--- a/tests/Xmp/XmpDocumentTest.php
+++ b/tests/Xmp/XmpDocumentTest.php
@@ -52,7 +52,10 @@ XML;
         self::assertSame('2024-03-30T12:34:56Z', $document->get(self::XMP_NAMESPACE, 'CreateDate'));
         self::assertSame('2024-03-30T12:34:56Z', $document->find('CreateDate'));
         self::assertSame(['First', 'Second'], $document->get(self::DC_NAMESPACE, 'subject'));
-        self::assertSame(['First', 'Second'], $document->find('subject'));
+        $subjects = $document->find('subject');
+        self::assertIsArray($subjects);
+        self::assertSame(['First', 'Second'], $subjects);
+        self::assertContainsOnlyString($subjects);
         self::assertNull($document->get(self::DC_NAMESPACE, 'title'));
     }
 


### PR DESCRIPTION
## Summary
- narrow `IfdEntry` values and TIFF decoder outputs to explicit scalar and rational unions
- propagate the refined EXIF value handling through helper utilities and maker-note/XMP APIs
- extend the PHPUnit suites covering EXIF helpers, convenience accessors, maker notes, and XMP lookups

## Testing
- composer ci:test:php:unit

------
https://chatgpt.com/codex/tasks/task_e_68f9f3286ee48323b5879d7419addd00