### PR TITLE
fix: remove deprecated sha1 raw flag

### DIFF
--- a/src/MakerNotes/AppleDecoder.php
+++ b/src/MakerNotes/AppleDecoder.php
@@ -31,7 +31,7 @@ final class AppleDecoder implements MakerNotesDecoderInterface
         return new MakerNotesMetadata(
             'Apple',
             strlen($raw),
-            sha1($raw, false)
+            sha1($raw)
         );
     }
 }


### PR DESCRIPTION
## Summary
- adjust the Apple maker notes decoder to rely on the default sha1 hex digest output

## Testing
- composer ci:cgl
- composer ci:test:php:unit *(fails: upstream suite contains existing type expectations that do not pass on a clean checkout)*
- composer ci:test:php:unit:coverage *(fails: environment does not provide a code coverage driver)*
- composer ci:test:php:phpstan *(fails: upstream static analysis reports pre-existing issues on a clean checkout)*

------
https://chatgpt.com/codex/tasks/task_e_68f9fb5968b48323b2428d405917f252