### PR TITLE
Remove JPEG XL and WebP compression enums

### DIFF
--- a/src/Value/Enum/Compression.php
+++ b/src/Value/Enum/Compression.php
@@ -28,8 +28,6 @@ enum Compression: int
     case THUNDERSCAN                = 32809;
     case JPEG_2000                  = 34712;
     case LOSSY_JPEG                 = 34892;
-    case JPEG_XL                    = 34926;
-    case WEBP                       = 34993;
 
     /**
      * Converts a raw compression id to the backed enum value.

--- a/tests/Value/Enum/EnumMappingTest.php
+++ b/tests/Value/Enum/EnumMappingTest.php
@@ -50,7 +50,6 @@ final class EnumMappingTest extends TestCase
     public function mapsCommonEnumValues(): void
     {
         self::assertSame(Compression::JPEG, Compression::fromExifValue(7));
-        self::assertSame(Compression::JPEG_XL, Compression::fromExifValue(34926));
         self::assertSame(Photometric::YCBCR, Photometric::fromExifValue(6));
         self::assertSame(Photometric::DEPTH_MAP, Photometric::fromExifValue(511));
         self::assertSame(PlanarConfiguration::CHUNKY, PlanarConfiguration::fromExifValue(1));


### PR DESCRIPTION
## Summary
- remove the JPEG_XL and WEBP cases from the compression enum
- update the enum mapping test to reflect the supported compression values

## Testing
- composer ci:test:php:unit
- composer ci:test:php:unit:coverage *(fails: No code coverage driver available in the environment)*
- composer ci:test:php:phpstan *(fails: existing issues in the codebase)*
- composer ci:test:php:cgl *(fails: existing formatting issues outside the touched files)*

------
https://chatgpt.com/codex/tasks/task_e_68fb24990df483239b1fae87157fe593