### PR TITLE
Remove EXIF host computer exposure from device metadata

### DIFF
--- a/src/Curate/Resolver/DeviceResolver.php
+++ b/src/Curate/Resolver/DeviceResolver.php
@@ -47,13 +47,17 @@ final readonly class DeviceResolver
         $software ??= $this->xmpString($xmpDocument, self::NS_XMP, 'CreatorTool');
         $hostComputer ??= $this->xmpString($xmpDocument, self::NS_TIFF, 'HostComputer');
 
-        if ($software === null && $hostComputer === null) {
+        if ($software === null) {
+            // Preserve host computer details from XMP as a best-effort fallback for the software chain.
+            $software = $hostComputer;
+        }
+
+        if ($software === null) {
             return null;
         }
 
         return new Device(
             software: $software,
-            hostComputer: $hostComputer,
         );
     }
 

--- a/src/Curate/Resolver/ExifTagResolver.php
+++ b/src/Curate/Resolver/ExifTagResolver.php
@@ -768,14 +768,6 @@ final readonly class ExifTagResolver
     }
 
     /**
-     * Returns the host computer string.
-     */
-    public function hostComputer(): ?string
-    {
-        return $this->stringValue($this->document?->ifd0, ExifTag::HOST_COMPUTER);
-    }
-
-    /**
      * Returns the gamma value.
      */
     public function gamma(): ?float

--- a/src/Curate/StructuredMetadataBuilder.php
+++ b/src/Curate/StructuredMetadataBuilder.php
@@ -20,7 +20,6 @@ use MagicSunday\ImageMeta\Curate\Resolver\ExifTagResolver;
 use MagicSunday\ImageMeta\Curate\Resolver\QuickTimeResolver;
 use MagicSunday\ImageMeta\Curate\Resolver\XmpResolver;
 use MagicSunday\ImageMeta\Model\Metadata;
-use MagicSunday\ImageMeta\Model\QuickTimeMeta;
 use MagicSunday\ImageMeta\Value\Apple;
 use MagicSunday\ImageMeta\Value\Audio;
 use MagicSunday\ImageMeta\Value\Author;
@@ -144,7 +143,7 @@ final class StructuredMetadataBuilder
         $gpsCoords = $exifResolver->gps();
         $gps       = new Gps($gpsCoords['lat'], $gpsCoords['lon'], $gpsCoords['alt']);
 
-        $device = $this->buildDevice($metadata->quickTime, $exifResolver, $quickTimeResolver);
+        $device = $this->buildDevice($exifResolver, $quickTimeResolver);
 
         $apple = new Apple($metadata->quickTime?->contentIdentifier());
         $xmp   = $xmpResolver->value();
@@ -339,7 +338,7 @@ final class StructuredMetadataBuilder
     /**
      * Builds a device value object using container level metadata.
      */
-    private function buildDevice(?QuickTimeMeta $quickTime, ExifTagResolver $exif, QuickTimeResolver $quickTimeResolver): Device
+    private function buildDevice(ExifTagResolver $exif, QuickTimeResolver $quickTimeResolver): Device
     {
         $softwareChain = CompositeResolver::first([
             fn () => $quickTimeResolver->string('com.apple.quicktime.software'),
@@ -348,7 +347,6 @@ final class StructuredMetadataBuilder
 
         return new Device(
             software: $softwareChain,
-            hostComputer: $exif->hostComputer(),
         );
     }
 

--- a/src/Model/Exif/ExifTag.php
+++ b/src/Model/Exif/ExifTag.php
@@ -55,8 +55,6 @@ final readonly class ExifTag
 
     public const int ARTIST = 0x013B;
 
-    public const int HOST_COMPUTER = 0x013C;
-
     public const int WHITE_POINT = 0x013E;
 
     public const int PRIMARY_CHROMATICITIES = 0x013F;

--- a/src/Value/Device.php
+++ b/src/Value/Device.php
@@ -17,12 +17,10 @@ namespace MagicSunday\ImageMeta\Value;
 final readonly class Device
 {
     /**
-     * @param string|null $software     Software version or build identifier.
-     * @param string|null $hostComputer Host computer string.
+     * @param string|null $software Software version or build identifier.
      */
     public function __construct(
         public ?string $software,
-        public ?string $hostComputer,
     ) {
     }
 }


### PR DESCRIPTION
## Summary
- remove the HOST_COMPUTER tag constant and EXIF resolver accessor
- drop the EXIF host computer field from the device aggregate and value object
- keep XMP host computer metadata as a software fallback in the device resolver

## Testing
- composer ci:test:php:unit

------
https://chatgpt.com/codex/tasks/task_e_68fb211feabc8323aa736f3e6ac76182