### PR TITLE
feat: add structured metadata builder

### DIFF
--- a/src/Curate/Resolver/AppleResolver.php
+++ b/src/Curate/Resolver/AppleResolver.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\ImageMeta\Curate\Resolver;
+
+use MagicSunday\ImageMeta\Model\QuickTimeMeta;
+use MagicSunday\ImageMeta\Value\Apple;
+
+/**
+ * Resolves Apple specific metadata from QuickTime containers.
+ */
+final readonly class AppleResolver
+{
+    /**
+     * Builds an Apple value object from available metadata.
+     */
+    public function resolve(?QuickTimeMeta $quickTimeMeta): ?Apple
+    {
+        if (!$quickTimeMeta instanceof QuickTimeMeta) {
+            return null;
+        }
+
+        $identifier = $quickTimeMeta->contentIdentifier();
+        if ($identifier === null) {
+            return null;
+        }
+
+        return new Apple($identifier);
+    }
+}

--- a/src/Curate/Resolver/CameraResolver.php
+++ b/src/Curate/Resolver/CameraResolver.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\ImageMeta\Curate\Resolver;
+
+use MagicSunday\ImageMeta\Model\Exif\ExifDocument;
+use MagicSunday\ImageMeta\Model\Xmp\XmpDocument;
+use MagicSunday\ImageMeta\Value\Camera;
+
+/**
+ * Resolves camera information from the available metadata sources.
+ */
+final readonly class CameraResolver
+{
+    use XmpPropertyAccess;
+
+    private const string NS_TIFF = 'http://ns.adobe.com/tiff/1.0/';
+    private const string NS_AUX  = 'http://ns.adobe.com/exif/1.0/aux/';
+    private const string NS_XMP  = 'http://ns.adobe.com/xap/1.0/';
+
+    /**
+     * Builds a camera value object from the provided metadata.
+     */
+    public function resolve(?ExifDocument $exifDocument, ?XmpDocument $xmpDocument): ?Camera
+    {
+        $make   = $exifDocument?->cameraMake() ?? $this->xmpString($xmpDocument, self::NS_TIFF, 'Make');
+        $model  = $exifDocument?->cameraModel() ?? $this->xmpString($xmpDocument, self::NS_TIFF, 'Model');
+        $serial = $this->xmpString($xmpDocument, self::NS_AUX, 'SerialNumber');
+        $tool   = $this->xmpString($xmpDocument, self::NS_XMP, 'CreatorTool');
+
+        if ($make === null && $model === null && $serial === null && $tool === null) {
+            return null;
+        }
+
+        return new Camera($make, $model, $serial, $tool);
+    }
+}

--- a/src/Curate/Resolver/CaptureResolver.php
+++ b/src/Curate/Resolver/CaptureResolver.php
@@ -1,0 +1,80 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\ImageMeta\Curate\Resolver;
+
+use DateTimeImmutable;
+use MagicSunday\ImageMeta\Model\Exif\ExifDocument;
+use MagicSunday\ImageMeta\Model\Xmp\XmpDocument;
+use MagicSunday\ImageMeta\Value\Capture;
+
+use function strtotime;
+
+/**
+ * Resolves capture timestamps while preferring EXIF derived values.
+ */
+final readonly class CaptureResolver
+{
+    use XmpPropertyAccess;
+
+    private const string NS_EXIF = 'http://ns.adobe.com/exif/1.0/';
+
+    /**
+     * Builds a capture value object from the available metadata sources.
+     */
+    public function resolve(?ExifDocument $exifDocument, ?XmpDocument $xmpDocument): ?Capture
+    {
+        $dateTime = $exifDocument?->captureDateTime();
+
+        if (!$dateTime instanceof DateTimeImmutable) {
+            $dateString = $this->xmpString($xmpDocument, self::NS_EXIF, 'DateTimeOriginal');
+            $dateTime   = $dateString !== null ? $this->parseDateTime($dateString) : null;
+        }
+
+        if (!$dateTime instanceof DateTimeImmutable) {
+            return null;
+        }
+
+        return new Capture($dateTime);
+    }
+
+    /**
+     * Parses either EXIF or ISO-8601 style timestamps.
+     */
+    private function parseDateTime(string $value): ?DateTimeImmutable
+    {
+        $value = trim($value);
+        if ($value === '') {
+            return null;
+        }
+
+        $formats = [
+            'Y-m-d\TH:i:sP',
+            'Y-m-d\TH:i:s',
+            'Y:m:d H:i:s',
+            'Y-m-d H:i:s',
+        ];
+
+        foreach ($formats as $format) {
+            $dateTime = DateTimeImmutable::createFromFormat($format, $value);
+            if ($dateTime instanceof DateTimeImmutable) {
+                return $dateTime;
+            }
+        }
+
+        $timestamp = strtotime($value);
+        if ($timestamp !== false) {
+            return new DateTimeImmutable('@' . $timestamp);
+        }
+
+        return null;
+    }
+}

--- a/src/Curate/Resolver/DeviceResolver.php
+++ b/src/Curate/Resolver/DeviceResolver.php
@@ -1,0 +1,82 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\ImageMeta\Curate\Resolver;
+
+use MagicSunday\ImageMeta\Model\QuickTimeMeta;
+use MagicSunday\ImageMeta\Model\Xmp\XmpDocument;
+use MagicSunday\ImageMeta\Value\Device;
+
+use function is_bool;
+use function is_float;
+use function is_int;
+use function is_string;
+
+/**
+ * Resolves device specific metadata from container level sources.
+ */
+final readonly class DeviceResolver
+{
+    use XmpPropertyAccess;
+
+    private const string NS_TIFF = 'http://ns.adobe.com/tiff/1.0/';
+    private const string NS_XMP  = 'http://ns.adobe.com/xap/1.0/';
+
+    private const string QUICKTIME_MAKE_KEY     = 'com.apple.quicktime.make';
+    private const string QUICKTIME_MODEL_KEY    = 'com.apple.quicktime.model';
+    private const string QUICKTIME_SOFTWARE_KEY = 'com.apple.quicktime.software';
+
+    /**
+     * Builds a device value object from available metadata.
+     */
+    public function resolve(?QuickTimeMeta $quickTimeMeta, ?XmpDocument $xmpDocument): ?Device
+    {
+        $manufacturer = null;
+        $model        = null;
+        $software     = null;
+
+        if ($quickTimeMeta instanceof QuickTimeMeta) {
+            $manufacturer = $this->stringFromMixed($quickTimeMeta->keys[self::QUICKTIME_MAKE_KEY] ?? null);
+            $model        = $this->stringFromMixed($quickTimeMeta->keys[self::QUICKTIME_MODEL_KEY] ?? null);
+            $software     = $this->stringFromMixed($quickTimeMeta->keys[self::QUICKTIME_SOFTWARE_KEY] ?? null);
+        }
+
+        $manufacturer ??= $this->xmpString($xmpDocument, self::NS_TIFF, 'Make');
+        $model        ??= $this->xmpString($xmpDocument, self::NS_TIFF, 'Model');
+        $software     ??= $this->xmpString($xmpDocument, self::NS_XMP, 'CreatorTool');
+
+        if ($manufacturer === null && $model === null && $software === null) {
+            return null;
+        }
+
+        return new Device($manufacturer, $model, $software);
+    }
+
+    /**
+     * Normalises arbitrary QuickTime metadata values to strings.
+     */
+    private function stringFromMixed(mixed $value): ?string
+    {
+        if (is_string($value)) {
+            return $value;
+        }
+
+        if (is_int($value) || is_float($value)) {
+            return (string) $value;
+        }
+
+        if (is_bool($value)) {
+            return $value ? '1' : '0';
+        }
+
+        return null;
+    }
+}

