### PR TITLE
fix: handle short signatures in format detector

### DIFF
--- a/src/Detect/FormatDetector.php
+++ b/src/Detect/FormatDetector.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace MagicSunday\ImageMeta\Detect;
 
+use MagicSunday\ImageMeta\Core\BoundsError;
 use MagicSunday\ImageMeta\Core\ParseError;
 use MagicSunday\ImageMeta\Core\Stream;
 
@@ -26,17 +27,25 @@ final class FormatDetector
      *
      * @return ContainerType detected container format
      *
-     * @throws ParseError when the signature does not match a known container
+     * @throws ParseError when the signature cannot be read or does not match a known container
      */
     public static function detect(Stream $stream): ContainerType
     {
-        $stream->seek(0);
-        $magic2 = $stream->read(2);
+        try {
+            $stream->seek(0);
+            $magic2 = $stream->read(2);
+        } catch (BoundsError $exception) {
+            throw new ParseError('Unable to read container signature', 0, $exception);
+        }
         if ($magic2 === "\xFF\xD8") {
             return ContainerType::JPEG;
         }
-        $stream->seek(4);
-        $brand = $stream->read(4); // 'ftyp'
+        try {
+            $stream->seek(4);
+            $brand = $stream->read(4); // 'ftyp'
+        } catch (BoundsError $exception) {
+            throw new ParseError('Unable to read container signature', 0, $exception);
+        }
         if ($brand === 'ftyp') {
             return ContainerType::ISOBMFF;
         }

--- a/tests/Detect/FormatDetector/FormatDetectorTest.php
+++ b/tests/Detect/FormatDetector/FormatDetectorTest.php
@@ -15,6 +15,7 @@ use MagicSunday\ImageMeta\Core\ParseError;
 use MagicSunday\ImageMeta\Core\Stream;
 use MagicSunday\ImageMeta\Detect\ContainerType;
 use MagicSunday\ImageMeta\Detect\FormatDetector;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
@@ -67,6 +68,34 @@ final class FormatDetectorTest extends TestCase
         $this->expectException(ParseError::class);
 
         FormatDetector::detect($stream);
+    }
+
+    /**
+     * Ensures that too short streams raise a parse error because the signature cannot be read.
+     *
+     * @param string $bytes byte sequence to test
+     */
+    #[Test]
+    #[DataProvider('tooShortStreamProvider')]
+    public function detectThrowsWhenSignatureCannotBeRead(string $bytes): void
+    {
+        $stream = $this->createStream($bytes);
+
+        $this->expectException(ParseError::class);
+        $this->expectExceptionMessage('Unable to read container signature');
+
+        FormatDetector::detect($stream);
+    }
+
+    /**
+     * Provides byte sequences that are insufficient to cover the signature reads.
+     *
+     * @return iterable<string, array{0: string}>
+     */
+    public static function tooShortStreamProvider(): iterable
+    {
+        yield 'empty stream' => [''];
+        yield 'single byte' => ["\xFF"];
     }
 
     /**


### PR DESCRIPTION
## Summary
- guard `FormatDetector::detect()` against `BoundsError` when reading signatures
- raise a descriptive `ParseError` when the signature bytes cannot be read
- cover zero- and single-byte streams with a PHPUnit test expecting `ParseError`

## Testing
- composer ci:test:php:unit
- composer ci:test:php:phpstan *(fails: existing findings reported in baseline)*

------
https://chatgpt.com/codex/tasks/task_e_68fa140c794c83239b4ed1311962d580