### PR TITLE
feat: add extended ExifDocument getters for structured metadata

### DIFF
--- a/src/Model/Exif/ExifDocument.php
+++ b/src/Model/Exif/ExifDocument.php
@@ -13,6 +13,7 @@ namespace MagicSunday\ImageMeta\Model\Exif;
 
 use DateTimeImmutable;
 use DateTimeZone;
+use Exception;
 use MagicSunday\ImageMeta\MakerNotes\MakerNotesMetadata;
 
 use function is_float;
@@ -20,6 +21,7 @@ use function is_int;
 use function is_string;
 use function rtrim;
 use function str_replace;
+use function strlen;
 use function substr;
 
 /**
@@ -84,6 +86,36 @@ final readonly class ExifDocument
     }
 
     /**
+     * Returns the camera owner name if present.
+     *
+     * @return string|null
+     */
+    public function ownerName(): ?string
+    {
+        return $this->str($this->exifIfd, ExifTag::CAMERA_OWNER_NAME);
+    }
+
+    /**
+     * Returns the camera body serial number if present.
+     *
+     * @return string|null
+     */
+    public function bodySerialNumber(): ?string
+    {
+        return $this->str($this->exifIfd, ExifTag::BODY_SERIAL_NUMBER);
+    }
+
+    /**
+     * Returns the lens serial number if present.
+     *
+     * @return string|null
+     */
+    public function lensSerialNumber(): ?string
+    {
+        return $this->str($this->exifIfd, ExifTag::LENS_SERIAL_NUMBER);
+    }
+
+    /**
      * Returns the EXIF orientation value if present.
      *
      * @return int|null
@@ -94,14 +126,67 @@ final readonly class ExifDocument
     }
 
     /**
+     * Returns the image width, preferring the EXIF-specific tag and falling back to IFD0.
+     *
+     * @return int|null
+     */
+    public function imageWidth(): ?int
+    {
+        $width = $this->int($this->exifIfd, ExifTag::EXIF_IMAGE_WIDTH);
+
+        return $width ?? $this->int($this->ifd0, ExifTag::IMAGE_WIDTH);
+    }
+
+    /**
+     * Returns the image height, preferring the EXIF-specific tag and falling back to IFD0.
+     *
+     * @return int|null
+     */
+    public function imageHeight(): ?int
+    {
+        $height = $this->int($this->exifIfd, ExifTag::EXIF_IMAGE_HEIGHT);
+
+        return $height ?? $this->int($this->ifd0, ExifTag::IMAGE_HEIGHT);
+    }
+
+    /**
+     * Returns the colour space identifier if present.
+     *
+     * @return int|null
+     */
+    public function colorSpace(): ?int
+    {
+        return $this->int($this->exifIfd, ExifTag::COLOR_SPACE);
+    }
+
+    /**
+     * Returns the image unique identifier if present.
+     *
+     * @return string|null
+     */
+    public function imageUniqueId(): ?string
+    {
+        return $this->str($this->exifIfd, ExifTag::IMAGE_UNIQUE_ID);
+    }
+
+    /**
      * Returns the ISO sensitivity value if present.
      *
      * @return int|null
      */
     public function iso(): ?int
     {
-        // EXIF ISO tag (PhotographicSensitivity)
-        return $this->int($this->exifIfd, ExifTag::PHOTOGRAPHIC_SENSITIVITY);
+        $iso = $this->int($this->exifIfd, ExifTag::ISO_SPEED);
+        if ($iso !== null) {
+            return $iso;
+        }
+
+        $iso = $this->int($this->exifIfd, ExifTag::PHOTOGRAPHIC_SENSITIVITY);
+        if ($iso !== null) {
+            return $iso;
+        }
+
+        return $this->int($this->ifd0, ExifTag::PHOTOGRAPHIC_SENSITIVITY);
     }
 
     /**
@@ -111,10 +196,7 @@ final readonly class ExifDocument
      */
     public function exposureTime(): ?float
     {
-        // Tag ExifTag::EXPOSURE_TIME (RATIONAL)
-        $entry = $this->exifIfd?->get(ExifTag::EXPOSURE_TIME);
-
-        return $entry instanceof IfdEntry ? ValueConverters::rationalToFloat($entry->value) : null;
+        return $this->rational($this->exifIfd, ExifTag::EXPOSURE_TIME);
     }
 
     /**
@@ -124,10 +206,7 @@ final readonly class ExifDocument
      */
     public function fNumber(): ?float
     {
-        // Tag ExifTag::F_NUMBER (RATIONAL)
-        $entry = $this->exifIfd?->get(ExifTag::F_NUMBER);
-
-        return $entry instanceof IfdEntry ? ValueConverters::rationalToFloat($entry->value) : null;
+        return $this->rational($this->exifIfd, ExifTag::F_NUMBER);
     }
 
     /**
@@ -137,10 +216,87 @@ final readonly class ExifDocument
      */
     public function focalLengthMm(): ?float
     {
-        // Tag ExifTag::FOCAL_LENGTH (RATIONAL)
-        $entry = $this->exifIfd?->get(ExifTag::FOCAL_LENGTH);
+        return $this->rational($this->exifIfd, ExifTag::FOCAL_LENGTH);
+    }
 
