### PR TITLE
feat: expose selective xmp parser access

### DIFF
--- a/src/Model/Metadata.php
+++ b/src/Model/Metadata.php
@@ -13,6 +13,7 @@ namespace MagicSunday\ImageMeta\Model;
 
 use MagicSunday\ImageMeta\Model\Exif\ExifDocument;
 use MagicSunday\ImageMeta\Model\Xmp\XmpDocument;
+use MagicSunday\ImageMeta\Parse\Xmp\XmpParser;
 
 /**
  * Aggregates extracted metadata blobs alongside parsed representations.
@@ -33,5 +34,26 @@ final readonly class Metadata
         public array $xmpBlobs = [],
         public ?XmpDocument $xmpDoc = null,
     ) {
+    }
+
+    /**
+     * Returns the primary XMP document, optionally parsing it via the lightweight parser when
+     * no pre-parsed document has been supplied.
+     *
+     * The method keeps existing behaviour for callers that already provided an \MagicSunday\ImageMeta\Model\Xmp\XmpDocument
+     * instance while allowing consumers of the aggregate to obtain a curated subset of XMP data without having
+     * to instantiate the parser manually.
+     */
+    public function selectiveXmpDocument(): ?XmpDocument
+    {
+        if ($this->xmpDoc !== null) {
+            return $this->xmpDoc;
+        }
+
+        if ($this->xmpBlobs === []) {
+            return null;
+        }
+
+        return (new XmpParser())->parse($this->xmpBlobs[0]);
     }
 }

--- a/tests/Model/Metadata/MetadataTest.php
+++ b/tests/Model/Metadata/MetadataTest.php
@@ -18,6 +18,7 @@ use MagicSunday\ImageMeta\Model\Exif\IfdEntry;
 use MagicSunday\ImageMeta\Model\Metadata;
 use MagicSunday\ImageMeta\Model\QuickTimeMeta;
 use MagicSunday\ImageMeta\Model\Xmp\XmpDocument;
+use MagicSunday\ImageMeta\Parse\Xmp\XmpParser;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -122,5 +123,52 @@ final class MetadataTest extends TestCase
             '2024-06-01',
             $metadata->xmpDoc?->get('http://ns.adobe.com/photoshop/1.0/', 'DateCreated')
         );
+    }
+
+    /**
+     * Ensures consumers can obtain a selectively parsed XMP document without pre-populating it.
+     */
+    #[Test]
+    public function exposesSelectiveXmpDocumentWhenUnavailable(): void
+    {
+        $xmp = <<<XML
+<x:xmpmeta xmlns:x="adobe:ns:meta/"
+    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+    xmlns:xmp="http://ns.adobe.com/xap/1.0/"
+    xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <rdf:RDF>
+    <rdf:Description>
+      <xmp:ModifyDate>2024-04-02T01:02:03Z</xmp:ModifyDate>
+      <dc:subject>
+        <rdf:Bag>
+          <rdf:li>One</rdf:li>
+          <rdf:li>Two</rdf:li>
+        </rdf:Bag>
+      </dc:subject>
+    </rdf:Description>
+  </rdf:RDF>
+</x:xmpmeta>
+XML;
+
+        $metadata = new Metadata([], null, null, [$xmp]);
+
+        $document = $metadata->selectiveXmpDocument();
+
+        self::assertInstanceOf(XmpDocument::class, $document);
+        self::assertSame('2024-04-02T01:02:03Z', $document->get('http://ns.adobe.com/xap/1.0/', 'ModifyDate'));
+        self::assertSame(['One', 'Two'], $document->find('subject'));
+    }
+
+    /**
+     * Ensures the already supplied XMP document is reused without invoking the parser again.
+     */
+    #[Test]
+    public function reusesExistingXmpDocument(): void
+    {
+        $xmpDoc = (new XmpParser())->parse('<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"></rdf:RDF>');
+
+        $metadata = new Metadata([], null, null, [], $xmpDoc);
+
+        self::assertSame($xmpDoc, $metadata->selectiveXmpDocument());
     }
 }


### PR DESCRIPTION
## Summary
- add a helper on `Metadata` that falls back to the lightweight `XmpParser`
- cover the new accessor with unit tests verifying parser output and reuse behaviour

## Testing
- composer ci:test:php:unit

------
https://chatgpt.com/codex/tasks/task_e_68fa1323cc448323bf347410f048accc