### PR TITLE
Remove interoperability version tag from EXIF handling

### DIFF
--- a/src/Curate/Resolver/ExifTagResolver.php
+++ b/src/Curate/Resolver/ExifTagResolver.php
@@ -43,15 +43,12 @@ use MagicSunday\ImageMeta\Value\FlashInfo;
 
 use function array_map;
 use function array_values;
-use function bin2hex;
 use function count;
 use function is_array;
 use function is_float;
 use function is_int;
 use function is_string;
 use function ord;
-use function strlen;
-use function strtoupper;
 use function trim;
 
 /**
@@ -397,34 +394,6 @@ final readonly class ExifTagResolver
     public function interopIndex(): ?string
     {
         return $this->stringValue($this->document?->interopIfd, ExifTag::INTEROPERABILITY_INDEX);
-    }
-
-    /**
-     * Returns the interoperability version in printable form.
-     */
-    public function interopVersion(): ?string
-    {
-        $value = $this->stringValue($this->document?->interopIfd, ExifTag::INTEROPERABILITY_VERSION);
-        if ($value === null) {
-            return null;
-        }
-
-        $trimmed = trim($value, "\0");
-        if ($trimmed === '') {
-            return null;
-        }
-
-        $printable = true;
-        $length    = strlen($trimmed);
-        for ($i = 0; $i < $length; ++$i) {
-            $ord = ord($trimmed[$i]);
-            if ($ord < 0x20 || $ord > 0x7E) {
-                $printable = false;
-                break;
-            }
-        }
-
-        return $printable ? $trimmed : strtoupper(bin2hex($trimmed));
     }
 
     /**

--- a/src/Curate/StructuredMetadataBuilder.php
+++ b/src/Curate/StructuredMetadataBuilder.php
@@ -75,10 +75,7 @@ final class StructuredMetadataBuilder
         $xmpResolver       = new XmpResolver($xmpDocument);
         $quickTimeResolver = new QuickTimeResolver($metadata->quickTime);
 
-        $interop = new Interop(
-            index: $exifResolver->interopIndex(),
-            version: $exifResolver->interopVersion(),
-        );
+        $interop = new Interop(index: $exifResolver->interopIndex());
 
         $tiff = new TiffData(
             samplesPerPixel: $exifResolver->samplesPerPixel(),

--- a/src/Model/Exif/ExifTag.php
+++ b/src/Model/Exif/ExifTag.php
@@ -265,8 +265,6 @@ final readonly class ExifTag
     // Interoperability IFD
     public const int INTEROPERABILITY_INDEX = 0x0001;
 
-    public const int INTEROPERABILITY_VERSION = 0x0002;
-
     /**
      * Prevent instantiation of this constants-only utility class.
      */

--- a/src/Value/Interop.php
+++ b/src/Value/Interop.php
@@ -17,12 +17,9 @@ namespace MagicSunday\ImageMeta\Value;
 final readonly class Interop
 {
     /**
-     * @param string|null $index   Interoperability index identifier such as "R98".
-     * @param string|null $version Interoperability version string or hexadecimal representation.
+     * @param string|null $index Interoperability index identifier such as "R98".
      */
-    public function __construct(
-        public ?string $index,
-        public ?string $version,
-    ) {
+    public function __construct(public ?string $index)
+    {
     }
 }

--- a/tests/Curate/StructuredMetadataBuilderTest.php
+++ b/tests/Curate/StructuredMetadataBuilderTest.php
@@ -112,8 +112,7 @@ final class StructuredMetadataBuilderTest extends TestCase
         ]);
 
         $interopIfd = new Ifd([
-            ExifTag::INTEROPERABILITY_INDEX   => new IfdEntry(ExifTag::INTEROPERABILITY_INDEX, 2, 4, 'R98'),
-            ExifTag::INTEROPERABILITY_VERSION => new IfdEntry(ExifTag::INTEROPERABILITY_VERSION, 7, 4, '0100'),
+            ExifTag::INTEROPERABILITY_INDEX => new IfdEntry(ExifTag::INTEROPERABILITY_INDEX, 2, 4, 'R98'),
         ]);
 
         $exifDocument = new ExifDocument($ifd0, $exifIfd, null, $interopIfd, null);
