### PR TITLE
fix: import global helpers in XmpParser

### DIFF
--- a/src/Parse/Xmp/XmpParser.php
+++ b/src/Parse/Xmp/XmpParser.php
@@ -14,6 +14,10 @@ namespace MagicSunday\ImageMeta\Parse\Xmp;
 use MagicSunday\ImageMeta\Model\Xmp\XmpDocument;
 use XMLReader;
 
+use function in_array;
+use function sprintf;
+use function trim;
+
 /**
  * Lightweight streaming XMP (RDF/XML) parser backed by XMLReader.
  * The parser extracts a curated subset of common fields and stores them


### PR DESCRIPTION
## Summary
- add function imports for the global helpers used in the Xmp parser

## Testing
- composer ci:cgl

------
https://chatgpt.com/codex/tasks/task_e_68f9f59da67c8323985650b9da2e6cfb