--- a/src/Curate/Resolver/ExposureResolver.php
+++ b/src/Curate/Resolver/ExposureResolver.php
@@ -1,0 +1,69 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\ImageMeta\Curate\Resolver;
+
+use MagicSunday\ImageMeta\Model\Exif\ExifDocument;
+use MagicSunday\ImageMeta\Model\Xmp\XmpDocument;
+use MagicSunday\ImageMeta\Value\Enum\ExposureProgram;
+use MagicSunday\ImageMeta\Value\Enum\MeteringMode;
+use MagicSunday\ImageMeta\Value\Enum\WhiteBalance;
+use MagicSunday\ImageMeta\Value\Exposure;
+use MagicSunday\ImageMeta\Value\FlashInfo;
+
+/**
+ * Resolves exposure related metadata by preferring EXIF tags.
+ */
+final readonly class ExposureResolver
+{
+    use XmpPropertyAccess;
+
+    private const string NS_EXIF = 'http://ns.adobe.com/exif/1.0/';
+
+    /**
+     * Builds an exposure value object from the provided metadata.
+     */
+    public function resolve(?ExifDocument $exifDocument, ?XmpDocument $xmpDocument): ?Exposure
+    {
+        $iso           = $exifDocument?->iso() ?? $this->xmpInt($xmpDocument, self::NS_EXIF, 'ISOSpeedRatings');
+        $exposureTime  = $exifDocument?->exposureTime() ?? $this->xmpFloat($xmpDocument, self::NS_EXIF, 'ExposureTime');
+        $aperture      = $exifDocument?->fNumber() ?? $this->xmpFloat($xmpDocument, self::NS_EXIF, 'FNumber');
+        $focalLength   = $exifDocument?->focalLengthMm() ?? $this->xmpFloat($xmpDocument, self::NS_EXIF, 'FocalLength');
+        $program       = ExposureProgram::fromExifValue($this->xmpInt($xmpDocument, self::NS_EXIF, 'ExposureProgram'));
+        $metering      = MeteringMode::fromExifValue($this->xmpInt($xmpDocument, self::NS_EXIF, 'MeteringMode'));
+        $whiteBalance  = WhiteBalance::fromExifValue($this->xmpInt($xmpDocument, self::NS_EXIF, 'WhiteBalance'));
+        $flash         = FlashInfo::fromExifValue($this->xmpInt($xmpDocument, self::NS_EXIF, 'Flash'));
+
+        if (
+            $iso === null
+            && $exposureTime === null
+            && $aperture === null
+            && $focalLength === null
+            && $program === null
+            && $metering === null
+            && $whiteBalance === null
+            && $flash === null
+        ) {
+            return null;
+        }
+
+        return new Exposure(
+            $iso,
+            $exposureTime,
+            $aperture,
+            $focalLength,
+            $program,
+            $metering,
+            $whiteBalance,
+            $flash,
+        );
+    }
+}

--- a/src/Curate/Resolver/GpsResolver.php
+++ b/src/Curate/Resolver/GpsResolver.php
@@ -1,0 +1,135 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\ImageMeta\Curate\Resolver;
+
+use MagicSunday\ImageMeta\Model\Exif\ExifDocument;
+use MagicSunday\ImageMeta\Model\Xmp\XmpDocument;
+use MagicSunday\ImageMeta\Value\Gps;
+
+use const PREG_SPLIT_NO_EMPTY;
+use function array_map;
+use function count;
+use function preg_split;
+use function trim;
+
+/**
+ * Resolves GPS information from EXIF and XMP sources.
+ */
+final readonly class GpsResolver
+{
+    use XmpPropertyAccess;
+
+    private const string NS_EXIF = 'http://ns.adobe.com/exif/1.0/';
+
+    /**
+     * Builds a GPS value object from the available metadata.
+     */
+    public function resolve(?ExifDocument $exifDocument, ?XmpDocument $xmpDocument): ?Gps
+    {
+        $lat = null;
+        $lon = null;
+        $alt = null;
+
+        if ($exifDocument instanceof ExifDocument) {
+            $gps = $exifDocument->gps();
+            $lat = $gps['lat'] ?? null;
+            $lon = $gps['lon'] ?? null;
+            $alt = $gps['alt'] ?? null;
+        }
+
+        if ($lat === null || $lon === null) {
+            $latString = $this->xmpString($xmpDocument, self::NS_EXIF, 'GPSLatitude');
+            $latRef    = $this->xmpString($xmpDocument, self::NS_EXIF, 'GPSLatitudeRef');
+            $lonString = $this->xmpString($xmpDocument, self::NS_EXIF, 'GPSLongitude');
+            $lonRef    = $this->xmpString($xmpDocument, self::NS_EXIF, 'GPSLongitudeRef');
+
+            $lat = $lat ?? $this->parseCoordinate($latString, $latRef);
+            $lon = $lon ?? $this->parseCoordinate($lonString, $lonRef);
+        }
+
+        if ($alt === null) {
+            $altitude = $this->xmpFloat($xmpDocument, self::NS_EXIF, 'GPSAltitude');
+            if ($altitude !== null) {
+                $altRef = $this->xmpInt($xmpDocument, self::NS_EXIF, 'GPSAltitudeRef');
+                if ($altRef === 1) {
+                    $altitude = -$altitude;
+                }
+
+                $alt = $altitude;
+            }
+        }
+
+        if ($lat === null && $lon === null && $alt === null) {
+            return null;
+        }
+
+        return new Gps($lat, $lon, $alt);
+    }
+
+    /**
+     * Parses an XMP coordinate representation.
+     */
+    private function parseCoordinate(?string $value, ?string $ref): ?float
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        $value = trim($value);
+        if ($value === '') {
+            return null;
+        }
+
+        $parts = preg_split('/[\\s,]+/', $value, -1, PREG_SPLIT_NO_EMPTY);
+        if ($parts === false || $parts === []) {
+            return null;
+        }
+
+        $parts = array_map(
+            static fn (string $component): string => trim($component),
+            $parts,
+        );
+
+        if (count($parts) === 3) {
+            $deg = $this->parseNumericString($parts[0]);
+            $min = $this->parseNumericString($parts[1]);
+            $sec = $this->parseNumericString($parts[2]);
+
+            if ($deg !== null && $min !== null && $sec !== null) {
+                $sign = $this->coordinateSign($ref);
+
+                return $sign * ($deg + $min / 60.0 + $sec / 3600.0);
+            }
+        }
+
+        $numeric = $this->parseNumericString($parts[0]);
+        if ($numeric === null) {
+            return null;
+        }
+
+        $sign = $this->coordinateSign($ref);
+
+        return $numeric * $sign;
+    }
+
+    /**
+     * Determines the sign for the given coordinate reference.
+     */
+    private function coordinateSign(?string $ref): float
+    {
+        if ($ref === 'S' || $ref === 'W') {
+            return -1.0;
+        }
+
+        return 1.0;
+    }
+}

