### PR TITLE
Fix ExifDocument function imports

### DIFF
--- a/src/Model/Exif/ExifDocument.php
+++ b/src/Model/Exif/ExifDocument.php
@@ -14,6 +14,8 @@ namespace MagicSunday\ImageMeta\Model\Exif;
 use DateTimeImmutable;
 use DateTimeZone;
 
+use function is_float;
+use function is_int;
 use function is_string;
 use function rtrim;
 use function str_replace;


### PR DESCRIPTION
## Summary
- import the is_float and is_int helpers for ExifDocument numeric parsing
- keep the global function imports sorted with the existing coding standard

## Testing
- composer ci:cgl

------
https://chatgpt.com/codex/tasks/task_e_68f9f597da108323a29e7ca2e8115de9