### PR TITLE
Fix coverage metadata declarations in tests

### DIFF
--- a/tests/Convenience/CaptureDateResolverTest.php
+++ b/tests/Convenience/CaptureDateResolverTest.php
@@ -17,12 +17,15 @@ use MagicSunday\ImageMeta\Model\Metadata;
 use MagicSunday\ImageMeta\Model\Xmp\XmpDocument;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 
 /**
  * @covers \MagicSunday\ImageMeta\Convenience\CaptureDateResolver
  */
 #[CoversClass(CaptureDateResolver::class)]
+#[UsesClass(Metadata::class)]
+#[UsesClass(XmpDocument::class)]
 final class CaptureDateResolverTest extends TestCase
 {
     private const string XMP_NAMESPACE = 'http://ns.adobe.com/xap/1.0/';

--- a/tests/Convenience/ExifConvenienceTest.php
+++ b/tests/Convenience/ExifConvenienceTest.php
@@ -20,12 +20,20 @@ use MagicSunday\ImageMeta\Model\Exif\Ifd;
 use MagicSunday\ImageMeta\Model\Exif\IfdEntry;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 
 /**
  * @covers \MagicSunday\ImageMeta\Convenience\ExifConvenience
  */
 #[CoversClass(ExifConvenience::class)]
+#[UsesClass(ExifDocument::class)]
+#[UsesClass(ExifNumericList::class)]
+#[UsesClass(ExifRational::class)]
+#[UsesClass(ExifRationalList::class)]
+#[UsesClass(Ifd::class)]
+#[UsesClass(IfdEntry::class)]
+#[UsesClass(ValueConverters::class)]
 final class ExifConvenienceTest extends TestCase
 {
     /**

--- a/tests/Model/Exif/ExifDocumentTest.php
+++ b/tests/Model/Exif/ExifDocumentTest.php
@@ -19,12 +19,18 @@ use MagicSunday\ImageMeta\Model\Exif\Ifd;
 use MagicSunday\ImageMeta\Model\Exif\IfdEntry;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 
 /**
  * @covers \MagicSunday\ImageMeta\Model\Exif\ExifDocument
  */
 #[CoversClass(ExifDocument::class)]
+#[UsesClass(ExifRational::class)]
+#[UsesClass(ExifRationalList::class)]
+#[UsesClass(Ifd::class)]
+#[UsesClass(IfdEntry::class)]
+#[UsesClass(ValueConverters::class)]
 final class ExifDocumentTest extends TestCase
 {
     /**

--- a/tests/Model/Exif/ValueConvertersTest.php
+++ b/tests/Model/Exif/ValueConvertersTest.php
@@ -21,12 +21,17 @@ use MagicSunday\ImageMeta\Model\Exif\ValueConverters;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 
 /**
  * @covers \MagicSunday\ImageMeta\Model\Exif\ValueConverters
  */
 #[CoversClass(ValueConverters::class)]
+#[UsesClass(ExifRational::class)]
+#[UsesClass(ExifRationalList::class)]
+#[UsesClass(Ifd::class)]
+#[UsesClass(IfdEntry::class)]
 final class ValueConvertersTest extends TestCase
 {
     /**

--- a/tests/Model/Metadata/MetadataTest.php
+++ b/tests/Model/Metadata/MetadataTest.php
@@ -21,6 +21,7 @@ use MagicSunday\ImageMeta\Model\Xmp\XmpDocument;
 use MagicSunday\ImageMeta\Parse\Xmp\XmpParser;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -29,6 +30,13 @@ use PHPUnit\Framework\TestCase;
  * @covers \MagicSunday\ImageMeta\Model\Metadata
  */
 #[CoversClass(Metadata::class)]
+#[UsesClass(ExifDocument::class)]
+#[UsesClass(ExifTag::class)]
+#[UsesClass(Ifd::class)]
+#[UsesClass(IfdEntry::class)]
+#[UsesClass(QuickTimeMeta::class)]
+#[UsesClass(XmpDocument::class)]
+#[UsesClass(XmpParser::class)]
 final class MetadataTest extends TestCase
 {
     /**


### PR DESCRIPTION
## Summary
- declare dependent fixture classes with `#[UsesClass]` so strict coverage metadata passes

## Testing
- composer ci:test:php:unit


------
https://chatgpt.com/codex/tasks/task_e_68fa207d3454832380f73fdb5b045c83