### PR TITLE
feat: align exif tags with exif 3.0 naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ $structured->related->livePhotoPairId;
 | --- | --- | --- | --- |
 | `Interop` | `index`, `version` | `InteropIndex`, `InteropVersion` | Hex fallback for binary data |
 | `TiffData` | `compression`, `photometric`, `ycbcrSubSampling`, `primaryChromaticities` | `Compression`, `PhotometricInterpretation`, `YCbCrSubSampling`, `PrimaryChromaticities` | `Compression`, `Photometric`, `ValueConverters::toPrimaryChromaticities()` |
-| `CompositeImageInfo` | `type`, `counts`, `exposureTimesTotal` | `CompositeImage`, `CompositeImageCount`, `CompositeImageExposureTimes` | `CompositeImage`, rational to float |
+| `CompositeImageInfo` | `type`, `counts`, `exposureTimesTotal` | `CompositeImage`, `SourceImageNumberOfCompositeImage`, `SourceExposureTimesOfCompositeImage` | `CompositeImage`, rational to float |
 | `Standards` | `exifVersion`, `flashpixVersion` | `ExifVersion`, `FlashpixVersion` | `ValueConverters::toExifVersion()` |
-| `Lens` | `lensInfo`, `maxApertureFNumber` | `LensInfo`, `MaxApertureValue` | `ValueConverters::apexToFNumber()` |
+| `Lens` | `lensSpecification`, `maxApertureFNumber` | `LensSpecification`, `MaxApertureValue` | `ValueConverters::apexToFNumber()` |
 | `Exposure` | `exposureBiasEv`, `gainControl`, `contrast` | `ExposureBiasValue`, `GainControl`, `Contrast` | `GainControl` enum |
 | `Scene` | `subjectDistanceRange` | `SubjectDistanceRange` | `SubjectDistanceRange` enum |
 | `Device` | `rawDevelopingSoftware`, `imageEditingSoftware`, `metadataEditingSoftware` | `RAWDevelopingSoftware`, `ImageEditingSoftware`, `MetadataEditingSoftware` | – |
@@ -46,9 +46,13 @@ $structured->related->livePhotoPairId;
 ```php
 $s = $meta->structured();
 $s->tiff->compression;              // Compression::JPEG
-$s->lens->lensInfo;                 // [minF, minAperture, maxF, maxAperture]
+$s->lens->lensSpecification;       // [minF, minAperture, maxF, maxAperture]
 $s->composite->type;                // CompositeImage::GeneralComposite
 $s->standards->exifVersion;         // "3.00"
 ```
+
+> [!NOTE]
+> The legacy accessors `lensInfo`, `compositeImageCount` and `compositeExposureTimes` remain available as deprecated aliases to
+> ease migration to the EXIF 3.0 naming scheme and will be removed in a future major release.
 
 The aggregate always instantiates each value object. Consumers therefore never have to deal with tag identifiers or container-specific key names.

--- a/src/Curate/Resolver/ExifTagResolver.php
+++ b/src/Curate/Resolver/ExifTagResolver.php
@@ -169,9 +169,9 @@ final readonly class ExifTagResolver
      *
      * @return array{0:float,1:float,2:float,3:float}|null
      */
-    public function lensInfo(): ?array
+    public function lensSpecification(): ?array
     {
-        $entry = $this->getEntry($this->document?->exifIfd, ExifTag::LENS_INFO);
+        $entry = $this->getEntry($this->document?->exifIfd, ExifTag::LENS_SPECIFICATION);
         if (!$entry instanceof IfdEntry) {
             return null;
         }
@@ -182,6 +182,18 @@ final readonly class ExifTagResolver
         }
 
         return $values;
+    }
+
+    /**
+     * Returns the lens specification array describing focal and aperture range.
+     *
+     * @deprecated Use lensSpecification() instead.
+     *
+     * @return array{0:float,1:float,2:float,3:float}|null
+     */
+    public function lensInfo(): ?array
+    {
+        return $this->lensSpecification();
     }
 
     /**
@@ -1398,13 +1410,15 @@ final readonly class ExifTagResolver
     }
 
     /**
-     * Returns the composite image counts.
+     * Returns the composite image source counts.
      *
      * @return array{0:int,1:int}|null
      */
