### PR TITLE
fix: prune non-EXIF photometric variants

### DIFF
--- a/src/Curate/Resolver/ExifTagResolver.php
+++ b/src/Curate/Resolver/ExifTagResolver.php
@@ -796,13 +796,13 @@ final readonly class ExifTagResolver
     private function sensitivityTagPriority(int $type): array
     {
         return match ($type) {
-            1 => [ExifTag::STANDARD_OUTPUT_SENSITIVITY],
-            2 => [ExifTag::RECOMMENDED_EXPOSURE_INDEX],
-            3 => [ExifTag::ISO_SPEED],
-            4 => [ExifTag::STANDARD_OUTPUT_SENSITIVITY, ExifTag::RECOMMENDED_EXPOSURE_INDEX],
-            5 => [ExifTag::STANDARD_OUTPUT_SENSITIVITY, ExifTag::ISO_SPEED],
-            6 => [ExifTag::RECOMMENDED_EXPOSURE_INDEX, ExifTag::ISO_SPEED],
-            7 => [ExifTag::STANDARD_OUTPUT_SENSITIVITY, ExifTag::RECOMMENDED_EXPOSURE_INDEX, ExifTag::ISO_SPEED],
+            1       => [ExifTag::STANDARD_OUTPUT_SENSITIVITY],
+            2       => [ExifTag::RECOMMENDED_EXPOSURE_INDEX],
+            3       => [ExifTag::ISO_SPEED],
+            4       => [ExifTag::STANDARD_OUTPUT_SENSITIVITY, ExifTag::RECOMMENDED_EXPOSURE_INDEX],
+            5       => [ExifTag::STANDARD_OUTPUT_SENSITIVITY, ExifTag::ISO_SPEED],
+            6       => [ExifTag::RECOMMENDED_EXPOSURE_INDEX, ExifTag::ISO_SPEED],
+            7       => [ExifTag::STANDARD_OUTPUT_SENSITIVITY, ExifTag::RECOMMENDED_EXPOSURE_INDEX, ExifTag::ISO_SPEED],
             default => [],
         };
     }

--- a/src/Value/Enum/Photometric.php
+++ b/src/Value/Enum/Photometric.php
@@ -16,19 +16,15 @@ namespace MagicSunday\ImageMeta\Value\Enum;
  */
 enum Photometric: int
 {
-    case WHITE_IS_ZERO      = 0;
-    case BLACK_IS_ZERO      = 1;
-    case RGB                = 2;
-    case PALETTE_COLOR      = 3;
-    case TRANSPARENCY_MASK  = 4;
-    case CMYK               = 5;
-    case YCBCR              = 6;
-    case CIELAB             = 8;
-    case ICCLAB             = 9;
-    case COLOR_FILTER_ARRAY = 32803;
-    case LINEAR_RAW         = 34892;
-    case DEPTH_MAP          = 511;
-    case SEMANTIC_MASK      = 514;
+    case WHITE_IS_ZERO     = 0;
+    case BLACK_IS_ZERO     = 1;
+    case RGB               = 2;
+    case PALETTE_COLOR     = 3;
+    case TRANSPARENCY_MASK = 4;
+    case CMYK              = 5;
+    case YCBCR             = 6;
+    case CIELAB            = 8;
+    case ICCLAB            = 9;
 
     /**
      * Converts raw values into the backed enum instance.

--- a/tests/Value/Enum/EnumMappingTest.php
+++ b/tests/Value/Enum/EnumMappingTest.php
@@ -52,7 +52,6 @@ final class EnumMappingTest extends TestCase
         self::assertSame(Compression::JPEG, Compression::fromExifValue(7));
         self::assertSame(Compression::JPEG_XL, Compression::fromExifValue(34926));
         self::assertSame(Photometric::YCBCR, Photometric::fromExifValue(6));
-        self::assertSame(Photometric::DEPTH_MAP, Photometric::fromExifValue(511));
         self::assertSame(PlanarConfiguration::CHUNKY, PlanarConfiguration::fromExifValue(1));
         self::assertSame(ResolutionUnit::CENTIMETER, ResolutionUnit::fromExifValue(3));
         self::assertSame(YCbCrPositioning::CO_SITED, YCbCrPositioning::fromExifValue(2));


### PR DESCRIPTION
## Summary
- remove the non-EXIF photometric cases from the Photometric enum
- update the enum mapping test to match the pruned photometric cases
- run php-cs-fixer on ExifTagResolver to satisfy the coding standards suite

## Testing
- composer ci:test:php:unit
- composer ci:test:php:unit:coverage *(fails: No code coverage driver available)*
- composer ci:test:php:phpstan *(fails: 65 strict rules findings in existing code)*
- composer ci:test:php:cgl

------
https://chatgpt.com/codex/tasks/task_e_68fb249f181883239e0eddbf00c7fabc