### PR TITLE
fix: remove sigma foveon file source

### DIFF
--- a/src/Value/Enum/FileSource.php
+++ b/src/Value/Enum/FileSource.php
@@ -20,7 +20,6 @@ enum FileSource: int
     case TRANSPARENCY_SCANNER = 1;
     case REFLECTION_SCANNER   = 2;
     case DIGITAL_CAMERA       = 3;
-    case SIGMA_FOVEON         = 0x8000;
 
     /**
      * Converts a raw EXIF file source into the backed enum.

--- a/tests/Value/Enum/EnumMappingTest.php
+++ b/tests/Value/Enum/EnumMappingTest.php
@@ -17,7 +17,6 @@ use MagicSunday\ImageMeta\Value\Enum\DepthFormat;
 use MagicSunday\ImageMeta\Value\Enum\DepthMeasureType;
 use MagicSunday\ImageMeta\Value\Enum\DepthUnits;
 use MagicSunday\ImageMeta\Value\Enum\ExposureMode;
-use MagicSunday\ImageMeta\Value\Enum\FileSource;
 use MagicSunday\ImageMeta\Value\Enum\GainControl;
 use MagicSunday\ImageMeta\Value\Enum\Photometric;
 use MagicSunday\ImageMeta\Value\Enum\PlanarConfiguration;
@@ -59,8 +58,10 @@ final class EnumMappingTest extends TestCase
         self::assertSame(ExposureMode::AUTO_BRACKET, ExposureMode::fromExifValue(2));
         self::assertSame(GainControl::HIGH_GAIN_UP, GainControl::fromExifValue(2));
         self::assertSame(SubjectDistanceRange::MACRO, SubjectDistanceRange::fromExifValue(SubjectDistanceRange::MACRO->value));
-        self::assertSame(FileSource::DIGITAL_CAMERA, FileSource::fromExifValue(3));
-        self::assertSame(FileSource::SIGMA_FOVEON, FileSource::fromExifValue(0x8000));
+        self::assertSame(
+            \MagicSunday\ImageMeta\Value\Enum\FileSource::DIGITAL_CAMERA,
+            \MagicSunday\ImageMeta\Value\Enum\FileSource::fromExifValue(3),
+        );
         self::assertSame(SensingMethod::COLOR_SEQUENTIAL_LINEAR, SensingMethod::fromExifValue(8));
         self::assertSame(CompositeImage::CAPTURED_WHILE_SHOOTING, CompositeImage::fromExifValue(3));
         self::assertSame(DepthFormat::INVERSE, DepthFormat::fromExifValue(2));


### PR DESCRIPTION
## Summary
- remove the legacy SIGMA_FOVEON enum case from FileSource
- update the enum mapping test to stop expecting the removed case

## Testing
- composer ci:test:php:unit
- composer ci:test:php:unit:coverage *(fails: No code coverage driver available)*
- composer ci:test:php:phpstan *(fails: Existing 65 errors in phpstan analyze)*
- composer ci:test:php:cgl *(fails: formatting diffs reported in ExifTagResolver)*

------
https://chatgpt.com/codex/tasks/task_e_68fb24a7436883238fe031643eec0890