### PR TITLE
Add required PHP extensions to composer configuration

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,12 @@
     },
     "require": {
         "php": "^8.4",
+        "ext-ctype": "*",
+        "ext-date": "*",
+        "ext-hash": "*",
+        "ext-iconv": "*",
+        "ext-json": "*",
+        "ext-pcre": "*",
         "ext-xmlreader": "*"
     },
     "require-dev": {


### PR DESCRIPTION
## Summary
- declare all PHP extensions required by the library at runtime in composer.json

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68fb22e2dee483238f62f398e30ee2aa