### PR TITLE
fix: type QuickTime content identifier constant

### DIFF
--- a/src/Model/QuickTimeMeta.php
+++ b/src/Model/QuickTimeMeta.php
@@ -19,7 +19,7 @@ final readonly class QuickTimeMeta
     /**
      * QuickTime metadata key used for the content identifier value.
      */
-    public const CONTENT_IDENTIFIER_KEY = 'com.apple.quicktime.content.identifier';
+    public const string CONTENT_IDENTIFIER_KEY = 'com.apple.quicktime.content.identifier';
 
     /**
      * Creates a new instance of QuickTime metadata information.


### PR DESCRIPTION
## Summary
- declare the QuickTime content identifier constant with an explicit string type

## Testing
- ./.build/bin/phpunit --configuration .build/phpunit.xml tests/Model/QuickTimeMeta/QuickTimeMetaTest.php
- composer ci:cgl *(fails: applies formatting changes outside this patch scope)*
- composer ci:test:php:unit *(fails: existing test suite errors in EXIF-related tests)*
- composer ci:test:php:unit:coverage *(fails: no code coverage driver available)*
- composer ci:test:php:phpstan *(fails: existing PHPStan issues in the project)*

------
https://chatgpt.com/codex/tasks/task_e_68f9fb556d788323b8bf469738b09ca3