### PR TITLE
feat: decode EXIF maker notes

### DIFF
--- a/src/MetadataReader.php
+++ b/src/MetadataReader.php
@@ -14,6 +14,8 @@ namespace MagicSunday\ImageMeta;
 use MagicSunday\ImageMeta\Core\Stream;
 use MagicSunday\ImageMeta\Detect\ContainerType;
 use MagicSunday\ImageMeta\Detect\FormatDetector;
+use MagicSunday\ImageMeta\MakerNotes\AppleDecoder;
+use MagicSunday\ImageMeta\MakerNotes\Registry;
 use MagicSunday\ImageMeta\Model\Metadata;
 use MagicSunday\ImageMeta\Parse\IsoBmff\IsoBmffExtractor;
 use MagicSunday\ImageMeta\Parse\Jpeg\JpegExtractor;
@@ -56,17 +58,20 @@ final class MetadataReader
         $exifBlobs = $jpeg->extractExifBlobs();
         $xmpBlobs  = $jpeg->extractXmpPackets();
 
-        $exifDoc = null;
-        $xmpDoc  = null;
+        $exifDoc    = null;
+        $xmpDoc     = null;
+        $makerNotes = null;
         if ($exifBlobs !== []) {
-            $exifDoc = (new TiffExifReader())->parseFromBlob($exifBlobs[0]);
+            $registry = $this->createMakerNotesRegistry();
+            $exifDoc  = (new TiffExifReader())->parseFromBlob($exifBlobs[0], $registry);
+            $makerNotes = $exifDoc->makerNotes();
         }
 
         if ($xmpBlobs !== []) {
             $xmpDoc = (new XmpParser())->parse($xmpBlobs[0]);
         }
 
-        return new Metadata($exifBlobs, null, $exifDoc, $xmpBlobs, $xmpDoc);
+        return new Metadata($exifBlobs, null, $exifDoc, $xmpBlobs, $xmpDoc, $makerNotes);
     }
 
     /**
@@ -80,16 +85,30 @@ final class MetadataReader
     {
         [$exifBlobs, $xmpBlobs, $qt] = (new IsoBmffExtractor($stream))->extract();
 
-        $exifDoc = null;
-        $xmpDoc  = null;
+        $exifDoc    = null;
+        $xmpDoc     = null;
+        $makerNotes = null;
         if ($exifBlobs !== []) {
-            $exifDoc = (new TiffExifReader())->parseFromBlob($exifBlobs[0]);
+            $registry = $this->createMakerNotesRegistry();
+            $exifDoc  = (new TiffExifReader())->parseFromBlob($exifBlobs[0], $registry);
+            $makerNotes = $exifDoc->makerNotes();
         }
 
         if ($xmpBlobs !== []) {
             $xmpDoc = (new XmpParser())->parse($xmpBlobs[0]);
         }
 
-        return new Metadata($exifBlobs, $qt, $exifDoc, $xmpBlobs, $xmpDoc);
+        return new Metadata($exifBlobs, $qt, $exifDoc, $xmpBlobs, $xmpDoc, $makerNotes);
+    }
+
+    /**
+     * Builds the maker notes registry populated with the bundled decoders.
+     */
+    private function createMakerNotesRegistry(): Registry
+    {
+        $registry = new Registry();
+        $registry->register('Apple', new AppleDecoder());
+
+        return $registry;
     }
 }

--- a/src/Model/Exif/ExifDocument.php
+++ b/src/Model/Exif/ExifDocument.php
@@ -13,6 +13,7 @@ namespace MagicSunday\ImageMeta\Model\Exif;
 
 use DateTimeImmutable;
 use DateTimeZone;
+use MagicSunday\ImageMeta\MakerNotes\MakerNotesMetadata;
 
 use function is_float;
 use function is_int;
