### PR TITLE
Add typed EXIF value objects for TIFF decoding

### DIFF
--- a/src/Convenience/ExifConvenience.php
+++ b/src/Convenience/ExifConvenience.php
@@ -18,9 +18,6 @@ use MagicSunday\ImageMeta\Model\Exif\IfdEntry;
 use MagicSunday\ImageMeta\Model\Exif\ValueConverters;
 use Throwable;
 
-use function array_is_list;
-use function is_array;
-use function is_float;
 use function is_int;
 use function is_string;
 use function strlen;
@@ -145,29 +142,13 @@ final class ExifConvenience
 
         $value = $entry->value;
 
-        if (is_array($value)) {
-            $first = self::firstNumericFromList($value);
-            if (is_int($first)) {
-                return $first;
-            }
-            if (is_float($first)) {
-                return (int) $first;
-            }
-
-            $rational = ValueConverters::rationalToFloat($value);
-            if ($rational !== null) {
-                return (int) $rational;
-            }
-
-            return null;
-        }
-
         if (is_int($value)) {
             return $value;
         }
 
-        if (is_float($value)) {
-            return (int) $value;
+        $numeric = ValueConverters::rationalToFloat($value);
+        if ($numeric !== null) {
+            return (int) $numeric;
         }
 
         return null;
@@ -214,21 +195,4 @@ final class ExifConvenience
         return $doc->exifIfd?->get($tag) ?? $doc->ifd0->get($tag) ?? null;
     }
 
-    /**
-     * Extracts the first numeric value from a list of scalars.
-     *
-     * @param array<int, mixed> $value Potential list of numeric ISO values.
-     *
-     * @return int|float|null
-     */
-    private static function firstNumericFromList(array $value): int|float|null
-    {
-        if (!array_is_list($value)) {
-            return null;
-        }
-
-        $first = $value[0] ?? null;
-
-        return is_int($first) || is_float($first) ? $first : null;
-    }
 }

--- a/src/Model/Exif/IfdEntry.php
+++ b/src/Model/Exif/IfdEntry.php
@@ -11,12 +11,16 @@ declare(strict_types=1);
 
 namespace MagicSunday\ImageMeta\Model\Exif;
 
+use MagicSunday\ImageMeta\Model\Exif\Value\ExifNumericList;
+use MagicSunday\ImageMeta\Model\Exif\Value\ExifRational;
+use MagicSunday\ImageMeta\Model\Exif\Value\ExifRationalList;
+
 /**
  * Represents a single entry within an image file directory (IFD).
  *
- * @phpstan-type ExifRational array{0:int,1:int}
- * @phpstan-type ExifNumericList list<int|float>
- * @phpstan-type ExifRationalList list<ExifRational>
+ * @phpstan-type ExifRational \MagicSunday\ImageMeta\Model\Exif\Value\ExifRational
+ * @phpstan-type ExifRationalList \MagicSunday\ImageMeta\Model\Exif\Value\ExifRationalList
+ * @phpstan-type ExifNumericList \MagicSunday\ImageMeta\Model\Exif\Value\ExifNumericList
  * @phpstan-type ExifValue int|float|string|ExifRational|ExifRationalList|ExifNumericList
  */
 final readonly class IfdEntry
@@ -31,7 +35,7 @@ final readonly class IfdEntry
         public int $tag,
         public int $type,
         public int $count,
-        public int|float|string|array $value,
+        public int|float|string|ExifRational|ExifRationalList|ExifNumericList $value,
     ) {
     }
 }

--- a/src/Model/Exif/Value/ExifNumericList.php
+++ b/src/Model/Exif/Value/ExifNumericList.php
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\ImageMeta\Model\Exif\Value;
+
+use ArrayIterator;
+use Countable;
+use IteratorAggregate;
+use Traversable;
+
+/**
+ * Represents an ordered list of integer or floating point EXIF values.
+ */
+final readonly class ExifNumericList implements Countable, IteratorAggregate
+{
+    /**
+     * @param list<int|float> $values
+     */
+    public function __construct(private array $values)
+    {
+    }
+
+    /**
+     * Returns the number of contained numeric values.
+     */
+    public function count(): int
+    {
+        return count($this->values);
+    }
+
+    /**
+     * Retrieves an iterator for the list contents.
+     *
+     * @return Traversable<int, int|float>
+     */
+    public function getIterator(): Traversable
+    {
+        return new ArrayIterator($this->values);
+    }
+
+    /**
+     * Returns the first numeric value from the list.
+     */
+    public function first(): int|float|null
+    {
+        return $this->values[0] ?? null;
+    }
+
+    /**
+     * Exposes the raw numeric values as a sequential array.
+     *
+     * @return list<int|float>
+     */
+    public function values(): array
+    {
+        return $this->values;
+    }
+}