--- a/src/Curate/Resolver/ImageResolver.php
+++ b/src/Curate/Resolver/ImageResolver.php
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\ImageMeta\Curate\Resolver;
+
+use MagicSunday\ImageMeta\Model\Exif\ExifDocument;
+use MagicSunday\ImageMeta\Model\Xmp\XmpDocument;
+use MagicSunday\ImageMeta\Value\Enum\ColorSpace;
+use MagicSunday\ImageMeta\Value\Enum\Orientation;
+use MagicSunday\ImageMeta\Value\Image;
+
+/**
+ * Resolves image level metadata such as orientation and colour space.
+ */
+final readonly class ImageResolver
+{
+    use XmpPropertyAccess;
+
+    private const string NS_TIFF = 'http://ns.adobe.com/tiff/1.0/';
+    private const string NS_EXIF = 'http://ns.adobe.com/exif/1.0/';
+
+    /**
+     * Builds an image value object from the available metadata sources.
+     */
+    public function resolve(?ExifDocument $exifDocument, ?XmpDocument $xmpDocument): ?Image
+    {
+        $orientation = Orientation::fromExifValue($exifDocument?->orientation());
+        if ($orientation === null) {
+            $orientation = Orientation::fromExifValue($this->xmpInt($xmpDocument, self::NS_TIFF, 'Orientation'));
+        }
+
+        $colorSpaceValue = $this->xmpInt($xmpDocument, self::NS_EXIF, 'ColorSpace');
+        $colorSpace      = ColorSpace::fromExifValue($colorSpaceValue);
+
+        if ($orientation === null && $colorSpace === null) {
+            return null;
+        }
+
+        return new Image($orientation, $colorSpace);
+    }
+}

--- a/src/Curate/Resolver/LensResolver.php
+++ b/src/Curate/Resolver/LensResolver.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\ImageMeta\Curate\Resolver;
+
+use MagicSunday\ImageMeta\Model\Exif\ExifDocument;
+use MagicSunday\ImageMeta\Model\Xmp\XmpDocument;
+use MagicSunday\ImageMeta\Value\Lens;
+
+/**
+ * Resolves lens metadata from EXIF and XMP data sets.
+ */
+final readonly class LensResolver
+{
+    use XmpPropertyAccess;
+
+    private const string NS_AUX  = 'http://ns.adobe.com/exif/1.0/aux/';
+    private const string NS_EXIF = 'http://ns.adobe.com/exif/1.0/';
+
+    /**
+     * Builds a lens value object from the provided metadata.
+     */
+    public function resolve(?ExifDocument $exifDocument, ?XmpDocument $xmpDocument): ?Lens
+    {
+        $model = $exifDocument?->lensModel()
+            ?? $this->xmpString($xmpDocument, self::NS_AUX, 'LensModel')
+            ?? $this->xmpString($xmpDocument, self::NS_AUX, 'Lens');
+
+        $focal = $exifDocument?->focalLengthMm() ?? $this->xmpFloat($xmpDocument, self::NS_EXIF, 'FocalLength');
+
+        if ($model === null && $focal === null) {
+            return null;
+        }
+
+        return new Lens($model, $focal);
+    }
+}

