### PR TITLE
chore: import trim helper in iso bmff extractor

### DIFF
--- a/src/Parse/IsoBmff/IsoBmffExtractor.php
+++ b/src/Parse/IsoBmff/IsoBmffExtractor.php
@@ -27,6 +27,7 @@ use function strcasecmp;
 use function strlen;
 use function strtolower;
 use function substr;
+use function trim;
 use function unpack;
 
 /**


### PR DESCRIPTION
## Summary
- import the native trim helper in `IsoBmffExtractor` so the existing call references the import block

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fa0fd27ec0832392be26fff3b7240e