### PR TITLE
feat: expose extended EXIF GPS metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,22 @@ $structured->related->livePhotoPairId;
 | `temporal.original` | EXIF `DateTimeOriginal` + `OffsetTimeOriginal` | XMP `exif:DateTimeOriginal` | `ValueConverters::parseOffset()` |
 | `derived.ev100` | Calculated from exposure values | – | `ValueConverters::calcEv100()` |
 
+### GPS metadata coverage
+
+ImageMeta normalises every entry from the EXIF 2.32 table 66 GPS IFD. The decoded data is exposed through
+`ExifDocument::gps()` and the convenience accessors on `Curate\Resolver\ExifTagResolver`. The following fields are
+available to consumers:
+
+* Coordinate references and values: `lat_ref`, `lat`, `lon_ref`, `lon`, `alt_ref`, `alt`.
+* Navigation metrics: `speed_ref`, `speed_ms`, `track_ref`, `track`, `img_direction_ref`, `img_direction`,
+  `dest_lat_ref`, `dest_lat`, `dest_lon_ref`, `dest_lon`, `dest_bearing_ref`, `dest_bearing`, `dest_distance_ref`,
+  `dest_distance_m`.
+* Metadata, timing and accuracy: `version`, `satellites`, `status`, `measure_mode`, `dop`, `map_datum`,
+  `processing_method`, `area_information`, `date`, `time`, `timestamp`, `differential`, `h_positioning_error`.
+
+All fields are trimmed and converted into PHP primitives (floats, ints, strings or `DateTimeImmutable`) so they can be
+used directly without consulting tag identifiers.
+
 ### EXIF 3.0 → Value objects
 
 | Value object | Fields | Source tag(s) | Converter/Enum |

