### PR TITLE
feat: add maker note decoders for major vendors

### DIFF
--- a/src/MakerNotes/CanonDecoder.php
+++ b/src/MakerNotes/CanonDecoder.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\ImageMeta\MakerNotes;
+
+use function sha1;
+use function strlen;
+
+/**
+ * Decoder that extracts basic metadata about Canon maker note payloads.
+ */
+final class CanonDecoder implements MakerNotesDecoderInterface
+{
+    /**
+     * Creates a metadata value object that describes the Canon maker note payload.
+     *
+     * @param string      $raw   Raw maker note data stream captured from the image file.
+     * @param string      $make  Reported camera make string.
+     * @param string|null $model Optional camera model identifier for the payload.
+     */
+    public function decode(string $raw, string $make, ?string $model): MakerNotesMetadata
+    {
+        return new MakerNotesMetadata(
+            'Canon',
+            strlen($raw),
+            sha1($raw)
+        );
+    }
+}

--- a/src/MakerNotes/NikonDecoder.php
+++ b/src/MakerNotes/NikonDecoder.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\ImageMeta\MakerNotes;
+
+use function sha1;
+use function strlen;
+
+/**
+ * Decoder that extracts basic metadata about Nikon maker note payloads.
+ */
+final class NikonDecoder implements MakerNotesDecoderInterface
+{
+    /**
+     * Creates a metadata value object that describes the Nikon maker note payload.
+     *
+     * @param string      $raw   Raw maker note data stream captured from the image file.
+     * @param string      $make  Reported camera make string.
+     * @param string|null $model Optional camera model identifier for the payload.
+     */
+    public function decode(string $raw, string $make, ?string $model): MakerNotesMetadata
+    {
+        return new MakerNotesMetadata(
+            'Nikon',
+            strlen($raw),
+            sha1($raw)
+        );
+    }
+}

--- a/src/MakerNotes/RegistryFactory.php
+++ b/src/MakerNotes/RegistryFactory.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\ImageMeta\MakerNotes;
+
+/**
+ * Factory that creates maker note registries with all built-in decoders registered.
+ */
+final class RegistryFactory
+{
+    /**
+     * Creates a registry pre-populated with the built-in maker note decoders.
+     */
+    public static function createDefault(): Registry
+    {
+        $registry = new Registry();
+
+        $appleDecoder = new AppleDecoder();
+        $canonDecoder = new CanonDecoder();
+        $nikonDecoder = new NikonDecoder();
+        $sonyDecoder = new SonyDecoder();
+
+        $registry->register('Apple', $appleDecoder);
+        $registry->register('Canon', $canonDecoder);
+        $registry->register('Canon Inc', $canonDecoder);
+        $registry->register('Canon Inc.', $canonDecoder);
+        $registry->register('Nikon', $nikonDecoder);
+        $registry->register('Nikon Corporation', $nikonDecoder);
+        $registry->register('Sony', $sonyDecoder);
+        $registry->register('Sony Corporation', $sonyDecoder);
+
+        return $registry;
+    }
+}

--- a/src/MakerNotes/SonyDecoder.php
+++ b/src/MakerNotes/SonyDecoder.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\ImageMeta\MakerNotes;
+
+use function sha1;
+use function strlen;
+
+/**
+ * Decoder that extracts basic metadata about Sony maker note payloads.
+ */
+final class SonyDecoder implements MakerNotesDecoderInterface
+{
+    /**
+     * Creates a metadata value object that describes the Sony maker note payload.
+     *
+     * @param string      $raw   Raw maker note data stream captured from the image file.
+     * @param string      $make  Reported camera make string.
+     * @param string|null $model Optional camera model identifier for the payload.
+     */
+    public function decode(string $raw, string $make, ?string $model): MakerNotesMetadata
+    {
+        return new MakerNotesMetadata(
+            'Sony',
+            strlen($raw),
+            sha1($raw)
+        );
+    }
+}

--- a/tests/MakerNotes/CanonDecoder/CanonDecoderTest.php
+++ b/tests/MakerNotes/CanonDecoder/CanonDecoderTest.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\ImageMeta\Tests\MakerNotes\CanonDecoder;
+
+use MagicSunday\ImageMeta\MakerNotes\CanonDecoder;
+use MagicSunday\ImageMeta\MakerNotes\MakerNotesMetadata;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+use function sha1;
+use function strlen;
+
+/**
+ * Validates the Canon maker notes decoder implementation.
+ *
+ * @covers \MagicSunday\ImageMeta\MakerNotes\CanonDecoder
+ */
+final class CanonDecoderTest extends TestCase
+{
+    /**
+     * Ensures the decoder returns consistent metadata for a Canon-style maker note payload.
+     */
+    #[Test]
+    public function decodeReturnsExpectedMetadata(): void
+    {
+        $raw     = "Canon\x00\x01\x00\x10\x00\x02\x00";
+        $decoder = new CanonDecoder();
+
+        $metadata = $decoder->decode($raw, 'Canon', 'Canon EOS R5');
+
+        self::assertInstanceOf(MakerNotesMetadata::class, $metadata);
+        self::assertSame('Canon', $metadata->vendor());
+        self::assertSame(strlen($raw), $metadata->length());
+        self::assertSame(sha1($raw), $metadata->sha1());
+    }
+}

