### PR TITLE
fix: normalize QuickTime data text encodings

### DIFF
--- a/src/Parse/IsoBmff/IsoBmffExtractor.php
+++ b/src/Parse/IsoBmff/IsoBmffExtractor.php
@@ -21,7 +21,9 @@ use function array_unique;
 use function array_unshift;
 use function array_values;
 use function explode;
+use function iconv;
 use function preg_match;
+use function rtrim;
 use function str_starts_with;
 use function strcasecmp;
 use function strlen;
@@ -783,14 +785,33 @@ final readonly class IsoBmffExtractor
         $type = $win->readU32BE();
         $win->readU32BE(); // locale
         $payloadSize = $data->contentSize - 8;
-        $payload     = $payloadSize > 0 ? $win->read($payloadSize) : '';
+        $payload = $payloadSize > 0 ? $win->read($payloadSize) : '';
 
-        if (
-            $type === self::DATA_TYPE_UTF8
-            || $type === self::DATA_TYPE_UTF16
-            || $type === self::DATA_TYPE_MAC_ROMAN
-        ) {
-            return trim($payload, "\0");
+        $trimmed = trim($payload, "\0");
+
+        if ($type === self::DATA_TYPE_UTF8) {
+            return $trimmed;
+        }
+
+        if ($type === self::DATA_TYPE_UTF16) {
+            $normalised = rtrim($payload, "\0");
+            $converted  = iconv('UTF-16BE', 'UTF-8//IGNORE', $normalised);
+
+            if ($converted !== false) {
+                return trim($converted, "\0");
+            }
+
+            return $trimmed;
+        }
+
+        if ($type === self::DATA_TYPE_MAC_ROMAN) {
+            $converted = iconv('macintosh', 'UTF-8//IGNORE', $trimmed);
+
+            if ($converted !== false) {
+                return trim($converted, "\0");
+            }
+
+            return $trimmed;
         }
 
         return $payload;

--- a/tests/Parse/IsoBmff/IsoBmffExtractorTest.php
+++ b/tests/Parse/IsoBmff/IsoBmffExtractorTest.php
@@ -19,6 +19,7 @@ use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 use function chr;
+use function iconv;
 use function fopen;
 use function fwrite;
 use function hex2bin;
@@ -177,6 +178,40 @@ final class IsoBmffExtractorTest extends TestCase
     }
 
     /**
+     * Verifies UTF-16BE QuickTime data payloads are converted to UTF-8.
+     */
+    #[Test]
+    public function testDecodeUtf16DataBoxToUtf8(): void
+    {
+        $value         = 'Identifier UTF16';
+        $encoded       = iconv('UTF-8', 'UTF-16BE', $value);
+        self::assertIsString($encoded);
+        $utf16Payload  = $encoded . "\0\0";
+        $file          = $this->createQuickTimeKeysFileWithData(2, $utf16Payload);
+        $extractor     = $this->createExtractor($file);
+        [, , $qtMeta]  = $extractor->extract();
+
+        self::assertInstanceOf(QuickTimeMeta::class, $qtMeta);
+        self::assertSame($value, $qtMeta->contentIdentifier());
+    }
+
+    /**
+     * Verifies MacRoman QuickTime data payloads are converted to UTF-8.
+     */
+    #[Test]
+    public function testDecodeMacRomanDataBoxToUtf8(): void
+    {
+        $value        = 'Café Society';
+        $macPayload   = 'Caf' . chr(0x8E) . ' Society' . "\0";
+        $file         = $this->createQuickTimeKeysFileWithData(7, $macPayload);
+        $extractor    = $this->createExtractor($file);
+        [, , $qtMeta] = $extractor->extract();
+
+        self::assertInstanceOf(QuickTimeMeta::class, $qtMeta);
+        self::assertSame($value, $qtMeta->contentIdentifier());
+    }
+
+    /**
      * Ensures items referencing external data are skipped.
      */
     #[Test]
@@ -247,12 +282,23 @@ final class IsoBmffExtractorTest extends TestCase
      */
     private function createFileWithQuickTimeKeys(string $value): string
     {
+        return $this->createQuickTimeKeysFileWithData(1, $value);
+    }
+
+    /**
+     * Builds a QuickTime `keys` metadata structure with a custom `data` payload.
+     *
+     * @param int    $type        Numeric QuickTime data type identifier.
+     * @param string $encodedData Raw payload bytes stored inside the `data` box.
+     */
+    private function createQuickTimeKeysFileWithData(int $type, string $encodedData): string
+    {
         $keysEntry = pack('N', 8 + strlen('com.apple.quicktime.content.identifier'))
             . 'mdta'
             . 'com.apple.quicktime.content.identifier';
         $keys = self::box('keys', "\0\0\0\0" . pack('N', 1) . $keysEntry);
 
-        $dataBox   = self::box('data', pack('N', 1) . pack('N', 0) . $value);
+        $dataBox   = self::box('data', pack('N', $type) . pack('N', 0) . $encodedData);
         $ilstEntry = self::box(pack('N', 1), $dataBox);
         $ilst      = self::box('ilst', $ilstEntry);
 


### PR DESCRIPTION
## Summary
- decode UTF-16 and MacRoman QuickTime `data` box payloads to UTF-8 while preserving NUL trimming
- add PHPUnit coverage ensuring UTF-16BE and MacRoman fixtures decode to clean UTF-8 identifiers

## Testing
- `composer ci:test:php:unit`
- `composer ci:test:php:phpstan` *(fails: existing repository issues reported by PHPStan)*

------
https://chatgpt.com/codex/tasks/task_e_68fa140b5e588323a9cc5ac1748872d3