### PR TITLE
Fix PHPStan iterable type warnings in Exif IfdEntry

### DIFF
--- a/src/Model/Exif/IfdEntry.php
+++ b/src/Model/Exif/IfdEntry.php
@@ -32,10 +32,10 @@ final readonly class IfdEntry
     /**
      * Normalises raw decoded values so callers may provide convenient array representations.
      *
-     * @param int                                                               $tag   The numeric identifier of the entry.
-     * @param int                                                               $type  The TIFF field type code.
-     * @param int                                                               $count The number of values stored in the entry.
-     * @param int|float|string|ExifRational|ExifRationalList|ExifNumericList|array $value  The raw value or values decoded from the IFD.
+     * @param int                                                                                   $tag   The numeric identifier of the entry.
+     * @param int                                                                                   $type  The TIFF field type code.
+     * @param int                                                                                   $count The number of values stored in the entry.
+     * @param int|float|string|ExifRational|ExifRationalList|ExifNumericList|array<int, int|float|array<int, int|float>> $value  The raw value or values decoded from the IFD.
      */
     public function __construct(
         int $tag,
@@ -52,9 +52,9 @@ final readonly class IfdEntry
     /**
      * Converts shorthand array inputs into strongly typed EXIF value objects.
      *
-     * @param int                                                               $type  TIFF field type code describing the payload.
-     * @param int                                                               $count Number of values stored for the entry.
-     * @param int|float|string|ExifRational|ExifRationalList|ExifNumericList|array $value Raw value passed to the constructor.
+     * @param int                                                                                   $type  TIFF field type code describing the payload.
+     * @param int                                                                                   $count Number of values stored for the entry.
+     * @param int|float|string|ExifRational|ExifRationalList|ExifNumericList|array<int, int|float|array<int, int|float>> $value Raw value passed to the constructor.
      *
      * @return int|float|string|ExifRational|ExifRationalList|ExifNumericList
      */
@@ -67,8 +67,13 @@ final readonly class IfdEntry
             return $value;
         }
 
+        /**
+         * @var array<int, int|float|array<int, int|float>> $arrayValue
+         */
+        $arrayValue = array_values($value);
+
         if ($type === 5 || $type === 10) {
-            $rationals = $this->normaliseRationalList($value);
+            $rationals = $this->normaliseRationalList($arrayValue);
 
             if (count($rationals) === 1) {
                 return $rationals[0];
@@ -77,7 +82,7 @@ final readonly class IfdEntry
             return new ExifRationalList($rationals);
         }
 
-        $numericValues = $this->normaliseNumericList($value);
+        $numericValues = $this->normaliseNumericList($arrayValue);
 
         if ($count === 1 && count($numericValues) === 1) {
             return $numericValues[0];
@@ -89,23 +94,27 @@ final readonly class IfdEntry
     /**
      * Builds a list of {@see ExifRational} objects from array inputs.
      *
-     * @param array<int, int|float|array<int, int|float>> $value The raw array representation.
+     * @param array<int, mixed> $value The raw array representation.
      *
      * @return list<ExifRational>
      */
     private function normaliseRationalList(array $value): array
     {
-        if ($this->isRationalPair($value)) {
-            return [$this->pairToRational($value)];
+        $pair = $this->extractRationalPair($value);
+
+        if ($pair !== null) {
+            return [$this->pairToRational($pair[0], $pair[1])];
         }
 
         $rationals = [];
         foreach ($value as $component) {
-            if (!$this->isRationalPair($component)) {
+            $pair = $this->extractRationalPair($component);
+
+            if ($pair === null) {
                 continue;
             }
 
-            $rationals[] = $this->pairToRational($component);
+            $rationals[] = $this->pairToRational($pair[0], $pair[1]);
         }
 
         return $rationals;
@@ -114,7 +123,7 @@ final readonly class IfdEntry
     /**
      * Extracts numeric list components from an array representation.
      *
-     * @param array<int, int|float> $value Raw numeric components.
+     * @param array<int, mixed> $value Raw numeric components.
      *
      * @return list<int|float>
      */
@@ -131,32 +140,42 @@ final readonly class IfdEntry
     }
 
     /**
-     * Determines whether the provided value represents a rational numerator/denominator pair.
+     * Extracts a rational numerator/denominator pair from the provided value.
      *
      * @param mixed $value Potential rational pair to inspect.
+     *
+     * @return array{0: int|float, 1: int|float}|null
      */
-    private function isRationalPair(mixed $value): bool
+    private function extractRationalPair(mixed $value): ?array
     {
         if (!is_array($value)) {
-            return false;
+            return null;
         }
 
         $components = array_values($value);
 
-        return isset($components[0], $components[1])
-            && (is_int($components[0]) || is_float($components[0]))
-            && (is_int($components[1]) || is_float($components[1]));
+        if (!isset($components[0], $components[1])) {
+            return null;
+        }
+
+        $numerator = $components[0];
+        $denominator = $components[1];
+
+        if ((!is_int($numerator) && !is_float($numerator)) || (!is_int($denominator) && !is_float($denominator))) {
+            return null;
+        }
+
+        return [0 => $numerator, 1 => $denominator];
     }
 
     /**
      * Converts a numerator/denominator array into an {@see ExifRational} instance.
      *
-     * @param array<int, int|float> $pair Numerator/denominator values.
+     * @param int|float $numerator Numerator value.
+     * @param int|float $denominator Denominator value.
      */
-    private function pairToRational(array $pair): ExifRational
+    private function pairToRational(int|float $numerator, int|float $denominator): ExifRational
     {
-        $components = array_values($pair);
-
-        return new ExifRational((int) $components[0], (int) $components[1]);
+        return new ExifRational((int) $numerator, (int) $denominator);
     }
 }


### PR DESCRIPTION
## Summary
- document iterable value shapes for Exif IFD entries and normalise array inputs before conversion
- ensure rational pairs are extracted safely and converted with explicit numerator/denominator arguments
- relax numeric list inputs to mixed values while filtering scalar components

## Testing
- composer ci:test:php:phpstan

------
https://chatgpt.com/codex/tasks/task_e_68fa16ab9fa08323bacf5deec57ddfaa