-        return $entry instanceof IfdEntry ? ValueConverters::rationalToFloat($entry->value) : null;
+    /**
+     * Returns the focal length in 35mm equivalent if available.
+     *
+     * @return int|null
+     */
+    public function focalLength35Mm(): ?int
+    {
+        return $this->int($this->exifIfd, ExifTag::FOCAL_LENGTH_IN_35MM_FILM);
+    }
+
+    /**
+     * Returns the camera exposure program code if present.
+     *
+     * @return int|null
+     */
+    public function exposureProgram(): ?int
+    {
+        return $this->int($this->exifIfd, ExifTag::EXPOSURE_PROGRAM);
+    }
+
+    /**
+     * Returns the metering mode code if present.
+     *
+     * @return int|null
+     */
+    public function meteringMode(): ?int
+    {
+        return $this->int($this->exifIfd, ExifTag::METERING_MODE);
+    }
+
+    /**
+     * Returns the flash status flags if present.
+     *
+     * @return int|null
+     */
+    public function flash(): ?int
+    {
+        return $this->int($this->exifIfd, ExifTag::FLASH);
+    }
+
+    /**
+     * Returns the white balance mode if present.
+     *
+     * @return int|null
+     */
+    public function whiteBalance(): ?int
+    {
+        return $this->int($this->exifIfd, ExifTag::WHITE_BALANCE);
+    }
+
+    /**
+     * Returns the exposure bias value in EV if present.
+     *
+     * @return float|null
+     */
+    public function exposureBias(): ?float
+    {
+        return $this->rational($this->exifIfd, ExifTag::EXPOSURE_BIAS_VALUE);
+    }
+
+    /**
+     * Returns the scene brightness value (APEX) if present.
+     *
+     * @return float|null
+     */
+    public function brightnessValue(): ?float
+    {
+        return $this->rational($this->exifIfd, ExifTag::BRIGHTNESS_VALUE);
+    }
+
+    /**
+     * Returns the maximum aperture value (APEX) if present.
+     *
+     * @return float|null
+     */
+    public function maxApertureApex(): ?float
+    {
+        return $this->rational($this->exifIfd, ExifTag::MAX_APERTURE_VALUE);
     }
 
     /**
@@ -154,6 +310,26 @@ final readonly class ExifDocument
     }
 
     /**
+     * Returns the raw DateTimeDigitized tag value.
+     *
+     * @return string|null
+     */
+    public function dateTimeDigitizedRaw(): ?string
+    {
+        return $this->str($this->exifIfd, ExifTag::DATETIME_DIGITIZED);
+    }
+
+    /**
+     * Returns the raw DateTime tag value from IFD0.
+     *
+     * @return string|null
+     */
+    public function dateTimeRaw(): ?string
+    {
+        return $this->str($this->ifd0, ExifTag::DATETIME);
+    }
+
+    /**
      * Returns the raw offset time for DateTimeOriginal.
      *
      * @return string|null
@@ -161,6 +337,26 @@ final readonly class ExifDocument
     public function offsetTimeOriginalRaw(): ?string
     {
         return $this->str($this->exifIfd, ExifTag::OFFSET_TIME_ORIGINAL);
+    }
+
+    /**
+     * Returns the raw offset time for DateTimeDigitized.
+     *
+     * @return string|null
+     */
+    public function offsetTimeDigitizedRaw(): ?string
+    {
+        return $this->str($this->exifIfd, ExifTag::OFFSET_TIME_DIGITIZED);
+    }
+
+    /**
+     * Returns the raw offset time for the DateTime tag.
+     *
+     * @return string|null
+     */
+    public function offsetTimeRaw(): ?string
+    {
+        return $this->str($this->exifIfd, ExifTag::OFFSET_TIME);
     }
 
     /**
@@ -184,19 +380,27 @@ final readonly class ExifDocument
      */
     public function captureDateTime(): ?DateTimeImmutable
     {
-        $raw = $this->dateTimeOriginalRaw();
-        if ($raw === null || $raw === '') {
-            return null;
-        }
+        return $this->parseExifDateTime($this->dateTimeOriginalRaw(), $this->offsetTimeOriginalRaw());
+    }
 
