### PR TITLE
feat: expose extended GPS metadata

### DIFF
--- a/src/Curate/Resolver/ExifTagResolver.php
+++ b/src/Curate/Resolver/ExifTagResolver.php
@@ -654,11 +654,334 @@ final readonly class ExifTagResolver
     /**
      * Returns the GPS coordinates as an array of floats.
      *
-     * @return array{lat:?float,lon:?float,alt:?float}
+     * @return array{
+     *     lat:?float,
+     *     lon:?float,
+     *     alt:?float,
+     *     version:?string,
+     *     satellites:?string,
+     *     status:?string,
+     *     measure_mode:?string,
+     *     dop:?float,
+     *     speed_ref:?string,
+     *     speed_ms:?float,
+     *     track_ref:?string,
+     *     track:?float,
+     *     img_direction_ref:?string,
+     *     img_direction:?float,
+     *     map_datum:?string,
+     *     dest_lat_ref:?string,
+     *     dest_lat:?float,
+     *     dest_lon_ref:?string,
+     *     dest_lon:?float,
+     *     dest_bearing_ref:?string,
+     *     dest_bearing:?float,
+     *     dest_distance_ref:?string,
+     *     dest_distance_m:?float,
+     *     processing_method:?string,
+     *     area_information:?string,
+     *     date:?string,
+     *     time:?string,
+     *     timestamp:?DateTimeImmutable,
+     *     differential:?int,
+     *     h_positioning_error:?float
+     * }
      */
     public function gps(): array
     {
-        return $this->document?->gps() ?? ['lat' => null, 'lon' => null, 'alt' => null];
+        return $this->document instanceof ExifDocument
+            ? $this->document->gps()
+            : ExifValueConverters::emptyGpsResult();
+    }
+
+    /**
+     * Returns the GPS date stamp in ISO 8601 calendar format.
+     */
+    public function gpsDate(): ?string
+    {
+        $value = $this->gpsField('date');
+
+        return is_string($value) ? $value : null;
+    }
+
+    /**
+     * Returns the GPS time stamp in HH:MM:SS(.fff) format.
+     */
+    public function gpsTime(): ?string
+    {
+        $value = $this->gpsField('time');
+
+        return is_string($value) ? $value : null;
+    }
+
+    /**
+     * Returns the combined GPS timestamp as a UTC DateTime instance.
+     */
+    public function gpsTimestamp(): ?DateTimeImmutable
+    {
+        $value = $this->gpsField('timestamp');
+
+        return $value instanceof DateTimeImmutable ? $value : null;
+    }
+
+    /**
+     * Returns the GPS version identifier string.
+     */
+    public function gpsVersion(): ?string
+    {
+        $value = $this->gpsField('version');
+
+        return is_string($value) ? $value : null;
+    }
+
+    /**
+     * Returns the reported GPS satellites description.
+     */
+    public function gpsSatellites(): ?string
+    {
+        $value = $this->gpsField('satellites');
+
+        return is_string($value) ? $value : null;
+    }
+
+    /**
+     * Returns the GPS receiver status.
+     */
+    public function gpsStatus(): ?string
+    {
+        $value = $this->gpsField('status');
+
+        return is_string($value) ? $value : null;
+    }
+
+    /**
+     * Returns the GPS measurement mode description.
+     */
+    public function gpsMeasureMode(): ?string
+    {
+        $value = $this->gpsField('measure_mode');
+
+        return is_string($value) ? $value : null;
+    }
+
+    /**
+     * Returns the GPS dilution of precision value.
+     */
+    public function gpsDop(): ?float
+    {
+        $value = $this->gpsField('dop');
+
+        return is_float($value) ? $value : (is_int($value) ? (float) $value : null);
+    }
+
+    /**
+     * Returns the GPS speed reference character.
+     */
+    public function gpsSpeedRef(): ?string
+    {
+        $value = $this->gpsField('speed_ref');
+
+        return is_string($value) ? $value : null;
+    }
+
+    /**
+     * Returns the GPS ground speed converted to metres per second.
+     */
+    public function gpsSpeed(): ?float
+    {
+        $value = $this->gpsField('speed_ms');
+
+        return is_float($value) ? $value : (is_int($value) ? (float) $value : null);
+    }
+
+    /**
+     * Returns the current track reference (true or magnetic).
+     */
+    public function gpsTrackRef(): ?string
+    {
+        $value = $this->gpsField('track_ref');
+
+        return is_string($value) ? $value : null;
+    }
+
+    /**
+     * Returns the movement track in degrees.
+     */
+    public function gpsTrack(): ?float
+    {
+        $value = $this->gpsField('track');
+
+        return is_float($value) ? $value : (is_int($value) ? (float) $value : null);
+    }
+
+    /**
+     * Returns the image direction reference (true or magnetic).
+     */
+    public function gpsImgDirectionRef(): ?string
+    {
+        $value = $this->gpsField('img_direction_ref');
+
+        return is_string($value) ? $value : null;
+    }
+
+    /**
+     * Returns the camera image direction in degrees.
+     */
+    public function gpsImgDirection(): ?float
+    {
+        $value = $this->gpsField('img_direction');
+
+        return is_float($value) ? $value : (is_int($value) ? (float) $value : null);
+    }
+
+    /**
+     * Returns the map datum string when present.
+     */
+    public function gpsMapDatum(): ?string
+    {
+        $value = $this->gpsField('map_datum');
+
+        return is_string($value) ? $value : null;
+    }
+
+    /**
+     * Returns the destination latitude reference (N/S).
+     */
+    public function gpsDestinationLatitudeRef(): ?string
+    {
+        $value = $this->gpsField('dest_lat_ref');
+
+        return is_string($value) ? $value : null;
+    }
+
+    /**
+     * Returns the destination latitude in decimal degrees.
+     */
+    public function gpsDestinationLatitude(): ?float
+    {
+        $value = $this->gpsField('dest_lat');
+
+        return is_float($value) ? $value : (is_int($value) ? (float) $value : null);
+    }
+
+    /**
+     * Returns the destination longitude reference (E/W).
+     */
+    public function gpsDestinationLongitudeRef(): ?string
+    {
+        $value = $this->gpsField('dest_lon_ref');
+
+        return is_string($value) ? $value : null;
+    }
+
+    /**
+     * Returns the destination longitude in decimal degrees.
+     */
+    public function gpsDestinationLongitude(): ?float
+    {
+        $value = $this->gpsField('dest_lon');
+
+        return is_float($value) ? $value : (is_int($value) ? (float) $value : null);
+    }
+
+    /**
+     * Returns the destination bearing reference (true or magnetic).
+     */
+    public function gpsDestinationBearingRef(): ?string
+    {
+        $value = $this->gpsField('dest_bearing_ref');
+
+        return is_string($value) ? $value : null;
+    }
+
+    /**
+     * Returns the destination bearing in degrees.
+     */
+    public function gpsDestinationBearing(): ?float
+    {
+        $value = $this->gpsField('dest_bearing');
+
+        return is_float($value) ? $value : (is_int($value) ? (float) $value : null);
+    }
+
+    /**
+     * Returns the destination distance reference (kilometres, miles or nautical miles).
+     */
+    public function gpsDestinationDistanceRef(): ?string
+    {
+        $value = $this->gpsField('dest_distance_ref');
+
+        return is_string($value) ? $value : null;
+    }
+
+    /**
+     * Returns the destination distance converted to metres.
+     */
+    public function gpsDestinationDistance(): ?float
+    {
+        $value = $this->gpsField('dest_distance_m');
+
+        return is_float($value) ? $value : (is_int($value) ? (float) $value : null);
+    }
+
+    /**
+     * Returns the GPS processing method description.
+     */
+    public function gpsProcessingMethod(): ?string
+    {
+        $value = $this->gpsField('processing_method');
+
+        return is_string($value) ? $value : null;
+    }
+
+    /**
+     * Returns additional GPS area information if available.
+     */
+    public function gpsAreaInformation(): ?string
+    {
+        $value = $this->gpsField('area_information');
+
+        return is_string($value) ? $value : null;
+    }
+
+    /**
+     * Returns the GPS differential correction indicator.
+     */
+    public function gpsDifferential(): ?int
+    {
+        $value = $this->gpsField('differential');
+
+        if (is_int($value)) {
+            return $value;
+        }
+
+        if (is_float($value)) {
+            return (int) round($value);
+        }
+
+        return null;
+    }
+
+    /**
+     * Returns the reported horizontal positioning error in metres.
+     */
+    public function gpsHorizontalPositioningError(): ?float
+    {
+        $value = $this->gpsField('h_positioning_error');
+
+        return is_float($value) ? $value : (is_int($value) ? (float) $value : null);
+    }
+
+    /**
+     * Returns a single field from the cached GPS metadata map.
+     *
+     * @return mixed
+     */
+    private function gpsField(string $key): mixed
+    {
+        $gps = $this->gps();
+
+        return $gps[$key] ?? null;
     }
 
     /**

--- a/src/Model/Exif/ExifDocument.php
+++ b/src/Model/Exif/ExifDocument.php
@@ -360,14 +360,45 @@ final readonly class ExifDocument
     }
 
     /**
-     * Returns the parsed GPS coordinates if present.
+     * Returns the parsed GPS metadata extracted from the GPS IFD.
      *
-     * @return array{lat:?float, lon:?float, alt:?float}
+     * @return array{
+     *     lat:?float,
+     *     lon:?float,
+     *     alt:?float,
+     *     version:?string,
+     *     satellites:?string,
+     *     status:?string,
+     *     measure_mode:?string,
+     *     dop:?float,
+     *     speed_ref:?string,
+     *     speed_ms:?float,
+     *     track_ref:?string,
+     *     track:?float,
+     *     img_direction_ref:?string,
+     *     img_direction:?float,
+     *     map_datum:?string,
+     *     dest_lat_ref:?string,
+     *     dest_lat:?float,
+     *     dest_lon_ref:?string,
+     *     dest_lon:?float,
+     *     dest_bearing_ref:?string,
+     *     dest_bearing:?float,
+     *     dest_distance_ref:?string,
+     *     dest_distance_m:?float,
+     *     processing_method:?string,
+     *     area_information:?string,
+     *     date:?string,
+     *     time:?string,
+     *     timestamp:?DateTimeImmutable,
+     *     differential:?int,
+     *     h_positioning_error:?float
+     * }
      */
     public function gps(): array
     {
         if (!$this->gpsIfd instanceof Ifd) {
-            return ['lat' => null, 'lon' => null, 'alt' => null];
+            return ValueConverters::emptyGpsResult();
         }
 
         return ValueConverters::gpsFromIfd($this->gpsIfd);

--- a/src/Model/Exif/ValueConverters.php
+++ b/src/Model/Exif/ValueConverters.php
@@ -11,13 +11,17 @@ declare(strict_types=1);
 
 namespace MagicSunday\ImageMeta\Model\Exif;
 
+use DateTimeImmutable;
+use DateTimeZone;
 use MagicSunday\ImageMeta\Value\FlashInfo;
 
 use function abs;
+use function array_map;
 use function count;
 use function ctype_digit;
 use function explode;
 use function floor;
+use function implode;
 use function is_float;
 use function is_int;
 use function is_numeric;
@@ -25,6 +29,7 @@ use function is_string;
 use function ltrim;
 use function preg_match;
 use function round;
+use function rtrim;
 use function sprintf;
 use function str_contains;
 use function str_replace;
@@ -135,6 +140,39 @@ final readonly class ValueConverters
     }
 
     /**
+     * Converts a GPS destination distance to metres based on the reference unit.
+     *
+     * @param string|null                                                         $ref   Distance reference (K, M or N).
+     * @param int|float|string|ExifRational|ExifRationalList|ExifNumericList|null $value The measured value.
+     */
+    public static function gpsDistanceToMetres(
+        ?string $ref,
+        int|float|string|ExifRational|ExifRationalList|ExifNumericList|null $value,
+    ): ?float {
+        if (!is_string($ref)) {
+            return null;
+        }
+
+        $numeric = self::rationalToFloat($value);
+        if ($numeric === null && is_string($value) && is_numeric($value)) {
+            $numeric = (float) $value;
+        }
+
+        if ($numeric === null) {
+            return null;
+        }
+
+        $normalizedRef = strtoupper(trim($ref));
+
+        return match ($normalizedRef) {
+            'K'     => $numeric * 1000.0,
+            'M'     => $numeric * 1609.344,
+            'N'     => $numeric * 1852.0,
+            default => null,
+        };
+    }
+
+    /**
      * Converts the EXIF flash bit field into a typed value object.
      *
      * @param int|float|string|ExifRational|ExifRationalList|ExifNumericList|null $value Flash tag value representation.
@@ -213,14 +251,119 @@ final readonly class ValueConverters
     }
 
     /**
-     * Extracts GPS latitude, longitude and altitude information from an IFD.
+     * Returns the default GPS metadata structure with all keys initialised to null.
+     *
+     * @return array{
+     *     lat:?float,
+     *     lon:?float,
+     *     alt:?float,
+     *     version:?string,
+     *     satellites:?string,
+     *     status:?string,
+     *     measure_mode:?string,
+     *     dop:?float,
+     *     speed_ref:?string,
+     *     speed_ms:?float,
+     *     track_ref:?string,
+     *     track:?float,
+     *     img_direction_ref:?string,
+     *     img_direction:?float,
+     *     map_datum:?string,
+     *     dest_lat_ref:?string,
+     *     dest_lat:?float,
+     *     dest_lon_ref:?string,
+     *     dest_lon:?float,
+     *     dest_bearing_ref:?string,
+     *     dest_bearing:?float,
+     *     dest_distance_ref:?string,
+     *     dest_distance_m:?float,
+     *     processing_method:?string,
+     *     area_information:?string,
+     *     date:?string,
+     *     time:?string,
+     *     timestamp:?DateTimeImmutable,
+     *     differential:?int,
+     *     h_positioning_error:?float
+     * }
+     */
+    public static function emptyGpsResult(): array
+    {
+        return [
+            'lat'                   => null,
+            'lon'                   => null,
+            'alt'                   => null,
+            'version'               => null,
+            'satellites'            => null,
+            'status'                => null,
+            'measure_mode'          => null,
+            'dop'                   => null,
+            'speed_ref'             => null,
+            'speed_ms'              => null,
+            'track_ref'             => null,
+            'track'                 => null,
+            'img_direction_ref'     => null,
+            'img_direction'         => null,
+            'map_datum'             => null,
+            'dest_lat_ref'          => null,
+            'dest_lat'              => null,
+            'dest_lon_ref'          => null,
+            'dest_lon'              => null,
+            'dest_bearing_ref'      => null,
+            'dest_bearing'          => null,
+            'dest_distance_ref'     => null,
+            'dest_distance_m'       => null,
+            'processing_method'     => null,
+            'area_information'      => null,
+            'date'                  => null,
+            'time'                  => null,
+            'timestamp'             => null,
+            'differential'          => null,
+            'h_positioning_error'   => null,
+        ];
+    }
+
+    /**
+     * Extracts GPS metadata including position, navigation and timing information from an IFD.
      *
      * @param Ifd $gps The GPS IFD containing coordinate tags.
      *
-     * @return array{lat:?float,lon:?float,alt:?float}
+     * @return array{
+     *     lat:?float,
+     *     lon:?float,
+     *     alt:?float,
+     *     version:?string,
+     *     satellites:?string,
+     *     status:?string,
+     *     measure_mode:?string,
+     *     dop:?float,
+     *     speed_ref:?string,
+     *     speed_ms:?float,
+     *     track_ref:?string,
+     *     track:?float,
+     *     img_direction_ref:?string,
+     *     img_direction:?float,
+     *     map_datum:?string,
+     *     dest_lat_ref:?string,
+     *     dest_lat:?float,
+     *     dest_lon_ref:?string,
+     *     dest_lon:?float,
+     *     dest_bearing_ref:?string,
+     *     dest_bearing:?float,
+     *     dest_distance_ref:?string,
+     *     dest_distance_m:?float,
+     *     processing_method:?string,
+     *     area_information:?string,
+     *     date:?string,
+     *     time:?string,
+     *     timestamp:?DateTimeImmutable,
+     *     differential:?int,
+     *     h_positioning_error:?float
+     * }
      */
     public static function gpsFromIfd(Ifd $gps): array
     {
+        $result = self::emptyGpsResult();
+
         $latRefEntry = $gps->get(ExifTag::GPS_LATITUDE_REF);
         $latValEntry = $gps->get(ExifTag::GPS_LATITUDE);
         $lonRefEntry = $gps->get(ExifTag::GPS_LONGITUDE_REF);
@@ -234,10 +377,9 @@ final readonly class ValueConverters
         $latPairs = $latVal instanceof ExifRationalList ? $latVal : null;
         $lonPairs = $lonVal instanceof ExifRationalList ? $lonVal : null;
 
-        $lat = self::dmsToFloat(is_string($latRef) ? $latRef : null, $latPairs);
-        $lon = self::dmsToFloat(is_string($lonRef) ? $lonRef : null, $lonPairs);
+        $result['lat'] = self::dmsToFloat(is_string($latRef) ? trim($latRef) : null, $latPairs);
+        $result['lon'] = self::dmsToFloat(is_string($lonRef) ? trim($lonRef) : null, $lonPairs);
 
-        $alt      = null;
         $altEntry = $gps->get(ExifTag::GPS_ALTITUDE);
         if ($altEntry instanceof IfdEntry && $altEntry->value instanceof ExifRational) {
             $alt = self::rationalToFloat($altEntry->value);
@@ -249,9 +391,101 @@ final readonly class ValueConverters
                     $alt = -$alt;
                 }
             }
