### PR TITLE
feat: extend EXIF value converters

### DIFF
--- a/src/Model/Exif/ValueConverters.php
+++ b/src/Model/Exif/ValueConverters.php
@@ -11,10 +11,28 @@ declare(strict_types=1);
 
 namespace MagicSunday\ImageMeta\Model\Exif;
 
+use MagicSunday\ImageMeta\Value\FlashInfo;
+
+use function abs;
 use function count;
+use function ctype_digit;
+use function explode;
+use function floor;
 use function is_float;
 use function is_int;
+use function is_numeric;
 use function is_string;
+use function ltrim;
+use function preg_match;
+use function round;
+use function sprintf;
+use function str_contains;
+use function str_replace;
+use function str_starts_with;
+use function strlen;
+use function substr;
+use function strtoupper;
+use function trim;
 
 /**
  * Helper methods that translate EXIF/TIFF values into PHP friendly scalars.
@@ -61,6 +79,137 @@ final readonly class ValueConverters
         }
 
         return null;
+    }
+
+    /**
+     * Converts a stored APEX aperture value into a traditional f-number.
+     *
+     * @param int|float|string|ExifRational|ExifRationalList|ExifNumericList|null $value The APEX value to convert.
+     */
+    public static function apexToFNumber(int|float|string|ExifRational|ExifRationalList|ExifNumericList|null $value): ?float
+    {
+        $apex = self::rationalToFloat($value);
+
+        if ($apex === null && is_string($value) && is_numeric($value)) {
+            $apex = (float) $value;
+        }
+
+        if ($apex === null) {
+            return null;
+        }
+
+        return 2 ** ($apex / 2.0);
+    }
+
+    /**
+     * Converts a GPS speed measurement into metres per second.
+     *
+     * @param string|null                                                 $ref   Speed reference (K, M or N).
+     * @param int|float|string|ExifRational|ExifRationalList|ExifNumericList|null $value The measured value.
+     */
+    public static function gpsSpeedToMs(
+        ?string $ref,
+        int|float|string|ExifRational|ExifRationalList|ExifNumericList|null $value,
+    ): ?float {
+        if (!is_string($ref)) {
+            return null;
+        }
+
+        $numeric = self::rationalToFloat($value);
+        if ($numeric === null && is_string($value) && is_numeric($value)) {
+            $numeric = (float) $value;
+        }
+
+        if ($numeric === null) {
+            return null;
+        }
+
+        $normalizedRef = strtoupper(trim($ref));
+
+        return match ($normalizedRef) {
+            'K' => $numeric / 3.6,
+            'M' => $numeric * 0.44704,
+            'N' => $numeric * 0.5144444444444444,
+            default => null,
+        };
+    }
+
+    /**
+     * Converts the EXIF flash bit field into a typed value object.
+     *
+     * @param int|float|string|ExifRational|ExifRationalList|ExifNumericList|null $value Flash tag value representation.
+     */
+    public static function flashFromShort(
+        int|float|string|ExifRational|ExifRationalList|ExifNumericList|null $value,
+    ): ?FlashInfo {
+        if ($value instanceof ExifNumericList) {
+            $first = $value->values[0] ?? null;
+            if ($first === null) {
+                return null;
+            }
+
+            $value = $first;
+        }
+
+        if ($value instanceof ExifRational) {
+            if ($value->denominator === 0) {
+                return null;
+            }
+
+            $value = (int) round((float) $value->numerator / (float) $value->denominator);
+        }
+
+        if ($value instanceof ExifRationalList) {
+            $first = $value->values[0] ?? null;
+
+            return self::flashFromShort($first);
+        }
+
+        if (is_float($value) || is_int($value)) {
+            return FlashInfo::fromExifValue((int) $value);
+        }
+
+        if (is_string($value) && is_numeric($value)) {
+            return FlashInfo::fromExifValue((int) $value);
+        }
+
+        return null;
+    }
+
+    /**
+     * Normalises EXIF offset time values to a canonical "+HH:MM" representation.
+     *
+     * @param int|float|string|null $value The raw offset value.
+     */
+    public static function parseOffsetString(int|float|string|null $value): ?string
+    {
+        $components = self::parseOffsetComponents($value);
+
+        if ($components === null) {
+            return null;
+        }
+
+        $sign = $components['sign'] < 0 ? '-' : '+';
+
+        return sprintf('%s%02d:%02d', $sign, $components['hours'], $components['minutes']);
+    }
+
+    /**
+     * Converts an EXIF offset time value to minutes relative to UTC.
+     *
+     * @param int|float|string|null $value The raw offset value.
+     */
+    public static function offsetToMinutes(int|float|string|null $value): ?int
+    {
+        $components = self::parseOffsetComponents($value);
+
+        if ($components === null) {
+            return null;
+        }
+
+        $minutes = $components['hours'] * 60 + $components['minutes'];
+
+        return $components['sign'] < 0 ? -$minutes : $minutes;
     }
 
     /**
@@ -130,5 +279,129 @@ final readonly class ValueConverters
         $sign = ($ref === 'S' || $ref === 'W') ? -1.0 : 1.0;
 
         return $sign * ($deg + $min / 60.0 + $sec / 3600.0);
+    }
+
+    /**
+     * Parses numeric and textual offset encodings into sign, hour and minute components.
+     *
+     * @param int|float|string|null $value The raw value to parse.
+     *
+     * @return array{sign:int, hours:int, minutes:int}|null
+     */
+    private static function parseOffsetComponents(int|float|string|null $value): ?array
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        $raw = is_string($value) ? trim($value) : (string) $value;
+        $raw = str_replace(["−", '–', '—'], '-', $raw);
+        $raw = str_replace(['＋'], '+', $raw);
+
+        if ($raw === '') {
+            return null;
+        }
+
+        $upper = strtoupper($raw);
+        if ($upper === 'Z' || $upper === 'UTC' || $upper === 'GMT') {
+            return ['sign' => 1, 'hours' => 0, 'minutes' => 0];
+        }
+
+        if (str_starts_with($upper, 'UTC') || str_starts_with($upper, 'GMT')) {
+            $raw = trim(substr($raw, 3));
+            $upper = strtoupper($raw);
+            if ($raw === '') {
+                return ['sign' => 1, 'hours' => 0, 'minutes' => 0];
+            }
+        }
+
+        $sign = 1;
+        $raw  = ltrim($raw);
+
+        if ($raw === '') {
+            return null;
+        }
+
+        $firstChar = $raw[0];
+        if ($firstChar === '+' || $firstChar === '-') {
+            $sign = $firstChar === '-' ? -1 : 1;
+            $raw  = substr($raw, 1);
+        }
+
+        $raw = trim($raw);
+        if ($raw === '') {
+            return null;
+        }
+
+        $normalized = str_replace([' ', '\t'], '', $raw);
+        $normalized = str_replace(',', '.', $normalized);
+
+        $hours   = null;
+        $minutes = null;
+
+        if (str_contains($normalized, ':')) {
+            $parts = explode(':', $normalized, 3);
+            if (count($parts) < 2) {
+                return null;
+            }
+
+            $hoursPart   = $parts[0];
+            $minutesPart = $parts[1];
+
+            if ($hoursPart === '' || $minutesPart === '') {
+                return null;
+            }
+
+            if (!ctype_digit($hoursPart) || !ctype_digit($minutesPart)) {
+                return null;
+            }
+
+            $hours   = (int) $hoursPart;
+            $minutes = (int) substr($minutesPart, 0, 2);
+        } elseif (preg_match('/^\d+(?:\.\d+)?$/', $normalized) === 1) {
+            if (str_contains($normalized, '.')) {
+                $floatHours = (float) $normalized;
+                $hours      = (int) floor(abs($floatHours));
+                $minutes    = (int) round((abs($floatHours) - $hours) * 60);
+            } else {
+                if (!ctype_digit($normalized)) {
+                    return null;
+                }
+
+                $length = strlen($normalized);
+                if ($length <= 2) {
+                    $hours   = (int) $normalized;
+                    $minutes = 0;
+                } else {
+                    $hours   = (int) substr($normalized, 0, $length - 2);
+                    $minutes = (int) substr($normalized, -2);
+                }
+            }
+        } else {
+            return null;
+        }
+
+        if ($hours === null || $minutes === null) {
+            return null;
+        }
+
+        if ($minutes >= 60) {
+            $hours  += (int) floor($minutes / 60);
+            $minutes = $minutes % 60;
+        }
+
+        if ($hours > 14) {
+            return null;
+        }
+
+        if ($minutes < 0 || $minutes > 59) {
+            return null;
+        }
+
+        return [
+            'sign'    => $sign,
+            'hours'   => $hours,
+            'minutes' => $minutes,
+        ];
     }
 }

