### PR TITLE
refactor: stop sourcing document name from EXIF

### DIFF
--- a/src/Curate/Resolver/ExifTagResolver.php
+++ b/src/Curate/Resolver/ExifTagResolver.php
@@ -235,14 +235,6 @@ final readonly class ExifTagResolver
     }
 
     /**
-     * Returns the document name value.
-     */
-    public function documentName(): ?string
-    {
-        return $this->stringValue($this->document?->ifd0, ExifTag::DOCUMENT_NAME);
-    }
-
-    /**
      * Returns the image description field.
      */
     public function imageDescription(): ?string

--- a/src/Curate/StructuredMetadataBuilder.php
+++ b/src/Curate/StructuredMetadataBuilder.php
@@ -495,6 +495,11 @@ final class StructuredMetadataBuilder
             fn () => $quickTime->int('ImageHeight'),
         ]);
 
+        $documentName = CompositeResolver::first([
+            fn () => $xmp->string('http://ns.adobe.com/tiff/1.0/', 'DocumentName'),
+            fn () => $xmp->string('http://purl.org/dc/elements/1.1/', 'title'),
+        ]);
+
         return new Image(
             width: $width,
             height: $height,
@@ -502,7 +507,7 @@ final class StructuredMetadataBuilder
             bitsPerSample: $exif->bitsPerSample(),
             colorSpace: $exif->colorSpace(),
             imageUniqueId: $exif->imageUniqueId(),
-            documentName: $exif->documentName(),
+            documentName: $documentName,
             description: CompositeResolver::first([
                 fn () => $exif->imageDescription(),
                 fn () => $xmp->string('http://purl.org/dc/elements/1.1/', 'description'),

--- a/src/Model/Exif/ExifTag.php
+++ b/src/Model/Exif/ExifTag.php
@@ -27,8 +27,6 @@ final readonly class ExifTag
 
     public const int PHOTOMETRIC_INTERPRETATION = 0x0106;
 
-    public const int DOCUMENT_NAME = 0x010D;
-
     public const int IMAGE_DESCRIPTION = 0x010E;
 
     public const int MAKE = 0x010F;

--- a/src/Value/Image.php
+++ b/src/Value/Image.php
@@ -26,7 +26,7 @@ final readonly class Image
      * @param int|null         $bitsPerSample Bits per colour channel.
      * @param ColorSpace|null  $colorSpace    Colour space used for the pixel data.
      * @param string|null      $imageUniqueId Globally unique image identifier.
-     * @param string|null      $documentName  Optional document or file name from the container.
+     * @param string|null      $documentName  Optional document or file name derived from metadata sources.
      * @param string|null      $description   Free-form description provided by the camera.
      */
     public function __construct(

--- a/tests/Curate/StructuredMetadataBuilderTest.php
+++ b/tests/Curate/StructuredMetadataBuilderTest.php
@@ -72,7 +72,6 @@ final class StructuredMetadataBuilderTest extends TestCase
             ExifTag::MAKE                       => new IfdEntry(ExifTag::MAKE, 2, 5, 'Canon'),
             ExifTag::MODEL                      => new IfdEntry(ExifTag::MODEL, 2, 8, 'EOS R6 II'),
             ExifTag::SOFTWARE                   => new IfdEntry(ExifTag::SOFTWARE, 2, 8, 'Firmware1'),
-            ExifTag::DOCUMENT_NAME              => new IfdEntry(ExifTag::DOCUMENT_NAME, 2, 12, 'IMG_5123.CR3'),
             ExifTag::IMAGE_DESCRIPTION          => new IfdEntry(ExifTag::IMAGE_DESCRIPTION, 2, 16, 'Sunset over Alps'),
             ExifTag::ORIENTATION                => new IfdEntry(ExifTag::ORIENTATION, 3, 1, Orientation::RIGHT_TOP->value),
             ExifTag::ARTIST                     => new IfdEntry(ExifTag::ARTIST, 2, 12, 'Jane Doe'),
@@ -124,6 +123,7 @@ final class StructuredMetadataBuilderTest extends TestCase
             '{http://iptc.org/std/Iptc4xmpCore/1.0/xmlns/}CreatorContactInfo/Iptc4xmpCore:CiEmailWork' => 'jane@example.com',
             '{http://ns.adobe.com/tiff/1.0/}Make'                                                      => 'Canon',
             '{http://ns.adobe.com/tiff/1.0/}Model'                                                     => 'EOS R6 II',
+            '{http://ns.adobe.com/tiff/1.0/}DocumentName'                                              => 'IMG_5123.CR3',
         ]);
 
         $quickTime = new QuickTimeMeta([


### PR DESCRIPTION
## Summary
- drop the EXIF document name constant and resolver helper
- derive the structured image document name from XMP metadata instead of EXIF
- refresh the structured metadata test fixture to populate document names via XMP

## Testing
- composer ci:test:php:unit

------
https://chatgpt.com/codex/tasks/task_e_68fb211edbe48323a6e415f243c09c14