-    public function compositeImageCount(): ?array
+    public function sourceImageNumberOfCompositeImage(): ?array
     {
-        $values = $this->normalizeNumericList($this->getValue($this->document?->exifIfd, ExifTag::COMPOSITE_IMAGE_COUNT));
+        $values = $this->normalizeNumericList(
+            $this->getValue($this->document?->exifIfd, ExifTag::SOURCE_IMAGE_NUMBER_OF_COMPOSITE_IMAGE),
+        );
         if (count($values) !== 2) {
             return null;
         }
@@ -1417,14 +1431,40 @@ final readonly class ExifTagResolver
      *
      * @return list<float>|null
      */
-    public function compositeExposureTimes(): ?array
+    public function sourceExposureTimesOfCompositeImage(): ?array
     {
-        $values = $this->normalizeRationalList($this->getValue($this->document?->exifIfd, ExifTag::COMPOSITE_IMAGE_EXPOSURE_TIMES));
+        $values = $this->normalizeRationalList(
+            $this->getValue($this->document?->exifIfd, ExifTag::SOURCE_EXPOSURE_TIMES_OF_COMPOSITE_IMAGE),
+        );
         if ($values === []) {
             return null;
         }
 
         return array_values($values);
+    }
+
+    /**
+     * Returns the composite image counts.
+     *
+     * @deprecated Use sourceImageNumberOfCompositeImage() instead.
+     *
+     * @return array{0:int,1:int}|null
+     */
+    public function compositeImageCount(): ?array
+    {
+        return $this->sourceImageNumberOfCompositeImage();
+    }
+
+    /**
+     * Returns the exposure times for composite image sources.
+     *
+     * @deprecated Use sourceExposureTimesOfCompositeImage() instead.
+     *
+     * @return list<float>|null
+     */
+    public function compositeExposureTimes(): ?array
+    {
+        return $this->sourceExposureTimesOfCompositeImage();
     }
 
     /**

--- a/src/Curate/Resolver/LensResolver.php
+++ b/src/Curate/Resolver/LensResolver.php
@@ -53,7 +53,7 @@ final readonly class LensResolver
             focalLengthMm: $focal,
             focalLengthIn35mm: $focal35,
             maxApertureFNumber: $maxAperture,
-            lensInfo: null,
+            lensSpecification: null,
         );
     }
 }

--- a/src/Curate/StructuredMetadataBuilder.php
+++ b/src/Curate/StructuredMetadataBuilder.php
@@ -102,8 +102,8 @@ final class StructuredMetadataBuilder
 
         $composite = new CompositeImageInfo(
             type: $exifResolver->compositeImage(),
-            counts: $exifResolver->compositeImageCount(),
-            exposureTimesTotal: $exifResolver->compositeExposureTimes(),
+            counts: $exifResolver->sourceImageNumberOfCompositeImage(),
+            exposureTimesTotal: $exifResolver->sourceExposureTimesOfCompositeImage(),
         );
 
         $standards = new Standards(
@@ -494,9 +494,9 @@ final class StructuredMetadataBuilder
         $focalLength = $exif->focalLength();
         $focalLength ??= $this->parseRationalString($xmp->string('http://ns.adobe.com/exif/1.0/aux/', 'FocalLength'));
 
-        $lensInfo = $exif->lensInfo();
-        if ($lensInfo === null) {
-            $lensInfo = $this->parseLensInfoString($xmp->string('http://ns.adobe.com/exif/1.0/aux/', 'LensInfo'));
+        $lensSpecification = $exif->lensSpecification();
+        if ($lensSpecification === null) {
+            $lensSpecification = $this->parseLensInfoString($xmp->string('http://ns.adobe.com/exif/1.0/aux/', 'LensInfo'));
         }
 
         return new Lens(
@@ -515,7 +515,7 @@ final class StructuredMetadataBuilder
             focalLengthMm: $focalLength,
             focalLengthIn35mm: $exif->focalLength35mm(),
             maxApertureFNumber: $exif->maxApertureFNumber(),
-            lensInfo: $lensInfo,
+            lensSpecification: $lensSpecification,
         );
     }
 

--- a/src/Model/Exif/ExifTag.php
+++ b/src/Model/Exif/ExifTag.php
@@ -207,7 +207,12 @@ final readonly class ExifTag
 
     public const int BODY_SERIAL_NUMBER = 0xA431;
 
-    public const int LENS_INFO = 0xA432;
+    public const int LENS_SPECIFICATION = 0xA432;
+
+    /**
+     * @deprecated Use self::LENS_SPECIFICATION instead.
+     */
+    public const int LENS_INFO = self::LENS_SPECIFICATION;
 
     public const int LENS_MAKE = 0xA433;
 
@@ -217,9 +222,19 @@ final readonly class ExifTag
 
     public const int COMPOSITE_IMAGE = 0xA460;
 
-    public const int COMPOSITE_IMAGE_COUNT = 0xA461;
+    public const int SOURCE_IMAGE_NUMBER_OF_COMPOSITE_IMAGE = 0xA461;
 
-    public const int COMPOSITE_IMAGE_EXPOSURE_TIMES = 0xA462;
+    /**
+     * @deprecated Use self::SOURCE_IMAGE_NUMBER_OF_COMPOSITE_IMAGE instead.
+     */
+    public const int COMPOSITE_IMAGE_COUNT = self::SOURCE_IMAGE_NUMBER_OF_COMPOSITE_IMAGE;
+
+    public const int SOURCE_EXPOSURE_TIMES_OF_COMPOSITE_IMAGE = 0xA462;
+
+    /**
+     * @deprecated Use self::SOURCE_EXPOSURE_TIMES_OF_COMPOSITE_IMAGE instead.
+     */
+    public const int COMPOSITE_IMAGE_EXPOSURE_TIMES = self::SOURCE_EXPOSURE_TIMES_OF_COMPOSITE_IMAGE;
 
     public const int GAMMA = 0xA500;
 

--- a/src/Value/Lens.php
+++ b/src/Value/Lens.php
@@ -17,13 +17,25 @@ namespace MagicSunday\ImageMeta\Value;
 final readonly class Lens
 {
     /**
-     * @param string|null                                 $lensMake           Lens manufacturer.
-     * @param string|null                                 $lensModel          Lens model description.
-     * @param string|null                                 $lensSerialNumber   Serial number reported by the lens.
-     * @param float|null                                  $focalLengthMm      Focal length used in millimetres.
-     * @param int|null                                    $focalLengthIn35mm  35mm equivalent focal length.
-     * @param float|null                                  $maxApertureFNumber Maximum aperture value as f-number.
-     * @param array{0:float,1:float,2:float,3:float}|null $lensInfo           Lens specification describing zoom and aperture range.
+     * @var array{0:float,1:float,2:float,3:float}|null
+     */
+    public ?array $lensSpecification;
+
+    /**
+     * @deprecated Use $lensSpecification instead.
+     * @var array{0:float,1:float,2:float,3:float}|null
+     */
+    public ?array $lensInfo;
+
+    /**
+     * @param string|null                                 $lensMake              Lens manufacturer.
+     * @param string|null                                 $lensModel             Lens model description.
+     * @param string|null                                 $lensSerialNumber      Serial number reported by the lens.
+     * @param float|null                                  $focalLengthMm         Focal length used in millimetres.
+     * @param int|null                                    $focalLengthIn35mm     35mm equivalent focal length.
+     * @param float|null                                  $maxApertureFNumber    Maximum aperture value as f-number.
+     * @param array{0:float,1:float,2:float,3:float}|null $lensSpecification     Lens specification describing zoom and aperture range.
+     * @param array{0:float,1:float,2:float,3:float}|null $lensInfoDeprecated    Deprecated lens specification argument for BC.
      */
     public function __construct(
         public ?string $lensMake,
@@ -32,7 +44,14 @@ final readonly class Lens
         public ?float $focalLengthMm,
         public ?int $focalLengthIn35mm,
         public ?float $maxApertureFNumber,
-        public ?array $lensInfo,
+        ?array $lensSpecification = null,
+        ?array $lensInfoDeprecated = null,
     ) {
+        if ($lensSpecification === null && $lensInfoDeprecated !== null) {
+            $lensSpecification = $lensInfoDeprecated;
+        }
+
+        $this->lensSpecification = $lensSpecification;
+        $this->lensInfo          = $lensSpecification;
     }
 }

--- a/tests/Curate/Resolver/ExifTagResolverTest.php
+++ b/tests/Curate/Resolver/ExifTagResolverTest.php
@@ -164,5 +164,37 @@ final class ExifTagResolverTest extends TestCase
         self::assertSame(2, $resolver->gpsDifferential());
         self::assertEqualsWithDelta(1.5, $resolver->gpsHorizontalPositioningError(), 0.000001);
     }