--- a/src/Curate/Resolver/XmpPropertyAccess.php
+++ b/src/Curate/Resolver/XmpPropertyAccess.php
@@ -1,0 +1,132 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\ImageMeta\Curate\Resolver;
+
+use MagicSunday\ImageMeta\Model\Xmp\XmpDocument;
+
+use function explode;
+use function is_array;
+use function is_numeric;
+use function is_string;
+use function preg_match;
+use function str_contains;
+use function trim;
+
+/**
+ * Helper methods for resolvers that need to read values from XMP documents.
+ */
+trait XmpPropertyAccess
+{
+    /**
+     * Reads a string value from the given XMP document.
+     */
+    protected function xmpString(?XmpDocument $document, string $namespaceUri, string $localName): ?string
+    {
+        $value = $this->xmpValue($document, $namespaceUri, $localName);
+
+        if (is_string($value)) {
+            $trimmed = trim($value);
+
+            return $trimmed !== '' ? $trimmed : null;
+        }
+
+        if (!is_array($value)) {
+            return null;
+        }
+
+        foreach ($value as $element) {
+            if (!is_string($element)) {
+                continue;
+            }
+
+            $trimmed = trim($element);
+            if ($trimmed !== '') {
+                return $trimmed;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Reads an integer value from the given XMP document.
+     */
+    protected function xmpInt(?XmpDocument $document, string $namespaceUri, string $localName): ?int
+    {
+        $string = $this->xmpString($document, $namespaceUri, $localName);
+
+        if ($string === null) {
+            return null;
+        }
+
+        $numeric = $this->parseNumericString($string);
+
+        return $numeric !== null ? (int) $numeric : null;
+    }
+
+    /**
+     * Reads a floating point value from the given XMP document.
+     */
+    protected function xmpFloat(?XmpDocument $document, string $namespaceUri, string $localName): ?float
+    {
+        $string = $this->xmpString($document, $namespaceUri, $localName);
+
+        if ($string === null) {
+            return null;
+        }
+
+        return $this->parseNumericString($string);
+    }
+
+    /**
+     * Returns the raw value stored in the XMP document.
+     */
+    protected function xmpValue(?XmpDocument $document, string $namespaceUri, string $localName): array|string|null
+    {
+        return $document instanceof XmpDocument ? $document->get($namespaceUri, $localName) : null;
+    }
+
+    /**
+     * Attempts to convert a textual representation into a floating point value.
+     */
+    protected function parseNumericString(string $value): ?float
+    {
+        $trimmed = trim($value);
+        if ($trimmed === '') {
+            return null;
+        }
+
+        if (is_numeric($trimmed)) {
+            return (float) $trimmed;
+        }
+
+        if (str_contains($trimmed, '/')) {
+            [$numerator, $denominator] = explode('/', $trimmed, 2);
+            $numerator   = trim($numerator);
+            $denominator = trim($denominator);
+
+            if ($denominator === '0' || $denominator === '-0') {
+                return null;
+            }
+
+            if (is_numeric($numerator) && is_numeric($denominator)) {
+                return (float) $numerator / (float) $denominator;
+            }
+        }
+
+        if (preg_match('/(-?\d+(?:\.\d+)?)/', $trimmed, $matches) === 1) {
+            return (float) $matches[1];
+        }
+
+        return null;
+    }
+}

--- a/src/Curate/Resolver/XmpResolver.php
+++ b/src/Curate/Resolver/XmpResolver.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\ImageMeta\Curate\Resolver;
+
+use MagicSunday\ImageMeta\Model\Xmp\XmpDocument;
+use MagicSunday\ImageMeta\Value\Xmp;
+
+/**
+ * Wraps the parsed XMP document inside a value object.
+ */
+final readonly class XmpResolver
+{
+    /**
+     * Builds the XMP value object when a document is available.
+     */
+    public function resolve(?XmpDocument $xmpDocument): ?Xmp
+    {
+        if (!$xmpDocument instanceof XmpDocument) {
+            return null;
+        }
+
+        return new Xmp($xmpDocument);
+    }
+}

--- a/src/Curate/StructuredMetadata.php
+++ b/src/Curate/StructuredMetadata.php
@@ -1,0 +1,52 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\ImageMeta\Curate;
+
+use MagicSunday\ImageMeta\Value\Apple;
+use MagicSunday\ImageMeta\Value\Camera;
+use MagicSunday\ImageMeta\Value\Capture;
+use MagicSunday\ImageMeta\Value\Device;
+use MagicSunday\ImageMeta\Value\Exposure;
+use MagicSunday\ImageMeta\Value\Gps;
+use MagicSunday\ImageMeta\Value\Image;
+use MagicSunday\ImageMeta\Value\Lens;
+use MagicSunday\ImageMeta\Value\Xmp;
+
+/**
+ * Aggregates curated metadata in a structured representation with typed sub objects.
+ */
+final readonly class StructuredMetadata
+{
+    /**
+     * @param Camera|null  $camera  Camera specific information.
+     * @param Lens|null    $lens    Lens information.
+     * @param Image|null   $image   Image level metadata.
+     * @param Exposure|null $exposure Exposure parameters used during capture.
+     * @param Capture|null $capture Capture timestamps.
+     * @param Gps|null     $gps     GPS coordinates.
+     * @param Device|null  $device  Device metadata from container sources.
+     * @param Apple|null   $apple   Apple specific metadata.
+     * @param Xmp|null     $xmp     Parsed XMP access wrapper.
+     */
+    public function __construct(
+        public ?Camera $camera,
+        public ?Lens $lens,
+        public ?Image $image,
+        public ?Exposure $exposure,
+        public ?Capture $capture,
+        public ?Gps $gps,
+        public ?Device $device,
+        public ?Apple $apple,
+        public ?Xmp $xmp,
+    ) {
+    }
+}

--- a/src/Curate/StructuredMetadataBuilder.php
+++ b/src/Curate/StructuredMetadataBuilder.php
@@ -1,0 +1,102 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\ImageMeta\Curate;
+
+use MagicSunday\ImageMeta\Curate\Resolver\AppleResolver;
+use MagicSunday\ImageMeta\Curate\Resolver\CameraResolver;
+use MagicSunday\ImageMeta\Curate\Resolver\CaptureResolver;
+use MagicSunday\ImageMeta\Curate\Resolver\DeviceResolver;
+use MagicSunday\ImageMeta\Curate\Resolver\ExposureResolver;
+use MagicSunday\ImageMeta\Curate\Resolver\GpsResolver;
+use MagicSunday\ImageMeta\Curate\Resolver\ImageResolver;
+use MagicSunday\ImageMeta\Curate\Resolver\LensResolver;
+use MagicSunday\ImageMeta\Curate\Resolver\XmpResolver;
+use MagicSunday\ImageMeta\Model\Metadata;
+
+/**
+ * Builds the structured metadata aggregate by orchestrating specialised resolvers.
+ */
+final class StructuredMetadataBuilder
+{
+    private CameraResolver $cameraResolver;
+
+    private LensResolver $lensResolver;
+
+    private ImageResolver $imageResolver;
+
+    private ExposureResolver $exposureResolver;
+
+    private CaptureResolver $captureResolver;
+
+    private GpsResolver $gpsResolver;
+
+    private DeviceResolver $deviceResolver;
+
+    private AppleResolver $appleResolver;
+
+    private XmpResolver $xmpResolver;
+
+    /**
+     * @param CameraResolver|null  $cameraResolver  Resolver for camera metadata.
+     * @param LensResolver|null    $lensResolver    Resolver for lens metadata.
+     * @param ImageResolver|null   $imageResolver   Resolver for image metadata.
+     * @param ExposureResolver|null $exposureResolver Resolver for exposure metadata.
+     * @param CaptureResolver|null $captureResolver Resolver for capture metadata.
+     * @param GpsResolver|null     $gpsResolver     Resolver for GPS metadata.
+     * @param DeviceResolver|null  $deviceResolver  Resolver for device metadata.
+     * @param AppleResolver|null   $appleResolver   Resolver for Apple metadata.
+     * @param XmpResolver|null     $xmpResolver     Resolver for wrapping XMP data.
+     */
+    public function __construct(
+        ?CameraResolver $cameraResolver = null,
+        ?LensResolver $lensResolver = null,
+        ?ImageResolver $imageResolver = null,
+        ?ExposureResolver $exposureResolver = null,
+        ?CaptureResolver $captureResolver = null,
+        ?GpsResolver $gpsResolver = null,
+        ?DeviceResolver $deviceResolver = null,
+        ?AppleResolver $appleResolver = null,
+        ?XmpResolver $xmpResolver = null,
+    ) {
+        $this->cameraResolver  = $cameraResolver ?? new CameraResolver();
+        $this->lensResolver    = $lensResolver ?? new LensResolver();
+        $this->imageResolver   = $imageResolver ?? new ImageResolver();
+        $this->exposureResolver = $exposureResolver ?? new ExposureResolver();
+        $this->captureResolver = $captureResolver ?? new CaptureResolver();
+        $this->gpsResolver     = $gpsResolver ?? new GpsResolver();
+        $this->deviceResolver  = $deviceResolver ?? new DeviceResolver();
+        $this->appleResolver   = $appleResolver ?? new AppleResolver();
+        $this->xmpResolver     = $xmpResolver ?? new XmpResolver();
+    }
+
+    /**
+     * Builds the structured metadata aggregate from the supplied metadata container.
+     */
+    public function build(Metadata $metadata): StructuredMetadata
+    {
+        $exifDocument = $metadata->exifDoc;
+        $xmpDocument  = $metadata->xmpDoc ?? $metadata->selectiveXmpDocument();
+        $quickTime    = $metadata->quickTime;
+
+        return new StructuredMetadata(
+            camera: $this->cameraResolver->resolve($exifDocument, $xmpDocument),
+            lens: $this->lensResolver->resolve($exifDocument, $xmpDocument),
+            image: $this->imageResolver->resolve($exifDocument, $xmpDocument),
+            exposure: $this->exposureResolver->resolve($exifDocument, $xmpDocument),
+            capture: $this->captureResolver->resolve($exifDocument, $xmpDocument),
+            gps: $this->gpsResolver->resolve($exifDocument, $xmpDocument),
+            device: $this->deviceResolver->resolve($quickTime, $xmpDocument),
+            apple: $this->appleResolver->resolve($quickTime),
+            xmp: $this->xmpResolver->resolve($xmpDocument),
+        );
+    }
+}

--- a/src/Model/Metadata.php
+++ b/src/Model/Metadata.php
@@ -11,16 +11,20 @@ declare(strict_types=1);
 
 namespace MagicSunday\ImageMeta\Model;
 
+use MagicSunday\ImageMeta\Curate\StructuredMetadata;
+use MagicSunday\ImageMeta\Curate\StructuredMetadataBuilder;
 use MagicSunday\ImageMeta\MakerNotes\MakerNotesMetadata;
 use MagicSunday\ImageMeta\Model\Exif\ExifDocument;
 use MagicSunday\ImageMeta\Model\Xmp\XmpDocument;
 use MagicSunday\ImageMeta\Parse\Xmp\XmpParser;
+use WeakMap;
 
 /**
  * Aggregates extracted metadata blobs alongside parsed representations.
  */
 final readonly class Metadata
 {
+
     /**
      * @param list<string>            $exifBlobs  TIFF‑EXIF blobs (first is primary)
      * @param QuickTimeMeta|null      $quickTime  QuickTime metadata extracted from ISO BMFF containers.
@@ -58,5 +62,24 @@ final readonly class Metadata
         }
 
         return (new XmpParser())->parse($this->xmpBlobs[0]);
+    }
+
+    /**
+     * Returns curated structured metadata derived lazily from the available sources.
+     */
+    public function structured(): StructuredMetadata
+    {
+        static $cache;
+
+        if (!$cache instanceof WeakMap) {
+            $cache = new WeakMap();
+        }
+
+        if (!isset($cache[$this])) {
+            $builder       = new StructuredMetadataBuilder();
+            $cache[$this] = $builder->build($this);
+        }
+
+        return $cache[$this];
     }
 }

--- a/src/Value/Apple.php
+++ b/src/Value/Apple.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\ImageMeta\Value;
+
+/**
+ * Holds Apple specific metadata coming from QuickTime containers.
+ */
+final readonly class Apple
+{
+    /**
+     * @param string|null $contentIdentifier Unique content identifier assigned by Apple platforms.
+     */
+    public function __construct(public ?string $contentIdentifier)
+    {
+    }
+}

--- a/src/Value/Camera.php
+++ b/src/Value/Camera.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\ImageMeta\Value;
+
+/**
+ * Captures camera specific information.
+ */
+final readonly class Camera
+{
+    /**
+     * @param string|null $make         Camera manufacturer.
+     * @param string|null $model        Camera model name.
+     * @param string|null $serialNumber Serial number reported by metadata.
+     * @param string|null $software     Software or processing application.
+     */
+    public function __construct(
+        public ?string $make,
+        public ?string $model,
+        public ?string $serialNumber = null,
+        public ?string $software = null,
+    ) {
+    }
+}

--- a/src/Value/Capture.php
+++ b/src/Value/Capture.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\ImageMeta\Value;
+
+use DateTimeImmutable;
+
+/**
+ * Holds capture specific timestamps.
+ */
+final readonly class Capture
+{
+    /**
+     * @param DateTimeImmutable|null $dateTime Capture timestamp.
+     */
+    public function __construct(public ?DateTimeImmutable $dateTime)
+    {
+    }
+}

--- a/src/Value/Device.php
+++ b/src/Value/Device.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\ImageMeta\Value;
+
+/**
+ * Provides device specific metadata extracted from container level sources.
+ */
+final readonly class Device
+{
+    /**
+     * @param string|null $manufacturer Device manufacturer as reported by the container.
+     * @param string|null $model        Device model.
+     * @param string|null $software     Software version or build identifier.
+     */
+    public function __construct(
+        public ?string $manufacturer,
+        public ?string $model,
+        public ?string $software,
+    ) {
+    }
+}

--- a/src/Value/Enum/ColorSpace.php
+++ b/src/Value/Enum/ColorSpace.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\ImageMeta\Value\Enum;
+
+/**
+ * Represents the image colour space information.
+ */
+enum ColorSpace: int
+{
+    case SRGB = 1;
+    case ADOBE_RGB = 2;
+    case UNCALIBRATED = 65535;
+
+    /**
+     * Creates an enum from the provided raw value when available.
+     */
+    public static function fromExifValue(int|string|null $value): ?self
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        $intValue = is_int($value) ? $value : (int) $value;
+
+        return self::tryFrom($intValue);
+    }
+}

--- a/src/Value/Enum/ExposureProgram.php
+++ b/src/Value/Enum/ExposureProgram.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\ImageMeta\Value\Enum;
+
+/**
+ * Describes the camera's exposure program.
+ */
+enum ExposureProgram: int
+{
+    case NOT_DEFINED = 0;
+    case MANUAL = 1;
+    case NORMAL = 2;
+    case APERTURE_PRIORITY = 3;
+    case SHUTTER_PRIORITY = 4;
+    case CREATIVE = 5;
+    case ACTION = 6;
+    case PORTRAIT = 7;
+    case LANDSCAPE = 8;
+    case BULB = 9;
+
+    /**
+     * Maps a numeric value to the corresponding enum case when possible.
+     */
+    public static function fromExifValue(int|string|null $value): ?self
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        $intValue = is_int($value) ? $value : (int) $value;
+
+        return self::tryFrom($intValue);
+    }
+}

--- a/src/Value/Enum/FlashFunction.php
+++ b/src/Value/Enum/FlashFunction.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\ImageMeta\Value\Enum;
+
+/**
+ * Describes whether the flash function is present on the camera.
+ */
+enum FlashFunction: int
+{
+    case PRESENT = 0;
+    case ABSENT = 1;
+
+    /**
+     * Converts the flash bit field into an enum instance.
+     */
+    public static function fromFlashBits(int $value): ?self
+    {
+        $functionBit = ($value >> 5) & 0x01;
+
+        return self::tryFrom($functionBit);
+    }
+}

--- a/src/Value/Enum/FlashMode.php
+++ b/src/Value/Enum/FlashMode.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\ImageMeta\Value\Enum;
+
+/**
+ * Enumerates the flash mode encoded inside the EXIF Flash tag.
+ */
+enum FlashMode: int
+{
+    case UNKNOWN = 0;
+    case COMPULSORY_FIRE = 1;
+    case COMPULSORY_SUPPRESS = 2;
+    case AUTO = 3;
+
+    /**
+     * Builds an enum instance from the bit field representation.
+     */
+    public static function fromFlashBits(int $value): ?self
+    {
+        $modeBits = ($value >> 3) & 0x03;
+
+        return self::tryFrom($modeBits);
+    }
+}

--- a/src/Value/Enum/FlashReturn.php
+++ b/src/Value/Enum/FlashReturn.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\ImageMeta\Value\Enum;
+
+/**
+ * Indicates the strobe return detection status encoded in the EXIF Flash tag.
+ */
+enum FlashReturn: int
+{
+    case NO_STROBE_DETECTION = 0;
+    case RESERVED = 1;
+    case NOT_DETECTED = 2;
+    case DETECTED = 3;
+
+    /**
+     * Creates an enum instance from the flash bit field.
+     */
+    public static function fromFlashBits(int $value): ?self
+    {
+        $returnBits = ($value >> 1) & 0x03;
+
+        return self::tryFrom($returnBits);
+    }
+}

--- a/src/Value/Enum/MeteringMode.php
+++ b/src/Value/Enum/MeteringMode.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\ImageMeta\Value\Enum;
+
+/**
+ * Defines the metering mode used to determine exposure.
+ */
+enum MeteringMode: int
+{
+    case UNKNOWN = 0;
+    case AVERAGE = 1;
+    case CENTER_WEIGHTED_AVERAGE = 2;
+    case SPOT = 3;
+    case MULTI_SPOT = 4;
+    case PATTERN = 5;
+    case PARTIAL = 6;
+    case OTHER = 255;
+
+    /**
+     * Attempts to convert the provided numeric value into an enum case.
+     */
+    public static function fromExifValue(int|string|null $value): ?self
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        $intValue = is_int($value) ? $value : (int) $value;
+
+        return self::tryFrom($intValue);
+    }
+}

