### PR TITLE
Adjust parse error test message expectation

### DIFF
--- a/tests/Core/ParseError/ParseErrorTest.php
+++ b/tests/Core/ParseError/ParseErrorTest.php
@@ -57,7 +57,7 @@ final class ParseErrorTest extends TestCase
         $path = sys_get_temp_dir() . '/imagemeta-missing-' . uniqid('', true);
 
         $this->expectException(ParseError::class);
-        $this->expectExceptionMessage("Cannot open: {$path}");
+        $this->expectExceptionMessage("Cannot open: $path");
 
         $previousHandler = set_error_handler(static function (int $errno, string $errstr) use ($path, &$previousHandler): bool {
             if (str_contains($errstr, $path)) {


### PR DESCRIPTION
## Summary
- update the ParseError test expectation to interpolate the path without braces

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68fa0fd273c48323b5710d60e6d5f49f