### PR TITLE
Refine EXIF convenience array shape handling

### DIFF
--- a/src/Convenience/ExifConvenience.php
+++ b/src/Convenience/ExifConvenience.php
@@ -178,7 +178,20 @@ final class ExifConvenience
      *
      * @param ExifDocument $doc parsed EXIF metadata
      *
-     * @return array<string, mixed> normalised metadata values
+     * @return array{
+     *     make: ?string,
+     *     model: ?string,
+     *     lens: ?string,
+     *     orientation: ?int,
+     *     captured_at: ?string,
+     *     exposure_s: ?float,
+     *     fnumber: ?float,
+     *     focal_mm: ?float,
+     *     iso: ?int,
+     *     gps_lat: ?float,
+     *     gps_lon: ?float,
+     *     gps_alt: ?float,
+     * } normalised metadata values
      */
     public static function toArray(ExifDocument $doc): array
     {
@@ -195,9 +208,9 @@ final class ExifConvenience
             'fnumber'     => self::fNumber($doc),
             'focal_mm'    => self::focalLength($doc),
             'iso'         => self::iso($doc),
-            'gps_lat'     => $gps['lat'],
-            'gps_lon'     => $gps['lon'],
-            'gps_alt'     => $gps['alt'],
+            'gps_lat'     => $gps['lat'] !== null ? (float) $gps['lat'] : null,
+            'gps_lon'     => $gps['lon'] !== null ? (float) $gps['lon'] : null,
+            'gps_alt'     => $gps['alt'] !== null ? (float) $gps['alt'] : null,
         ];
     }
 

--- a/tests/Convenience/ExifConvenienceTest.php
+++ b/tests/Convenience/ExifConvenienceTest.php
@@ -146,4 +146,56 @@ final class ExifConvenienceTest extends TestCase
 
         self::assertNull(ExifConvenience::captureDateTime($doc));
     }
+
+    /**
+     * Ensures the flattened metadata representation exposes the expected shape and value types.
+     */
+    #[Test]
+    public function toArrayReturnsNormalisedShape(): void
+    {
+        $ifd0 = new Ifd([
+            ExifTag::MAKE        => new IfdEntry(ExifTag::MAKE, 2, 5, 'Canon'),
+            ExifTag::MODEL       => new IfdEntry(ExifTag::MODEL, 2, 3, 'EOS'),
+            ExifTag::ORIENTATION => new IfdEntry(ExifTag::ORIENTATION, 3, 1, 1),
+        ]);
+
+        $exifIfd = new Ifd([
+            ExifTag::LENS_MODEL            => new IfdEntry(ExifTag::LENS_MODEL, 2, 7, 'EF 50mm'),
+            ExifTag::EXPOSURE_TIME         => new IfdEntry(ExifTag::EXPOSURE_TIME, 5, 1, [1, 2]),
+            ExifTag::F_NUMBER              => new IfdEntry(ExifTag::F_NUMBER, 5, 1, [18, 10]),
+            ExifTag::FOCAL_LENGTH          => new IfdEntry(ExifTag::FOCAL_LENGTH, 5, 1, [50, 1]),
+            ExifTag::ISO_SPEED             => new IfdEntry(ExifTag::ISO_SPEED, 3, 1, 200),
+            ExifTag::DATETIME_ORIGINAL     => new IfdEntry(ExifTag::DATETIME_ORIGINAL, 2, 19, '2024:05:01 12:34:56'),
+            ExifTag::OFFSET_TIME_ORIGINAL  => new IfdEntry(ExifTag::OFFSET_TIME_ORIGINAL, 2, 6, '+02:00'),
+        ]);
+
+        $gpsIfd = new Ifd([
+            ExifTag::GPS_LATITUDE_REF  => new IfdEntry(ExifTag::GPS_LATITUDE_REF, 2, 2, 'N'),
+            ExifTag::GPS_LATITUDE      => new IfdEntry(ExifTag::GPS_LATITUDE, 5, 3, [[51, 1], [30, 1], [0, 1]]),
+            ExifTag::GPS_LONGITUDE_REF => new IfdEntry(ExifTag::GPS_LONGITUDE_REF, 2, 2, 'E'),
+            ExifTag::GPS_LONGITUDE     => new IfdEntry(ExifTag::GPS_LONGITUDE, 5, 3, [[0, 1], [7, 1], [3000, 100]]),
+            ExifTag::GPS_ALTITUDE_REF  => new IfdEntry(ExifTag::GPS_ALTITUDE_REF, 1, 1, 0),
+            ExifTag::GPS_ALTITUDE      => new IfdEntry(ExifTag::GPS_ALTITUDE, 5, 1, [450, 10]),
+        ]);
+
+        $doc    = new ExifDocument($ifd0, $exifIfd, $gpsIfd, null, null);
+        $result = ExifConvenience::toArray($doc);
+
+        $expected = [
+            'make'        => 'Canon',
+            'model'       => 'EOS',
+            'lens'        => 'EF 50mm',
+            'orientation' => 1,
+            'captured_at' => '2024-05-01T12:34:56+02:00',
+            'exposure_s'  => 0.5,
+            'fnumber'     => 1.8,
+            'focal_mm'    => 50.0,
+            'iso'         => 200,
+            'gps_lat'     => 51.5,
+            'gps_lon'     => 0.125,
+            'gps_alt'     => 45.0,
+        ];
+
+        self::assertSame($expected, $result);
+    }
 }


### PR DESCRIPTION
## Summary
- document `ExifConvenience::toArray()` with a precise array shape and normalise GPS floats
- ensure the flattened convenience payload returns typed values compatible with the new docblock
- extend the PHPUnit suite with coverage for the array representation

## Testing
- composer ci:test:php:unit

------
https://chatgpt.com/codex/tasks/task_e_68f9f595642083238f8752b0b4b65914