### PR TITLE
Add string types to test constants

### DIFF
--- a/tests/Convenience/CaptureDateResolverTest.php
+++ b/tests/Convenience/CaptureDateResolverTest.php
@@ -25,7 +25,7 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(CaptureDateResolver::class)]
 final class CaptureDateResolverTest extends TestCase
 {
-    private const XMP_NAMESPACE = 'http://ns.adobe.com/xap/1.0/';
+    private const string XMP_NAMESPACE = 'http://ns.adobe.com/xap/1.0/';
 
     /**
      * Uses only XMP metadata to confirm the resolver falls back to the CreateDate string and

--- a/tests/MetadataReader/MetadataReaderTest.php
+++ b/tests/MetadataReader/MetadataReaderTest.php
@@ -34,8 +34,8 @@ use function unlink;
  */
 final class MetadataReaderTest extends TestCase
 {
-    private const EXIF_SIGNATURE = "Exif\0\0";
-    private const XMP_SIGNATURE  = "http://ns.adobe.com/xap/1.0/\0";
+    private const string EXIF_SIGNATURE = "Exif\0\0";
+    private const string XMP_SIGNATURE  = "http://ns.adobe.com/xap/1.0/\0";
 
     private const int MARKER_APP1 = 0xE1;
 

--- a/tests/Parse/Jpeg/JpegExtractorTest.php
+++ b/tests/Parse/Jpeg/JpegExtractorTest.php
@@ -34,10 +34,10 @@ use function strlen;
  */
 final class JpegExtractorTest extends TestCase
 {
-    private const EXIF_SIGNATURE = "Exif\0\0";
-    private const XMP_SIGNATURE  = "http://ns.adobe.com/xap/1.0/\0";
-    private const ICC_SIGNATURE  = "ICC_PROFILE\0";
-    private const IPTC_SIGNATURE = "Photoshop 3.0\0";
+    private const string EXIF_SIGNATURE = "Exif\0\0";
+    private const string XMP_SIGNATURE  = "http://ns.adobe.com/xap/1.0/\0";
+    private const string ICC_SIGNATURE  = "ICC_PROFILE\0";
+    private const string IPTC_SIGNATURE = "Photoshop 3.0\0";
 
     private const int MARKER_APP1  = 0xE1;
     private const int MARKER_APP2  = 0xE2;

--- a/tests/Xmp/XmpDocumentTest.php
+++ b/tests/Xmp/XmpDocumentTest.php
@@ -21,9 +21,9 @@ use PHPUnit\Framework\TestCase;
  */
 final class XmpDocumentTest extends TestCase
 {
-    private const DC_NAMESPACE   = 'http://purl.org/dc/elements/1.1/';
-    private const XMP_NAMESPACE  = 'http://ns.adobe.com/xap/1.0/';
-    private const EXIF_NAMESPACE = 'http://ns.adobe.com/exif/1.0/';
+    private const string DC_NAMESPACE   = 'http://purl.org/dc/elements/1.1/';
+    private const string XMP_NAMESPACE  = 'http://ns.adobe.com/xap/1.0/';
+    private const string EXIF_NAMESPACE = 'http://ns.adobe.com/exif/1.0/';
 
     /**
      * Verifies reader-sourced documents expose their values through accessors.

--- a/tests/Xmp/XmpReaderTest.php
+++ b/tests/Xmp/XmpReaderTest.php
@@ -22,7 +22,7 @@ use PHPUnit\Framework\TestCase;
  */
 final class XmpReaderTest extends TestCase
 {
-    private const DC_NAMESPACE = 'http://purl.org/dc/elements/1.1/';
+    private const string DC_NAMESPACE = 'http://purl.org/dc/elements/1.1/';
 
     /**
      * Ensures mixed text and CDATA nodes are concatenated verbatim.


### PR DESCRIPTION
## Summary
- add explicit string type declarations to string constants across the test suite

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68fa00e020b883238b92594722345aaa