### PR TITLE
refactor: centralize binary unpack helpers

### DIFF
--- a/src/Core/MemoryBuffer.php
+++ b/src/Core/MemoryBuffer.php
@@ -11,11 +11,10 @@ declare(strict_types=1);
 
 namespace MagicSunday\ImageMeta\Core;
 
-use function is_float;
-use function is_int;
+use MagicSunday\ImageMeta\Core\Util\Unpack;
+
 use function ord;
 use function strlen;
-use function unpack;
 
 /**
  * Provides a simple, bounds-checked in-memory buffer abstraction.
@@ -165,7 +164,7 @@ final class MemoryBuffer
         $lo = $this->readU32LE();
         $hi = $this->readU32LE();
 
-        return ($hi << 32) | $lo;
+        return Unpack::combineUint32($hi, $lo);
     }
 
     /**
@@ -178,31 +177,21 @@ final class MemoryBuffer
         $hi = $this->readU32BE();
         $lo = $this->readU32BE();
 
-        return ($hi << 32) | $lo;
+        return Unpack::combineUint32($hi, $lo);
     }
 
     /**
      * Reads bytes from the buffer and unpacks the first value using the provided format.
      *
-     * @param string $format Format accepted by {@see unpack}.
+     * @param string $format Format accepted by {@see Unpack::int}.
      * @param int    $length Number of bytes to consume before unpacking.
      *
      * @return int
      */
     private function unpackInt(string $format, int $length): int
     {
-        $bytes  = $this->read($length);
-        $result = unpack($format, $bytes);
+        $bytes = $this->read($length);
 
-        if ($result === false || !isset($result[1])) {
-            throw new ParseError('Failed to unpack integer from buffer.');
-        }
-
-        $value = $result[1];
-        if (!is_int($value) && !is_float($value)) {
-            throw new ParseError('Unpack returned a non-numeric value.');
-        }
-
-        return (int) $value;
+        return Unpack::int($format, $bytes, 'integer from buffer');
     }
 }

--- a/src/Core/Stream.php
+++ b/src/Core/Stream.php
@@ -11,16 +11,15 @@ declare(strict_types=1);
 
 namespace MagicSunday\ImageMeta\Core;
 
+use MagicSunday\ImageMeta\Core\Util\Unpack;
+
 use function fopen;
 use function fread;
 use function fseek;
 use function fstat;
 use function is_array;
-use function is_float;
-use function is_int;
 use function ord;
 use function strlen;
-use function unpack;
 
 /**
  * Provides a bounds-checked streaming reader over a binary resource handle.
@@ -172,7 +171,7 @@ final class Stream
         $hi = $this->readU32BE();
         $lo = $this->readU32BE();
 
-        return ($hi << 32) | $lo;
+        return Unpack::combineUint32($hi, $lo);
     }
 
     /**
@@ -193,25 +192,15 @@ final class Stream
     /**
      * Reads the requested number of bytes and unpacks the first value using the provided format.
      *
-     * @param string $format Format string understood by {@see unpack}.
+     * @param string $format Format string understood by {@see Unpack::int}.
      * @param int    $length Number of bytes to consume from the stream.
      *
      * @return int
      */
     private function unpackInt(string $format, int $length): int
     {
-        $bytes  = $this->read($length);
-        $result = unpack($format, $bytes);
+        $bytes = $this->read($length);
 
-        if ($result === false || !isset($result[1])) {
-            throw new ParseError('Failed to unpack integer from stream.');
-        }
-
-        $value = $result[1];
-        if (!is_int($value) && !is_float($value)) {
-            throw new ParseError('Unpack returned a non-numeric value.');
-        }
-
-        return (int) $value;
+        return Unpack::int($format, $bytes, 'integer from stream');
     }
 }

--- a/src/Core/StreamWindow.php
+++ b/src/Core/StreamWindow.php
@@ -11,10 +11,9 @@ declare(strict_types=1);
 
 namespace MagicSunday\ImageMeta\Core;
 
-use function is_float;
-use function is_int;
+use MagicSunday\ImageMeta\Core\Util\Unpack;
+
 use function ord;
-use function unpack;
 
 /**
  * Represents a bounded view into a parent stream with an independent cursor.
@@ -135,31 +134,21 @@ final class StreamWindow
         $hi = $this->readU32BE();
         $lo = $this->readU32BE();
 
-        return ($hi << 32) | $lo;
+        return Unpack::combineUint32($hi, $lo);
     }
 
     /**
      * Reads a fixed number of bytes from the window and unpacks the first value using the given format.
      *
-     * @param string $format Format string understood by {@see unpack}.
+     * @param string $format Format string understood by {@see Unpack::int}.
      * @param int    $length Number of bytes to read before unpacking.
      *
      * @return int
      */
     private function unpackInt(string $format, int $length): int
     {
-        $bytes  = $this->read($length);
-        $result = unpack($format, $bytes);
+        $bytes = $this->read($length);
 
-        if ($result === false || !isset($result[1])) {
-            throw new ParseError('Failed to unpack integer from window.');
-        }
-
-        $value = $result[1];
-        if (!is_int($value) && !is_float($value)) {
-            throw new ParseError('Unpack returned a non-numeric value.');
-        }
-
-        return (int) $value;
+        return Unpack::int($format, $bytes, 'integer from window');
     }
 }

