### PR TITLE
fix: guard maker notes digest input

### DIFF
--- a/src/Parse/Tiff/TiffExifReader.php
+++ b/src/Parse/Tiff/TiffExifReader.php
@@ -305,7 +305,9 @@ final class TiffExifReader
      */
     private function makerNotesDigest(): MakerNotesMetadata
     {
-        return new MakerNotesMetadata('Unknown', strlen($this->makerNoteRaw), sha1($this->makerNoteRaw));
+        $raw = $this->makerNoteRaw ?? '';
+
+        return new MakerNotesMetadata('Unknown', strlen($raw), sha1($raw));
     }
 
     /**


### PR DESCRIPTION
## Summary
- ensure maker note digest calculations use a non-null string fallback

## Testing
- composer ci:test:php:phpstan

------
https://chatgpt.com/codex/tasks/task_e_68fa6fc1d2008323ae04de404c482a54