### PR TITLE
docs: annotate JPEG extractor test helpers

### DIFF
--- a/tests/Parse/Jpeg/JpegExtractorTest.php
+++ b/tests/Parse/Jpeg/JpegExtractorTest.php
@@ -226,6 +226,9 @@ final class JpegExtractorTest extends TestCase
 
     /**
      * Builds a JPEG binary by wrapping payload segments with SOI/EOI markers.
+     *
+     * @param list<string> $segments
+     * @return string
      */
     private static function jpeg(string ...$segments): string
     {
@@ -234,6 +237,10 @@ final class JpegExtractorTest extends TestCase
 
     /**
      * Wraps a payload with a JPEG marker and two-byte length field.
+     *
+     * @param int    $marker
+     * @param string $payload
+     * @return string
      */
     private static function segment(int $marker, string $payload): string
     {
@@ -242,6 +249,9 @@ final class JpegExtractorTest extends TestCase
 
     /**
      * Creates a stream-backed extractor for an in-memory JPEG binary.
+     *
+     * @param string        $jpeg
+     * @return JpegExtractor
      */
     private function createExtractor(string $jpeg): JpegExtractor
     {


### PR DESCRIPTION
## Summary
- document the parameter and return types for the JPEG test helper methods

## Testing
- not run (doc-only change)


------
https://chatgpt.com/codex/tasks/task_e_68fa03c68fa083238364d3169778dd83