### PR TITLE
fix: align legacy resolvers with extended value objects

### DIFF
--- a/src/Curate/Resolver/CameraResolver.php
+++ b/src/Curate/Resolver/CameraResolver.php
@@ -31,15 +31,24 @@ final readonly class CameraResolver
      */
     public function resolve(?ExifDocument $exifDocument, ?XmpDocument $xmpDocument): ?Camera
     {
-        $make   = $exifDocument?->cameraMake() ?? $this->xmpString($xmpDocument, self::NS_TIFF, 'Make');
-        $model  = $exifDocument?->cameraModel() ?? $this->xmpString($xmpDocument, self::NS_TIFF, 'Model');
-        $serial = $this->xmpString($xmpDocument, self::NS_AUX, 'SerialNumber');
-        $tool   = $this->xmpString($xmpDocument, self::NS_XMP, 'CreatorTool');
+        $make       = $exifDocument?->cameraMake() ?? $this->xmpString($xmpDocument, self::NS_TIFF, 'Make');
+        $model      = $exifDocument?->cameraModel() ?? $this->xmpString($xmpDocument, self::NS_TIFF, 'Model');
+        $owner      = $exifDocument?->ownerName() ?? $this->xmpString($xmpDocument, self::NS_AUX, 'OwnerName');
+        $serial     = $exifDocument?->bodySerialNumber() ?? $this->xmpString($xmpDocument, self::NS_AUX, 'SerialNumber');
+        $firmware   = $exifDocument?->cameraFirmware() ?? $this->xmpString($xmpDocument, self::NS_XMP, 'CreatorTool');
 
-        if ($make === null && $model === null && $serial === null && $tool === null) {
+        if ($make === null && $model === null && $owner === null && $serial === null && $firmware === null) {
             return null;
         }
 
-        return new Camera($make, $model, $serial, $tool);
+        return new Camera(
+            make: $make,
+            model: $model,
+            ownerName: $owner,
+            serialNumber: $serial,
+            firmware: $firmware,
+            fileSource: null,
+            sensingMethod: null,
+        );
     }
 }

--- a/src/Curate/Resolver/DeviceResolver.php
+++ b/src/Curate/Resolver/DeviceResolver.php
@@ -30,8 +30,6 @@ final readonly class DeviceResolver
     private const string NS_TIFF = 'http://ns.adobe.com/tiff/1.0/';
     private const string NS_XMP  = 'http://ns.adobe.com/xap/1.0/';
 
