### PR TITLE
Fix EXIF sensitivity tag IDs and ISO fallback handling

### DIFF
--- a/src/Curate/Resolver/ExifTagResolver.php
+++ b/src/Curate/Resolver/ExifTagResolver.php
@@ -456,17 +456,38 @@ final readonly class ExifTagResolver
     }
 
     /**
+     * Returns the EXIF sensitivity type enumeration describing the recorded ISO metrics.
+     */
+    public function sensitivityType(): ?int
+    {
+        return $this->numericValue($this->document?->exifIfd, ExifTag::SENSITIVITY_TYPE);
+    }
+
+    /**
      * Returns the ISO sensitivity with fallbacks defined by EXIF 3.0.
      */
     public function iso(): ?int
     {
-        $values = [
-            $this->document?->iso(),
-            $this->numericValue($this->document?->exifIfd, ExifTag::STANDARD_OUTPUT_SENSITIVITY),
-            $this->numericValue($this->document?->exifIfd, ExifTag::RECOMMENDED_EXPOSURE_INDEX),
-        ];
+        $iso = $this->document?->iso();
+        if ($iso !== null) {
+            return $iso;
+        }
 
-        foreach ($values as $value) {
+        $sensitivityType = $this->sensitivityType();
+        if ($sensitivityType !== null) {
+            foreach ($this->sensitivityTagPriority($sensitivityType) as $tag) {
+                $value = $this->numericValue($this->document?->exifIfd, $tag);
+                if ($value !== null) {
+                    return (int) $value;
+                }
+            }
+        }
+
+        foreach ([
+            ExifTag::STANDARD_OUTPUT_SENSITIVITY,
+            ExifTag::RECOMMENDED_EXPOSURE_INDEX,
+        ] as $tag) {
+            $value = $this->numericValue($this->document?->exifIfd, $tag);
             if ($value !== null) {
                 return (int) $value;
             }
@@ -781,6 +802,25 @@ final readonly class ExifTagResolver
     public function gamma(): ?float
     {
         return $this->rationalValue($this->document?->exifIfd, ExifTag::GAMMA);
+    }
+
+    /**
+     * Maps the EXIF sensitivity type enumeration to ISO-related tag priorities.
+     *
+     * @return list<int>
+     */
+    private function sensitivityTagPriority(int $type): array
+    {
+        return match ($type) {
+            1 => [ExifTag::STANDARD_OUTPUT_SENSITIVITY],
+            2 => [ExifTag::RECOMMENDED_EXPOSURE_INDEX],
+            3 => [ExifTag::ISO_SPEED],
+            4 => [ExifTag::STANDARD_OUTPUT_SENSITIVITY, ExifTag::RECOMMENDED_EXPOSURE_INDEX],
+            5 => [ExifTag::STANDARD_OUTPUT_SENSITIVITY, ExifTag::ISO_SPEED],
+            6 => [ExifTag::RECOMMENDED_EXPOSURE_INDEX, ExifTag::ISO_SPEED],
+            7 => [ExifTag::STANDARD_OUTPUT_SENSITIVITY, ExifTag::RECOMMENDED_EXPOSURE_INDEX, ExifTag::ISO_SPEED],
+            default => [],
+        };
     }
 
     /**

--- a/src/Model/Exif/ExifTag.php
+++ b/src/Model/Exif/ExifTag.php
@@ -83,7 +83,9 @@ final readonly class ExifTag
 
     public const int PHOTOGRAPHIC_SENSITIVITY = 0x8827;
 
-    public const int STANDARD_OUTPUT_SENSITIVITY = 0x8830;
+    public const int SENSITIVITY_TYPE = 0x8830;
+
+    public const int STANDARD_OUTPUT_SENSITIVITY = 0x8831;
 
     public const int RECOMMENDED_EXPOSURE_INDEX = 0x8832;
 

--- a/tests/Curate/StructuredMetadataBuilderTest.php
+++ b/tests/Curate/StructuredMetadataBuilderTest.php
@@ -272,4 +272,24 @@ final class StructuredMetadataBuilderTest extends TestCase
         self::assertNull($structured->camera->make);
         self::assertNull($structured->depth->format);
     }
+
+    /**
+     * Verifies the ISO fallback uses the Standard Output Sensitivity tag when available.
+     */
+    #[Test]
+    public function usesStandardOutputSensitivityFallback(): void
+    {
+        $ifd0    = new Ifd([]);
+        $exifIfd = new Ifd([
+            ExifTag::SENSITIVITY_TYPE            => new IfdEntry(ExifTag::SENSITIVITY_TYPE, 3, 1, 1),
+            ExifTag::STANDARD_OUTPUT_SENSITIVITY => new IfdEntry(ExifTag::STANDARD_OUTPUT_SENSITIVITY, 3, 1, 640),
+        ]);
+
+        $exifDocument = new ExifDocument($ifd0, $exifIfd, null, null, null);
+        $metadata     = new Metadata(['primary'], null, $exifDocument);
+
+        $structured = (new StructuredMetadataBuilder())->build($metadata);
+
+        self::assertSame(640, $structured->exposure->iso);
+    }
 }


### PR DESCRIPTION
## Summary
- add the missing SENSITIVITY_TYPE constant and correct the STANDARD_OUTPUT_SENSITIVITY tag ID
- update the EXIF ISO resolver to respect sensitivity type hints when resolving fallbacks
- cover the Standard Output Sensitivity fallback in the structured metadata builder tests

## Testing
- composer ci:test:php:unit

------
https://chatgpt.com/codex/tasks/task_e_68fb21119db483238d1a49a09b5a89e1