--- a/tests/Model/Exif/ValueConvertersTest.php
+++ b/tests/Model/Exif/ValueConvertersTest.php
@@ -18,6 +18,10 @@ use MagicSunday\ImageMeta\Model\Exif\ExifTag;
 use MagicSunday\ImageMeta\Model\Exif\Ifd;
 use MagicSunday\ImageMeta\Model\Exif\IfdEntry;
 use MagicSunday\ImageMeta\Model\Exif\ValueConverters;
+use MagicSunday\ImageMeta\Value\Enum\FlashFunction;
+use MagicSunday\ImageMeta\Value\Enum\FlashMode;
+use MagicSunday\ImageMeta\Value\Enum\FlashReturn;
+use MagicSunday\ImageMeta\Value\FlashInfo;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
@@ -32,6 +36,7 @@ use PHPUnit\Framework\TestCase;
 #[UsesClass(ExifRationalList::class)]
 #[UsesClass(Ifd::class)]
 #[UsesClass(IfdEntry::class)]
+#[UsesClass(FlashInfo::class)]
 final class ValueConvertersTest extends TestCase
 {
     /**
@@ -106,6 +111,146 @@ final class ValueConvertersTest extends TestCase
         yield 'empty numeric list' => [new ExifNumericList([])];
         yield 'string' => ['invalid'];
         yield 'null' => [null];
+    }
+
+    /**
+     * @param mixed       $value    The APEX encoded value.
+     * @param float|null  $expected The expected f-number.
+     */
+    #[Test]
+    #[DataProvider('provideApexValues')]
+    public function convertsApexValuesToFNumber(mixed $value, ?float $expected): void
+    {
+        $result = ValueConverters::apexToFNumber($value);
+
+        if ($expected === null) {
+            self::assertNull($result);
+
+            return;
+        }
+
+        self::assertNotNull($result);
+        self::assertEqualsWithDelta($expected, $result, 0.000001);
+    }
+
+    /**
+     * @return iterable<string, array{mixed, float|null}>
+     */
+    public static function provideApexValues(): iterable
+    {
+        yield 'zero apex results in f1' => [new ExifRational(0, 1), 1.0];
+        yield 'positive apex rational' => [new ExifRational(5, 1), 2 ** (5 / 2)];
+        yield 'numeric string apex' => ['3', 2 ** 1.5];
+        yield 'invalid rational' => [new ExifRational(1, 0), null];
+    }
+
+    /**
+     * @param string|null $ref      The speed reference.
+     * @param mixed       $value    The raw speed value.
+     * @param float|null  $expected The expected metres per second.
+     */
+    #[Test]
+    #[DataProvider('provideGpsSpeedValues')]
+    public function convertsGpsSpeedToMetresPerSecond(?string $ref, mixed $value, ?float $expected): void
+    {
+        $result = ValueConverters::gpsSpeedToMs($ref, $value);
+
+        if ($expected === null) {
+            self::assertNull($result);
+
+            return;
+        }
+
+        self::assertNotNull($result);
+        self::assertEqualsWithDelta($expected, $result, 0.000001);
+    }
+
+    /**
+     * @return iterable<string, array{string|null, mixed, float|null}>
+     */
+    public static function provideGpsSpeedValues(): iterable
+    {
+        yield 'kilometres per hour' => ['K', new ExifRational(360, 10), 10.0];
+        yield 'miles per hour' => ['M', new ExifRational(223, 10), 22.3 * 0.44704];
+        yield 'knots' => ['N', new ExifRational(40, 1), 20.577777777777776];
+        yield 'string numeric value' => ['K', '54', 15.0];
+        yield 'unknown reference' => ['X', new ExifRational(36, 1), null];
+        yield 'null reference' => [null, new ExifRational(36, 1), null];
+        yield 'invalid rational value' => ['K', new ExifRational(1, 0), null];
+    }
+
+    /**
+     * Ensures flash bit fields are converted into value objects.
+     */
+    #[Test]
+    public function convertsFlashShortToValueObject(): void
+    {
+        $info = ValueConverters::flashFromShort(new ExifNumericList([63]));
+
+        self::assertInstanceOf(FlashInfo::class, $info);
+        self::assertTrue($info->fired);
+        self::assertSame(FlashMode::AUTO, $info->mode);
+        self::assertSame(FlashReturn::DETECTED, $info->returnDetection);
+        self::assertSame(FlashFunction::ABSENT, $info->functionPresence);
+        self::assertFalse($info->redEyeReduction);
+    }
+
+    /**
+     * Ensures invalid flash values return null to avoid runtime errors.
+     */
+    #[Test]
+    public function returnsNullForInvalidFlashValue(): void
+    {
+        self::assertNull(ValueConverters::flashFromShort(new ExifRational(1, 0)));
+        self::assertNull(ValueConverters::flashFromShort('invalid'));
+    }
+
+    /**
+     * @param mixed       $value    The raw offset representation.
+     * @param string|null $expected The expected canonical offset string.
+     */
+    #[Test]
+    #[DataProvider('provideOffsetStrings')]
+    public function normalisesOffsetStrings(mixed $value, ?string $expected): void
+    {
+        self::assertSame($expected, ValueConverters::parseOffsetString($value));
+    }
+
+    /**
+     * @return iterable<string, array{mixed, string|null}>
+     */
+    public static function provideOffsetStrings(): iterable
+    {
+        yield 'already normalised' => ['+01:30', '+01:30'];
+        yield 'missing sign with colon' => ['05:45', '+05:45'];
+        yield 'compact digits' => ['0530', '+05:30'];
+        yield 'decimal hours' => ['-5.5', '-05:30'];
+        yield 'utc prefix' => ['UTC-4', '-04:00'];
+        yield 'zulu designator' => ['Z', '+00:00'];
+        yield 'invalid string' => ['abc', null];
+        yield 'out of range' => ['+15:00', null];
+    }
+
+    /**
+     * @param mixed     $value    The raw offset value.
+     * @param int|null  $expected Expected minutes from UTC.
+     */
+    #[Test]
+    #[DataProvider('provideOffsetMinutes')]
+    public function convertsOffsetToMinutes(mixed $value, ?int $expected): void
+    {
+        self::assertSame($expected, ValueConverters::offsetToMinutes($value));
+    }
+
+    /**
+     * @return iterable<string, array{mixed, int|null}>
+     */
+    public static function provideOffsetMinutes(): iterable
+    {
+        yield 'positive offset' => ['+01:30', 90];
+        yield 'negative compact' => ['-0330', -210];
+        yield 'decimal hours' => ['2.25', 135];
+        yield 'invalid input' => ['invalid', null];
     }
 
     /**


### PR DESCRIPTION
## Summary
- add helpers to convert EXIF aperture, GPS speed, flash and offset data into usable values
- expose timezone offset normalisation utilities for downstream timestamp handling
- cover the new conversions with PHPUnit cases, including edge conditions

## Testing
- composer ci:test:php:unit

------
https://chatgpt.com/codex/tasks/task_e_68fa8fade7788323b51019c7d78e3203