--- a/src/Value/Enum/Orientation.php
+++ b/src/Value/Enum/Orientation.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\ImageMeta\Value\Enum;
+
+/**
+ * Enumerates the known EXIF orientation values.
+ */
+enum Orientation: int
+{
+    case TOP_LEFT = 1;
+    case TOP_RIGHT = 2;
+    case BOTTOM_RIGHT = 3;
+    case BOTTOM_LEFT = 4;
+    case LEFT_TOP = 5;
+    case RIGHT_TOP = 6;
+    case RIGHT_BOTTOM = 7;
+    case LEFT_BOTTOM = 8;
+
+    /**
+     * Converts a raw EXIF orientation value into an enum instance.
+     */
+    public static function fromExifValue(?int $value): ?self
+    {
+        return $value !== null ? self::tryFrom($value) : null;
+    }
+}

--- a/src/Value/Enum/WhiteBalance.php
+++ b/src/Value/Enum/WhiteBalance.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\ImageMeta\Value\Enum;
+
+/**
+ * Enumerates the white balance modes recorded by EXIF.
+ */
+enum WhiteBalance: int
+{
+    case AUTO = 0;
+    case MANUAL = 1;
+
+    /**
+     * Converts a raw value to an enum case if supported.
+     */
+    public static function fromExifValue(int|string|null $value): ?self
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        $intValue = is_int($value) ? $value : (int) $value;
+
+        return self::tryFrom($intValue);
+    }
+}