@@ -27,11 +28,12 @@ use function substr;
 final readonly class ExifDocument
 {
     /**
-     * @param Ifd      $ifd0       Root IFD of the TIFF structure.
-     * @param Ifd|null $exifIfd    Sub IFD containing EXIF-specific tags.
-     * @param Ifd|null $gpsIfd     Sub IFD containing GPS-related tags.
-     * @param Ifd|null $interopIfd Sub IFD containing interoperability tags.
-     * @param Ifd|null $ifd1       Optional next IFD, typically thumbnails.
+     * @param Ifd                    $ifd0       Root IFD of the TIFF structure.
+     * @param Ifd|null               $exifIfd    Sub IFD containing EXIF-specific tags.
+     * @param Ifd|null               $gpsIfd     Sub IFD containing GPS-related tags.
+     * @param Ifd|null               $interopIfd Sub IFD containing interoperability tags.
+     * @param Ifd|null               $ifd1       Optional next IFD, typically thumbnails.
+     * @param MakerNotesMetadata|null $makerNotes Decoded maker note metadata provided by vendor decoders.
      */
     public function __construct(
         public Ifd $ifd0,
@@ -39,7 +41,16 @@ final readonly class ExifDocument
         public ?Ifd $gpsIfd,
         public ?Ifd $interopIfd,
         public ?Ifd $ifd1,
+        public ?MakerNotesMetadata $makerNotes = null,
     ) {
+    }
+
+    /**
+     * Returns the decoded maker note metadata when a decoder is available.
+     */
+    public function makerNotes(): ?MakerNotesMetadata
+    {
+        return $this->makerNotes;
     }
 
     /**

--- a/src/Model/Exif/ExifTag.php
+++ b/src/Model/Exif/ExifTag.php
@@ -45,6 +45,8 @@ final readonly class ExifTag
 
     public const int FOCAL_LENGTH = 0x920A;
 
+    public const int MAKER_NOTE = 0x927C;
+
     public const int LENS_MODEL = 0xA434;
 
     // GPS sub IFD

--- a/src/Model/Metadata.php
+++ b/src/Model/Metadata.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace MagicSunday\ImageMeta\Model;
 
+use MagicSunday\ImageMeta\MakerNotes\MakerNotesMetadata;
 use MagicSunday\ImageMeta\Model\Exif\ExifDocument;
 use MagicSunday\ImageMeta\Model\Xmp\XmpDocument;
 use MagicSunday\ImageMeta\Parse\Xmp\XmpParser;
@@ -21,11 +22,12 @@ use MagicSunday\ImageMeta\Parse\Xmp\XmpParser;
 final readonly class Metadata
 {
     /**
-     * @param list<string>       $exifBlobs TIFF‑EXIF blobs (first is primary)
-     * @param QuickTimeMeta|null $quickTime QuickTime metadata extracted from ISO BMFF containers.
-     * @param ExifDocument|null  $exifDoc   Parsed representation of the primary EXIF document.
-     * @param list<string>       $xmpBlobs  XMP packets (RDF/XML), first is primary
-     * @param XmpDocument|null   $xmpDoc    Parsed representation of the primary XMP packet.
+     * @param list<string>          $exifBlobs TIFF‑EXIF blobs (first is primary)
+     * @param QuickTimeMeta|null    $quickTime QuickTime metadata extracted from ISO BMFF containers.
+     * @param ExifDocument|null     $exifDoc   Parsed representation of the primary EXIF document.
+     * @param list<string>          $xmpBlobs  XMP packets (RDF/XML), first is primary
+     * @param XmpDocument|null      $xmpDoc    Parsed representation of the primary XMP packet.
+     * @param MakerNotesMetadata|null $makerNotes Decoded maker notes metadata for the primary EXIF blob.
      */
     public function __construct(
         public array $exifBlobs,
@@ -33,6 +35,7 @@ final readonly class Metadata
         public ?ExifDocument $exifDoc = null,
         public array $xmpBlobs = [],
         public ?XmpDocument $xmpDoc = null,
+        public ?MakerNotesMetadata $makerNotes = null,
     ) {
     }
 

--- a/src/Parse/Tiff/TiffExifReader.php
+++ b/src/Parse/Tiff/TiffExifReader.php
@@ -15,6 +15,8 @@ use MagicSunday\ImageMeta\Core\Endian;
 use MagicSunday\ImageMeta\Core\MemoryBuffer;
 use MagicSunday\ImageMeta\Core\ParseError;
 use MagicSunday\ImageMeta\Core\Util\Unpack;
+use MagicSunday\ImageMeta\MakerNotes\MakerNotesMetadata;
+use MagicSunday\ImageMeta\MakerNotes\Registry;
 use MagicSunday\ImageMeta\Model\Exif\ExifDocument;
 use MagicSunday\ImageMeta\Model\Exif\ExifNumericList;
 use MagicSunday\ImageMeta\Model\Exif\ExifRational;
@@ -44,17 +46,21 @@ final class TiffExifReader
 
     private bool $bigTiff = false;
 
+    private ?string $makerNoteRaw = null;
+
     /**
      * Parses an EXIF TIFF blob into a structured document model.
      *
-     * @param string $tiffBlob Raw TIFF data including headers.
+     * @param string        $tiffBlob            Raw TIFF data including headers.
+     * @param Registry|null $makerNotesRegistry  Optional registry used to decode manufacturer-specific maker notes.
      *
      * @return ExifDocument
      */
-    public function parseFromBlob(string $tiffBlob): ExifDocument
+    public function parseFromBlob(string $tiffBlob, ?Registry $makerNotesRegistry = null): ExifDocument
     {
         $this->buf = new MemoryBuffer($tiffBlob);
         $this->buf->seek(0);
+        $this->makerNoteRaw = null;
 
         // byte order
         $boSig    = $this->buf->read(2);
@@ -104,7 +110,9 @@ final class TiffExifReader
             $ifd1 = $this->readIfd($nextOffset);
         }
 
-        return new ExifDocument($ifd0, $exifIfd, $gpsIfd, $interopIfd, $ifd1);
+        $makerNotes = $this->resolveMakerNotes($makerNotesRegistry, $ifd0, $exifIfd);
+
+        return new ExifDocument($ifd0, $exifIfd, $gpsIfd, $interopIfd, $ifd1, $makerNotes);
     }
 
     /**
@@ -159,42 +167,14 @@ final class TiffExifReader
         $cnt      = $this->bigTiff ? $this->readU64() : $this->readU32();
         $valOrOff = $this->bigTiff ? $this->readU64() : $this->readU32();
 
-        $value = $this->decodeValue($type, $cnt, $valOrOff);
+        [$rawBytes] = $this->valueBytes($type, $cnt, $valOrOff);
+        $value      = $this->decodeBytes($type, $cnt, $rawBytes);
 
-        return [$tag => new IfdEntry($tag, $type, $cnt, $value)];
-    }
-
-    /**
-     * Decodes the value referenced by a directory entry.
-     *
-     * @param int $type          TIFF field type code.
-     * @param int $count         Number of values represented.
-     * @param int $valueOrOffset Inline value bytes or an offset into the blob.
-     *
-     * @return int|float|string|ExifRational|ExifRationalList|ExifNumericList
-     */
-    private function decodeValue(int $type, int $count, int $valueOrOffset): int|float|string|ExifRational|ExifRationalList|ExifNumericList
-    {
-        $unitSize        = $this->bytesPerComponent($type);
-        $dataSize        = $unitSize * $count;
-        $inlineThreshold = $this->bigTiff ? 8 : 4;
-
-        if ($dataSize <= $inlineThreshold) {
-            // valueOrOffset is inline value area
-            $raw   = $this->uXToBytes($valueOrOffset, $inlineThreshold);
-            $bytes = substr($raw, 0, $dataSize);
-
-            return $this->decodeBytes($type, $count, $bytes);
+        if ($tag === ExifTag::MAKER_NOTE) {
+            $this->makerNoteRaw = $rawBytes;
         }
 
-        // valueOrOffset is an offset into the TIFF blob
-        $off = $valueOrOffset;
-        $cur = $this->buf->tell();
-        $this->buf->seek($off);
-        $bytes = $this->buf->read($dataSize);
-        $this->buf->seek($cur);
-
-        return $this->decodeBytes($type, $count, $bytes);
+        return [$tag => new IfdEntry($tag, $type, $cnt, $value)];
     }
 
     /**
@@ -259,6 +239,82 @@ final class TiffExifReader
         }
 
         return $count === 1 ? $vals[0] : new ExifNumericList($vals);
+    }
+
+    /**
+     * Extracts the raw bytes addressed by a directory entry.
+     *
+     * @param int $type          TIFF field type code.
+     * @param int $count         Number of values represented.
+     * @param int $valueOrOffset Inline value bytes or an offset into the blob.
+     *
+     * @return array{0: string, 1: int|null}
+     */
+    private function valueBytes(int $type, int $count, int $valueOrOffset): array
+    {
+        $unitSize        = $this->bytesPerComponent($type);
+        $dataSize        = $unitSize * $count;
+        $inlineThreshold = $this->bigTiff ? 8 : 4;
+
+        if ($dataSize <= $inlineThreshold) {
+            $raw = $this->uXToBytes($valueOrOffset, $inlineThreshold);
+
+            return [substr($raw, 0, $dataSize), null];
+        }
+
+        $offset   = $valueOrOffset;
+        $current  = $this->buf->tell();
+        $this->buf->seek($offset);
+        $bytes = $this->buf->read($dataSize);
+        $this->buf->seek($current);
+
+        return [$bytes, $offset];
+    }
+
+    /**
+     * Resolves maker note metadata using the provided registry when available.
+     */
+    private function resolveMakerNotes(?Registry $registry, Ifd $ifd0, ?Ifd $exifIfd): ?MakerNotesMetadata
+    {
+        if ($registry === null || !$exifIfd instanceof Ifd || $this->makerNoteRaw === null) {
+            return null;
+        }
+
+        $make = $this->stringFromIfd($ifd0, ExifTag::MAKE);
+        if ($make === null || $make === '') {
+            return null;
+        }
+
+        $decoder = $registry->find($make);
+        if ($decoder === null) {
+            return null;
+        }
+
+        $model = $this->stringFromIfd($ifd0, ExifTag::MODEL);
+
+        return $decoder->decode($this->makerNoteRaw, $make, $model);
+    }
+
+    /**
+     * Returns the trimmed string value for a specific tag within an IFD.
+     */
+    private function stringFromIfd(?Ifd $ifd, int $tag): ?string
+    {
+        if (!$ifd instanceof Ifd) {
+            return null;
+        }
+
+        $entry = $ifd->get($tag);
+        if (!$entry instanceof IfdEntry) {
+            return null;
+        }
+
+        $value = $entry->value;
+        if (!is_string($value)) {
+            return null;
+        }
+
+        return rtrim($value, "\0");
     }
 
     /**

--- a/tests/MakerNotes/MakerNotesPropagationTest.php
+++ b/tests/MakerNotes/MakerNotesPropagationTest.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\ImageMeta\Tests\MakerNotes;
+
+use MagicSunday\ImageMeta\MakerNotes\MakerNotesMetadata;
+use MagicSunday\ImageMeta\Model\Exif\ExifDocument;
+use MagicSunday\ImageMeta\Model\Exif\Ifd;
+use MagicSunday\ImageMeta\Model\Metadata;
+use function str_repeat;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Verifies that maker note metadata propagates through the model layer.
+ */
+final class MakerNotesPropagationTest extends TestCase
+{
+    /**
+     * Ensures the EXIF document exposes the provided maker notes metadata.
+     */
+    #[Test]
+    public function exifDocumentReturnsMakerNotes(): void
+    {
+        $makerNotes = new MakerNotesMetadata('Acme', 4, str_repeat('0', 40));
+        $document   = new ExifDocument(new Ifd([]), null, null, null, null, $makerNotes);
+
+        self::assertSame($makerNotes, $document->makerNotes());
+    }
+
+    /**
+     * Ensures the aggregate metadata object stores the optional maker notes metadata.
+     */
+    #[Test]
+    public function metadataAggregateCarriesMakerNotes(): void
+    {
+        $makerNotes = new MakerNotesMetadata('Acme', 4, str_repeat('0', 40));
+        $metadata   = new Metadata([], null, null, [], null, $makerNotes);
+
+        self::assertSame($makerNotes, $metadata->makerNotes);
+    }
+}

--- a/tests/Parse/Tiff/TiffExifReaderTest.php
+++ b/tests/Parse/Tiff/TiffExifReaderTest.php
@@ -14,6 +14,9 @@ namespace MagicSunday\ImageMeta\Tests\Parse\Tiff;
 use MagicSunday\ImageMeta\Core\BoundsError;
 use MagicSunday\ImageMeta\Core\Endian;
 use MagicSunday\ImageMeta\Core\ParseError;
+use MagicSunday\ImageMeta\MakerNotes\MakerNotesDecoderInterface;
+use MagicSunday\ImageMeta\MakerNotes\MakerNotesMetadata;
+use MagicSunday\ImageMeta\MakerNotes\Registry;
 use MagicSunday\ImageMeta\Model\Exif\ExifDocument;
 use MagicSunday\ImageMeta\Model\Exif\ExifNumericList;
 use MagicSunday\ImageMeta\Model\Exif\ExifRational;
@@ -31,9 +34,12 @@ use function count;
 use function implode;
 use function ord;
 use function pack;
+use function sha1;
 use function str_pad;
 use function str_repeat;
 use function strlen;
+use function substr;
+use function unpack;
 
 /**
  * Exercises the TIFF EXIF reader with synthetic Classic TIFF and BigTIFF payloads.
@@ -140,6 +146,50 @@ final class TiffExifReaderTest extends TestCase
         $this->expectExceptionMessage('Truncated value for TIFF type 1');
 
         $decodeBytes->invoke($reader, 1, 2, "\x01");
+    }
+
+    /**
+     * Ensures maker note metadata is decoded when a matching decoder is registered.
+     */
+    #[Test]
+    public function decodesMakerNotesWithRegisteredDecoder(): void
+    {
+        [$blob, $makerNoteData] = self::buildClassicMakerNoteBlob();
+
+        $decoder = new class implements MakerNotesDecoderInterface {
+            public function decode(string $raw, string $make, ?string $model): MakerNotesMetadata
+            {
+                $offset = unpack('Voffset', substr($raw, 0, 4));
+                $pointer = $offset['offset'] ?? 0;
+                $vendor  = substr($raw, $pointer, 4);
+
+                return new MakerNotesMetadata($vendor !== '' ? $vendor : 'Unknown', strlen($raw), sha1($raw));
+            }
+        };
+
+        $registry = new Registry();
+        $registry->register('Acme', $decoder);
+
+        $document   = (new TiffExifReader())->parseFromBlob($blob, $registry);
+        $makerNotes = $document->makerNotes();
+
+        self::assertInstanceOf(MakerNotesMetadata::class, $makerNotes);
+        self::assertSame('DATA', $makerNotes->vendor());
+        self::assertSame(strlen($makerNoteData), $makerNotes->length());
+        self::assertSame(sha1($makerNoteData), $makerNotes->sha1());
+    }
+
+    /**
+     * Ensures maker note metadata remains null when no decoder is available for the camera make.
+     */
+    #[Test]
+    public function makerNotesRemainNullWithoutDecoder(): void
+    {
+        [$blob]    = self::buildClassicMakerNoteBlob();
+        $document  = (new TiffExifReader())->parseFromBlob($blob, new Registry());
+        $makerNote = $document->makerNotes();
+
+        self::assertNull($makerNote);
     }
 
     /**
@@ -380,6 +430,48 @@ final class TiffExifReaderTest extends TestCase
             . pack('v', $type)
             . pack('V', $count)
             . pack('V', $valueOrOffset);
+    }
+
+    /**
+     * Builds a Classic TIFF blob containing maker note data referenced from the EXIF IFD.
+     *
+     * @return array{0: string, 1: string}
+     */
+    private static function buildClassicMakerNoteBlob(): array
+    {
+        $header = 'II' . pack('v', 0x002A) . pack('V', 8);
+
+        $makeString  = "AcmeCam\0";
+        $modelString = "ZX-1\0";
+        $makerNote   = pack('V', 8) . 'NOTE' . 'DATA';
+
+        $ifd0EntryCount = 3;
+        $ifd0Size       = 2 + $ifd0EntryCount * 12 + 4;
+        $makeOffset     = 8 + $ifd0Size;
+        $modelOffset    = $makeOffset + strlen($makeString);
+        $exifOffset     = $modelOffset + strlen($modelString);
+
+        $ifd0Entries = [
+            self::packClassicEntry(ExifTag::MAKE, 2, strlen($makeString), $makeOffset),
+            self::packClassicEntry(ExifTag::MODEL, 2, strlen($modelString), $modelOffset),
+            self::packClassicEntry(ExifTag::EXIF_IFD_POINTER, 4, 1, $exifOffset),
+        ];
+
+        $blob = $header;
+        $blob .= pack('v', $ifd0EntryCount) . implode('', $ifd0Entries) . pack('V', 0);
+        $blob .= $makeString;
+        $blob .= $modelString;
+
+        $exifEntryCount   = 1;
+        $exifIfdSize      = 2 + $exifEntryCount * 12 + 4;
+        $makerNoteOffset  = $exifOffset + $exifIfdSize;
+        $exifEntries      = [
+            self::packClassicEntry(ExifTag::MAKER_NOTE, 7, strlen($makerNote), $makerNoteOffset),
+        ];
+        $blob .= pack('v', $exifEntryCount) . implode('', $exifEntries) . pack('V', 0);
+        $blob .= $makerNote;
+
+        return [$blob, $makerNote];
     }
 
     /**


### PR DESCRIPTION
## Summary
- add maker-note constant and expose decoded metadata from `ExifDocument` and `Metadata`
- enhance the TIFF EXIF reader to extract raw maker-note payloads and decode them through the registry
- register the bundled Apple decoder in `MetadataReader` and cover maker-note plumbing and parsing scenarios with tests

## Testing
- `composer ci:test:php:unit`


------
https://chatgpt.com/codex/tasks/task_e_68fa279b5dbc8323b4fe224cfeaac7b2