### PR TITLE
chore: import substr in memory buffer

### DIFF
--- a/src/Core/MemoryBuffer.php
+++ b/src/Core/MemoryBuffer.php
@@ -13,6 +13,7 @@ namespace MagicSunday\ImageMeta\Core;
 
 use function ord;
 use function strlen;
+use function substr;
 use function unpack;
 
 /**


### PR DESCRIPTION
## Summary
- add the missing substr function import to MemoryBuffer so all globals are declared

## Testing
- composer ci:cgl

------
https://chatgpt.com/codex/tasks/task_e_68f9f5978500832390fa9feb0d31f782