-        $offset = $this->offsetTimeOriginalRaw(); // like "+01:00"
-        $tz     = ($offset !== null && $offset !== '') ? new DateTimeZone($offset) : new DateTimeZone('UTC');
+    /**
+     * Returns the digitised timestamp combining the raw value and offset tags.
+     *
+     * @return DateTimeImmutable|null
+     */
+    public function dateTimeDigitized(): ?DateTimeImmutable
+    {
+        return $this->parseExifDateTime($this->dateTimeDigitizedRaw(), $this->offsetTimeDigitizedRaw());
+    }
 
-        // EXIF uses "YYYY:MM:DD HH:MM:SS"
-        $normalized = str_replace(':', '-', substr($raw, 0, 10)) . substr($raw, 10); // YYYY-MM-DD HH:MM:SS
-        $dt         = DateTimeImmutable::createFromFormat('Y-m-d H:i:s', $normalized, $tz);
-
-        return $dt !== false ? $dt : null;
+    /**
+     * Returns the DateTime tag combined with its optional offset.
+     *
+     * @return DateTimeImmutable|null
+     */
+    public function dateTime(): ?DateTimeImmutable
+    {
+        return $this->parseExifDateTime($this->dateTimeRaw(), $this->offsetTimeRaw());
     }
 
     /**
@@ -263,5 +467,47 @@ final readonly class ExifDocument
         }
 
         return null;
+    }
+
+    /**
+     * Returns a rational or numeric value converted to float if present in the given IFD.
+     *
+     * @return float|null
+     */
+    private function rational(?Ifd $ifd, int $tag): ?float
+    {
+        if (!$ifd instanceof Ifd) {
+            return null;
+        }
+
+        $entry = $ifd->get($tag);
+
+        return $entry instanceof IfdEntry ? ValueConverters::rationalToFloat($entry->value) : null;
+    }
+
+    /**
+     * Normalises EXIF timestamp strings and optional offsets into immutable datetime instances.
+     *
+     * @param string|null $rawDateTime Raw EXIF datetime formatted as "YYYY:MM:DD HH:MM:SS".
+     * @param string|null $rawOffset   Optional timezone offset such as "+01:00".
+     */
+    private function parseExifDateTime(?string $rawDateTime, ?string $rawOffset): ?DateTimeImmutable
+    {
+        if ($rawDateTime === null || $rawDateTime === '' || strlen($rawDateTime) < 19) {
+            return null;
+        }
+
+        try {
+            $tz = ($rawOffset !== null && $rawOffset !== '')
+                ? new DateTimeZone($rawOffset)
+                : new DateTimeZone('UTC');
+        } catch (Exception) {
+            return null;
+        }
+
+        $normalized = str_replace(':', '-', substr($rawDateTime, 0, 10)) . substr($rawDateTime, 10);
+        $dt         = DateTimeImmutable::createFromFormat('Y-m-d H:i:s', $normalized, $tz);
+
+        return $dt !== false ? $dt : null;
     }
 }