+
+    /**
+     * Ensures EXIF 3.0 tags expose both new accessors and their deprecated aliases.
+     */
+    #[Test]
+    public function exposesExif30LensAndCompositeMetadataWithAliases(): void
+    {
+        $exifIfd = new Ifd([
+            ExifTag::LENS_SPECIFICATION                        => new IfdEntry(ExifTag::LENS_SPECIFICATION, 5, 4, [[35, 1], [20, 5], [150, 1], [28, 5]]),
+            ExifTag::SOURCE_IMAGE_NUMBER_OF_COMPOSITE_IMAGE    => new IfdEntry(ExifTag::SOURCE_IMAGE_NUMBER_OF_COMPOSITE_IMAGE, 3, 2, new ExifNumericList([9, 4])),
+            ExifTag::SOURCE_EXPOSURE_TIMES_OF_COMPOSITE_IMAGE  => new IfdEntry(ExifTag::SOURCE_EXPOSURE_TIMES_OF_COMPOSITE_IMAGE, 5, 4, [[1, 120], [1, 60], [1, 30], [1, 15]]),
+        ]);
+
+        $document = new ExifDocument(new Ifd([]), $exifIfd, null, null, null);
+        $resolver = new ExifTagResolver($document);
+
+        self::assertSame([35.0, 4.0, 150.0, 5.6], $resolver->lensSpecification());
+        self::assertSame($resolver->lensSpecification(), $resolver->lensInfo());
+
+        self::assertSame([9, 4], $resolver->sourceImageNumberOfCompositeImage());
+        self::assertSame(
+            $resolver->sourceImageNumberOfCompositeImage(),
+            $resolver->compositeImageCount(),
+        );
+
+        $exposureTimes = $resolver->sourceExposureTimesOfCompositeImage();
+        self::assertSame($exposureTimes, $resolver->compositeExposureTimes());
+        self::assertNotNull($exposureTimes);
+        self::assertCount(4, $exposureTimes);
+        self::assertEqualsWithDelta(0.008333333333333333, $exposureTimes[0], 1e-12);
+        self::assertEqualsWithDelta(0.06666666666666667, $exposureTimes[3], 1e-12);
+    }
 }
 