--- a/src/Core/Util/Unpack.php
+++ b/src/Core/Util/Unpack.php
@@ -1,0 +1,90 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\ImageMeta\Core\Util;
+
+use MagicSunday\ImageMeta\Core\ParseError;
+
+use function is_float;
+use function is_int;
+use function unpack;
+
+/**
+ * Provides helpers for unpacking numeric values from binary data.
+ */
+final class Unpack
+{
+    /**
+     * Unpacks a value from the provided bytes and returns it as an integer.
+     *
+     * @param string $format  Format accepted by {@see unpack}.
+     * @param string $bytes   Bytes to unpack the value from.
+     * @param string $context Human-readable description used in error messages.
+     *
+     * @return int
+     */
+    public static function int(string $format, string $bytes, string $context): int
+    {
+        return (int) self::numeric($format, $bytes, $context);
+    }
+
+    /**
+     * Unpacks a value from the provided bytes and returns it as a float.
+     *
+     * @param string $format  Format accepted by {@see unpack}.
+     * @param string $bytes   Bytes to unpack the value from.
+     * @param string $context Human-readable description used in error messages.
+     *
+     * @return float
+     */
+    public static function float(string $format, string $bytes, string $context): float
+    {
+        return (float) self::numeric($format, $bytes, $context);
+    }
+
+    /**
+     * Combines two 32-bit unsigned integers into a single 64-bit value.
+     *
+     * @param int $hi High-order 32 bits.
+     * @param int $lo Low-order 32 bits.
+     *
+     * @return int
+     */
+    public static function combineUint32(int $hi, int $lo): int
+    {
+        return (($hi & 0xFFFFFFFF) << 32) | ($lo & 0xFFFFFFFF);
+    }
+
+    /**
+     * Unpacks a numeric value using {@see unpack} while validating the result.
+     *
+     * @param string $format  Format accepted by {@see unpack}.
+     * @param string $bytes   Bytes to unpack the value from.
+     * @param string $context Human-readable description used in error messages.
+     *
+     * @return int|float
+     */
+    private static function numeric(string $format, string $bytes, string $context): int|float
+    {
+        $result = unpack($format, $bytes);
+
+        if ($result === false || !isset($result[1])) {
+            throw new ParseError('Failed to unpack ' . $context . '.');
+        }
+
+        $value = $result[1];
+        if (!is_int($value) && !is_float($value)) {
+            throw new ParseError('Unpacked ' . $context . ' is not numeric.');
+        }
+
+        return $value;
+    }
+}

--- a/src/Parse/IsoBmff/IsoBmffExtractor.php
+++ b/src/Parse/IsoBmff/IsoBmffExtractor.php
@@ -14,6 +14,7 @@ namespace MagicSunday\ImageMeta\Parse\IsoBmff;
 use MagicSunday\ImageMeta\Core\ParseError;
 use MagicSunday\ImageMeta\Core\Stream;
 use MagicSunday\ImageMeta\Core\StreamWindow;
+use MagicSunday\ImageMeta\Core\Util\Unpack;
 use MagicSunday\ImageMeta\Model\QuickTimeMeta;
 
 use function array_merge;
@@ -22,8 +23,6 @@ use function array_unshift;
 use function array_values;
 use function explode;
 use function iconv;
-use function is_float;
-use function is_int;
 use function is_string;
 use function preg_match;
 use function rtrim;
@@ -34,7 +33,6 @@ use function strlen;
 use function strtolower;
 use function substr;
 use function trim;