--- a/src/Curate/Resolver/ExifTagResolver.php
+++ b/src/Curate/Resolver/ExifTagResolver.php
@@ -903,8 +903,11 @@ final readonly class ExifTagResolver
      * Returns the GPS coordinates as an array of floats.
      *
      * @return array{
+     *     lat_ref:?string,
      *     lat:?float,
+     *     lon_ref:?string,
      *     lon:?float,
+     *     alt_ref:?int,
      *     alt:?float,
      *     version:?string,
      *     satellites:?string,
@@ -940,6 +943,44 @@ final readonly class ExifTagResolver
         return $this->document instanceof ExifDocument
             ? $this->document->gps()
             : ExifValueConverters::emptyGpsResult();
+    }
+
+    /**
+     * Returns the latitude reference indicating north or south hemisphere.
+     */
+    public function gpsLatitudeRef(): ?string
+    {
+        $value = $this->gpsField('lat_ref');
+
+        return is_string($value) ? $value : null;
+    }
+
+    /**
+     * Returns the longitude reference indicating east or west hemisphere.
+     */
+    public function gpsLongitudeRef(): ?string
+    {
+        $value = $this->gpsField('lon_ref');
+
+        return is_string($value) ? $value : null;
+    }
+
+    /**
+     * Returns the altitude reference (0 above, 1 below sea level).
+     */
+    public function gpsAltitudeRef(): ?int
+    {
+        $value = $this->gpsField('alt_ref');
+
+        if (is_int($value)) {
+            return $value;
+        }
+
+        if (is_float($value)) {
+            return (int) round($value);
+        }
+
+        return null;
     }
 
     /**

--- a/src/Model/Exif/ExifDocument.php
+++ b/src/Model/Exif/ExifDocument.php
@@ -689,8 +689,11 @@ final readonly class ExifDocument
      * Returns the parsed GPS metadata extracted from the GPS IFD.
      *
      * @return array{
+     *     lat_ref:?string,
      *     lat:?float,
+     *     lon_ref:?string,
      *     lon:?float,
+     *     alt_ref:?int,
      *     alt:?float,
      *     version:?string,
      *     satellites:?string,

--- a/src/Model/Exif/ExifTag.php
+++ b/src/Model/Exif/ExifTag.php
@@ -241,7 +241,7 @@ final readonly class ExifTag
 
     public const int DEVICE_SETTING_DESCRIPTION = 0xA40B;
 
-    // GPS sub IFD
+    // GPS sub IFD (Table 66 – EXIF 2.32)
     public const int GPS_VERSION_ID = 0x0000;
 
     public const int GPS_LATITUDE_REF = 0x0001;

--- a/src/Model/Exif/ValueConverters.php
+++ b/src/Model/Exif/ValueConverters.php
@@ -254,8 +254,11 @@ final readonly class ValueConverters
      * Returns the default GPS metadata structure with all keys initialised to null.
      *
      * @return array{
+     *     lat_ref:?string,
      *     lat:?float,
+     *     lon_ref:?string,
      *     lon:?float,
+     *     alt_ref:?int,
      *     alt:?float,
      *     version:?string,
      *     satellites:?string,
@@ -289,8 +292,11 @@ final readonly class ValueConverters
     public static function emptyGpsResult(): array
     {
         return [
+            'lat_ref'               => null,
             'lat'                   => null,
+            'lon_ref'               => null,
             'lon'                   => null,
+            'alt_ref'               => null,
             'alt'                   => null,
             'version'               => null,
             'satellites'            => null,
@@ -328,8 +334,11 @@ final readonly class ValueConverters
      * @param Ifd $gps The GPS IFD containing coordinate tags.
      *
      * @return array{
+     *     lat_ref:?string,
      *     lat:?float,
+     *     lon_ref:?string,
      *     lon:?float,
+     *     alt_ref:?int,
      *     alt:?float,
      *     version:?string,
      *     satellites:?string,
@@ -374,22 +383,32 @@ final readonly class ValueConverters
         $lonRef = $lonRefEntry?->value;
         $lonVal = $lonValEntry?->value;
 
+        $result['lat_ref'] = is_string($latRef) ? strtoupper(trim($latRef)) : null;
+        $result['lon_ref'] = is_string($lonRef) ? strtoupper(trim($lonRef)) : null;
+
         $latPairs = $latVal instanceof ExifRationalList ? $latVal : null;
         $lonPairs = $lonVal instanceof ExifRationalList ? $lonVal : null;
 
-        $result['lat'] = self::dmsToFloat(is_string($latRef) ? trim($latRef) : null, $latPairs);
-        $result['lon'] = self::dmsToFloat(is_string($lonRef) ? trim($lonRef) : null, $lonPairs);
+        $result['lat'] = self::dmsToFloat($result['lat_ref'], $latPairs);
+        $result['lon'] = self::dmsToFloat($result['lon_ref'], $lonPairs);
+
+        $altRefEntry = $gps->get(ExifTag::GPS_ALTITUDE_REF);
+        $altRefValue = $altRefEntry?->value;
+        if ($altRefValue instanceof ExifNumericList) {
+            $altRefValue = $altRefValue->values[0] ?? null;
+        }
+        if (is_int($altRefValue)) {
+            $result['alt_ref'] = $altRefValue;
+        } elseif (is_float($altRefValue)) {
+            $result['alt_ref'] = (int) round($altRefValue);
+        }
 
         $altEntry = $gps->get(ExifTag::GPS_ALTITUDE);
         if ($altEntry instanceof IfdEntry && $altEntry->value instanceof ExifRational) {
             $alt = self::rationalToFloat($altEntry->value);
 
-            $altRef = $gps->get(ExifTag::GPS_ALTITUDE_REF);
-            if ($alt !== null && $altRef instanceof IfdEntry) {
-                $refValue = $altRef->value;
-                if (is_int($refValue) && $refValue === 1) {
-                    $alt = -$alt;
-                }
+            if ($alt !== null && $result['alt_ref'] === 1) {
+                $alt = -$alt;
             }
 
             $result['alt'] = $alt;

--- a/tests/Curate/Resolver/ExifTagResolverTest.php
+++ b/tests/Curate/Resolver/ExifTagResolverTest.php
@@ -127,10 +127,16 @@ final class ExifTagResolverTest extends TestCase
         $resolver = new ExifTagResolver($document);
 
         $gps = $resolver->gps();
+        self::assertSame('N', $gps['lat_ref']);
         self::assertEqualsWithDelta(51.5, $gps['lat'], 0.000001);
+        self::assertSame('E', $gps['lon_ref']);
         self::assertEqualsWithDelta(8.5, $gps['lon'], 0.000001);
+        self::assertSame(0, $gps['alt_ref']);
         self::assertEqualsWithDelta(150.0, $gps['alt'], 0.000001);
 
+        self::assertSame('N', $resolver->gpsLatitudeRef());
+        self::assertSame('E', $resolver->gpsLongitudeRef());
+        self::assertSame(0, $resolver->gpsAltitudeRef());
         self::assertSame('3.0.0.0', $resolver->gpsVersion());
         self::assertSame('05', $resolver->gpsSatellites());
         self::assertSame('A', $resolver->gpsStatus());

--- a/tests/Model/Exif/ExifDocumentTest.php
+++ b/tests/Model/Exif/ExifDocumentTest.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace MagicSunday\ImageMeta\Tests\Model\Exif;
 
+use DateTimeImmutable;
 use MagicSunday\ImageMeta\Model\Exif\ExifDocument;
 use MagicSunday\ImageMeta\Model\Exif\ExifNumericList;
 use MagicSunday\ImageMeta\Model\Exif\ExifRational;
@@ -129,6 +130,136 @@ final class ExifDocumentTest extends TestCase
         self::assertEqualsWithDelta(40.441666, $gps['lat'], 0.000001);
         self::assertEqualsWithDelta(79.983333, $gps['lon'], 0.000001);
         self::assertEquals(123.0, $gps['alt']);
+    }
+
+    /**
+     * Ensures the GPS helper exposes every decoded field from table 66 including references.
+     */
+    #[Test]
+    public function exposesCompleteGpsMetadata(): void
+    {
+        $gpsIfd = new Ifd([
+            ExifTag::GPS_VERSION_ID        => new IfdEntry(ExifTag::GPS_VERSION_ID, 1, 4, [3, 0, 0, 0]),
+            ExifTag::GPS_LATITUDE_REF      => new IfdEntry(ExifTag::GPS_LATITUDE_REF, 2, 2, 'S'),
+            ExifTag::GPS_LATITUDE          => new IfdEntry(
+                ExifTag::GPS_LATITUDE,
+                5,
+                3,
+                new ExifRationalList([
+                    new ExifRational(33, 1),
+                    new ExifRational(52, 1),
+                    new ExifRational(1234, 100),
+                ]),
+            ),
+            ExifTag::GPS_LONGITUDE_REF => new IfdEntry(ExifTag::GPS_LONGITUDE_REF, 2, 2, 'W'),
+            ExifTag::GPS_LONGITUDE     => new IfdEntry(
+                ExifTag::GPS_LONGITUDE,
+                5,
+                3,
+                new ExifRationalList([
+                    new ExifRational(18, 1),
+                    new ExifRational(24, 1),
+                    new ExifRational(5678, 100),
+                ]),
+            ),
+            ExifTag::GPS_ALTITUDE_REF        => new IfdEntry(ExifTag::GPS_ALTITUDE_REF, 1, 1, 1),
+            ExifTag::GPS_ALTITUDE            => new IfdEntry(ExifTag::GPS_ALTITUDE, 5, 1, new ExifRational(250, 1)),
+            ExifTag::GPS_TIME_STAMP          => new IfdEntry(
+                ExifTag::GPS_TIME_STAMP,
+                5,
+                3,
+                new ExifRationalList([
+                    new ExifRational(5, 1),
+                    new ExifRational(6, 1),
+                    new ExifRational(789, 100),
+                ]),
+            ),
+            ExifTag::GPS_DATE_STAMP          => new IfdEntry(ExifTag::GPS_DATE_STAMP, 2, 10, '2024:05:07'),
+            ExifTag::GPS_SATELLITES          => new IfdEntry(ExifTag::GPS_SATELLITES, 2, 2, '07'),
+            ExifTag::GPS_STATUS              => new IfdEntry(ExifTag::GPS_STATUS, 2, 1, 'V'),
+            ExifTag::GPS_MEASURE_MODE        => new IfdEntry(ExifTag::GPS_MEASURE_MODE, 2, 1, '2'),
+            ExifTag::GPS_DOP                 => new IfdEntry(ExifTag::GPS_DOP, 5, 1, new ExifRational(15, 10)),
+            ExifTag::GPS_SPEED_REF           => new IfdEntry(ExifTag::GPS_SPEED_REF, 2, 1, 'N'),
+            ExifTag::GPS_SPEED               => new IfdEntry(ExifTag::GPS_SPEED, 5, 1, new ExifRational(12345, 1000)),
+            ExifTag::GPS_TRACK_REF           => new IfdEntry(ExifTag::GPS_TRACK_REF, 2, 1, 'M'),
+            ExifTag::GPS_TRACK               => new IfdEntry(ExifTag::GPS_TRACK, 5, 1, new ExifRational(54321, 100)),
+            ExifTag::GPS_IMG_DIRECTION_REF   => new IfdEntry(ExifTag::GPS_IMG_DIRECTION_REF, 2, 1, 'T'),
+            ExifTag::GPS_IMG_DIRECTION       => new IfdEntry(ExifTag::GPS_IMG_DIRECTION, 5, 1, new ExifRational(90, 1)),
+            ExifTag::GPS_MAP_DATUM           => new IfdEntry(ExifTag::GPS_MAP_DATUM, 2, 9, "WGS-84\0"),
+            ExifTag::GPS_DEST_LATITUDE_REF   => new IfdEntry(ExifTag::GPS_DEST_LATITUDE_REF, 2, 1, 'N'),
+            ExifTag::GPS_DEST_LATITUDE       => new IfdEntry(
+                ExifTag::GPS_DEST_LATITUDE,
+                5,
+                3,
+                new ExifRationalList([
+                    new ExifRational(34, 1),
+                    new ExifRational(0, 1),
+                    new ExifRational(0, 1),
+                ]),
+            ),
+            ExifTag::GPS_DEST_LONGITUDE_REF => new IfdEntry(ExifTag::GPS_DEST_LONGITUDE_REF, 2, 1, 'E'),
+            ExifTag::GPS_DEST_LONGITUDE     => new IfdEntry(
+                ExifTag::GPS_DEST_LONGITUDE,
+                5,
+                3,
+                new ExifRationalList([
+                    new ExifRational(19, 1),
+                    new ExifRational(0, 1),
+                    new ExifRational(0, 1),
+                ]),
+            ),
+            ExifTag::GPS_DEST_BEARING_REF   => new IfdEntry(ExifTag::GPS_DEST_BEARING_REF, 2, 1, 'T'),
+            ExifTag::GPS_DEST_BEARING       => new IfdEntry(ExifTag::GPS_DEST_BEARING, 5, 1, new ExifRational(45, 1)),
+            ExifTag::GPS_DEST_DISTANCE_REF  => new IfdEntry(ExifTag::GPS_DEST_DISTANCE_REF, 2, 1, 'M'),
+            ExifTag::GPS_DEST_DISTANCE      => new IfdEntry(ExifTag::GPS_DEST_DISTANCE, 5, 1, new ExifRational(100, 1)),
+            ExifTag::GPS_PROCESSING_METHOD  => new IfdEntry(ExifTag::GPS_PROCESSING_METHOD, 7, 11, "ASCII\0\0\0SURVEY"),
+            ExifTag::GPS_AREA_INFORMATION   => new IfdEntry(ExifTag::GPS_AREA_INFORMATION, 7, 13, "ASCII\0\0\0Test Area"),
+            ExifTag::GPS_DIFFERENTIAL       => new IfdEntry(ExifTag::GPS_DIFFERENTIAL, 3, 1, 1),
+            ExifTag::GPS_H_POSITIONING_ERROR => new IfdEntry(ExifTag::GPS_H_POSITIONING_ERROR, 5, 1, new ExifRational(5, 10)),
+        ]);
+
+        $doc = new ExifDocument(new Ifd([]), null, $gpsIfd, null, null);
+
+        $gps = $doc->gps();
+
+        self::assertSame('S', $gps['lat_ref']);
+        self::assertEqualsWithDelta(-33.870094, $gps['lat'], 0.000001);
+        self::assertSame('W', $gps['lon_ref']);
+        self::assertEqualsWithDelta(-18.415772, $gps['lon'], 0.000001);
+        self::assertSame(1, $gps['alt_ref']);
+        self::assertEqualsWithDelta(-250.0, $gps['alt'], 0.000001);
+
+        self::assertSame('3.0.0.0', $gps['version']);
+        self::assertSame('07', $gps['satellites']);
+        self::assertSame('V', $gps['status']);
+        self::assertSame('2', $gps['measure_mode']);
+        self::assertEqualsWithDelta(1.5, $gps['dop'], 0.000001);
+        self::assertSame('N', $gps['speed_ref']);
+        self::assertEqualsWithDelta(6.3508166667, $gps['speed_ms'], 0.000001);
+        self::assertSame('M', $gps['track_ref']);
+        self::assertEqualsWithDelta(543.21, $gps['track'], 0.000001);
+        self::assertSame('T', $gps['img_direction_ref']);
+        self::assertEqualsWithDelta(90.0, $gps['img_direction'], 0.000001);
+        self::assertSame('WGS-84', $gps['map_datum']);
+        self::assertSame('N', $gps['dest_lat_ref']);
+        self::assertEqualsWithDelta(34.0, $gps['dest_lat'], 0.000001);
+        self::assertSame('E', $gps['dest_lon_ref']);
+        self::assertEqualsWithDelta(19.0, $gps['dest_lon'], 0.000001);
+        self::assertSame('T', $gps['dest_bearing_ref']);
+        self::assertEqualsWithDelta(45.0, $gps['dest_bearing'], 0.000001);
+        self::assertSame('M', $gps['dest_distance_ref']);
+        self::assertEqualsWithDelta(160934.4, $gps['dest_distance_m'], 0.000001);
+        self::assertSame('SURVEY', $gps['processing_method']);
+        self::assertSame('Test Area', $gps['area_information']);
+        self::assertSame('2024-05-07', $gps['date']);
+        self::assertSame('05:06:07.89', $gps['time']);
+
+        $timestamp = $gps['timestamp'];
+        self::assertInstanceOf(DateTimeImmutable::class, $timestamp);
+        self::assertSame('2024-05-07T05:06:07+00:00', $timestamp->format(DATE_ATOM));
+
+        self::assertSame(1, $gps['differential']);
+        self::assertEqualsWithDelta(0.5, $gps['h_positioning_error'], 0.000001);
     }
 
     /**


### PR DESCRIPTION
## Summary
- expose the latitude, longitude and altitude reference codes in the GPS metadata map and resolver helpers
- cover the complete table 66 GPS payload with dedicated ExifDocument and ExifTagResolver tests
- document the supported GPS fields in the README for future reference

## Testing
- composer ci:test:php:unit

------
https://chatgpt.com/codex/tasks/task_e_68fb3d1d22c4832381c1bbc081e17c7e