--- a/src/Value/Exposure.php
+++ b/src/Value/Exposure.php
@@ -1,0 +1,44 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\ImageMeta\Value;
+
+use MagicSunday\ImageMeta\Value\Enum\ExposureProgram;
+use MagicSunday\ImageMeta\Value\Enum\MeteringMode;
+use MagicSunday\ImageMeta\Value\Enum\WhiteBalance;
+
+/**
+ * Aggregates exposure related measurements.
+ */
+final readonly class Exposure
+{
+    /**
+     * @param int|null           $iso                 ISO sensitivity.
+     * @param float|null         $exposureTimeSeconds Exposure time in seconds.
+     * @param float|null         $apertureFNumber     Aperture (f-number).
+     * @param float|null         $focalLengthMm       Focal length used in millimetres.
+     * @param ExposureProgram|null $program           Selected exposure program.
+     * @param MeteringMode|null    $meteringMode      Metering mode.
+     * @param WhiteBalance|null    $whiteBalance      White balance setting.
+     * @param FlashInfo|null       $flash             Flash details.
+     */
+    public function __construct(
+        public ?int $iso,
+        public ?float $exposureTimeSeconds,
+        public ?float $apertureFNumber,
+        public ?float $focalLengthMm,
+        public ?ExposureProgram $program = null,
+        public ?MeteringMode $meteringMode = null,
+        public ?WhiteBalance $whiteBalance = null,
+        public ?FlashInfo $flash = null,
+    ) {
+    }
+}

--- a/src/Value/FlashInfo.php
+++ b/src/Value/FlashInfo.php
@@ -1,0 +1,58 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\ImageMeta\Value;
+
+use MagicSunday\ImageMeta\Value\Enum\FlashFunction;
+use MagicSunday\ImageMeta\Value\Enum\FlashMode;
+use MagicSunday\ImageMeta\Value\Enum\FlashReturn;
+
+/**
+ * Represents flash related capture information as exposed by EXIF and XMP.
+ */
+final readonly class FlashInfo
+{
+    /**
+     * @param bool                    $fired            Whether the flash fired.
+     * @param FlashMode|null          $mode             Selected flash mode.
+     * @param FlashReturn|null        $returnDetection  Detected return light status.
+     * @param FlashFunction|null      $functionPresence Whether the camera features a flash function.
+     * @param bool                    $redEyeReduction  Indicates red-eye reduction support.
+     */
+    public function __construct(
+        public bool $fired,
+        public ?FlashMode $mode = null,
+        public ?FlashReturn $returnDetection = null,
+        public ?FlashFunction $functionPresence = null,
+        public bool $redEyeReduction = false,
+    ) {
+    }
+
+    /**
+     * Creates an instance from the numeric EXIF Flash tag value.
+     */
+    public static function fromExifValue(int|string|null $value): ?self
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        $intValue = is_int($value) ? $value : (int) $value;
+
+        return new self(
+            fired: (bool) ($intValue & 0x01),
+            mode: FlashMode::fromFlashBits($intValue),
+            returnDetection: FlashReturn::fromFlashBits($intValue),
+            functionPresence: FlashFunction::fromFlashBits($intValue),
+            redEyeReduction: (bool) ($intValue & 0x40),
+        );
+    }
+}

--- a/src/Value/Gps.php
+++ b/src/Value/Gps.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\ImageMeta\Value;
+
+/**
+ * Describes the GPS position at capture time.
+ */
+final readonly class Gps
+{
+    /**
+     * @param float|null $latitude  Latitude in decimal degrees.
+     * @param float|null $longitude Longitude in decimal degrees.
+     * @param float|null $altitude  Altitude in metres relative to sea level.
+     */
+    public function __construct(
+        public ?float $latitude,
+        public ?float $longitude,
+        public ?float $altitude,
+    ) {
+    }
+}