--- a/src/Model/Exif/ExifTag.php
+++ b/src/Model/Exif/ExifTag.php
@@ -17,9 +17,15 @@ namespace MagicSunday\ImageMeta\Model\Exif;
 final readonly class ExifTag
 {
     // Image file directory (IFD0)
+    public const int IMAGE_WIDTH = 0x0100;
+
+    public const int IMAGE_HEIGHT = 0x0101;
+
     public const int MAKE = 0x010F;
 
     public const int MODEL = 0x0110;
+
+    public const int DATETIME = 0x0132;
 
     public const int ORIENTATION = 0x0112;
 
@@ -35,19 +41,55 @@ final readonly class ExifTag
 
     public const int F_NUMBER = 0x829D;
 
+    public const int EXPOSURE_PROGRAM = 0x8822;
+
     public const int PHOTOGRAPHIC_SENSITIVITY = 0x8827;
 
     public const int ISO_SPEED = 0x8833;
 
     public const int DATETIME_ORIGINAL = 0x9003;
 
+    public const int DATETIME_DIGITIZED = 0x9004;
+
+    public const int OFFSET_TIME = 0x9010;
+
     public const int OFFSET_TIME_ORIGINAL = 0x9011;
+
+    public const int OFFSET_TIME_DIGITIZED = 0x9012;
+
+    public const int BRIGHTNESS_VALUE = 0x9203;
+
+    public const int EXPOSURE_BIAS_VALUE = 0x9204;
+
+    public const int MAX_APERTURE_VALUE = 0x9205;
+
+    public const int METERING_MODE = 0x9207;
+
+    public const int FLASH = 0x9209;
 
     public const int FOCAL_LENGTH = 0x920A;
 
     public const int MAKER_NOTE = 0x927C;
 
+    public const int COLOR_SPACE = 0xA001;
+
+    public const int EXIF_IMAGE_WIDTH = 0xA002;
+
+    public const int EXIF_IMAGE_HEIGHT = 0xA003;
+
+    public const int WHITE_BALANCE = 0xA403;
+
+    public const int FOCAL_LENGTH_IN_35MM_FILM = 0xA405;
+
+    public const int IMAGE_UNIQUE_ID = 0xA420;
+
+    public const int CAMERA_OWNER_NAME = 0xA430;
+
+    public const int BODY_SERIAL_NUMBER = 0xA431;
+
     public const int LENS_MODEL = 0xA434;
+
+    public const int LENS_SERIAL_NUMBER = 0xA435;
 
     // GPS sub IFD
     public const int GPS_LATITUDE_REF = 0x0001;

--- a/tests/Model/Exif/ExifDocumentTest.php
+++ b/tests/Model/Exif/ExifDocumentTest.php
@@ -125,4 +125,125 @@ final class ExifDocumentTest extends TestCase
         self::assertEqualsWithDelta(79.983333, $gps['lon'], 0.000001);
         self::assertEquals(123.0, $gps['alt']);
     }
