### PR TITLE
Add constant for QuickTime content identifier key

### DIFF
--- a/src/Model/QuickTimeMeta.php
+++ b/src/Model/QuickTimeMeta.php
@@ -17,6 +17,11 @@ namespace MagicSunday\ImageMeta\Model;
 final readonly class QuickTimeMeta
 {
     /**
+     * QuickTime metadata key used for the content identifier value.
+     */
+    public const CONTENT_IDENTIFIER_KEY = 'com.apple.quicktime.content.identifier';
+
+    /**
      * Creates a new instance of QuickTime metadata information.
      *
      * @param array<string, string|int|float|bool> $keys Map of QuickTime metadata keys and their values.
@@ -32,7 +37,7 @@ final readonly class QuickTimeMeta
      */
     public function contentIdentifier(): ?string
     {
-        $key = 'com.apple.quicktime.content.identifier';
+        $key = self::CONTENT_IDENTIFIER_KEY;
 
         return isset($this->keys[$key]) ? (string) $this->keys[$key] : null;
     }

--- a/tests/Model/QuickTimeMeta/QuickTimeMetaTest.php
+++ b/tests/Model/QuickTimeMeta/QuickTimeMetaTest.php
@@ -30,7 +30,7 @@ final class QuickTimeMetaTest extends TestCase
     {
         $identifier = 'abc-123';
         $keys       = [
-            'com.apple.quicktime.content.identifier' => $identifier,
+            QuickTimeMeta::CONTENT_IDENTIFIER_KEY => $identifier,
             'com.apple.quicktime.location.ISO6709'   => '+12.345-067.890/',
         ];
 


### PR DESCRIPTION
## Summary
- add a documented QuickTimeMeta::CONTENT_IDENTIFIER_KEY constant for the content identifier metadata key
- reuse the new constant in the contentIdentifier accessor and its unit test

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f9f59e2df88323bc86ea8966e70c0e