--- a/src/Model/Exif/Value/ExifRational.php
+++ b/src/Model/Exif/Value/ExifRational.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\ImageMeta\Model\Exif\Value;
+
+/**
+ * Represents a single TIFF rational value.
+ */
+final readonly class ExifRational
+{
+    public function __construct(
+        public int $numerator,
+        public int $denominator,
+    ) {
+    }
+
+    /**
+     * Returns the rational pair as a two element array.
+     *
+     * @return array{0:int,1:int}
+     */
+    public function toArray(): array
+    {
+        return [$this->numerator, $this->denominator];
+    }
+
+    /**
+     * Converts the rational to a floating point value.
+     *
+     * @return float|null
+     */
+    public function asFloat(): ?float
+    {
+        if ($this->denominator === 0) {
+            return null;
+        }
+
+        return $this->numerator / $this->denominator;
+    }
+}

--- a/src/Model/Exif/Value/ExifRationalList.php
+++ b/src/Model/Exif/Value/ExifRationalList.php
@@ -1,0 +1,94 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\ImageMeta\Model\Exif\Value;
+
+use ArrayIterator;
+use Countable;
+use IteratorAggregate;
+use Traversable;
+
+/**
+ * Represents an ordered list of TIFF rational values.
+ */
+final readonly class ExifRationalList implements Countable, IteratorAggregate
+{
+    /**
+     * @param list<ExifRational> $values
+     */
+    public function __construct(private array $values)
+    {
+    }
+
+    /**
+     * Creates a list from raw rational pairs.
+     *
+     * @param list<array{0:int,1:int}> $pairs
+     */
+    public static function fromPairs(array $pairs): self
+    {
+        $values = [];
+        foreach ($pairs as $pair) {
+            $values[] = new ExifRational($pair[0], $pair[1]);
+        }
+
+        return new self($values);
+    }
+
+    /**
+     * Returns the number of contained rationals.
+     */
+    public function count(): int
+    {
+        return count($this->values);
+    }
+
+    /**
+     * Retrieves an iterator for the list contents.
+     *
+     * @return Traversable<int, ExifRational>
+     */
+    public function getIterator(): Traversable
+    {
+        return new ArrayIterator($this->values);
+    }
+
+    /**
+     * Returns the first rational from the list.
+     */
+    public function first(): ?ExifRational
+    {
+        return $this->values[0] ?? null;
+    }
+
+    /**
+     * Retrieves the rational at the given index.
+     */
+    public function get(int $index): ?ExifRational
+    {
+        return $this->values[$index] ?? null;
+    }
+
+    /**
+     * Returns the contained rationals as raw numerator/denominator tuples.
+     *
+     * @return list<array{0:int,1:int}>
+     */
+    public function toArray(): array
+    {
+        $pairs = [];
+        foreach ($this->values as $value) {
+            $pairs[] = $value->toArray();
+        }
+
+        return $pairs;
+    }
+}

--- a/src/Model/Exif/ValueConverters.php
+++ b/src/Model/Exif/ValueConverters.php
@@ -11,6 +11,10 @@ declare(strict_types=1);
 
 namespace MagicSunday\ImageMeta\Model\Exif;
 
+use MagicSunday\ImageMeta\Model\Exif\Value\ExifNumericList;
+use MagicSunday\ImageMeta\Model\Exif\Value\ExifRational;
+use MagicSunday\ImageMeta\Model\Exif\Value\ExifRationalList;
+
 use function array_is_list;
 use function count;
 use function is_array;
@@ -34,17 +38,17 @@ final readonly class ValueConverters
      *
      * @return float|null
      */