--- a/tests/MakerNotes/NikonDecoder/NikonDecoderTest.php
+++ b/tests/MakerNotes/NikonDecoder/NikonDecoderTest.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\ImageMeta\Tests\MakerNotes\NikonDecoder;
+
+use MagicSunday\ImageMeta\MakerNotes\MakerNotesMetadata;
+use MagicSunday\ImageMeta\MakerNotes\NikonDecoder;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+use function sha1;
+use function strlen;
+
+/**
+ * Validates the Nikon maker notes decoder implementation.
+ *
+ * @covers \MagicSunday\ImageMeta\MakerNotes\NikonDecoder
+ */
+final class NikonDecoderTest extends TestCase
+{
+    /**
+     * Ensures the decoder returns consistent metadata for a Nikon-style maker note payload.
+     */
+    #[Test]
+    public function decodeReturnsExpectedMetadata(): void
+    {
+        $raw     = "Nikon\x00\x02\x00\x08\x00\x00\x01";
+        $decoder = new NikonDecoder();
+
+        $metadata = $decoder->decode($raw, 'Nikon Corporation', 'NIKON Z 8');
+
+        self::assertInstanceOf(MakerNotesMetadata::class, $metadata);
+        self::assertSame('Nikon', $metadata->vendor());
+        self::assertSame(strlen($raw), $metadata->length());
+        self::assertSame(sha1($raw), $metadata->sha1());
+    }
+}

--- a/tests/MakerNotes/RegistryTest.php
+++ b/tests/MakerNotes/RegistryTest.php
@@ -11,9 +11,13 @@ declare(strict_types=1);
 
 namespace MagicSunday\ImageMeta\Tests\MakerNotes;
 
+use MagicSunday\ImageMeta\MakerNotes\CanonDecoder;
 use MagicSunday\ImageMeta\MakerNotes\MakerNotesDecoderInterface;
 use MagicSunday\ImageMeta\MakerNotes\MakerNotesMetadata;
+use MagicSunday\ImageMeta\MakerNotes\NikonDecoder;
 use MagicSunday\ImageMeta\MakerNotes\Registry;
+use MagicSunday\ImageMeta\MakerNotes\RegistryFactory;
+use MagicSunday\ImageMeta\MakerNotes\SonyDecoder;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -92,5 +96,18 @@ final class RegistryTest extends TestCase
         });
 
         self::assertNull($registry->find('Nikon Corporation'));
+    }
+
+    /**
+     * Ensures the factory registers the built-in decoders for common vendor prefixes.
+     */
+    #[Test]
+    public function factoryRegistersBuiltInDecoders(): void
+    {
+        $registry = RegistryFactory::createDefault();
+
+        self::assertInstanceOf(CanonDecoder::class, $registry->find('Canon Inc.'));
+        self::assertInstanceOf(NikonDecoder::class, $registry->find('Nikon Corporation'));
+        self::assertInstanceOf(SonyDecoder::class, $registry->find('Sony Corporation'));
     }
 }

--- a/tests/MakerNotes/SonyDecoder/SonyDecoderTest.php
+++ b/tests/MakerNotes/SonyDecoder/SonyDecoderTest.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\ImageMeta\Tests\MakerNotes\SonyDecoder;
+
+use MagicSunday\ImageMeta\MakerNotes\MakerNotesMetadata;
+use MagicSunday\ImageMeta\MakerNotes\SonyDecoder;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+use function sha1;
+use function strlen;
+
+/**
+ * Validates the Sony maker notes decoder implementation.
+ *
+ * @covers \MagicSunday\ImageMeta\MakerNotes\SonyDecoder
+ */
+final class SonyDecoderTest extends TestCase
+{
+    /**
+     * Ensures the decoder returns consistent metadata for a Sony-style maker note payload.
+     */
+    #[Test]
+    public function decodeReturnsExpectedMetadata(): void
+    {
+        $raw     = "SONY\x00\x03\x00\x12\x00\x04";
+        $decoder = new SonyDecoder();
+
+        $metadata = $decoder->decode($raw, 'Sony', 'ILCE-7RM5');
+
+        self::assertInstanceOf(MakerNotesMetadata::class, $metadata);
+        self::assertSame('Sony', $metadata->vendor());
+        self::assertSame(strlen($raw), $metadata->length());
+        self::assertSame(sha1($raw), $metadata->sha1());
+    }
+}


### PR DESCRIPTION
## Summary
- add Canon, Nikon, and Sony maker note decoder implementations
- wire the new decoders into a registry factory with common vendor prefixes
- cover the decoders and registry bootstrap with PHPUnit suites

## Testing
- composer ci:test:php:unit

------
https://chatgpt.com/codex/tasks/task_e_68fa279b7798832386b263c65b5660b2