--- a/tests/Curate/StructuredMetadataBuilderTest.php
+++ b/tests/Curate/StructuredMetadataBuilderTest.php
@@ -117,7 +117,7 @@ final class StructuredMetadataBuilderTest extends TestCase
             ExifTag::FOCAL_LENGTH              => new IfdEntry(ExifTag::FOCAL_LENGTH, 5, 1, [[85, 1]]),
             ExifTag::FOCAL_LENGTH_IN_35MM_FILM => new IfdEntry(ExifTag::FOCAL_LENGTH_IN_35MM_FILM, 3, 1, 85),
             ExifTag::MAX_APERTURE_VALUE        => new IfdEntry(ExifTag::MAX_APERTURE_VALUE, 5, 1, [[1995, 1000]]),
-            ExifTag::LENS_INFO                 => new IfdEntry(ExifTag::LENS_INFO, 5, 4, [[35, 1], [40, 10], [150, 1], [56, 10]]),
+            ExifTag::LENS_SPECIFICATION        => new IfdEntry(ExifTag::LENS_SPECIFICATION, 5, 4, [[35, 1], [40, 10], [150, 1], [56, 10]]),
             ExifTag::LENS_MODEL                => new IfdEntry(ExifTag::LENS_MODEL, 2, 15, 'EF 85mm f/1.4L'),
             ExifTag::LENS_MAKE                 => new IfdEntry(ExifTag::LENS_MAKE, 2, 5, 'Canon'),
             ExifTag::LENS_SERIAL_NUMBER        => new IfdEntry(ExifTag::LENS_SERIAL_NUMBER, 2, 10, '1234ABC'),
@@ -207,7 +207,10 @@ final class StructuredMetadataBuilderTest extends TestCase
         self::assertSame('EF 85mm f/1.4L', $structured->lens->lensModel);
         self::assertSame(85.0, $structured->lens->focalLengthMm);
         self::assertSame(85, $structured->lens->focalLengthIn35mm);
