### PR TITLE
refactor: unify XMP parser implementations

### DIFF
--- a/src/Parse/Xmp/XmpParser.php
+++ b/src/Parse/Xmp/XmpParser.php
@@ -14,187 +14,149 @@ namespace MagicSunday\ImageMeta\Parse\Xmp;
 use MagicSunday\ImageMeta\Model\Xmp\XmpDocument;
 use XMLReader;
 
-use function in_array;
+use function array_filter;
+use function array_key_exists;
+use function array_values;
 use function sprintf;
 use function trim;
 
 /**
- * Lightweight streaming XMP (RDF/XML) parser backed by XMLReader.
- * The parser extracts a curated subset of common fields and stores them
- * using Clark notation while gracefully skipping everything else.
+ * Performs a lightweight XMP RDF/XML pass using \XMLReader to capture simple properties.
  */
 final class XmpParser
 {
     private const string RDF_NAMESPACE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#';
 
-    private const string DC_NAMESPACE = 'http://purl.org/dc/elements/1.1/';
-
-    private const string XMP_NAMESPACE = 'http://ns.adobe.com/xap/1.0/';
-
-    private const string EXIF_NAMESPACE = 'http://ns.adobe.com/exif/1.0/';
-
     /**
-     * Parses the provided XMP payload into a document object.
+     * Parses an XMP packet and returns a document containing discovered properties.
      *
-     * @param string $xmpXml The raw XMP XML fragment.
+     * The resulting document stores values keyed by Clark notation ("{namespace}local") and
+     * flattens RDF containers (Bag/Seq/Alt) into PHP lists.
      *
-     * @return XmpDocument Parsed values keyed by Clark notation.
+     * @param string $xml The raw XML payload containing the XMP packet.
+     *
+     * @return XmpDocument Parsed XMP representation.
      */
-    public function parse(string $xmpXml): XmpDocument
+    public function parse(string $xml): XmpDocument
     {
-        $reader = XMLReader::XML($xmpXml, 'UTF-8', LIBXML_NONET | LIBXML_NOERROR | LIBXML_NOWARNING);
+        $reader = XMLReader::XML($xml, null, LIBXML_NONET | LIBXML_NOERROR | LIBXML_NOWARNING);
         if (!$reader instanceof XMLReader) {
             return new XmpDocument([]);
         }
 
-        $properties = [];
-        /** @var array{string, string}|null $pendingBag Tracks the surrounding element for dc:subject bags. */
-        $pendingBag = null;
+        $data = [];
+        /** @var array<int, array{string, string}> $elementPath */
+        $elementPath = [];
+        /** @var array<int, string> $textBuffers */
+        $textBuffers = [];
+        /** @var array<int, list<string>> $listBuffers */
+        $listBuffers = [];
 
         while ($reader->read()) {
-            if ($reader->nodeType === XMLReader::END_ELEMENT) {
-                if ($pendingBag !== null && $this->matchesElement($reader, $pendingBag[0], $pendingBag[1])) {
-                    $pendingBag = null;
-                }
+            switch ($reader->nodeType) {
+                case XMLReader::ELEMENT:
+                    $depth     = $reader->depth;
+                    $namespace = $reader->namespaceURI;
+                    $localName = $reader->localName;
 
-                continue;
-            }
+                    $elementPath[$depth] = [$namespace, $localName];
+                    $textBuffers[$depth] = '';
 
-            if ($reader->nodeType !== XMLReader::ELEMENT) {
-                continue;
-            }
+                    if ($namespace !== self::RDF_NAMESPACE) {
+                        $listBuffers[$depth] = [];
+                    }
 
-            $namespace = $reader->namespaceURI;
-            $localName = $reader->localName;
+                    if ($reader->isEmptyElement) {
+                        if ($namespace !== self::RDF_NAMESPACE) {
+                            $value = $this->finalizeValue($listBuffers[$depth], $textBuffers[$depth]);
+                            if ($value !== null) {
+                                $data[$this->buildClarkName($namespace, $localName)] = $value;
+                            }
+                        }
 
-            if ($namespace === self::RDF_NAMESPACE && $localName === 'Bag' && $pendingBag !== null) {
-                $bag = $this->readBag($reader);
-                if ($bag !== []) {
-                    [$bagNs, $bagLocal]                          = $pendingBag;
-                    $properties[$this->qname($bagNs, $bagLocal)] = $bag;
-                }
+                        unset($elementPath[$depth], $textBuffers[$depth], $listBuffers[$depth]);
+                    }
 
-                continue;
-            }
+                    break;
 
-            if ($namespace === self::DC_NAMESPACE && $localName === 'subject') {
-                $pendingBag = $reader->isEmptyElement ? null : [$namespace, $localName];
-                continue;
-            }
+                case XMLReader::TEXT:
+                case XMLReader::WHITESPACE:
+                case XMLReader::SIGNIFICANT_WHITESPACE:
+                case XMLReader::CDATA:
+                    $depth = $reader->depth - 1;
+                    if ($depth >= 0 && array_key_exists($depth, $textBuffers)) {
+                        $textBuffers[$depth] .= $reader->value;
+                    }
 
-            if ($this->isStringProperty($namespace, $localName)) {
-                $text = $this->readElementText($reader);
-                if ($text !== '') {
-                    $properties[$this->qname($namespace, $localName)] = $text;
-                }
+                    break;
+
+                case XMLReader::END_ELEMENT:
+                    $depth = $reader->depth;
+                    $info  = $elementPath[$depth] ?? null;
+                    if ($info === null) {
+                        break;
+                    }
+
+                    [$namespace, $localName] = $info;
+                    if ($namespace === self::RDF_NAMESPACE && $localName === 'li') {
+                        $text = trim($textBuffers[$depth] ?? '');
+                        if ($text !== '') {
+                            for ($parentDepth = $depth - 1; $parentDepth >= 0; --$parentDepth) {
+                                if (isset($listBuffers[$parentDepth])) {
+                                    $listBuffers[$parentDepth][] = $text;
+                                    break;
+                                }
+                            }
+                        }
+                    } elseif ($namespace !== self::RDF_NAMESPACE) {
+                        $value = $this->finalizeValue($listBuffers[$depth], $textBuffers[$depth]);
+                        if ($value !== null) {
+                            $data[$this->buildClarkName($namespace, $localName)] = $value;
+                        }
+                    }
+
+                    unset($elementPath[$depth], $textBuffers[$depth], $listBuffers[$depth]);
+                    break;
             }
         }
 
         $reader->close();
 
-        return new XmpDocument($properties);
+        return new XmpDocument($data);
     }
 
     /**
-     * Determines whether the current element should be captured as a scalar string property.
+     * Finalises the collected container/list data for the current element.
      *
-     * @param string $namespace Namespace URI associated with the element.
-     * @param string $localName Local element name as read from the stream.
+     * @param list<string> $items
+     * @param string       $text
      *
-     * @return bool True when the element maps to a scalar value in the resulting document.
+     * @return list<string>|string|null
      */
-    private function isStringProperty(string $namespace, string $localName): bool
+    private function finalizeValue(array $items, string $text): array|string|null
     {
-        return ($namespace === self::XMP_NAMESPACE && in_array($localName, ['CreateDate', 'ModifyDate'], true))
-            || ($namespace === self::EXIF_NAMESPACE && in_array($localName, ['DateTimeOriginal', 'OffsetTimeOriginal'], true));
+        $items = array_values(array_filter($items, static fn (string $value): bool => $value !== ''));
+        if ($items !== []) {
+            return $items;
+        }
+
+        $text = trim($text);
+
+        return $text === '' ? null : $text;
     }
 
     /**
-     * Checks whether the current reader position matches the provided qualified name.
+     * Combines namespace URI and local name into a Clark notation key.
      *
-     * @param XMLReader $reader    XML reader currently positioned on an element.
-     * @param string    $namespace Expected namespace URI.
-     * @param string    $localName Expected local element name.
+     * @param string $namespaceUri Namespace URI assigned to the element.
+     * @param string $localName    Element name without namespace prefix.
      *
-     * @return bool True when the reader points at an element with the provided name.
+     * @return string Clark notation string representing the element.
      */
-    private function matchesElement(XMLReader $reader, string $namespace, string $localName): bool
-    {
-        return $reader->namespaceURI === $namespace && $reader->localName === $localName;
-    }
-
-    /**
-     * Builds a Clark notation qualified name for the provided pair.
-     *
-     * @param string $namespaceUri The element namespace URI.
-     * @param string $localName    The element's local name.
-     *
-     * @return string
-     */
-    private function qname(string $namespaceUri, string $localName): string
+    private function buildClarkName(string $namespaceUri, string $localName): string
     {
         return $namespaceUri !== ''
             ? sprintf('{%s}%s', $namespaceUri, $localName)
             : $localName;
-    }
-
-    /**
-     * Reads the concatenated text content of the current element.
-     *
-     * @param XMLReader $reader The active XML reader.
-     *
-     * @return string
-     */
-    private function readElementText(XMLReader $reader): string
-    {
-        $text = '';
-        if ($reader->isEmptyElement) {
-            return $text;
-        }
-
-        $depth = $reader->depth;
-        while ($reader->read()) {
-            if ($reader->nodeType === XMLReader::TEXT || $reader->nodeType === XMLReader::CDATA) {
-                $text .= $reader->value;
-            } elseif ($reader->nodeType === XMLReader::END_ELEMENT && $reader->depth === $depth) {
-                break;
-            }
-        }
-
-        return trim($text);
-    }
-
-    /**
-     * Reads an rdf:Bag container into a list of items.
-     *
-     * @param XMLReader $reader The active XML reader.
-     *
-     * @return list<string>
-     */
-    private function readBag(XMLReader $reader): array
-    {
-        $items = [];
-        if ($reader->isEmptyElement) {
-            return $items;
-        }
-
-        $depth = $reader->depth;
-        while ($reader->read()) {
-            if ($reader->nodeType === XMLReader::END_ELEMENT && $reader->depth === $depth) {
-                break;
-            }
-
-            if ($reader->nodeType === XMLReader::ELEMENT
-                && $reader->namespaceURI === self::RDF_NAMESPACE
-                && $reader->localName === 'li'
-            ) {
-                $value = $this->readElementText($reader);
-                if ($value !== '') {
-                    $items[] = $value;
-                }
-            }
-        }
-
-        return $items;
     }
 }

--- a/src/Parse/Xmp/XmpReader.php
+++ b/src/Parse/Xmp/XmpReader.php
@@ -12,151 +12,29 @@ declare(strict_types=1);
 namespace MagicSunday\ImageMeta\Parse\Xmp;
 
 use MagicSunday\ImageMeta\Model\Xmp\XmpDocument;
-use XMLReader;
-
-use function array_filter;
-use function array_key_exists;
-use function array_values;
-use function sprintf;
-use function trim;
 
 /**
- * Performs a lightweight XMP RDF/XML pass using \XMLReader to capture simple properties.
+ * @deprecated Use {@see XmpParser}. The class remains as a thin wrapper for backwards compatibility.
  */
 final class XmpReader
 {
-    private const string RDF_NAMESPACE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#';
+    private readonly XmpParser $parser;
 
     /**
-     * Parses an XMP packet and returns a document containing discovered properties.
+     * @param XmpParser|null $parser Optional parser instance used for delegation.
+     */
+    public function __construct(?XmpParser $parser = null)
+    {
+        $this->parser = $parser ?? new XmpParser();
+    }
+
+    /**
+     * @param string $xml Raw XMP payload that should be parsed.
      *
-     * The resulting document stores values keyed by Clark notation ("{namespace}local") and
-     * flattens RDF containers (Bag/Seq/Alt) into PHP lists.
-     *
-     * @param string $xml The raw XML payload containing the XMP packet.
-     *
-     * @return XmpDocument Parsed XMP representation.
+     * @return XmpDocument Parsed XMP representation produced by the delegate parser.
      */
     public function parse(string $xml): XmpDocument
     {
-        $reader = XMLReader::XML($xml, null, LIBXML_NONET | LIBXML_NOERROR | LIBXML_NOWARNING);
-        if (!$reader instanceof XMLReader) {
-            return new XmpDocument([]);
-        }
-
-        $data = [];
-        /** @var array<int, array{string, string}> $elementPath */
-        $elementPath = [];
-        /** @var array<int, string> $textBuffers */
-        $textBuffers = [];
-        /** @var array<int, list<string>> $listBuffers */
-        $listBuffers = [];
-
-        while ($reader->read()) {
-            switch ($reader->nodeType) {
-                case XMLReader::ELEMENT:
-                    $depth     = $reader->depth;
-                    $namespace = $reader->namespaceURI;
-                    $localName = $reader->localName;
-
-                    $elementPath[$depth] = [$namespace, $localName];
-                    $textBuffers[$depth] = '';
-
-                    if ($namespace !== self::RDF_NAMESPACE) {
-                        $listBuffers[$depth] = [];
-                    }
-
-                    if ($reader->isEmptyElement) {
-                        if ($namespace !== self::RDF_NAMESPACE) {
-                            $value = $this->finalizeValue($listBuffers[$depth], $textBuffers[$depth]);
-                            if ($value !== null) {
-                                $data[$this->buildClarkName($namespace, $localName)] = $value;
-                            }
-                        }
-
-                        unset($elementPath[$depth], $textBuffers[$depth], $listBuffers[$depth]);
-                    }
-
-                    break;
-
-                case XMLReader::TEXT:
-                case XMLReader::WHITESPACE:
-                case XMLReader::SIGNIFICANT_WHITESPACE:
-                case XMLReader::CDATA:
-                    $depth = $reader->depth - 1;
-                    if ($depth >= 0 && array_key_exists($depth, $textBuffers)) {
-                        $textBuffers[$depth] .= $reader->value;
-                    }
-
-                    break;
-
-                case XMLReader::END_ELEMENT:
-                    $depth = $reader->depth;
-                    $info  = $elementPath[$depth] ?? null;
-                    if ($info === null) {
-                        break;
-                    }
-
-                    [$namespace, $localName] = $info;
-                    if ($namespace === self::RDF_NAMESPACE && $localName === 'li') {
-                        $text = trim($textBuffers[$depth] ?? '');
-                        if ($text !== '') {
-                            for ($parentDepth = $depth - 1; $parentDepth >= 0; --$parentDepth) {
-                                if (isset($listBuffers[$parentDepth])) {
-                                    $listBuffers[$parentDepth][] = $text;
-                                    break;
-                                }
-                            }
-                        }
-                    } elseif ($namespace !== self::RDF_NAMESPACE) {
-                        $value = $this->finalizeValue($listBuffers[$depth], $textBuffers[$depth]);
-                        if ($value !== null) {
-                            $data[$this->buildClarkName($namespace, $localName)] = $value;
-                        }
-                    }
-
-                    unset($elementPath[$depth], $textBuffers[$depth], $listBuffers[$depth]);
-                    break;
-            }
-        }
-
-        $reader->close();
-
-        return new XmpDocument($data);
-    }
-
-    /**
-     * Finalises the collected container/list data for the current element.
-     *
-     * @param list<string> $items
-     * @param string       $text
-     *
-     * @return list<string>|string|null
-     */
-    private function finalizeValue(array $items, string $text): array|string|null
-    {
-        $items = array_values(array_filter($items, static fn (string $value): bool => $value !== ''));
-        if ($items !== []) {
-            return $items;
-        }
-
-        $text = trim($text);
-
-        return $text === '' ? null : $text;
-    }
-
-    /**
-     * Combines namespace URI and local name into a Clark notation key.
-     *
-     * @param string $namespaceUri Namespace URI assigned to the element.
-     * @param string $localName    Element name without namespace prefix.
-     *
-     * @return string Clark notation string representing the element.
-     */
-    private function buildClarkName(string $namespaceUri, string $localName): string
-    {
-        return $namespaceUri !== ''
-            ? sprintf('{%s}%s', $namespaceUri, $localName)
-            : $localName;
+        return $this->parser->parse($xml);
     }
 }

--- a/tests/Parse/Xmp/XmpParser/XmpParserTest.php
+++ b/tests/Parse/Xmp/XmpParser/XmpParserTest.php
@@ -95,6 +95,18 @@ XML;
     public static function provideInvalidXmpFragments(): iterable
     {
         yield 'broken xml declaration' => ['<?xml version="1.0"?><rdf:RDF'];
-        yield 'unsupported namespace' => ['<root xmlns="urn:example"><value>ignored</value></root>'];
+    }
+
+    /**
+     * Ensures elements from arbitrary namespaces are preserved using Clark notation.
+     */
+    #[Test]
+    public function parseCapturesValuesFromGenericNamespaces(): void
+    {
+        $xml = '<root xmlns="urn:example"><value>captured</value></root>';
+
+        $document = (new XmpParser())->parse($xml);
+
+        self::assertSame('captured', $document->get('urn:example', 'value'));
     }
 }


### PR DESCRIPTION
## Summary
- replace the bespoke XMP parser logic with the generic streaming reader implementation
- keep XmpReader as a backwards-compatible wrapper that delegates to the parser
- expand the XMP parser tests to cover generic namespaces while keeping invalid XML coverage

## Testing
- composer ci:test:php:unit

------
https://chatgpt.com/codex/tasks/task_e_68fa23efa1e88323ae4358f8c34be549