### PR TITLE
fix: document apple maker note metadata shape

### DIFF
--- a/src/MakerNotes/AppleDecoder.php
+++ b/src/MakerNotes/AppleDecoder.php
@@ -26,14 +26,17 @@ final class AppleDecoder implements MakerNotesDecoderInterface
      * @param string      $make  Reported camera make string.
      * @param string|null $model Optional camera model identifier.
      *
-     * @return array{_vendor: string, _length: int, _sha1: string} Normalised metadata describing the vendor, payload length, and hash.
+     * @return array{_vendor: 'Apple', _length: int, _sha1: non-empty-string} Normalised metadata describing the vendor, payload length, and hash.
      */
     public function decode(string $raw, string $make, ?string $model): array
     {
+        $payloadLength = strlen($raw);
+        $payloadHash   = sha1($raw, false);
+
         return [
             '_vendor' => 'Apple',
-            '_length' => strlen($raw),
-            '_sha1'   => sha1($raw, false),
+            '_length' => $payloadLength,
+            '_sha1'   => $payloadHash,
         ];
     }
 }

--- a/tests/MakerNotes/AppleDecoder/AppleDecoderTest.php
+++ b/tests/MakerNotes/AppleDecoder/AppleDecoderTest.php
@@ -36,10 +36,12 @@ final class AppleDecoderTest extends TestCase
 
         $metadata = $decoder->decode($raw, 'Apple', 'iPhone');
 
-        self::assertSame(['_vendor', '_length', '_sha1'], array_keys($metadata));
-        self::assertSame('Apple', $metadata['_vendor']);
-        self::assertSame(strlen($raw), $metadata['_length']);
-        self::assertSame(40, strlen($metadata['_sha1']));
-        self::assertSame(sha1($raw), $metadata['_sha1']);
+        $expected = [
+            '_vendor' => 'Apple',
+            '_length' => strlen($raw),
+            '_sha1'   => sha1($raw),
+        ];
+
+        self::assertSame($expected, $metadata);
     }
 }


### PR DESCRIPTION
## Summary
- document the Apple maker note metadata as a concrete array shape
- return the computed length and hash via dedicated variables to avoid mixed inference
- align the Apple decoder unit test with the shape-specific expectations

## Testing
- not run (vendor binaries not installed)


------
https://chatgpt.com/codex/tasks/task_e_68f9f59bf91c832383274fad01d2d310