-        self::assertSame([35.0, 4.0, 150.0, 5.6], $structured->lens->lensInfo);
+        self::assertSame([35.0, 4.0, 150.0, 5.6], $structured->lens->lensSpecification);
+        // Deprecated alias retained for BC to ease migration to EXIF 3.0 terminology.
+        /** @phpstan-ignore-next-line deprecated alias exercised intentionally */
+        self::assertSame($structured->lens->lensSpecification, $structured->lens->lensInfo);
         self::assertEqualsWithDelta(1.9965, $structured->lens->maxApertureFNumber, 0.001);
 
         self::assertSame(6720, $structured->image->width);
@@ -299,8 +302,8 @@ final class StructuredMetadataBuilderTest extends TestCase
             ExifTag::EXPOSURE_TIME                  => new IfdEntry(ExifTag::EXPOSURE_TIME, 5, 1, [[1, 120]]),
             ExifTag::F_NUMBER                       => new IfdEntry(ExifTag::F_NUMBER, 5, 1, [[19, 10]]),
             ExifTag::COMPOSITE_IMAGE                => new IfdEntry(ExifTag::COMPOSITE_IMAGE, 3, 1, CompositeImage::GENERAL_COMPOSITE->value),
-            ExifTag::COMPOSITE_IMAGE_COUNT          => new IfdEntry(ExifTag::COMPOSITE_IMAGE_COUNT, 3, 2, new ExifNumericList([9, 4])),
-            ExifTag::COMPOSITE_IMAGE_EXPOSURE_TIMES => new IfdEntry(ExifTag::COMPOSITE_IMAGE_EXPOSURE_TIMES, 5, 4, [[1, 120], [1, 60], [1, 30], [1, 15]]),
+            ExifTag::SOURCE_IMAGE_NUMBER_OF_COMPOSITE_IMAGE   => new IfdEntry(ExifTag::SOURCE_IMAGE_NUMBER_OF_COMPOSITE_IMAGE, 3, 2, new ExifNumericList([9, 4])),
+            ExifTag::SOURCE_EXPOSURE_TIMES_OF_COMPOSITE_IMAGE => new IfdEntry(ExifTag::SOURCE_EXPOSURE_TIMES_OF_COMPOSITE_IMAGE, 5, 4, [[1, 120], [1, 60], [1, 30], [1, 15]]),
             ExifTag::DATETIME_ORIGINAL              => new IfdEntry(ExifTag::DATETIME_ORIGINAL, 2, 19, '2024:02:01 20:45:00'),
             ExifTag::OFFSET_TIME_ORIGINAL           => new IfdEntry(ExifTag::OFFSET_TIME_ORIGINAL, 2, 6, '+01:00'),
         ]);

--- a/tests/Model/Exif/ExifTagTest.php
+++ b/tests/Model/Exif/ExifTagTest.php
@@ -171,12 +171,15 @@ final class ExifTagTest extends TestCase
             'CAMERA_OWNER_NAME'              => 0xA430,
             'BODY_SERIAL_NUMBER'             => 0xA431,
             'LENS_INFO'                      => 0xA432,
+            'LENS_SPECIFICATION'             => 0xA432,
             'LENS_MAKE'                      => 0xA433,
             'LENS_MODEL'                     => 0xA434,
             'LENS_SERIAL_NUMBER'             => 0xA435,
             'COMPOSITE_IMAGE'                => 0xA460,
             'COMPOSITE_IMAGE_COUNT'          => 0xA461,
+            'SOURCE_IMAGE_NUMBER_OF_COMPOSITE_IMAGE' => 0xA461,
             'COMPOSITE_IMAGE_EXPOSURE_TIMES' => 0xA462,
+            'SOURCE_EXPOSURE_TIMES_OF_COMPOSITE_IMAGE' => 0xA462,
             'GAMMA'                          => 0xA500,
 
             // Environmental sensing and processing notes


### PR DESCRIPTION
## Summary
- rename the EXIF lens and composite constants to their EXIF 3.0 counterparts with deprecated aliases for backward compatibility
- update resolvers, builders and lens value object to expose the new lensSpecification and composite source accessors while keeping legacy methods
- refresh documentation and extend PHPUnit coverage to describe and verify the new APIs alongside their deprecated aliases

## Testing
- composer ci:test:php:unit
- composer ci:test:php:phpstan *(fails with existing warnings in the codebase)*

------
https://chatgpt.com/codex/tasks/task_e_68fb3d1ddc608323ade9a86458110af0