+
+            $result['alt'] = $alt;
         }
 
-        return ['lat' => $lat, 'lon' => $lon, 'alt' => $alt];
+        $versionEntry     = $gps->get(ExifTag::GPS_VERSION_ID);
+        $satellitesEntry  = $gps->get(ExifTag::GPS_SATELLITES);
+        $statusEntry      = $gps->get(ExifTag::GPS_STATUS);
+        $measureEntry     = $gps->get(ExifTag::GPS_MEASURE_MODE);
+        $dopEntry         = $gps->get(ExifTag::GPS_DOP);
+        $speedRefEntry    = $gps->get(ExifTag::GPS_SPEED_REF);
+        $speedEntry       = $gps->get(ExifTag::GPS_SPEED);
+        $trackRefEntry    = $gps->get(ExifTag::GPS_TRACK_REF);
+        $trackEntry       = $gps->get(ExifTag::GPS_TRACK);
+        $imgDirRefEntry   = $gps->get(ExifTag::GPS_IMG_DIRECTION_REF);
+        $imgDirEntry      = $gps->get(ExifTag::GPS_IMG_DIRECTION);
+        $mapDatumEntry    = $gps->get(ExifTag::GPS_MAP_DATUM);
+        $destLatRefEntry  = $gps->get(ExifTag::GPS_DEST_LATITUDE_REF);
+        $destLatEntry     = $gps->get(ExifTag::GPS_DEST_LATITUDE);
+        $destLonRefEntry  = $gps->get(ExifTag::GPS_DEST_LONGITUDE_REF);
+        $destLonEntry     = $gps->get(ExifTag::GPS_DEST_LONGITUDE);
+        $destBearRefEntry = $gps->get(ExifTag::GPS_DEST_BEARING_REF);
+        $destBearEntry    = $gps->get(ExifTag::GPS_DEST_BEARING);
+        $destDistRefEntry = $gps->get(ExifTag::GPS_DEST_DISTANCE_REF);
+        $destDistEntry    = $gps->get(ExifTag::GPS_DEST_DISTANCE);
+        $processEntry     = $gps->get(ExifTag::GPS_PROCESSING_METHOD);
+        $areaEntry        = $gps->get(ExifTag::GPS_AREA_INFORMATION);
+        $dateEntry        = $gps->get(ExifTag::GPS_DATE_STAMP);
+        $timeEntry        = $gps->get(ExifTag::GPS_TIME_STAMP);
+
+        $result['version']    = self::formatGpsVersion($versionEntry?->value);
+        $result['satellites'] = self::sanitizeString($satellitesEntry?->value);
+        $result['status']     = self::sanitizeString($statusEntry?->value);
+        $result['measure_mode'] = self::sanitizeString($measureEntry?->value);
+        $result['dop']          = self::rationalToFloat($dopEntry?->value);
+
+        $speedRefValue        = $speedRefEntry?->value;
+        $speedRef             = is_string($speedRefValue) ? strtoupper(trim($speedRefValue)) : null;
+        $result['speed_ref']  = $speedRef;
+        $result['speed_ms']   = self::gpsSpeedToMs($speedRef, $speedEntry?->value);
+
+        $trackRefValue       = $trackRefEntry?->value;
+        $result['track_ref'] = is_string($trackRefValue) ? strtoupper(trim($trackRefValue)) : null;
+        $result['track']     = self::rationalToFloat($trackEntry?->value);
+
+        $imgDirRefValue             = $imgDirRefEntry?->value;
+        $result['img_direction_ref'] = is_string($imgDirRefValue) ? strtoupper(trim($imgDirRefValue)) : null;
+        $result['img_direction']     = self::rationalToFloat($imgDirEntry?->value);
+
+        $result['map_datum'] = self::sanitizeString($mapDatumEntry?->value);
+
+        $destLatRefValue        = $destLatRefEntry?->value;
+        $destLatVal             = $destLatEntry?->value;
+        $destLatPairs           = $destLatVal instanceof ExifRationalList ? $destLatVal : null;
+        $result['dest_lat_ref'] = is_string($destLatRefValue) ? strtoupper(trim($destLatRefValue)) : null;
+        $result['dest_lat']     = self::dmsToFloat($result['dest_lat_ref'], $destLatPairs);
+
+        $destLonRefValue        = $destLonRefEntry?->value;
+        $destLonVal             = $destLonEntry?->value;
+        $destLonPairs           = $destLonVal instanceof ExifRationalList ? $destLonVal : null;
+        $result['dest_lon_ref'] = is_string($destLonRefValue) ? strtoupper(trim($destLonRefValue)) : null;
+        $result['dest_lon']     = self::dmsToFloat($result['dest_lon_ref'], $destLonPairs);
+
+        $destBearingRefValue        = $destBearRefEntry?->value;
+        $result['dest_bearing_ref'] = is_string($destBearingRefValue) ? strtoupper(trim($destBearingRefValue)) : null;
+        $result['dest_bearing']     = self::rationalToFloat($destBearEntry?->value);
+
+        $destDistanceRefValue        = $destDistRefEntry?->value;
+        $result['dest_distance_ref'] = is_string($destDistanceRefValue) ? strtoupper(trim($destDistanceRefValue)) : null;
+        $result['dest_distance_m']   = self::gpsDistanceToMetres($result['dest_distance_ref'], $destDistEntry?->value);
+
+        $result['processing_method'] = self::decodeUndefinedString($processEntry?->value);
+        $result['area_information']  = self::decodeUndefinedString($areaEntry?->value);
+
+        $result['date'] = self::normalizeGpsDate($dateEntry?->value);
+        $timeParts       = $timeEntry instanceof IfdEntry && $timeEntry->value instanceof ExifRationalList
+            ? self::parseGpsTime($timeEntry->value)
+            : null;
+        $result['time']      = self::formatGpsTime($timeParts);
+        $result['timestamp'] = self::combineGpsDateTime($result['date'], $timeParts);
+
+        $diffEntry = $gps->get(ExifTag::GPS_DIFFERENTIAL);
+        $diffValue = $diffEntry?->value;
+        if ($diffValue instanceof ExifNumericList) {
+            $diffValue = $diffValue->values[0] ?? null;
+        }
+        if (is_int($diffValue)) {
+            $result['differential'] = $diffValue;
+        } elseif (is_float($diffValue)) {
+            $result['differential'] = (int) round($diffValue);
+        }
+
+        $hPositionEntry = $gps->get(ExifTag::GPS_H_POSITIONING_ERROR);
+        $result['h_positioning_error'] = self::rationalToFloat($hPositionEntry?->value);
+
+        return $result;
     }
 
     /**
@@ -279,6 +513,212 @@ final readonly class ValueConverters
         $sign = ($ref === 'S' || $ref === 'W') ? -1.0 : 1.0;
 
         return $sign * ($deg + $min / 60.0 + $sec / 3600.0);
+    }
+
+    /**
+     * Converts a GPS version payload into a dotted string.
+     *
+     * @param mixed $value Raw value extracted from the IFD entry.
+     */
+    private static function formatGpsVersion(mixed $value): ?string
+    {
+        if ($value instanceof ExifNumericList) {
+            $components = array_map(static fn (int|float $component): int => (int) $component, $value->values);
+
+            return implode('.', $components);
+        }
+
+        if (is_string($value)) {
+            $value = trim(str_replace("\0", '', $value));
+            if ($value === '') {
+                return null;
+            }
+
+            return $value;
+        }
+
+        if (is_int($value)) {
+            return (string) $value;
+        }
+
+        if (is_float($value)) {
+            return (string) $value;
+        }
+
+        return null;
+    }
+
+    /**
+     * Normalises ASCII-like EXIF strings by trimming whitespace and null padding.
+     *
+     * @param mixed $value Raw value extracted from the IFD entry.
+     */
+    private static function sanitizeString(mixed $value): ?string
+    {
+        if (!is_string($value)) {
+            return null;
+        }
+
+        $clean = trim(str_replace("\0", '', $value));
+
+        return $clean === '' ? null : $clean;
+    }
+
+    /**
+     * Decodes undefined GPS ASCII strings with optional encoding prefixes.
+     *
+     * @param mixed $value Raw value extracted from the IFD entry.
+     */
+    private static function decodeUndefinedString(mixed $value): ?string
+    {
+        if (!is_string($value)) {
+            return null;
+        }
+
+        $data = $value;
+        $prefixes = [
+            "ASCII\0\0\0",
+            "UNICODE\0",
+            "JIS\0\0\0\0\0",
+        ];
+
+        foreach ($prefixes as $prefix) {
+            if (str_starts_with($data, $prefix)) {
+                $data = substr($data, strlen($prefix));
+                break;
+            }
+        }
+
+        $data = str_replace("\0", '', $data);
+        $data = trim($data);
+
+        return $data === '' ? null : $data;
+    }
+
+    /**
+     * Normalises a GPS date stamp into an ISO 8601 calendar date.
+     *
+     * @param mixed $value Raw value extracted from the IFD entry.
+     */
+    private static function normalizeGpsDate(mixed $value): ?string
+    {
+        if (!is_string($value)) {
+            return null;
+        }
+
+        $value = trim(str_replace("\0", '', $value));
+        if ($value === '') {
+            return null;
+        }
+
+        if (!preg_match('/^\d{4}:\d{2}:\d{2}$/', $value)) {
+            return null;
+        }
+
+        return str_replace(':', '-', $value);
+    }
+
+    /**
+     * Extracts hour, minute and second components from a GPS time stamp list.
+     *
+     * @return array{hours:int, minutes:int, seconds:float}|null
+     */
+    private static function parseGpsTime(ExifRationalList $value): ?array
+    {
+        if (count($value->values) < 3) {
+            return null;
+        }
+
+        $hours   = self::rationalToFloat($value->values[0]);
+        $minutes = self::rationalToFloat($value->values[1]);
+        $seconds = self::rationalToFloat($value->values[2]);
+
+        if ($hours === null || $minutes === null || $seconds === null) {
+            return null;
+        }
+
+        return [
+            'hours'   => (int) floor($hours),
+            'minutes' => (int) floor($minutes),
+            'seconds' => $seconds,
+        ];
+    }
+
+    /**
+     * Formats GPS time components into a human readable HH:MM:SS(.ffffff) string.
+     *
+     * @param array{hours:int, minutes:int, seconds:float}|null $timeParts
+     */
+    private static function formatGpsTime(?array $timeParts): ?string
+    {
+        if ($timeParts === null) {
+            return null;
+        }
+
+        $secondsFloat = $timeParts['seconds'];
+        $secondsInt   = (int) floor($secondsFloat);
+        $fraction     = $secondsFloat - $secondsInt;
+        $microseconds = (int) round($fraction * 1_000_000);
+
+        if ($microseconds >= 1_000_000) {
+            $secondsInt++;
+            $microseconds -= 1_000_000;
+        }
+
+        $time = sprintf('%02d:%02d:%02d', $timeParts['hours'], $timeParts['minutes'], $secondsInt);
+
+        if ($microseconds > 0) {
+            $micro = rtrim(sprintf('%06d', $microseconds), '0');
+            if ($micro === '') {
+                $micro = '0';
+            }
+
+            $time .= '.' . $micro;
+        }
+
+        return $time;
+    }
+
+    /**
+     * Combines a GPS date and time into a UTC timestamp.
+     *
+     * @param array{hours:int, minutes:int, seconds:float}|null $timeParts
+     */
+    private static function combineGpsDateTime(?string $date, ?array $timeParts): ?DateTimeImmutable
+    {
+        if ($date === null || $timeParts === null) {
+            return null;
+        }
+
+        $secondsFloat = $timeParts['seconds'];
+        $secondsInt   = (int) floor($secondsFloat);
+        $fraction     = $secondsFloat - $secondsInt;
+        $microseconds = (int) round($fraction * 1_000_000);
+
+        if ($microseconds >= 1_000_000) {
+            $secondsInt++;
+            $microseconds -= 1_000_000;
+        }
+
+        $timeString = sprintf('%02d:%02d:%02d', $timeParts['hours'], $timeParts['minutes'], $secondsInt);
+        $format     = 'Y-m-d H:i:s';
+
+        if ($microseconds > 0) {
+            $timeString .= sprintf('.%06d', $microseconds);
+            $format     .= '.u';
+        }
+
+        $dateTime = DateTimeImmutable::createFromFormat(
+            $format,
+            $date . ' ' . $timeString,
+            new DateTimeZone('UTC'),
+        );
+
+        if ($dateTime === false) {
+            return null;
+        }
+
+        return $dateTime;
     }
 
     /**

--- a/tests/Curate/Resolver/ExifTagResolverTest.php
+++ b/tests/Curate/Resolver/ExifTagResolverTest.php
@@ -1,0 +1,168 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\ImageMeta\Tests\Curate\Resolver;
+
+use DateTimeImmutable;
+use MagicSunday\ImageMeta\Curate\Resolver\ExifTagResolver;
+use MagicSunday\ImageMeta\Model\Exif\ExifDocument;
+use MagicSunday\ImageMeta\Model\Exif\ExifNumericList;
+use MagicSunday\ImageMeta\Model\Exif\ExifRational;
+use MagicSunday\ImageMeta\Model\Exif\ExifRationalList;
+use MagicSunday\ImageMeta\Model\Exif\ExifTag;
+use MagicSunday\ImageMeta\Model\Exif\Ifd;
+use MagicSunday\ImageMeta\Model\Exif\IfdEntry;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\UsesClass;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \MagicSunday\ImageMeta\Curate\Resolver\ExifTagResolver
+ */
+#[CoversClass(ExifTagResolver::class)]
+#[UsesClass(ExifDocument::class)]
+#[UsesClass(Ifd::class)]
+#[UsesClass(IfdEntry::class)]
+#[UsesClass(ExifRational::class)]
+#[UsesClass(ExifRationalList::class)]
+#[UsesClass(ExifNumericList::class)]
+final class ExifTagResolverTest extends TestCase
+{
+    /**
+     * Ensures the resolver exposes the extended GPS metadata decoded from the GPS IFD.
+     */
+    #[Test]
+    public function exposesExtendedGpsMetadata(): void
+    {
+        $gpsIfd = new Ifd([
+            ExifTag::GPS_VERSION_ID        => new IfdEntry(ExifTag::GPS_VERSION_ID, 1, 4, [3, 0, 0, 0]),
+            ExifTag::GPS_LATITUDE_REF      => new IfdEntry(ExifTag::GPS_LATITUDE_REF, 2, 2, 'N'),
+            ExifTag::GPS_LATITUDE          => new IfdEntry(
+                ExifTag::GPS_LATITUDE,
+                5,
+                3,
+                new ExifRationalList([
+                    new ExifRational(51, 1),
+                    new ExifRational(30, 1),
+                    new ExifRational(0, 1),
+                ]),
+            ),
+            ExifTag::GPS_LONGITUDE_REF => new IfdEntry(ExifTag::GPS_LONGITUDE_REF, 2, 2, 'E'),
+            ExifTag::GPS_LONGITUDE     => new IfdEntry(
+                ExifTag::GPS_LONGITUDE,
+                5,
+                3,
+                new ExifRationalList([
+                    new ExifRational(8, 1),
+                    new ExifRational(30, 1),
+                    new ExifRational(0, 1),
+                ]),
+            ),
+            ExifTag::GPS_ALTITUDE_REF        => new IfdEntry(ExifTag::GPS_ALTITUDE_REF, 1, 1, 0),
+            ExifTag::GPS_ALTITUDE            => new IfdEntry(ExifTag::GPS_ALTITUDE, 5, 1, new ExifRational(150, 1)),
+            ExifTag::GPS_TIME_STAMP          => new IfdEntry(
+                ExifTag::GPS_TIME_STAMP,
+                5,
+                3,
+                new ExifRationalList([
+                    new ExifRational(12, 1),
+                    new ExifRational(34, 1),
+                    new ExifRational(56789, 1000),
+                ]),
+            ),
+            ExifTag::GPS_DATE_STAMP          => new IfdEntry(ExifTag::GPS_DATE_STAMP, 2, 10, '2024:05:06'),
+            ExifTag::GPS_SATELLITES          => new IfdEntry(ExifTag::GPS_SATELLITES, 2, 2, '05'),
+            ExifTag::GPS_STATUS              => new IfdEntry(ExifTag::GPS_STATUS, 2, 1, 'A'),
+            ExifTag::GPS_MEASURE_MODE        => new IfdEntry(ExifTag::GPS_MEASURE_MODE, 2, 1, '3'),
+            ExifTag::GPS_DOP                 => new IfdEntry(ExifTag::GPS_DOP, 5, 1, new ExifRational(25, 10)),
+            ExifTag::GPS_SPEED_REF           => new IfdEntry(ExifTag::GPS_SPEED_REF, 2, 1, 'K'),
+            ExifTag::GPS_SPEED               => new IfdEntry(ExifTag::GPS_SPEED, 5, 1, new ExifRational(72000, 1000)),
+            ExifTag::GPS_TRACK_REF           => new IfdEntry(ExifTag::GPS_TRACK_REF, 2, 1, 'T'),
+            ExifTag::GPS_TRACK               => new IfdEntry(ExifTag::GPS_TRACK, 5, 1, new ExifRational(12345, 100)),
+            ExifTag::GPS_IMG_DIRECTION_REF   => new IfdEntry(ExifTag::GPS_IMG_DIRECTION_REF, 2, 1, 'M'),
+            ExifTag::GPS_IMG_DIRECTION       => new IfdEntry(ExifTag::GPS_IMG_DIRECTION, 5, 1, new ExifRational(2500, 10)),
+            ExifTag::GPS_MAP_DATUM           => new IfdEntry(ExifTag::GPS_MAP_DATUM, 2, 6, 'WGS-84'),
+            ExifTag::GPS_DEST_LATITUDE_REF   => new IfdEntry(ExifTag::GPS_DEST_LATITUDE_REF, 2, 1, 'N'),
+            ExifTag::GPS_DEST_LATITUDE       => new IfdEntry(
+                ExifTag::GPS_DEST_LATITUDE,
+                5,
+                3,
+                new ExifRationalList([
+                    new ExifRational(41, 1),
+                    new ExifRational(0, 1),
+                    new ExifRational(0, 1),
+                ]),
+            ),
+            ExifTag::GPS_DEST_LONGITUDE_REF => new IfdEntry(ExifTag::GPS_DEST_LONGITUDE_REF, 2, 1, 'E'),
+            ExifTag::GPS_DEST_LONGITUDE     => new IfdEntry(
+                ExifTag::GPS_DEST_LONGITUDE,
+                5,
+                3,
+                new ExifRationalList([
+                    new ExifRational(8, 1),
+                    new ExifRational(30, 1),
+                    new ExifRational(0, 1),
+                ]),
+            ),
+            ExifTag::GPS_DEST_BEARING_REF   => new IfdEntry(ExifTag::GPS_DEST_BEARING_REF, 2, 1, 'T'),
+            ExifTag::GPS_DEST_BEARING       => new IfdEntry(ExifTag::GPS_DEST_BEARING, 5, 1, new ExifRational(123, 1)),
+            ExifTag::GPS_DEST_DISTANCE_REF  => new IfdEntry(ExifTag::GPS_DEST_DISTANCE_REF, 2, 1, 'K'),
+            ExifTag::GPS_DEST_DISTANCE      => new IfdEntry(ExifTag::GPS_DEST_DISTANCE, 5, 1, new ExifRational(42, 1)),
+            ExifTag::GPS_PROCESSING_METHOD  => new IfdEntry(ExifTag::GPS_PROCESSING_METHOD, 7, 11, "ASCII\0\0\0NETWORK"),
+            ExifTag::GPS_AREA_INFORMATION   => new IfdEntry(ExifTag::GPS_AREA_INFORMATION, 7, 13, "ASCII\0\0\0AreaName"),
+            ExifTag::GPS_DIFFERENTIAL       => new IfdEntry(ExifTag::GPS_DIFFERENTIAL, 3, 1, 2),
+            ExifTag::GPS_H_POSITIONING_ERROR => new IfdEntry(ExifTag::GPS_H_POSITIONING_ERROR, 5, 1, new ExifRational(15, 10)),
+        ]);
+
+        $document = new ExifDocument(new Ifd([]), null, $gpsIfd, null, null);
+        $resolver = new ExifTagResolver($document);
+
+        $gps = $resolver->gps();
+        self::assertEqualsWithDelta(51.5, $gps['lat'], 0.000001);
+        self::assertEqualsWithDelta(8.5, $gps['lon'], 0.000001);
+        self::assertEqualsWithDelta(150.0, $gps['alt'], 0.000001);
+
+        self::assertSame('3.0.0.0', $resolver->gpsVersion());
+        self::assertSame('05', $resolver->gpsSatellites());
+        self::assertSame('A', $resolver->gpsStatus());
+        self::assertSame('3', $resolver->gpsMeasureMode());
+        self::assertEqualsWithDelta(2.5, $resolver->gpsDop(), 0.000001);
+        self::assertSame('K', $resolver->gpsSpeedRef());
+        self::assertEqualsWithDelta(20.0, $resolver->gpsSpeed(), 0.000001);
+        self::assertSame('T', $resolver->gpsTrackRef());
+        self::assertEqualsWithDelta(123.45, $resolver->gpsTrack(), 0.000001);
+        self::assertSame('M', $resolver->gpsImgDirectionRef());
+        self::assertEqualsWithDelta(250.0, $resolver->gpsImgDirection(), 0.000001);
+        self::assertSame('WGS-84', $resolver->gpsMapDatum());
+        self::assertSame('N', $resolver->gpsDestinationLatitudeRef());
+        self::assertEqualsWithDelta(41.0, $resolver->gpsDestinationLatitude(), 0.000001);
+        self::assertSame('E', $resolver->gpsDestinationLongitudeRef());
+        self::assertEqualsWithDelta(8.5, $resolver->gpsDestinationLongitude(), 0.000001);
+        self::assertSame('T', $resolver->gpsDestinationBearingRef());
+        self::assertEqualsWithDelta(123.0, $resolver->gpsDestinationBearing(), 0.000001);
+        self::assertSame('K', $resolver->gpsDestinationDistanceRef());
+        self::assertEqualsWithDelta(42000.0, $resolver->gpsDestinationDistance(), 0.000001);
+        self::assertSame('NETWORK', $resolver->gpsProcessingMethod());
+        self::assertSame('AreaName', $resolver->gpsAreaInformation());
+        self::assertSame('2024-05-06', $resolver->gpsDate());
+        self::assertSame('12:34:56.789', $resolver->gpsTime());
+
+        $timestamp = $resolver->gpsTimestamp();
+        self::assertInstanceOf(DateTimeImmutable::class, $timestamp);
+        self::assertSame('2024-05-06T12:34:56+00:00', $timestamp->format(DATE_ATOM));
+        self::assertSame('12:34:56.789000', $timestamp->format('H:i:s.u'));
+
+        self::assertSame(2, $resolver->gpsDifferential());
+        self::assertEqualsWithDelta(1.5, $resolver->gpsHorizontalPositioningError(), 0.000001);
+    }
+}
+