+
+    /**
+     * Ensures extended EXIF getters expose camera ownership, dimensions and exposure metadata.
+     */
+    #[Test]
+    public function exposesExtendedExifValues(): void
+    {
+        $ifd0 = new Ifd([
+            ExifTag::MAKE         => new IfdEntry(ExifTag::MAKE, 2, 1, 'Canon'),
+            ExifTag::MODEL        => new IfdEntry(ExifTag::MODEL, 2, 1, 'EOS R6'),
+            ExifTag::IMAGE_WIDTH  => new IfdEntry(ExifTag::IMAGE_WIDTH, 4, 1, 4000),
+            ExifTag::IMAGE_HEIGHT => new IfdEntry(ExifTag::IMAGE_HEIGHT, 4, 1, 2667),
+            ExifTag::DATETIME     => new IfdEntry(ExifTag::DATETIME, 2, 1, '2024:05:02 09:10:11'),
+        ]);
+
+        $exifIfd = new Ifd([
+            ExifTag::CAMERA_OWNER_NAME        => new IfdEntry(ExifTag::CAMERA_OWNER_NAME, 2, 1, "Jane Doe\0"),
+            ExifTag::BODY_SERIAL_NUMBER       => new IfdEntry(ExifTag::BODY_SERIAL_NUMBER, 2, 1, '123456789'),
+            ExifTag::LENS_MODEL               => new IfdEntry(ExifTag::LENS_MODEL, 2, 1, 'RF70-200mm'),
+            ExifTag::LENS_SERIAL_NUMBER       => new IfdEntry(ExifTag::LENS_SERIAL_NUMBER, 2, 1, 'LNS987654321'),
+            ExifTag::EXIF_IMAGE_WIDTH         => new IfdEntry(ExifTag::EXIF_IMAGE_WIDTH, 4, 1, 5472),
+            ExifTag::EXIF_IMAGE_HEIGHT        => new IfdEntry(ExifTag::EXIF_IMAGE_HEIGHT, 4, 1, 3648),
+            ExifTag::COLOR_SPACE              => new IfdEntry(ExifTag::COLOR_SPACE, 3, 1, 1),
+            ExifTag::IMAGE_UNIQUE_ID          => new IfdEntry(ExifTag::IMAGE_UNIQUE_ID, 2, 1, "UNIQUE-ID-123\0"),
+            ExifTag::ISO_SPEED                => new IfdEntry(ExifTag::ISO_SPEED, 3, 1, 800),
+            ExifTag::EXPOSURE_TIME            => new IfdEntry(ExifTag::EXPOSURE_TIME, 5, 1, new ExifRational(1, 60)),
+            ExifTag::F_NUMBER                 => new IfdEntry(ExifTag::F_NUMBER, 5, 1, new ExifRational(56, 10)),
+            ExifTag::FOCAL_LENGTH             => new IfdEntry(ExifTag::FOCAL_LENGTH, 5, 1, new ExifRational(85, 1)),
+            ExifTag::FOCAL_LENGTH_IN_35MM_FILM => new IfdEntry(ExifTag::FOCAL_LENGTH_IN_35MM_FILM, 3, 1, 85),
+            ExifTag::EXPOSURE_PROGRAM         => new IfdEntry(ExifTag::EXPOSURE_PROGRAM, 3, 1, 3),
+            ExifTag::METERING_MODE            => new IfdEntry(ExifTag::METERING_MODE, 3, 1, 5),
+            ExifTag::FLASH                    => new IfdEntry(ExifTag::FLASH, 3, 1, 0x5F),
+            ExifTag::WHITE_BALANCE            => new IfdEntry(ExifTag::WHITE_BALANCE, 3, 1, 1),
+            ExifTag::EXPOSURE_BIAS_VALUE      => new IfdEntry(ExifTag::EXPOSURE_BIAS_VALUE, 10, 1, new ExifRational(-1, 2)),
+            ExifTag::BRIGHTNESS_VALUE         => new IfdEntry(ExifTag::BRIGHTNESS_VALUE, 10, 1, new ExifRational(55, 10)),
+            ExifTag::MAX_APERTURE_VALUE       => new IfdEntry(ExifTag::MAX_APERTURE_VALUE, 5, 1, new ExifRational(28, 10)),
+            ExifTag::DATETIME_ORIGINAL        => new IfdEntry(ExifTag::DATETIME_ORIGINAL, 2, 1, '2024:05:02 09:10:11'),
+            ExifTag::OFFSET_TIME_ORIGINAL     => new IfdEntry(ExifTag::OFFSET_TIME_ORIGINAL, 2, 1, '+01:30'),
+            ExifTag::DATETIME_DIGITIZED       => new IfdEntry(ExifTag::DATETIME_DIGITIZED, 2, 1, '2024:05:02 09:15:00'),
+            ExifTag::OFFSET_TIME_DIGITIZED    => new IfdEntry(ExifTag::OFFSET_TIME_DIGITIZED, 2, 1, '+01:30'),
+            ExifTag::OFFSET_TIME              => new IfdEntry(ExifTag::OFFSET_TIME, 2, 1, '+01:30'),
+        ]);
+
+        $doc = new ExifDocument($ifd0, $exifIfd, null, null, null);
+
+        self::assertSame('Jane Doe', $doc->ownerName());
+        self::assertSame('123456789', $doc->bodySerialNumber());
+        self::assertSame('LNS987654321', $doc->lensSerialNumber());
+        self::assertSame(5472, $doc->imageWidth());
+        self::assertSame(3648, $doc->imageHeight());
+        self::assertSame(1, $doc->colorSpace());
+        self::assertSame('UNIQUE-ID-123', $doc->imageUniqueId());
+        self::assertSame(800, $doc->iso());
+        self::assertEqualsWithDelta(0.016666666666667, $doc->exposureTime(), 0.000000000000001);
+        self::assertEqualsWithDelta(5.6, $doc->fNumber(), 0.000000000000001);
+        self::assertEqualsWithDelta(85.0, $doc->focalLengthMm(), 0.000000000000001);
+        self::assertSame(85, $doc->focalLength35Mm());
+        self::assertSame(3, $doc->exposureProgram());
+        self::assertSame(5, $doc->meteringMode());
+        self::assertSame(0x5F, $doc->flash());
+        self::assertSame(1, $doc->whiteBalance());
+        self::assertEqualsWithDelta(-0.5, $doc->exposureBias(), 0.000000000000001);
+        self::assertEqualsWithDelta(5.5, $doc->brightnessValue(), 0.000000000000001);
+        self::assertEqualsWithDelta(2.8, $doc->maxApertureApex(), 0.000000000000001);
+
+        $captured = $doc->captureDateTime();
+        self::assertNotNull($captured);
+        self::assertSame('2024-05-02T09:10:11+01:30', $captured->format(DATE_ATOM));
+
+        $digitized = $doc->dateTimeDigitized();
+        self::assertNotNull($digitized);
+        self::assertSame('2024-05-02T09:15:00+01:30', $digitized->format(DATE_ATOM));
+
+        $general = $doc->dateTime();
+        self::assertNotNull($general);
+        self::assertSame('2024-05-02T09:10:11+01:30', $general->format(DATE_ATOM));
+
+        self::assertSame('2024:05:02 09:10:11', $doc->dateTimeRaw());
+        self::assertSame('2024:05:02 09:15:00', $doc->dateTimeDigitizedRaw());
+        self::assertSame('+01:30', $doc->offsetTimeRaw());
+        self::assertSame('+01:30', $doc->offsetTimeDigitizedRaw());
+    }
+
+    /**
+     * Ensures image dimension getters fall back to values stored within IFD0 when EXIF tags are absent.
+     */
+    #[Test]
+    public function imageDimensionsFallbackToIfd0(): void
+    {
+        $ifd0 = new Ifd([
+            ExifTag::IMAGE_WIDTH  => new IfdEntry(ExifTag::IMAGE_WIDTH, 4, 1, 1024),
+            ExifTag::IMAGE_HEIGHT => new IfdEntry(ExifTag::IMAGE_HEIGHT, 4, 1, 768),
+        ]);
+
+        $doc = new ExifDocument($ifd0, null, null, null, null);
+
+        self::assertSame(1024, $doc->imageWidth());
+        self::assertSame(768, $doc->imageHeight());
+    }
+
+    /**
+     * Ensures the ISO getter falls back to legacy tags when the ISO speed tag is missing.
+     */
+    #[Test]
+    public function isoFallsBackToLegacyTags(): void
+    {
+        $ifd0 = new Ifd([
+            ExifTag::PHOTOGRAPHIC_SENSITIVITY => new IfdEntry(ExifTag::PHOTOGRAPHIC_SENSITIVITY, 3, 1, 200),
+        ]);
+
+        $exifIfd = new Ifd([
+            ExifTag::PHOTOGRAPHIC_SENSITIVITY => new IfdEntry(ExifTag::PHOTOGRAPHIC_SENSITIVITY, 3, 1, 320),
+        ]);
+
+        $doc = new ExifDocument($ifd0, $exifIfd, null, null, null);
+
+        self::assertSame(320, $doc->iso());
+
+        $docWithoutExif = new ExifDocument($ifd0, null, null, null, null);
+        self::assertSame(200, $docWithoutExif->iso());
+    }
 }


### PR DESCRIPTION
## Summary
- add missing EXIF tag identifiers required by the structured metadata builder
- expose new ExifDocument getters for ownership, dimensions, exposure data, and timestamp offsets with appropriate fallbacks
- cover the new accessors with targeted PHPUnit tests using synthetic IFD entries

## Testing
- composer ci:test:php:unit

------
https://chatgpt.com/codex/tasks/task_e_68fa8e1a89f08323b21d991ca61d259e