--- a/src/Value/Image.php
+++ b/src/Value/Image.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\ImageMeta\Value;
+
+use MagicSunday\ImageMeta\Value\Enum\ColorSpace;
+use MagicSunday\ImageMeta\Value\Enum\Orientation;
+
+/**
+ * Encapsulates image level metadata.
+ */
+final readonly class Image
+{
+    /**
+     * @param Orientation|null $orientation Image orientation when stored on disk.
+     * @param ColorSpace|null  $colorSpace  Colour space used for the pixel data.
+     */
+    public function __construct(
+        public ?Orientation $orientation,
+        public ?ColorSpace $colorSpace,
+    ) {
+    }
+}

--- a/src/Value/Lens.php
+++ b/src/Value/Lens.php
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\ImageMeta\Value;
+
+/**
+ * Represents lens information used when capturing the image.
+ */
+final readonly class Lens
+{
+    /**
+     * @param string|null $model           Lens model description.
+     * @param float|null  $focalLengthMm   Focal length used in millimetres.
+     */
+    public function __construct(
+        public ?string $model,
+        public ?float $focalLengthMm,
+    ) {
+    }
+}

--- a/src/Value/Xmp.php
+++ b/src/Value/Xmp.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\ImageMeta\Value;
+
+use MagicSunday\ImageMeta\Model\Xmp\XmpDocument;
+
+/**
+ * Provides access to the parsed XMP document used during curation.
+ */
+final readonly class Xmp
+{
+    /**
+     * @param XmpDocument|null $document Parsed XMP document.
+     */
+    public function __construct(public ?XmpDocument $document)
+    {
+    }
+}

--- a/tests/Curate/StructuredMetadataBuilderTest.php
+++ b/tests/Curate/StructuredMetadataBuilderTest.php
@@ -1,0 +1,174 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\ImageMeta\Tests\Curate;
+
+use DateTimeImmutable;
+use MagicSunday\ImageMeta\Curate\StructuredMetadataBuilder;
+use MagicSunday\ImageMeta\Model\Exif\ExifDocument;
+use MagicSunday\ImageMeta\Model\Exif\ExifTag;
+use MagicSunday\ImageMeta\Model\Exif\Ifd;
+use MagicSunday\ImageMeta\Model\Exif\IfdEntry;
+use MagicSunday\ImageMeta\Model\Metadata;
+use MagicSunday\ImageMeta\Model\QuickTimeMeta;
+use MagicSunday\ImageMeta\Model\Xmp\XmpDocument;
+use MagicSunday\ImageMeta\Value\Enum\ColorSpace;
+use MagicSunday\ImageMeta\Value\Enum\ExposureProgram;
+use MagicSunday\ImageMeta\Value\Enum\FlashFunction;
+use MagicSunday\ImageMeta\Value\Enum\FlashMode;
+use MagicSunday\ImageMeta\Value\Enum\FlashReturn;
+use MagicSunday\ImageMeta\Value\Enum\MeteringMode;
+use MagicSunday\ImageMeta\Value\Enum\Orientation;
+use MagicSunday\ImageMeta\Value\Enum\WhiteBalance;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \MagicSunday\ImageMeta\Curate\StructuredMetadataBuilder
+ * @covers \MagicSunday\ImageMeta\Curate\StructuredMetadata
+ * @covers \MagicSunday\ImageMeta\Curate\Resolver\CameraResolver
+ * @covers \MagicSunday\ImageMeta\Curate\Resolver\LensResolver
+ * @covers \MagicSunday\ImageMeta\Curate\Resolver\ImageResolver
+ * @covers \MagicSunday\ImageMeta\Curate\Resolver\ExposureResolver
+ * @covers \MagicSunday\ImageMeta\Curate\Resolver\CaptureResolver
+ * @covers \MagicSunday\ImageMeta\Curate\Resolver\GpsResolver
+ * @covers \MagicSunday\ImageMeta\Curate\Resolver\DeviceResolver
+ * @covers \MagicSunday\ImageMeta\Curate\Resolver\AppleResolver
+ * @covers \MagicSunday\ImageMeta\Curate\Resolver\XmpResolver
+ */
+final class StructuredMetadataBuilderTest extends TestCase
+{
+    /**
+     * Ensures the builder combines EXIF, XMP and QuickTime data into a typed structure.
+     */
+    #[Test]
+    public function buildsStructuredAggregateFromAvailableSources(): void
+    {
+        $ifd0 = new Ifd([
+            ExifTag::MAKE        => new IfdEntry(ExifTag::MAKE, 2, 5, 'Canon'),
+            ExifTag::MODEL       => new IfdEntry(ExifTag::MODEL, 2, 5, 'EOS R5'),
+            ExifTag::ORIENTATION => new IfdEntry(ExifTag::ORIENTATION, 3, 1, 6),
+        ]);
+
+        $exifIfd = new Ifd([
+            ExifTag::PHOTOGRAPHIC_SENSITIVITY => new IfdEntry(ExifTag::PHOTOGRAPHIC_SENSITIVITY, 3, 1, 400),
+            ExifTag::EXPOSURE_TIME            => new IfdEntry(ExifTag::EXPOSURE_TIME, 5, 1, [[1, 125]]),
+            ExifTag::F_NUMBER                 => new IfdEntry(ExifTag::F_NUMBER, 5, 1, [[9, 2]]),
+            ExifTag::FOCAL_LENGTH             => new IfdEntry(ExifTag::FOCAL_LENGTH, 5, 1, [[85, 1]]),
+        ]);
+
+        $gpsIfd = new Ifd([
+            ExifTag::GPS_LATITUDE_REF  => new IfdEntry(ExifTag::GPS_LATITUDE_REF, 2, 1, 'N'),
+            ExifTag::GPS_LATITUDE      => new IfdEntry(ExifTag::GPS_LATITUDE, 5, 3, [[48, 1], [12, 1], [30, 1]]),
+            ExifTag::GPS_LONGITUDE_REF => new IfdEntry(ExifTag::GPS_LONGITUDE_REF, 2, 1, 'E'),
+            ExifTag::GPS_LONGITUDE     => new IfdEntry(ExifTag::GPS_LONGITUDE, 5, 3, [[11, 1], [34, 1], [45, 1]]),
+            ExifTag::GPS_ALTITUDE      => new IfdEntry(ExifTag::GPS_ALTITUDE, 5, 1, [[120, 1]]),
+            ExifTag::GPS_ALTITUDE_REF  => new IfdEntry(ExifTag::GPS_ALTITUDE_REF, 1, 1, 0),
+        ]);
+
+        $exifDocument = new ExifDocument($ifd0, $exifIfd, $gpsIfd, null, null);
+
+        $xmpDocument = new XmpDocument([
+            '{http://ns.adobe.com/exif/1.0/}ISOSpeedRatings' => '640',
+            '{http://ns.adobe.com/exif/1.0/}ExposureTime'    => '1/60',
+            '{http://ns.adobe.com/exif/1.0/}FNumber'         => '2.8',
+            '{http://ns.adobe.com/exif/1.0/}FocalLength'     => '50/1',
+            '{http://ns.adobe.com/exif/1.0/}ExposureProgram' => '3',
+            '{http://ns.adobe.com/exif/1.0/}MeteringMode'    => '5',
+            '{http://ns.adobe.com/exif/1.0/}WhiteBalance'    => '1',
+            '{http://ns.adobe.com/exif/1.0/}Flash'           => '127',
+            '{http://ns.adobe.com/exif/1.0/}ColorSpace'      => '1',
+            '{http://ns.adobe.com/exif/1.0/}DateTimeOriginal' => '2024-03-01T12:34:56+02:00',
+            '{http://ns.adobe.com/exif/1.0/}GPSLatitude'     => '48, 12, 30',
+            '{http://ns.adobe.com/exif/1.0/}GPSLatitudeRef'  => 'N',
+            '{http://ns.adobe.com/exif/1.0/}GPSLongitude'    => '11, 34, 45',
+            '{http://ns.adobe.com/exif/1.0/}GPSLongitudeRef' => 'E',
+            '{http://ns.adobe.com/exif/1.0/aux/}LensModel'   => 'RF 50mm F1.2L',
+            '{http://ns.adobe.com/exif/1.0/aux/}SerialNumber' => '12345',
+            '{http://ns.adobe.com/xap/1.0/}CreatorTool'      => 'Lightroom Classic',
+            '{http://ns.adobe.com/tiff/1.0/}Make'            => 'Canon',
+            '{http://ns.adobe.com/tiff/1.0/}Model'           => 'EOS R5',
+        ]);
+
+        $quickTime = new QuickTimeMeta([
+            QuickTimeMeta::CONTENT_IDENTIFIER_KEY => 'asset-id',
+            'com.apple.quicktime.make'            => 'Apple',
+            'com.apple.quicktime.model'           => 'iPhone 15',
+            'com.apple.quicktime.software'        => '17.4.1',
+        ]);
+
+        $metadata = new Metadata([
+            'primary-exif',
+        ], $quickTime, $exifDocument, ['<xmp/>'], $xmpDocument);
+
+        $structured = (new StructuredMetadataBuilder())->build($metadata);
+
+        self::assertSame('Canon', $structured->camera?->make);
+        self::assertSame('EOS R5', $structured->camera?->model);
+        self::assertSame('12345', $structured->camera?->serialNumber);
+        self::assertSame('Lightroom Classic', $structured->camera?->software);
+
+        self::assertSame('RF 50mm F1.2L', $structured->lens?->model);
+        self::assertSame(85.0, $structured->lens?->focalLengthMm);
+
+        self::assertSame(Orientation::RIGHT_TOP, $structured->image?->orientation);
+        self::assertSame(ColorSpace::SRGB, $structured->image?->colorSpace);
+
+        self::assertSame(400, $structured->exposure?->iso);
+        self::assertSame(0.008, $structured->exposure?->exposureTimeSeconds);
+        self::assertSame(4.5, $structured->exposure?->apertureFNumber);
+        self::assertSame(85.0, $structured->exposure?->focalLengthMm);
+        self::assertSame(ExposureProgram::APERTURE_PRIORITY, $structured->exposure?->program);
+        self::assertSame(MeteringMode::PATTERN, $structured->exposure?->meteringMode);
+        self::assertSame(WhiteBalance::MANUAL, $structured->exposure?->whiteBalance);
+
+        $flash = $structured->exposure?->flash;
+        self::assertNotNull($flash);
+        self::assertTrue($flash->fired);
+        self::assertSame(FlashMode::AUTO, $flash->mode);
+        self::assertSame(FlashReturn::DETECTED, $flash->returnDetection);
+        self::assertSame(FlashFunction::ABSENT, $flash->functionPresence);
+        self::assertTrue($flash->redEyeReduction);
+
+        $capture = $structured->capture?->dateTime;
+        self::assertInstanceOf(DateTimeImmutable::class, $capture);
+        self::assertSame('2024-03-01T12:34:56+02:00', $capture->format('c'));
+
+        $gps = $structured->gps;
+        self::assertNotNull($gps);
+        self::assertEqualsWithDelta(48.208333333333, (float) $gps->latitude, 0.000000000001);
+        self::assertEqualsWithDelta(11.579166666667, (float) $gps->longitude, 0.000000000001);
+        self::assertSame(120.0, $gps->altitude);
+
+        $device = $structured->device;
+        self::assertNotNull($device);
+        self::assertSame('Apple', $device->manufacturer);
+        self::assertSame('iPhone 15', $device->model);
+        self::assertSame('17.4.1', $device->software);
+
+        self::assertSame('asset-id', $structured->apple?->contentIdentifier);
+        self::assertSame($xmpDocument, $structured->xmp?->document);
+    }
+
+    /**
+     * Ensures the aggregated structured metadata is cached per metadata instance.
+     */
+    #[Test]
+    public function cachesStructuredAggregate(): void
+    {
+        $metadata = new Metadata([], null, null, []);
+
+        $first  = $metadata->structured();
+        $second = $metadata->structured();
+
+        self::assertSame($first, $second);
+    }
+}