@@ -137,8 +136,7 @@ final class StructuredMetadataBuilderTest extends TestCase
 
         $structured = (new StructuredMetadataBuilder())->build($metadata);
 
-        self::assertSame('R98', $structured->interop->index);
-        self::assertSame('0100', $structured->interop->version);
+        self::assertSame(['index' => 'R98'], get_object_vars($structured->interop));
 
         self::assertSame(Compression::JPEG, $structured->tiff->compression);
         self::assertSame(Photometric::YCBCR, $structured->tiff->photometric);
@@ -261,7 +259,7 @@ final class StructuredMetadataBuilderTest extends TestCase
 
         $structured = (new StructuredMetadataBuilder())->build($metadata);
 
-        self::assertNull($structured->interop->index);
+        self::assertSame(['index' => null], get_object_vars($structured->interop));
         self::assertNull($structured->tiff->compression);
         self::assertNull($structured->camera->make);
     }

--- a/tests/Model/Exif/ExifTagTest.php
+++ b/tests/Model/Exif/ExifTagTest.php
@@ -103,7 +103,6 @@ final class ExifTagTest extends TestCase
             'IMAGE_WIDTH'                    => 0x0100,
             'INTEROPERABILITY_IFD_POINTER'   => 0xA005,
             'INTEROPERABILITY_INDEX'         => 0x0001,
-            'INTEROPERABILITY_VERSION'       => 0x0002,
             'ISO_SPEED'                      => 0x8833,
             'LENS_INFO'                      => 0xA432,
             'LENS_MAKE'                      => 0xA433,

--- a/tests/Parse/Tiff/TiffExifReaderTest.php
+++ b/tests/Parse/Tiff/TiffExifReaderTest.php
@@ -225,6 +225,7 @@ final class TiffExifReaderTest extends TestCase
         $interop = $doc->interopIfd;
         self::assertNotNull($interop);
         self::assertSame('R98', $interop->get(0x0001)?->value);
+        self::assertNull($interop->get(0x0002));
 
         $gpsIfd = $doc->gpsIfd;
         self::assertNotNull($gpsIfd);
@@ -273,7 +274,8 @@ final class TiffExifReaderTest extends TestCase
 
         $interop = $doc->interopIfd;
         self::assertNotNull($interop);
-        self::assertSame('R98', $interop->get(0x0002)?->value);
+        self::assertSame('R98', $interop->get(0x0001)?->value);
+        self::assertNull($interop->get(0x0002));
 
         $gpsIfd = $doc->gpsIfd;
         self::assertNotNull($gpsIfd);
@@ -403,7 +405,12 @@ final class TiffExifReaderTest extends TestCase
         $blob .= str_repeat("\0", 16); // pad to 220
 
         $interopEntries = [
-            self::packBigTiffEntry(0x0002, 2, 4, self::inlineAsciiToInt('R98', 8)),
+            self::packBigTiffEntry(
+                ExifTag::INTEROPERABILITY_INDEX,
+                2,
+                4,
+                self::inlineAsciiToInt('R98', 8),
+            ),
         ];
         $blob .= pack('V', count($interopEntries)) . pack('V', 0) . implode('', $interopEntries) . pack('V', 0) . pack('V', 0);
 


### PR DESCRIPTION
## Summary
- drop the InteroperabilityVersion tag constant in favour of the EXIF 3.0 interoperability set
- simplify the interoperability resolver/value/builder usage to expose only the index field
- update TIFF reader fixtures and structured metadata tests to assert the absence of the deprecated version tag

## Testing
- composer ci:test:php:unit

------
https://chatgpt.com/codex/tasks/task_e_68fb2ba2516083239533cefb7c27a218