### PR TITLE
Fix typing for XmpDocument::find callback

### DIFF
--- a/src/Model/Xmp/XmpDocument.php
+++ b/src/Model/Xmp/XmpDocument.php
@@ -26,7 +26,12 @@ final readonly class XmpDocument
     /**
      * @param array<string, string|array<int, string>> $data Map of Clark notation => value
      */
-    public function __construct(public array $data)
+    public function __construct(
+        /**
+         * @var array<string, string|array<int, string>>
+         */
+        public array $data
+    )
     {
     }
 
@@ -58,9 +63,9 @@ final readonly class XmpDocument
         return array_find(
             $this->data,
             /**
-             * @param array<int, string>|string $value
+             * @param string|array<int, string> $value
              */
-            fn (array|string $value, int|string $key): bool => $this->matchesLocalName((string) $key, $localName)
+            fn (array|string $value, string $key): bool => $this->matchesLocalName($key, $localName)
                 && (is_string($value) || is_array($value))
         );
     }


### PR DESCRIPTION
## Summary
- annotate the promoted data property with its string and array union type
- update the find callback signature to rely on string keys and the documented value type

## Testing
- .build/bin/phpunit tests/Xmp/XmpDocumentTest.php

------
https://chatgpt.com/codex/tasks/task_e_68f9f59b0d148323b7bab37421102082