-use function unpack;
 
 /**
  * Streaming ISOBMFF reader for HEIC/AVIF/MP4/MOV.
@@ -944,7 +942,7 @@ final readonly class IsoBmffExtractor
             0       => 0,
             1       => $window->readU8(),
             2       => $window->readU16BE(),
-            3       => $this->unpackInteger('N', "\0" . $window->read(3)),
+            3       => Unpack::int('N', "\0" . $window->read(3), '24-bit integer value'),
             4       => $window->readU32BE(),
             8       => $window->readU64BE(),
             default => throw new ParseError('unsupported integer size ' . $bytes),
@@ -992,31 +990,9 @@ final readonly class IsoBmffExtractor
             return null;
         }
 
-        $value = $this->unpackInteger('N', $fourcc);
+        $value = Unpack::int('N', $fourcc, 'four-character code');
 
         return $value > 0 ? $value : null;
-    }
-
-    /**
-     * @param string $format
-     * @param string $bytes
-     *
-     * @return int
-     */
-    private function unpackInteger(string $format, string $bytes): int
-    {
-        $result = unpack($format, $bytes);
-
-        if ($result === false || !isset($result[1])) {
-            throw new ParseError('Failed to unpack integer value.');
-        }
-
-        $value = $result[1];
-        if (!is_int($value) && !is_float($value)) {
-            throw new ParseError('Unpacked value is not numeric.');
-        }
-
-        return (int) $value;
     }
 
     /**

--- a/src/Parse/Tiff/TiffExifReader.php
+++ b/src/Parse/Tiff/TiffExifReader.php
@@ -14,6 +14,7 @@ namespace MagicSunday\ImageMeta\Parse\Tiff;
 use MagicSunday\ImageMeta\Core\Endian;
 use MagicSunday\ImageMeta\Core\MemoryBuffer;
 use MagicSunday\ImageMeta\Core\ParseError;
+use MagicSunday\ImageMeta\Core\Util\Unpack;
 use MagicSunday\ImageMeta\Model\Exif\ExifDocument;
 use MagicSunday\ImageMeta\Model\Exif\ExifNumericList;
 use MagicSunday\ImageMeta\Model\Exif\ExifRational;
@@ -31,7 +32,6 @@ use function rtrim;
 use function sprintf;
 use function strlen;
 use function substr;
-use function unpack;
 
 /**
  * Parses classic TIFF and BigTIFF structures embedded in EXIF payloads.
@@ -365,18 +365,9 @@ final class TiffExifReader
      */
     private function unpackU16(string $b): int
     {
-        $result = $this->bo === Endian::Little ? unpack('v', $b) : unpack('n', $b);
+        $format = $this->bo === Endian::Little ? 'v' : 'n';
 
-        if ($result === false || !isset($result[1])) {
-            throw new ParseError('Failed to unpack 16-bit value from TIFF bytes.');
-        }
-
-        $value = $result[1];
-        if (!is_int($value) && !is_float($value)) {
-            throw new ParseError('Unpacked 16-bit value is not numeric.');
-        }
-
-        return (int) $value;
+        return Unpack::int($format, $b, '16-bit value from TIFF bytes');
     }
 
     /**
@@ -402,18 +393,9 @@ final class TiffExifReader
      */
     private function unpackU32(string $b): int
     {
-        $result = $this->bo === Endian::Little ? unpack('V', $b) : unpack('N', $b);
+        $format = $this->bo === Endian::Little ? 'V' : 'N';
 
-        if ($result === false || !isset($result[1])) {
-            throw new ParseError('Failed to unpack 32-bit value from TIFF bytes.');
-        }
-
-        $value = $result[1];
-        if (!is_int($value) && !is_float($value)) {
-            throw new ParseError('Unpacked 32-bit value is not numeric.');
-        }
-
-        return (int) $value;
+        return Unpack::int($format, $b, '32-bit value from TIFF bytes');
     }
 
     /**
@@ -439,18 +421,9 @@ final class TiffExifReader
      */
     private function unpackFloat(string $b): float
     {
-        $result = $this->bo === Endian::Little ? unpack('g', $b) : unpack('G', $b);
+        $format = $this->bo === Endian::Little ? 'g' : 'G';
 
-        if ($result === false || !isset($result[1])) {
-            throw new ParseError('Failed to unpack 32-bit float from TIFF bytes.');
-        }
-
-        $value = $result[1];
-        if (!is_int($value) && !is_float($value)) {
-            throw new ParseError('Unpacked 32-bit float is not numeric.');
-        }
-
-        return (float) $value;
+        return Unpack::float($format, $b, '32-bit float from TIFF bytes');
     }
 
     /**
@@ -462,18 +435,9 @@ final class TiffExifReader
      */
     private function unpackDouble(string $b): float
     {
-        $result = $this->bo === Endian::Little ? unpack('e', $b) : unpack('E', $b);
+        $format = $this->bo === Endian::Little ? 'e' : 'E';
 
-        if ($result === false || !isset($result[1])) {
-            throw new ParseError('Failed to unpack 64-bit float from TIFF bytes.');
-        }
-
-        $value = $result[1];
-        if (!is_int($value) && !is_float($value)) {
-            throw new ParseError('Unpacked 64-bit float is not numeric.');
-        }
-
-        return (float) $value;
+        return Unpack::float($format, $b, '64-bit float from TIFF bytes');
     }
 
     /**


### PR DESCRIPTION
## Summary
- extract a shared binary unpack utility to consolidate integer/float validation and 64-bit composition
- update stream and buffer readers to reuse the helpers for big-endian reads
- align ISO BMFF and TIFF parsing helpers with the shared unpack logic

## Testing
- composer ci:test:php:unit
- composer ci:test:php:phpstan
- composer ci:test:php:cgl

------
https://chatgpt.com/codex/tasks/task_e_68fa2013ee308323989619f7f1c2544b