-    private const string QUICKTIME_MAKE_KEY     = 'com.apple.quicktime.make';
-    private const string QUICKTIME_MODEL_KEY    = 'com.apple.quicktime.model';
     private const string QUICKTIME_SOFTWARE_KEY = 'com.apple.quicktime.software';
 
     /**
@@ -39,25 +37,27 @@ final readonly class DeviceResolver
      */
     public function resolve(?QuickTimeMeta $quickTimeMeta, ?XmpDocument $xmpDocument): ?Device
     {
-        $manufacturer = null;
-        $model        = null;
         $software     = null;
+        $hostComputer = null;
 
         if ($quickTimeMeta instanceof QuickTimeMeta) {
-            $manufacturer = $this->stringFromMixed($quickTimeMeta->keys[self::QUICKTIME_MAKE_KEY] ?? null);
-            $model        = $this->stringFromMixed($quickTimeMeta->keys[self::QUICKTIME_MODEL_KEY] ?? null);
             $software     = $this->stringFromMixed($quickTimeMeta->keys[self::QUICKTIME_SOFTWARE_KEY] ?? null);
         }
 
-        $manufacturer ??= $this->xmpString($xmpDocument, self::NS_TIFF, 'Make');
-        $model        ??= $this->xmpString($xmpDocument, self::NS_TIFF, 'Model');
         $software     ??= $this->xmpString($xmpDocument, self::NS_XMP, 'CreatorTool');
+        $hostComputer ??= $this->xmpString($xmpDocument, self::NS_TIFF, 'HostComputer');
 
-        if ($manufacturer === null && $model === null && $software === null) {
+        if ($software === null && $hostComputer === null) {
             return null;
         }
 
-        return new Device($manufacturer, $model, $software);
+        return new Device(
+            software: $software,
+            hostComputer: $hostComputer,
+            rawDevelopingSoftware: null,
+            imageEditingSoftware: null,
+            metadataEditingSoftware: null,
+        );
     }
 
     /**

--- a/src/Curate/Resolver/ExposureResolver.php
+++ b/src/Curate/Resolver/ExposureResolver.php
@@ -36,34 +36,43 @@ final readonly class ExposureResolver
         $iso           = $exifDocument?->iso() ?? $this->xmpInt($xmpDocument, self::NS_EXIF, 'ISOSpeedRatings');
         $exposureTime  = $exifDocument?->exposureTime() ?? $this->xmpFloat($xmpDocument, self::NS_EXIF, 'ExposureTime');
         $aperture      = $exifDocument?->fNumber() ?? $this->xmpFloat($xmpDocument, self::NS_EXIF, 'FNumber');
-        $focalLength   = $exifDocument?->focalLengthMm() ?? $this->xmpFloat($xmpDocument, self::NS_EXIF, 'FocalLength');
-        $program       = ExposureProgram::fromExifValue($this->xmpInt($xmpDocument, self::NS_EXIF, 'ExposureProgram'));
-        $metering      = MeteringMode::fromExifValue($this->xmpInt($xmpDocument, self::NS_EXIF, 'MeteringMode'));
-        $whiteBalance  = WhiteBalance::fromExifValue($this->xmpInt($xmpDocument, self::NS_EXIF, 'WhiteBalance'));
-        $flash         = FlashInfo::fromExifValue($this->xmpInt($xmpDocument, self::NS_EXIF, 'Flash'));
+        $exposureBias  = $exifDocument?->exposureBias();
+        $program       = ExposureProgram::fromExifValue($exifDocument?->exposureProgram() ?? $this->xmpInt($xmpDocument, self::NS_EXIF, 'ExposureProgram'));
+        $metering      = MeteringMode::fromExifValue($exifDocument?->meteringMode() ?? $this->xmpInt($xmpDocument, self::NS_EXIF, 'MeteringMode'));
+        $flash         = FlashInfo::fromExifValue($exifDocument?->flash() ?? $this->xmpInt($xmpDocument, self::NS_EXIF, 'Flash'));
+        $whiteBalance  = WhiteBalance::fromExifValue($exifDocument?->whiteBalance() ?? $this->xmpInt($xmpDocument, self::NS_EXIF, 'WhiteBalance'));
+        $brightness    = $exifDocument?->brightnessValue();
 
         if (
             $iso === null
             && $exposureTime === null
             && $aperture === null
-            && $focalLength === null
+            && $exposureBias === null
             && $program === null
             && $metering === null
             && $whiteBalance === null
             && $flash === null
+            && $brightness === null
         ) {
             return null;
         }
 
         return new Exposure(
-            $iso,
-            $exposureTime,
-            $aperture,
-            $focalLength,
-            $program,
-            $metering,
-            $whiteBalance,
-            $flash,
+            iso: $iso,
+            exposureTimeSec: $exposureTime,
+            fNumber: $aperture,
+            exposureBiasEv: $exposureBias,
+            program: $program,
+            meteringMode: $metering,
+            flash: $flash,
+            whiteBalance: $whiteBalance,
+            brightnessEv: $brightness,
+            exposureMode: null,
+            gainControl: null,
+            contrast: null,
+            saturation: null,
+            sharpness: null,
+            digitalZoomRatio: null,
         );
     }
 }

--- a/src/Curate/Resolver/ImageResolver.php
+++ b/src/Curate/Resolver/ImageResolver.php
@@ -32,18 +32,40 @@ final readonly class ImageResolver
      */
     public function resolve(?ExifDocument $exifDocument, ?XmpDocument $xmpDocument): ?Image
     {
-        $orientation = Orientation::fromExifValue($exifDocument?->orientation());
-        if ($orientation === null) {
-            $orientation = Orientation::fromExifValue($this->xmpInt($xmpDocument, self::NS_TIFF, 'Orientation'));
-        }
+        $orientation = Orientation::fromExifValue($exifDocument?->orientation())
+            ?? Orientation::fromExifValue($this->xmpInt($xmpDocument, self::NS_TIFF, 'Orientation'));
 
-        $colorSpaceValue = $this->xmpInt($xmpDocument, self::NS_EXIF, 'ColorSpace');
+        $colorSpaceValue = $exifDocument?->colorSpace() ?? $this->xmpInt($xmpDocument, self::NS_EXIF, 'ColorSpace');
         $colorSpace      = ColorSpace::fromExifValue($colorSpaceValue);
 
-        if ($orientation === null && $colorSpace === null) {
+        $width       = $exifDocument?->imageWidth();
+        $height      = $exifDocument?->imageHeight();
+        $bitsPerSample = null;
+        $uniqueId    = $exifDocument?->imageUniqueId();
+        $documentName = $this->xmpString($xmpDocument, self::NS_TIFF, 'DocumentName');
+        $description  = $this->xmpString($xmpDocument, self::NS_TIFF, 'ImageDescription');
+
+        if (
+            $orientation === null
+            && $colorSpace === null
+            && $width === null
+            && $height === null
+            && $uniqueId === null
+            && $documentName === null
+            && $description === null
+        ) {
             return null;
         }
 
-        return new Image($orientation, $colorSpace);
+        return new Image(
+            width: $width,
+            height: $height,
+            orientation: $orientation,
+            bitsPerSample: $bitsPerSample,
+            colorSpace: $colorSpace,
+            imageUniqueId: $uniqueId,
+            documentName: $documentName,
+            description: $description,
+        );
     }
 }

--- a/src/Curate/Resolver/LensResolver.php
+++ b/src/Curate/Resolver/LensResolver.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace MagicSunday\ImageMeta\Curate\Resolver;
 
+use MagicSunday\ImageMeta\Core\ValueConverters;
 use MagicSunday\ImageMeta\Model\Exif\ExifDocument;
 use MagicSunday\ImageMeta\Model\Xmp\XmpDocument;
 use MagicSunday\ImageMeta\Value\Lens;
@@ -30,16 +31,29 @@ final readonly class LensResolver
      */
     public function resolve(?ExifDocument $exifDocument, ?XmpDocument $xmpDocument): ?Lens
     {
+        $make = $exifDocument?->lensMake() ?? $this->xmpString($xmpDocument, self::NS_AUX, 'LensMake');
         $model = $exifDocument?->lensModel()
             ?? $this->xmpString($xmpDocument, self::NS_AUX, 'LensModel')
             ?? $this->xmpString($xmpDocument, self::NS_AUX, 'Lens');
-
+        $serial = $exifDocument?->lensSerialNumber() ?? $this->xmpString($xmpDocument, self::NS_AUX, 'LensSerialNumber');
         $focal = $exifDocument?->focalLengthMm() ?? $this->xmpFloat($xmpDocument, self::NS_EXIF, 'FocalLength');
+        $focal35 = $exifDocument?->focalLength35Mm();
 
-        if ($model === null && $focal === null) {
+        $maxApex = $exifDocument?->maxApertureApex();
+        $maxAperture = $maxApex !== null ? ValueConverters::apexToFNumber($maxApex) : null;
+
+        if ($make === null && $model === null && $serial === null && $focal === null && $focal35 === null) {
             return null;
         }
 
-        return new Lens($model, $focal);
+        return new Lens(
+            lensMake: $make,
+            lensModel: $model,
+            lensSerialNumber: $serial,
+            focalLengthMm: $focal,
+            focalLengthIn35mm: $focal35,
+            maxApertureFNumber: $maxAperture,
+            lensInfo: null,
+        );
     }
 }

--- a/src/Model/Metadata.php
+++ b/src/Model/Metadata.php
@@ -21,9 +21,16 @@ use MagicSunday\ImageMeta\Parse\Xmp\XmpParser;
 /**
  * Aggregates extracted metadata blobs alongside parsed representations.
  */
-final readonly class Metadata
+final class Metadata
 {
-    private ?StructuredMetadata $structured;
+    public readonly array $exifBlobs;
+    public readonly ?QuickTimeMeta $quickTime;
+    public readonly ?ExifDocument $exifDoc;
+    public readonly array $xmpBlobs;
+    public readonly ?XmpDocument $xmpDoc;
+    public readonly ?MakerNotesMetadata $makerNotes;
+
+    private ?StructuredMetadata $structured = null;
 
     /**
      * @param list<string>            $exifBlobs  TIFF‑EXIF blobs (first is primary)
@@ -34,13 +41,19 @@ final readonly class Metadata
      * @param MakerNotesMetadata|null $makerNotes Decoded maker notes metadata for the primary EXIF blob.
      */
     public function __construct(
-        public array $exifBlobs,
-        public ?QuickTimeMeta $quickTime,
-        public ?ExifDocument $exifDoc = null,
-        public array $xmpBlobs = [],
-        public ?XmpDocument $xmpDoc = null,
-        public ?MakerNotesMetadata $makerNotes = null,
+        array $exifBlobs,
+        ?QuickTimeMeta $quickTime,
+        ?ExifDocument $exifDoc = null,
+        array $xmpBlobs = [],
+        ?XmpDocument $xmpDoc = null,
+        ?MakerNotesMetadata $makerNotes = null,
     ) {
+        $this->exifBlobs  = $exifBlobs;
+        $this->quickTime  = $quickTime;
+        $this->exifDoc    = $exifDoc;
+        $this->xmpBlobs   = $xmpBlobs;
+        $this->xmpDoc     = $xmpDoc;
+        $this->makerNotes = $makerNotes;
     }
 
     /**
@@ -69,7 +82,7 @@ final readonly class Metadata
      */
     public function structured(): StructuredMetadata
     {
-        if (!isset($this->structured)) {
+        if ($this->structured === null) {
             $builder           = new StructuredMetadataBuilder();
             $this->structured = $builder->build($this);
         }


### PR DESCRIPTION
## Summary
- update the legacy curate resolvers to populate the extended EXIF 3.0 value objects
- allow `Metadata::structured()` to lazily cache structured metadata without readonly violations

## Testing
- composer ci:test:php:unit

------
https://chatgpt.com/codex/tasks/task_e_68fb09b50180832395347fc9116b1ca9