### PR TITLE
Ensure Photometric enum ignores non-EXIF cases

### DIFF
--- a/src/Value/Enum/Photometric.php
+++ b/src/Value/Enum/Photometric.php
@@ -12,7 +12,7 @@ declare(strict_types=1);
 namespace MagicSunday\ImageMeta\Value\Enum;
 
 /**
- * Enumerates TIFF/EXIF photometric interpretations.
+ * Enumerates TIFF/EXIF photometric interpretations defined in EXIF 3.0.
  */
 enum Photometric: int
 {

--- a/tests/Value/Enum/EnumMappingTest.php
+++ b/tests/Value/Enum/EnumMappingTest.php
@@ -57,4 +57,14 @@ final class EnumMappingTest extends TestCase
         self::assertSame(SensingMethod::COLOR_SEQUENTIAL_LINEAR, SensingMethod::fromExifValue(8));
         self::assertSame(CompositeImage::CAPTURED_WHILE_SHOOTING, CompositeImage::fromExifValue(3));
     }
+
+    /**
+     * Ensures the enum does not expose values that are not defined by EXIF 3.0.
+     */
+    #[Test]
+    public function doesNotMapNonExif30PhotometricValues(): void
+    {
+        self::assertNull(Photometric::fromExifValue(511));
+        self::assertNull(Photometric::fromExifValue(514));
+    }
 }


### PR DESCRIPTION
## Summary
- clarify that the Photometric enum only represents EXIF 3.0 photometric interpretations
- add a PHPUnit regression test that asserts unsupported values such as 511 and 514 no longer map to enum cases

## Testing
- composer ci:test:php:unit
- composer ci:test:php:unit:coverage *(fails: Xdebug coverage driver not available in container)*
- composer ci:test:php:phpstan *(fails: existing project-level PHPStan findings)*
- composer ci:cgl


------
https://chatgpt.com/codex/tasks/task_e_68fb25c4211883239de28697dbc65676