### PR TITLE
Mark MakerNotesMetadata as readonly

### DIFF
--- a/src/MakerNotes/MakerNotesMetadata.php
+++ b/src/MakerNotes/MakerNotesMetadata.php
@@ -18,7 +18,7 @@ use function preg_match;
 /**
  * Immutable value object that describes normalised maker note metadata.
  */
-final class MakerNotesMetadata
+final readonly class MakerNotesMetadata
 {
     /**
      * @param string $vendor Vendor responsible for the maker note payload. Must not be empty.


### PR DESCRIPTION
## Summary
- declare `MakerNotesMetadata` as a final readonly class to emphasise immutability

## Testing
- `.build/bin/phpunit --configuration .build/phpunit.xml tests/MakerNotes`
- `composer ci:cgl`
- `composer ci:test:php:unit`
- `composer ci:test:php:unit:coverage`
- `composer ci:test:php:phpstan`


------
https://chatgpt.com/codex/tasks/task_e_68f9fb562850832388ebd6a97103fabb