--- a/tests/Curate/Value/FlashInfoTest.php
+++ b/tests/Curate/Value/FlashInfoTest.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\ImageMeta\Tests\Curate\Value;
+
+use MagicSunday\ImageMeta\Value\Enum\FlashFunction;
+use MagicSunday\ImageMeta\Value\Enum\FlashMode;
+use MagicSunday\ImageMeta\Value\Enum\FlashReturn;
+use MagicSunday\ImageMeta\Value\FlashInfo;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \MagicSunday\ImageMeta\Value\FlashInfo
+ */
+final class FlashInfoTest extends TestCase
+{
+    /**
+     * Ensures flash bit fields are decoded into typed information.
+     */
+    #[Test]
+    public function createsInstanceFromExifBitField(): void
+    {
+        $info = FlashInfo::fromExifValue(127);
+
+        self::assertNotNull($info);
+        self::assertTrue($info->fired);
+        self::assertSame(FlashMode::AUTO, $info->mode);
+        self::assertSame(FlashReturn::DETECTED, $info->returnDetection);
+        self::assertSame(FlashFunction::ABSENT, $info->functionPresence);
+        self::assertTrue($info->redEyeReduction);
+    }
+
+    /**
+     * Ensures null is returned when no value is supplied.
+     */
+    #[Test]
+    public function returnsNullWhenNoValueIsProvided(): void
+    {
+        self::assertNull(FlashInfo::fromExifValue(null));
+    }
+}


### PR DESCRIPTION
## Summary
- add immutable value objects and enums to describe curated metadata facets
- add resolver-driven StructuredMetadataBuilder and expose it via Metadata::structured()
- cover builder assembly and flash info decoding with PHPUnit tests

## Testing
- composer ci:test:php:unit

------
https://chatgpt.com/codex/tasks/task_e_68fa83d21ca08323a56f3ee8791d8897