### PR TITLE
Add digest fallback for unknown maker notes

### DIFF
--- a/src/Parse/Tiff/TiffExifReader.php
+++ b/src/Parse/Tiff/TiffExifReader.php
@@ -31,6 +31,7 @@ use function is_int;
 use function ord;
 use function pack;
 use function rtrim;
+use function sha1;
 use function sprintf;
 use function strlen;
 use function substr;
@@ -276,23 +277,35 @@ final class TiffExifReader
      */
     private function resolveMakerNotes(?Registry $registry, Ifd $ifd0, ?Ifd $exifIfd): ?MakerNotesMetadata
     {
-        if ($registry === null || !$exifIfd instanceof Ifd || $this->makerNoteRaw === null) {
+        if ($this->makerNoteRaw === null) {
             return null;
+        }
+
+        if ($registry === null || !$exifIfd instanceof Ifd) {
+            return $this->makerNotesDigest();
         }
 
         $make = $this->stringFromIfd($ifd0, ExifTag::MAKE);
         if ($make === null || $make === '') {
-            return null;
+            return $this->makerNotesDigest();
         }
 
         $decoder = $registry->find($make);
         if ($decoder === null) {
-            return null;
+            return $this->makerNotesDigest();
         }
 
         $model = $this->stringFromIfd($ifd0, ExifTag::MODEL);
 
         return $decoder->decode($this->makerNoteRaw, $make, $model);
+    }
+
+    /**
+     * Creates a digest metadata instance for unknown maker notes.
+     */
+    private function makerNotesDigest(): MakerNotesMetadata
+    {
+        return new MakerNotesMetadata('Unknown', strlen($this->makerNoteRaw), sha1($this->makerNoteRaw));
     }
 
     /**

--- a/tests/Parse/Tiff/TiffExifReaderTest.php
+++ b/tests/Parse/Tiff/TiffExifReaderTest.php
@@ -180,16 +180,28 @@ final class TiffExifReaderTest extends TestCase
     }
 
     /**
-     * Ensures maker note metadata remains null when no decoder is available for the camera make.
+     * Ensures maker note metadata falls back to a digest when no decoder matches the make string.
      */
     #[Test]
-    public function makerNotesRemainNullWithoutDecoder(): void
+    public function makerNotesFallbackToDigestWithoutMatchingDecoder(): void
     {
-        [$blob]    = self::buildClassicMakerNoteBlob();
-        $document  = (new TiffExifReader())->parseFromBlob($blob, new Registry());
-        $makerNote = $document->makerNotes();
+        [$blob, $makerNoteData] = self::buildClassicMakerNoteBlob();
 
-        self::assertNull($makerNote);
+        $registry = new Registry();
+        $registry->register('Other', new class implements MakerNotesDecoderInterface {
+            public function decode(string $raw, string $make, ?string $model): MakerNotesMetadata
+            {
+                return new MakerNotesMetadata('Other', strlen($raw), sha1($raw));
+            }
+        });
+
+        $document   = (new TiffExifReader())->parseFromBlob($blob, $registry);
+        $makerNotes = $document->makerNotes();
+
+        self::assertInstanceOf(MakerNotesMetadata::class, $makerNotes);
+        self::assertSame('Unknown', $makerNotes->vendor());
+        self::assertSame(strlen($makerNoteData), $makerNotes->length());
+        self::assertSame(sha1($makerNoteData), $makerNotes->sha1());
     }
 
     /**


### PR DESCRIPTION
## Summary
- add a maker-notes digest fallback when no decoder matches the camera make
- extend TIFF EXIF reader tests to cover the digest fallback behaviour

## Testing
- composer ci:test:php:unit

------
https://chatgpt.com/codex/tasks/task_e_68fa2fd945a48323bd84978b64496c83