-    public static function rationalToFloat(int|float|string|array|null $v): ?float
+    public static function rationalToFloat(int|float|string|ExifRational|ExifRationalList|ExifNumericList|null $v): ?float
     {
-        if (is_array($v)) {
-            $pair = self::normaliseRationalPair($v);
-            if ($pair !== null && $pair[1] !== 0) {
-                return (float) $pair[0] / (float) $pair[1];
-            }
+        $pair = self::extractRational($v);
+        if ($pair instanceof ExifRational) {
+            return $pair->asFloat();
+        }
 
-            $list = self::normaliseRationalList($v);
-            if ($list !== null && isset($list[0]) && $list[0][1] !== 0) {
-                return (float) $list[0][0] / (float) $list[0][1];
+        if ($v instanceof ExifNumericList) {
+            $first = $v->first();
+            if ($first !== null) {
+                return (float) $first;
             }
 
             return null;
@@ -71,18 +75,19 @@ final readonly class ValueConverters
         $lonRef = $gps->get(ExifTag::GPS_LONGITUDE_REF)?->value ?? null;
         $lonVal = $gps->get(ExifTag::GPS_LONGITUDE)?->value ?? null;
 
-        $latPairs = is_array($latVal) ? self::normaliseRationalList($latVal) : null;
-        $lonPairs = is_array($lonVal) ? self::normaliseRationalList($lonVal) : null;
+        $latPairs = self::extractRationalList($latVal);
+        $lonPairs = self::extractRationalList($lonVal);
 
         $lat = self::dmsToFloat($latRef, $latPairs);
         $lon = self::dmsToFloat($lonRef, $lonPairs);
 
         $alt = null;
-        if (($e = $gps->get(ExifTag::GPS_ALTITUDE)) && is_array($e->value)) {
-            $altPair = self::normaliseRationalPair($e->value);
-            if ($altPair !== null && $altPair[1] !== 0) {
-                $alt = $altPair[0] / $altPair[1];
+        if ($altEntry = $gps->get(ExifTag::GPS_ALTITUDE)) {
+            $altPair = self::extractRational($altEntry->value);
+            if ($altPair instanceof ExifRational) {
+                $alt = $altPair->asFloat();
             }
+
             if ($alt !== null && ($ref = $gps->get(ExifTag::GPS_ALTITUDE_REF)) && (int) ($ref->value ?? 0) === 1) {
                 $alt = -$alt;
             }
@@ -94,19 +99,21 @@ final readonly class ValueConverters
     /**
      * Converts EXIF GPS degrees/minutes/seconds to a float coordinate.
      *
-     * @param string|null        $ref   Direction reference (N/E/S/W).
+     * @param string|null          $ref Direction reference (N/E/S/W).
      * @param ExifRationalList|null $val Rational triplet describing the coordinate.
      *
      * @return float|null
      */
-    private static function dmsToFloat(?string $ref, ?array $val): ?float
+    private static function dmsToFloat(?string $ref, ?ExifRationalList $val): ?float
     {
-        if (!is_string($ref) || !is_array($val) || count($val) < 3) {
+        if (!is_string($ref) || $val === null || $val->count() < 3) {
             return null;
         }
-        $deg = self::rationalToFloat($val[0] ?? null);
-        $min = self::rationalToFloat($val[1] ?? null);
-        $sec = self::rationalToFloat($val[2] ?? null);
+
+        $deg = $val->get(0)?->asFloat();
+        $min = $val->get(1)?->asFloat();
+        $sec = $val->get(2)?->asFloat();
+
         if ($deg === null || $min === null || $sec === null) {
             return null;
         }
@@ -117,11 +124,59 @@ final readonly class ValueConverters
     }
 
     /**
+     * Extracts a rational pair from the provided EXIF value.
+     *
+     * @param ExifValue|null $value
+     */
+    private static function extractRational(int|float|string|ExifRational|ExifRationalList|ExifNumericList|null $value): ?ExifRational
+    {
+        if ($value instanceof ExifRational) {
+            return $value;
+        }
+
+        if ($value instanceof ExifRationalList) {
+            return $value->first();
+        }
+
+        if (is_array($value)) {
+            $pair = self::normaliseRationalPair($value);
+
+            return $pair === null ? null : new ExifRational($pair[0], $pair[1]);
+        }
+
+        return null;
+    }
+
+    /**
+     * Extracts a rational list from the provided EXIF value.
+     *
+     * @param ExifValue|null $value
+     */
+    private static function extractRationalList(int|float|string|ExifRational|ExifRationalList|ExifNumericList|null $value): ?ExifRationalList
+    {
+        if ($value instanceof ExifRationalList) {
+            return $value;
+        }
+
+        if ($value instanceof ExifRational) {
+            return new ExifRationalList([$value]);
+        }
+
+        if (is_array($value)) {
+            $pairs = self::normaliseRationalList($value);
+
+            return $pairs === null ? null : ExifRationalList::fromPairs($pairs);
+        }
+
+        return null;
+    }
+
+    /**
      * Normalises a potential rational pair into a strict two-element array.
      *
      * @param array<int, mixed> $value Candidate value from EXIF data.
      *
-     * @return ExifRational|null
+     * @return array{0:int,1:int}|null
      */
     private static function normaliseRationalPair(array $value): ?array
     {
@@ -144,7 +199,7 @@ final readonly class ValueConverters
      *
      * @param array<int, mixed> $value Candidate value from EXIF data.
      *
-     * @return ExifRationalList|null
+     * @return list<array{0:int,1:int}>|null
      */
     private static function normaliseRationalList(array $value): ?array
     {

--- a/src/Parse/Tiff/TiffExifReader.php
+++ b/src/Parse/Tiff/TiffExifReader.php
@@ -18,6 +18,9 @@ use MagicSunday\ImageMeta\Model\Exif\ExifDocument;
 use MagicSunday\ImageMeta\Model\Exif\ExifTag;
 use MagicSunday\ImageMeta\Model\Exif\Ifd;
 use MagicSunday\ImageMeta\Model\Exif\IfdEntry;
+use MagicSunday\ImageMeta\Model\Exif\Value\ExifNumericList;
+use MagicSunday\ImageMeta\Model\Exif\Value\ExifRational;
+use MagicSunday\ImageMeta\Model\Exif\Value\ExifRationalList;
 
 use function chr;
 use function ord;
@@ -157,7 +160,7 @@ final class TiffExifReader
      *
      * @return ExifValue
      */
-    private function decodeValue(int $type, int $count, int $valueOrOffset): int|float|string|array
+    private function decodeValue(int $type, int $count, int $valueOrOffset): int|float|string|ExifRational|ExifRationalList|ExifNumericList
     {
         $unitSize         = $this->bytesPerComponent($type);
         $dataSize        = $unitSize * $count;
@@ -190,7 +193,7 @@ final class TiffExifReader
      *
      * @return ExifValue
      */
-    private function decodeBytes(int $type, int $count, string $bytes): int|float|string|array
+    private function decodeBytes(int $type, int $count, string $bytes): int|float|string|ExifRational|ExifRationalList|ExifNumericList
     {
         $componentSize = $this->bytesPerComponent($type);
         $bytesLength   = strlen($bytes);
@@ -215,10 +218,10 @@ final class TiffExifReader
             for ($i = 0; $i < $count; ++$i) {
                 $num               = $this->read32FromBytes($bytes, $i * 8 + 0, $type === 10);
                 $den               = $this->read32FromBytes($bytes, $i * 8 + 4, $type === 10);
-                $rationalValues[] = [$num, $den];
+                $rationalValues[] = new ExifRational($num, $den);
             }
 
-            return $count === 1 ? $rationalValues[0] : $rationalValues;
+            return $count === 1 ? $rationalValues[0] : new ExifRationalList($rationalValues);
         }
 
         $vals   = [];
@@ -239,7 +242,7 @@ final class TiffExifReader
             $cursor += $componentSize;
         }
 
-        return $count === 1 ? $vals[0] : $vals;
+        return $count === 1 ? $vals[0] : new ExifNumericList($vals);
     }
 
     /**

--- a/tests/Convenience/ExifConvenienceTest.php
+++ b/tests/Convenience/ExifConvenienceTest.php
@@ -16,6 +16,8 @@ use MagicSunday\ImageMeta\Model\Exif\ExifDocument;
 use MagicSunday\ImageMeta\Model\Exif\ExifTag;
 use MagicSunday\ImageMeta\Model\Exif\Ifd;
 use MagicSunday\ImageMeta\Model\Exif\IfdEntry;
+use MagicSunday\ImageMeta\Model\Exif\Value\ExifNumericList;
+use MagicSunday\ImageMeta\Model\Exif\Value\ExifRational;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -57,8 +59,9 @@ final class ExifConvenienceTest extends TestCase
     #[Test]
     public function isoExtractsFirstEntryFromArray(): void
     {
-        $ifd0 = new Ifd([
-            ExifTag::PHOTOGRAPHIC_SENSITIVITY => new IfdEntry(ExifTag::PHOTOGRAPHIC_SENSITIVITY, 3, 3, [100, 200, 400]),
+        $value = new ExifNumericList([100, 200, 400]);
+        $ifd0  = new Ifd([
+            ExifTag::PHOTOGRAPHIC_SENSITIVITY => new IfdEntry(ExifTag::PHOTOGRAPHIC_SENSITIVITY, 3, count($value), $value),
         ]);
 
         $doc = new ExifDocument($ifd0, null, null, null, null);
@@ -72,8 +75,9 @@ final class ExifConvenienceTest extends TestCase
     #[Test]
     public function isoCastsFloatValuesToInteger(): void
     {
-        $ifd0 = new Ifd([
-            ExifTag::PHOTOGRAPHIC_SENSITIVITY => new IfdEntry(ExifTag::PHOTOGRAPHIC_SENSITIVITY, 11, 2, [200.0, 400.0]),
+        $value = new ExifNumericList([200.0, 400.0]);
+        $ifd0  = new Ifd([
+            ExifTag::PHOTOGRAPHIC_SENSITIVITY => new IfdEntry(ExifTag::PHOTOGRAPHIC_SENSITIVITY, 11, count($value), $value),
         ]);
 
         $doc = new ExifDocument($ifd0, null, null, null, null);
@@ -88,7 +92,7 @@ final class ExifConvenienceTest extends TestCase
     public function isoDerivesValueFromRationalPair(): void
     {
         $ifd0 = new Ifd([
-            ExifTag::PHOTOGRAPHIC_SENSITIVITY => new IfdEntry(ExifTag::PHOTOGRAPHIC_SENSITIVITY, 5, 1, [320, 1]),
+            ExifTag::PHOTOGRAPHIC_SENSITIVITY => new IfdEntry(ExifTag::PHOTOGRAPHIC_SENSITIVITY, 5, 1, new ExifRational(320, 1)),
         ]);
 
         $doc = new ExifDocument($ifd0, null, null, null, null);

--- a/tests/Model/Exif/ExifDocumentTest.php
+++ b/tests/Model/Exif/ExifDocumentTest.php
@@ -15,6 +15,8 @@ use MagicSunday\ImageMeta\Model\Exif\ExifDocument;
 use MagicSunday\ImageMeta\Model\Exif\ExifTag;
 use MagicSunday\ImageMeta\Model\Exif\Ifd;
 use MagicSunday\ImageMeta\Model\Exif\IfdEntry;
+use MagicSunday\ImageMeta\Model\Exif\Value\ExifRational;
+use MagicSunday\ImageMeta\Model\Exif\Value\ExifRationalList;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -39,21 +41,24 @@ final class ExifDocumentTest extends TestCase
 
         $exifIfd = new Ifd([
             ExifTag::PHOTOGRAPHIC_SENSITIVITY => new IfdEntry(ExifTag::PHOTOGRAPHIC_SENSITIVITY, 3, 1, 200),
-            ExifTag::EXPOSURE_TIME            => new IfdEntry(ExifTag::EXPOSURE_TIME, 5, 1, [1, 125]),
-            ExifTag::F_NUMBER                 => new IfdEntry(ExifTag::F_NUMBER, 5, 1, [28, 10]),
-            ExifTag::FOCAL_LENGTH             => new IfdEntry(ExifTag::FOCAL_LENGTH, 5, 1, [50, 1]),
+            ExifTag::EXPOSURE_TIME            => new IfdEntry(ExifTag::EXPOSURE_TIME, 5, 1, new ExifRational(1, 125)),
+            ExifTag::F_NUMBER                 => new IfdEntry(ExifTag::F_NUMBER, 5, 1, new ExifRational(28, 10)),
+            ExifTag::FOCAL_LENGTH             => new IfdEntry(ExifTag::FOCAL_LENGTH, 5, 1, new ExifRational(50, 1)),
             ExifTag::LENS_MODEL               => new IfdEntry(ExifTag::LENS_MODEL, 2, 1, 'RF50mm F1.2L USM'),
             ExifTag::DATETIME_ORIGINAL        => new IfdEntry(ExifTag::DATETIME_ORIGINAL, 2, 1, '2024:05:01 12:34:56'),
             ExifTag::OFFSET_TIME_ORIGINAL     => new IfdEntry(ExifTag::OFFSET_TIME_ORIGINAL, 2, 1, '+02:00'),
         ]);
 
+        $gpsLat = ExifRationalList::fromPairs([[40, 1], [26, 1], [3000, 100]]);
+        $gpsLon = ExifRationalList::fromPairs([[79, 1], [58, 1], [6000, 100]]);
+
         $gpsIfd = new Ifd([
             ExifTag::GPS_LATITUDE_REF  => new IfdEntry(ExifTag::GPS_LATITUDE_REF, 2, 2, 'N'),
-            ExifTag::GPS_LATITUDE      => new IfdEntry(ExifTag::GPS_LATITUDE, 5, 3, [[40, 1], [26, 1], [3000, 100]]),
+            ExifTag::GPS_LATITUDE      => new IfdEntry(ExifTag::GPS_LATITUDE, 5, count($gpsLat), $gpsLat),
             ExifTag::GPS_LONGITUDE_REF => new IfdEntry(ExifTag::GPS_LONGITUDE_REF, 2, 2, 'E'),
-            ExifTag::GPS_LONGITUDE     => new IfdEntry(ExifTag::GPS_LONGITUDE, 5, 3, [[79, 1], [58, 1], [6000, 100]]),
+            ExifTag::GPS_LONGITUDE     => new IfdEntry(ExifTag::GPS_LONGITUDE, 5, count($gpsLon), $gpsLon),
             ExifTag::GPS_ALTITUDE_REF  => new IfdEntry(ExifTag::GPS_ALTITUDE_REF, 1, 1, 0),
-            ExifTag::GPS_ALTITUDE      => new IfdEntry(ExifTag::GPS_ALTITUDE, 5, 1, [123, 1]),
+            ExifTag::GPS_ALTITUDE      => new IfdEntry(ExifTag::GPS_ALTITUDE, 5, 1, new ExifRational(123, 1)),
         ]);
 
         $doc = new ExifDocument($ifd0, $exifIfd, $gpsIfd, null, null);

--- a/tests/Model/Exif/IfdEntry/IfdEntryTest.php
+++ b/tests/Model/Exif/IfdEntry/IfdEntryTest.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 namespace MagicSunday\ImageMeta\Tests\Model\Exif\IfdEntry;
 
 use MagicSunday\ImageMeta\Model\Exif\IfdEntry;
+use MagicSunday\ImageMeta\Model\Exif\Value\ExifNumericList;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
@@ -35,12 +36,12 @@ final class IfdEntryTest extends TestCase
     }
 
     /**
-     * Verifies that complex values such as arrays are exposed unchanged.
+     * Verifies that complex value objects are exposed unchanged.
      */
     #[Test]
-    public function testConstructorPreservesArrayValues(): void
+    public function testConstructorPreservesComplexValues(): void
     {
-        $value = [1, 2, 3];
+        $value = new ExifNumericList([1, 2, 3]);
 
         $entry = new IfdEntry(0x8769, 3, count($value), $value);
 

--- a/tests/Model/Exif/ValueConvertersTest.php
+++ b/tests/Model/Exif/ValueConvertersTest.php
@@ -14,6 +14,9 @@ namespace MagicSunday\ImageMeta\Tests\Model\Exif;
 use MagicSunday\ImageMeta\Model\Exif\ExifTag;
 use MagicSunday\ImageMeta\Model\Exif\Ifd;
 use MagicSunday\ImageMeta\Model\Exif\IfdEntry;
+use MagicSunday\ImageMeta\Model\Exif\Value\ExifNumericList;
+use MagicSunday\ImageMeta\Model\Exif\Value\ExifRational;
+use MagicSunday\ImageMeta\Model\Exif\Value\ExifRationalList;
 use MagicSunday\ImageMeta\Model\Exif\ValueConverters;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -30,22 +33,20 @@ final class ValueConvertersTest extends TestCase
     #[DataProvider('provideValidRationals')]
     /**
      * Ensures rational values represented as numerator/denominator pairs or lists are converted to floats.
-     *
-     * @param array{0:int,1:int}|list<array{0:int,1:int}> $value
      */
-    public function convertsRationalPairsToFloat(array $value, float $expected): void
+    public function convertsRationalPairsToFloat(ExifRational|ExifRationalList $value, float $expected): void
     {
         self::assertSame($expected, ValueConverters::rationalToFloat($value));
     }
 
     /**
-     * @return iterable<string, array{array{0:int,1:int}|list<array{0:int,1:int}>, float}>
+     * @return iterable<string, array{ExifRational|ExifRationalList, float}>
      */
     public static function provideValidRationals(): iterable
     {
-        yield 'positive integer' => [[3, 1], 3.0];
-        yield 'fractional value' => [[5, 2], 2.5];
-        yield 'list of rationals' => [[[5, 2], [3, 1]], 2.5];
+        yield 'positive integer' => [new ExifRational(3, 1), 3.0];
+        yield 'fractional value' => [new ExifRational(5, 2), 2.5];
+        yield 'list of rationals' => [ExifRationalList::fromPairs([[5, 2], [3, 1]]), 2.5];
     }
 
     #[Test]
@@ -82,9 +83,9 @@ final class ValueConvertersTest extends TestCase
      */
     public static function provideInvalidInputs(): iterable
     {
-        yield 'denominator zero' => [[[1, 0]]];
-        yield 'not enough elements' => [[[1]]];
-        yield 'non rational list' => [[[1, 2, 3]]];
+        yield 'denominator zero' => [new ExifRational(1, 0)];
+        yield 'empty rational list' => [new ExifRationalList([])];
+        yield 'empty numeric list' => [new ExifNumericList([])];
         yield 'string' => ['invalid'];
         yield 'null' => [null];
     }
@@ -95,13 +96,16 @@ final class ValueConvertersTest extends TestCase
      */
     public function extractsGpsCoordinatesWithPositiveAltitude(): void
     {
+        $lat = ExifRationalList::fromPairs([[51, 1], [30, 1], [0, 1]]);
+        $lon = ExifRationalList::fromPairs([[0, 1], [7, 1], [3000, 100]]);
+
         $gps = new Ifd([
             ExifTag::GPS_LATITUDE_REF  => new IfdEntry(ExifTag::GPS_LATITUDE_REF, 2, 2, 'N'),
-            ExifTag::GPS_LATITUDE      => new IfdEntry(ExifTag::GPS_LATITUDE, 5, 3, [[51, 1], [30, 1], [0, 1]]),
+            ExifTag::GPS_LATITUDE      => new IfdEntry(ExifTag::GPS_LATITUDE, 5, count($lat), $lat),
             ExifTag::GPS_LONGITUDE_REF => new IfdEntry(ExifTag::GPS_LONGITUDE_REF, 2, 2, 'E'),
-            ExifTag::GPS_LONGITUDE     => new IfdEntry(ExifTag::GPS_LONGITUDE, 5, 3, [[0, 1], [7, 1], [3000, 100]]),
+            ExifTag::GPS_LONGITUDE     => new IfdEntry(ExifTag::GPS_LONGITUDE, 5, count($lon), $lon),
             ExifTag::GPS_ALTITUDE_REF  => new IfdEntry(ExifTag::GPS_ALTITUDE_REF, 1, 1, 0),
-            ExifTag::GPS_ALTITUDE      => new IfdEntry(ExifTag::GPS_ALTITUDE, 5, 1, [450, 10]),
+            ExifTag::GPS_ALTITUDE      => new IfdEntry(ExifTag::GPS_ALTITUDE, 5, 1, new ExifRational(450, 10)),
         ]);
 
         $result = ValueConverters::gpsFromIfd($gps);
@@ -117,13 +121,16 @@ final class ValueConvertersTest extends TestCase
      */
     public function extractsGpsCoordinatesWithNegativeHemisphereAndAltitude(): void
     {
+        $lat = ExifRationalList::fromPairs([[33, 1], [15, 1], [1800, 100]]);
+        $lon = ExifRationalList::fromPairs([[70, 1], [45, 1], [0, 1]]);
+
         $gps = new Ifd([
             ExifTag::GPS_LATITUDE_REF  => new IfdEntry(ExifTag::GPS_LATITUDE_REF, 2, 2, 'S'),
-            ExifTag::GPS_LATITUDE      => new IfdEntry(ExifTag::GPS_LATITUDE, 5, 3, [[33, 1], [15, 1], [1800, 100]]),
+            ExifTag::GPS_LATITUDE      => new IfdEntry(ExifTag::GPS_LATITUDE, 5, count($lat), $lat),
             ExifTag::GPS_LONGITUDE_REF => new IfdEntry(ExifTag::GPS_LONGITUDE_REF, 2, 2, 'W'),
-            ExifTag::GPS_LONGITUDE     => new IfdEntry(ExifTag::GPS_LONGITUDE, 5, 3, [[70, 1], [45, 1], [0, 1]]),
+            ExifTag::GPS_LONGITUDE     => new IfdEntry(ExifTag::GPS_LONGITUDE, 5, count($lon), $lon),
             ExifTag::GPS_ALTITUDE_REF  => new IfdEntry(ExifTag::GPS_ALTITUDE_REF, 1, 1, 1),
-            ExifTag::GPS_ALTITUDE      => new IfdEntry(ExifTag::GPS_ALTITUDE, 5, 1, [250, 2]),
+            ExifTag::GPS_ALTITUDE      => new IfdEntry(ExifTag::GPS_ALTITUDE, 5, 1, new ExifRational(250, 2)),
         ]);
 
         $result = ValueConverters::gpsFromIfd($gps);
@@ -139,11 +146,14 @@ final class ValueConvertersTest extends TestCase
      */
     public function extractsGpsCoordinatesWithoutAltitude(): void
     {
+        $lat = ExifRationalList::fromPairs([[10, 1], [0, 1], [0, 1]]);
+        $lon = ExifRationalList::fromPairs([[20, 1], [30, 1], [0, 1]]);
+
         $gps = new Ifd([
             ExifTag::GPS_LATITUDE_REF  => new IfdEntry(ExifTag::GPS_LATITUDE_REF, 2, 2, 'N'),
-            ExifTag::GPS_LATITUDE      => new IfdEntry(ExifTag::GPS_LATITUDE, 5, 3, [[10, 1], [0, 1], [0, 1]]),
+            ExifTag::GPS_LATITUDE      => new IfdEntry(ExifTag::GPS_LATITUDE, 5, count($lat), $lat),
             ExifTag::GPS_LONGITUDE_REF => new IfdEntry(ExifTag::GPS_LONGITUDE_REF, 2, 2, 'E'),
-            ExifTag::GPS_LONGITUDE     => new IfdEntry(ExifTag::GPS_LONGITUDE, 5, 3, [[20, 1], [30, 1], [0, 1]]),
+            ExifTag::GPS_LONGITUDE     => new IfdEntry(ExifTag::GPS_LONGITUDE, 5, count($lon), $lon),
         ]);
 
         $result = ValueConverters::gpsFromIfd($gps);

--- a/tests/Parse/Tiff/TiffExifReaderTest.php
+++ b/tests/Parse/Tiff/TiffExifReaderTest.php
@@ -16,6 +16,9 @@ use MagicSunday\ImageMeta\Core\Endian;
 use MagicSunday\ImageMeta\Core\ParseError;
 use MagicSunday\ImageMeta\Model\Exif\ExifDocument;
 use MagicSunday\ImageMeta\Model\Exif\ExifTag;
+use MagicSunday\ImageMeta\Model\Exif\Value\ExifNumericList;
+use MagicSunday\ImageMeta\Model\Exif\Value\ExifRational;
+use MagicSunday\ImageMeta\Model\Exif\Value\ExifRationalList;
 use MagicSunday\ImageMeta\Parse\Tiff\TiffExifReader;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
@@ -113,7 +116,8 @@ final class TiffExifReaderTest extends TestCase
 
         $entry = $document->ifd0->get(ExifTag::GPS_ALTITUDE_REF);
         self::assertNotNull($entry);
-        self::assertSame([1, 2, 3], $entry->value);
+        self::assertInstanceOf(ExifNumericList::class, $entry->value);
+        self::assertSame([1, 2, 3], $entry->value->values());
     }
 
     /**
@@ -151,7 +155,9 @@ final class TiffExifReaderTest extends TestCase
         $exifIfd = $doc->exifIfd;
         self::assertNotNull($exifIfd);
         self::assertSame(200, $exifIfd->get(ExifTag::PHOTOGRAPHIC_SENSITIVITY)?->value);
-        self::assertSame([28, 10], $exifIfd->get(ExifTag::F_NUMBER)?->value);
+        $fNumber = $exifIfd->get(ExifTag::F_NUMBER)?->value;
+        self::assertInstanceOf(ExifRational::class, $fNumber);
+        self::assertSame([28, 10], $fNumber->toArray());
 
         $interop = $doc->interopIfd;
         self::assertNotNull($interop);
@@ -159,9 +165,15 @@ final class TiffExifReaderTest extends TestCase
 
         $gpsIfd = $doc->gpsIfd;
         self::assertNotNull($gpsIfd);
-        self::assertSame([[40, 1], [30, 1], [15, 1]], $gpsIfd->get(ExifTag::GPS_LATITUDE)?->value);
-        self::assertSame([[70, 1], [45, 1], [30, 1]], $gpsIfd->get(ExifTag::GPS_LONGITUDE)?->value);
-        self::assertSame([150, 1], $gpsIfd->get(ExifTag::GPS_ALTITUDE)?->value);
+        $gpsLat = $gpsIfd->get(ExifTag::GPS_LATITUDE)?->value;
+        self::assertInstanceOf(ExifRationalList::class, $gpsLat);
+        self::assertSame([[40, 1], [30, 1], [15, 1]], $gpsLat->toArray());
+        $gpsLon = $gpsIfd->get(ExifTag::GPS_LONGITUDE)?->value;
+        self::assertInstanceOf(ExifRationalList::class, $gpsLon);
+        self::assertSame([[70, 1], [45, 1], [30, 1]], $gpsLon->toArray());
+        $gpsAlt = $gpsIfd->get(ExifTag::GPS_ALTITUDE)?->value;
+        self::assertInstanceOf(ExifRational::class, $gpsAlt);
+        self::assertSame([150, 1], $gpsAlt->toArray());
 
         $gps = $doc->gps();
         self::assertEqualsWithDelta(40.504166, $gps['lat'], 1e-6);
@@ -182,7 +194,9 @@ final class TiffExifReaderTest extends TestCase
         $exifIfd = $doc->exifIfd;
         self::assertNotNull($exifIfd);
         self::assertSame(320, $exifIfd->get(ExifTag::PHOTOGRAPHIC_SENSITIVITY)?->value);
-        self::assertSame([35, 10], $exifIfd->get(ExifTag::FOCAL_LENGTH)?->value);
+        $focalLength = $exifIfd->get(ExifTag::FOCAL_LENGTH)?->value;
+        self::assertInstanceOf(ExifRational::class, $focalLength);
+        self::assertSame([35, 10], $focalLength->toArray());
 
         $interop = $doc->interopIfd;
         self::assertNotNull($interop);
@@ -190,9 +204,15 @@ final class TiffExifReaderTest extends TestCase
 
         $gpsIfd = $doc->gpsIfd;
         self::assertNotNull($gpsIfd);
-        self::assertSame([[51, 1], [30, 1], [15, 1]], $gpsIfd->get(ExifTag::GPS_LATITUDE)?->value);
-        self::assertSame([[8, 1], [12, 1], [30, 1]], $gpsIfd->get(ExifTag::GPS_LONGITUDE)?->value);
-        self::assertSame([500, 10], $gpsIfd->get(ExifTag::GPS_ALTITUDE)?->value);
+        $gpsLat = $gpsIfd->get(ExifTag::GPS_LATITUDE)?->value;
+        self::assertInstanceOf(ExifRationalList::class, $gpsLat);
+        self::assertSame([[51, 1], [30, 1], [15, 1]], $gpsLat->toArray());
+        $gpsLon = $gpsIfd->get(ExifTag::GPS_LONGITUDE)?->value;
+        self::assertInstanceOf(ExifRationalList::class, $gpsLon);
+        self::assertSame([[8, 1], [12, 1], [30, 1]], $gpsLon->toArray());
+        $gpsAlt = $gpsIfd->get(ExifTag::GPS_ALTITUDE)?->value;
+        self::assertInstanceOf(ExifRational::class, $gpsAlt);
+        self::assertSame([500, 10], $gpsAlt->toArray());
 
         $gps = $doc->gps();
         self::assertEqualsWithDelta(51.504167, $gps['lat'], 1e-6);


### PR DESCRIPTION
## Summary
- introduce dedicated value objects for TIFF numeric and rational EXIF payloads
- update the TIFF reader and convenience utilities to emit the new typed values
- adjust existing tests to cover the stricter value typing

## Testing
- composer ci:test:php:unit

------
https://chatgpt.com/codex/tasks/task_e_68f9f5996d4c8323bfdfc7af4462b557