### PR TITLE
Relocate XMP tests into module-specific suites

### DIFF
--- a/tests/Model/Xmp/XmpDocumentTest.php
+++ b/tests/Model/Xmp/XmpDocumentTest.php
@@ -9,7 +9,7 @@
 
 declare(strict_types=1);
 
-namespace MagicSunday\ImageMeta\Tests\Xmp;
+namespace MagicSunday\ImageMeta\Tests\Model\Xmp;
 
 use MagicSunday\ImageMeta\Parse\Xmp\XmpParser;
 use MagicSunday\ImageMeta\Parse\Xmp\XmpReader;

--- a/tests/Parse/Xmp/XmpReaderTest.php
+++ b/tests/Parse/Xmp/XmpReaderTest.php
@@ -9,7 +9,7 @@
 
 declare(strict_types=1);
 
-namespace MagicSunday\ImageMeta\Tests\Xmp;
+namespace MagicSunday\ImageMeta\Tests\Parse\Xmp;
 
 use MagicSunday\ImageMeta\Parse\Xmp\XmpReader;
 use PHPUnit\Framework\Attributes\Test;


### PR DESCRIPTION
## Summary
- move `tests/Xmp/XmpReaderTest.php` into the parse test suite and adjust its namespace
- move `tests/Xmp/XmpDocumentTest.php` into the model test suite and update the namespace declaration

## Testing
- `composer ci:test:php:unit` *(fails: pre-existing unit test errors in EXIF and Core suites)*
- `composer ci:test:php:unit:coverage` *(fails: no code coverage driver available in the container)*
- `composer ci:test:php:phpstan` *(fails: pre-existing analysis issues reported by PHPStan)*
- `composer ci:cgl` *(fails: fixer reports style adjustments outside the scope of this change)*

------
https://chatgpt.com/codex/tasks/task_e_68fa0fb91cb4832398088731c80ccbf9