### PR TITLE
Fix MemoryBuffer short-read detection and Exif convenience inputs

### DIFF
--- a/src/Core/MemoryBuffer.php
+++ b/src/Core/MemoryBuffer.php
@@ -13,7 +13,6 @@ namespace MagicSunday\ImageMeta\Core;
 
 use function ord;
 use function strlen;
-use function substr;
 use function unpack;
 
 /**

--- a/src/Model/Exif/IfdEntry.php
+++ b/src/Model/Exif/IfdEntry.php
@@ -11,22 +11,152 @@ declare(strict_types=1);
 
 namespace MagicSunday\ImageMeta\Model\Exif;
 
+use function array_values;
+use function is_array;
+use function is_float;
+use function is_int;
+
 /**
  * Represents a single entry within an image file directory (IFD).
  */
 final readonly class IfdEntry
 {
+    public int $tag;
+
+    public int $type;
+
+    public int $count;
+
+    public int|float|string|ExifRational|ExifRationalList|ExifNumericList $value;
+
     /**
-     * @param int                                      $tag   The numeric identifier of the entry.
-     * @param int                                      $type  The TIFF field type code.
-     * @param int                                      $count The number of values stored in the entry.
-     * @param int|float|string|ExifRational|ExifRationalList|ExifNumericList $value The raw value or values decoded from the IFD.
+     * Normalises raw decoded values so callers may provide convenient array representations.
+     *
+     * @param int                                                               $tag   The numeric identifier of the entry.
+     * @param int                                                               $type  The TIFF field type code.
+     * @param int                                                               $count The number of values stored in the entry.
+     * @param int|float|string|ExifRational|ExifRationalList|ExifNumericList|array $value  The raw value or values decoded from the IFD.
      */
     public function __construct(
-        public int $tag,
-        public int $type,
-        public int $count,
-        public int|float|string|ExifRational|ExifRationalList|ExifNumericList $value,
+        int $tag,
+        int $type,
+        int $count,
+        int|float|string|ExifRational|ExifRationalList|ExifNumericList|array $value,
     ) {
+        $this->tag   = $tag;
+        $this->type  = $type;
+        $this->count = $count;
+        $this->value = $this->normaliseValue($type, $count, $value);
+    }
+
+    /**
+     * Converts shorthand array inputs into strongly typed EXIF value objects.
+     *
+     * @param int                                                               $type  TIFF field type code describing the payload.
+     * @param int                                                               $count Number of values stored for the entry.
+     * @param int|float|string|ExifRational|ExifRationalList|ExifNumericList|array $value Raw value passed to the constructor.
+     *
+     * @return int|float|string|ExifRational|ExifRationalList|ExifNumericList
+     */
+    private function normaliseValue(
+        int $type,
+        int $count,
+        int|float|string|ExifRational|ExifRationalList|ExifNumericList|array $value,
+    ): int|float|string|ExifRational|ExifRationalList|ExifNumericList {
+        if (!is_array($value)) {
+            return $value;
+        }
+
+        if ($type === 5 || $type === 10) {
+            $rationals = $this->normaliseRationalList($value);
+
+            if (count($rationals) === 1) {
+                return $rationals[0];
+            }
+
+            return new ExifRationalList($rationals);
+        }
+
+        $numericValues = $this->normaliseNumericList($value);
+
+        if ($count === 1 && count($numericValues) === 1) {
+            return $numericValues[0];
+        }
+
+        return new ExifNumericList($numericValues);
+    }
+
+    /**
+     * Builds a list of {@see ExifRational} objects from array inputs.
+     *
+     * @param array<int, int|float|array<int, int|float>> $value The raw array representation.
+     *
+     * @return list<ExifRational>
+     */
+    private function normaliseRationalList(array $value): array
+    {
+        if ($this->isRationalPair($value)) {
+            return [$this->pairToRational($value)];
+        }
+
+        $rationals = [];
+        foreach ($value as $component) {
+            if (!$this->isRationalPair($component)) {
+                continue;
+            }
+
+            $rationals[] = $this->pairToRational($component);
+        }
+
+        return $rationals;
+    }
+
+    /**
+     * Extracts numeric list components from an array representation.
+     *
+     * @param array<int, int|float> $value Raw numeric components.
+     *
+     * @return list<int|float>
+     */
+    private function normaliseNumericList(array $value): array
+    {
+        $numericValues = [];
+        foreach ($value as $component) {
+            if (is_int($component) || is_float($component)) {
+                $numericValues[] = $component;
+            }
+        }
+
+        return $numericValues;
+    }
+
+    /**
+     * Determines whether the provided value represents a rational numerator/denominator pair.
+     *
+     * @param mixed $value Potential rational pair to inspect.
+     */
+    private function isRationalPair(mixed $value): bool
+    {
+        if (!is_array($value)) {
+            return false;
+        }
+
+        $components = array_values($value);
+
+        return isset($components[0], $components[1])
+            && (is_int($components[0]) || is_float($components[0]))
+            && (is_int($components[1]) || is_float($components[1]));
+    }
+
+    /**
+     * Converts a numerator/denominator array into an {@see ExifRational} instance.
+     *
+     * @param array<int, int|float> $pair Numerator/denominator values.
+     */
+    private function pairToRational(array $pair): ExifRational
+    {
+        $components = array_values($pair);
+
+        return new ExifRational((int) $components[0], (int) $components[1]);
     }
 }

--- a/tests/Model/Exif/ValueConvertersTest.php
+++ b/tests/Model/Exif/ValueConvertersTest.php
@@ -83,17 +83,17 @@ final class ValueConvertersTest extends TestCase
     /**
      * Ensures invalid values cannot be converted and return null instead.
      *
-     * @param array|null $value The invalid rational input to convert.
+     * @param mixed $value The invalid rational input to convert.
      */
     #[Test]
     #[DataProvider('provideInvalidInputs')]
-    public function returnsNullForInvalidRationalInputs(array|null $value): void
+    public function returnsNullForInvalidRationalInputs(mixed $value): void
     {
         self::assertNull(ValueConverters::rationalToFloat($value));
     }
 
     /**
-     * @return iterable<string, array{array|null}>
+     * @return iterable<string, array{mixed}>
      */
     public static function provideInvalidInputs(): iterable
     {


### PR DESCRIPTION
## Summary
- normalise Exif IFD entries so convenience tests can express rationals and numeric lists as arrays
- loosen invalid rational input tests to accept a wider range of mixed values
- allow MemoryBuffer::read to honour the namespace-level substr override for short-read detection

## Testing
- composer ci:test:php:unit

------
https://chatgpt.com/codex/tasks/task_e_68fa1253f970832380fff89cdb71d689