--- a/tests/Model/Exif/ValueConvertersTest.php
+++ b/tests/Model/Exif/ValueConvertersTest.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace MagicSunday\ImageMeta\Tests\Model\Exif;
 
+use DateTimeImmutable;
 use MagicSunday\ImageMeta\Model\Exif\ExifNumericList;
 use MagicSunday\ImageMeta\Model\Exif\ExifRational;
 use MagicSunday\ImageMeta\Model\Exif\ExifRationalList;
@@ -379,5 +380,130 @@ final class ValueConvertersTest extends TestCase
         self::assertEqualsWithDelta(10.0, $result['lat'], 0.000001);
         self::assertEqualsWithDelta(20.5, $result['lon'], 0.000001);
         self::assertNull($result['alt']);
+    }
+
+    /**
+     * Ensures EXIF 3.0 GPS tags are decoded into a rich metadata map including temporal and navigation fields.
+     */
+    #[Test]
+    public function extractsExtendedGpsMetadata(): void
+    {
+        $gps = new Ifd([
+            ExifTag::GPS_VERSION_ID        => new IfdEntry(ExifTag::GPS_VERSION_ID, 1, 4, [3, 0, 0, 0]),
+            ExifTag::GPS_LATITUDE_REF      => new IfdEntry(ExifTag::GPS_LATITUDE_REF, 2, 2, 'N'),
+            ExifTag::GPS_LATITUDE          => new IfdEntry(
+                ExifTag::GPS_LATITUDE,
+                5,
+                3,
+                new ExifRationalList([
+                    new ExifRational(51, 1),
+                    new ExifRational(30, 1),
+                    new ExifRational(0, 1),
+                ]),
+            ),
+            ExifTag::GPS_LONGITUDE_REF => new IfdEntry(ExifTag::GPS_LONGITUDE_REF, 2, 2, 'E'),
+            ExifTag::GPS_LONGITUDE     => new IfdEntry(
+                ExifTag::GPS_LONGITUDE,
+                5,
+                3,
+                new ExifRationalList([
+                    new ExifRational(8, 1),
+                    new ExifRational(30, 1),
+                    new ExifRational(0, 1),
+                ]),
+            ),
+            ExifTag::GPS_ALTITUDE_REF        => new IfdEntry(ExifTag::GPS_ALTITUDE_REF, 1, 1, 0),
+            ExifTag::GPS_ALTITUDE            => new IfdEntry(ExifTag::GPS_ALTITUDE, 5, 1, new ExifRational(150, 1)),
+            ExifTag::GPS_TIME_STAMP          => new IfdEntry(
+                ExifTag::GPS_TIME_STAMP,
+                5,
+                3,
+                new ExifRationalList([
+                    new ExifRational(12, 1),
+                    new ExifRational(34, 1),
+                    new ExifRational(56789, 1000),
+                ]),
+            ),
+            ExifTag::GPS_DATE_STAMP          => new IfdEntry(ExifTag::GPS_DATE_STAMP, 2, 10, '2024:05:06'),
+            ExifTag::GPS_SATELLITES          => new IfdEntry(ExifTag::GPS_SATELLITES, 2, 2, '05'),
+            ExifTag::GPS_STATUS              => new IfdEntry(ExifTag::GPS_STATUS, 2, 1, 'A'),
+            ExifTag::GPS_MEASURE_MODE        => new IfdEntry(ExifTag::GPS_MEASURE_MODE, 2, 1, '3'),
+            ExifTag::GPS_DOP                 => new IfdEntry(ExifTag::GPS_DOP, 5, 1, new ExifRational(25, 10)),
+            ExifTag::GPS_SPEED_REF           => new IfdEntry(ExifTag::GPS_SPEED_REF, 2, 1, 'K'),
+            ExifTag::GPS_SPEED               => new IfdEntry(ExifTag::GPS_SPEED, 5, 1, new ExifRational(72000, 1000)),
+            ExifTag::GPS_TRACK_REF           => new IfdEntry(ExifTag::GPS_TRACK_REF, 2, 1, 'T'),
+            ExifTag::GPS_TRACK               => new IfdEntry(ExifTag::GPS_TRACK, 5, 1, new ExifRational(12345, 100)),
+            ExifTag::GPS_IMG_DIRECTION_REF   => new IfdEntry(ExifTag::GPS_IMG_DIRECTION_REF, 2, 1, 'M'),
+            ExifTag::GPS_IMG_DIRECTION       => new IfdEntry(ExifTag::GPS_IMG_DIRECTION, 5, 1, new ExifRational(2500, 10)),
+            ExifTag::GPS_MAP_DATUM           => new IfdEntry(ExifTag::GPS_MAP_DATUM, 2, 6, 'WGS-84'),
+            ExifTag::GPS_DEST_LATITUDE_REF   => new IfdEntry(ExifTag::GPS_DEST_LATITUDE_REF, 2, 1, 'N'),
+            ExifTag::GPS_DEST_LATITUDE       => new IfdEntry(
+                ExifTag::GPS_DEST_LATITUDE,
+                5,
+                3,
+                new ExifRationalList([
+                    new ExifRational(41, 1),
+                    new ExifRational(0, 1),
+                    new ExifRational(0, 1),
+                ]),
+            ),
+            ExifTag::GPS_DEST_LONGITUDE_REF => new IfdEntry(ExifTag::GPS_DEST_LONGITUDE_REF, 2, 1, 'E'),
+            ExifTag::GPS_DEST_LONGITUDE     => new IfdEntry(
+                ExifTag::GPS_DEST_LONGITUDE,
+                5,
+                3,
+                new ExifRationalList([
+                    new ExifRational(8, 1),
+                    new ExifRational(30, 1),
+                    new ExifRational(0, 1),
+                ]),
+            ),
+            ExifTag::GPS_DEST_BEARING_REF   => new IfdEntry(ExifTag::GPS_DEST_BEARING_REF, 2, 1, 'T'),
+            ExifTag::GPS_DEST_BEARING       => new IfdEntry(ExifTag::GPS_DEST_BEARING, 5, 1, new ExifRational(123, 1)),
+            ExifTag::GPS_DEST_DISTANCE_REF  => new IfdEntry(ExifTag::GPS_DEST_DISTANCE_REF, 2, 1, 'K'),
+            ExifTag::GPS_DEST_DISTANCE      => new IfdEntry(ExifTag::GPS_DEST_DISTANCE, 5, 1, new ExifRational(42, 1)),
+            ExifTag::GPS_PROCESSING_METHOD  => new IfdEntry(ExifTag::GPS_PROCESSING_METHOD, 7, 11, "ASCII\0\0\0NETWORK"),
+            ExifTag::GPS_AREA_INFORMATION   => new IfdEntry(ExifTag::GPS_AREA_INFORMATION, 7, 13, "ASCII\0\0\0AreaName"),
+            ExifTag::GPS_DIFFERENTIAL       => new IfdEntry(ExifTag::GPS_DIFFERENTIAL, 3, 1, 2),
+            ExifTag::GPS_H_POSITIONING_ERROR => new IfdEntry(ExifTag::GPS_H_POSITIONING_ERROR, 5, 1, new ExifRational(15, 10)),
+        ]);
+
+        $result = ValueConverters::gpsFromIfd($gps);
+
+        self::assertEqualsWithDelta(51.5, $result['lat'], 0.000001);
+        self::assertEqualsWithDelta(8.5, $result['lon'], 0.000001);
+        self::assertEqualsWithDelta(150.0, $result['alt'], 0.000001);
+        self::assertSame('3.0.0.0', $result['version']);
+        self::assertSame('05', $result['satellites']);
+        self::assertSame('A', $result['status']);
+        self::assertSame('3', $result['measure_mode']);
+        self::assertEqualsWithDelta(2.5, $result['dop'], 0.000001);
+        self::assertSame('K', $result['speed_ref']);
+        self::assertEqualsWithDelta(20.0, $result['speed_ms'], 0.000001);
+        self::assertSame('T', $result['track_ref']);
+        self::assertEqualsWithDelta(123.45, $result['track'], 0.000001);
+        self::assertSame('M', $result['img_direction_ref']);
+        self::assertEqualsWithDelta(250.0, $result['img_direction'], 0.000001);
+        self::assertSame('WGS-84', $result['map_datum']);
+        self::assertSame('N', $result['dest_lat_ref']);
+        self::assertEqualsWithDelta(41.0, $result['dest_lat'], 0.000001);
+        self::assertSame('E', $result['dest_lon_ref']);
+        self::assertEqualsWithDelta(8.5, $result['dest_lon'], 0.000001);
+        self::assertSame('T', $result['dest_bearing_ref']);
+        self::assertEqualsWithDelta(123.0, $result['dest_bearing'], 0.000001);
+        self::assertSame('K', $result['dest_distance_ref']);
+        self::assertEqualsWithDelta(42000.0, $result['dest_distance_m'], 0.000001);
+        self::assertSame('NETWORK', $result['processing_method']);
+        self::assertSame('AreaName', $result['area_information']);
+        self::assertSame('2024-05-06', $result['date']);
+        self::assertSame('12:34:56.789', $result['time']);
+
+        $timestamp = $result['timestamp'];
+        self::assertInstanceOf(DateTimeImmutable::class, $timestamp);
+        self::assertSame('2024-05-06T12:34:56+00:00', $timestamp->format(DATE_ATOM));
+        self::assertSame('12:34:56.789000', $timestamp->format('H:i:s.u'));
+
+        self::assertSame(2, $result['differential']);
+        self::assertEqualsWithDelta(1.5, $result['h_positioning_error'], 0.000001);
     }
 }


### PR DESCRIPTION
## Summary
- decode the full EXIF 3.0 GPS metadata set in the EXIF value converters and document helper
- surface GPS timestamps, speed/bearing, destination, processing method and differential data via the EXIF tag resolver
- cover the extended GPS handling with synthetic PHPUnit fixtures for the converters and resolver

## Testing
- composer ci:test:php:unit

------
https://chatgpt.com/codex/tasks/task_e_68fb2ba0110083239fc5f029376cfdc3