### PR TITLE
feat: expose EXIF table 64 accessors

### DIFF
--- a/src/Curate/Resolver/ExifTagResolver.php
+++ b/src/Curate/Resolver/ExifTagResolver.php
@@ -476,7 +476,9 @@ final readonly class ExifTagResolver
      */
     public function stripOffsets(): ?array
     {
-        return $this->integerList($this->document?->ifd0, ExifTag::STRIP_OFFSETS);
+        $offsets = $this->document?->stripOffsets();
+
+        return $offsets !== null ? array_values($offsets) : null;
     }
 
     /**
@@ -486,7 +488,9 @@ final readonly class ExifTagResolver
      */
     public function stripByteCounts(): ?array
     {
-        return $this->integerList($this->document?->ifd0, ExifTag::STRIP_BYTE_COUNTS);
+        $counts = $this->document?->stripByteCounts();
+
+        return $counts !== null ? array_values($counts) : null;
     }
 
     /**
@@ -496,7 +500,25 @@ final readonly class ExifTagResolver
      */
     public function transferFunction(): ?array
     {
-        return $this->integerList($this->document?->ifd0, ExifTag::TRANSFER_FUNCTION);
+        $values = $this->document?->transferFunction();
+
+        return $values !== null ? array_values($values) : null;
+    }
+
+    /**
+     * Returns the JPEG thumbnail offset when present.
+     */
+    public function jpegThumbnailOffset(): ?int
+    {
+        return $this->document?->jpegThumbnailOffset();
+    }
+
+    /**
+     * Returns the JPEG thumbnail length when present.
+     */
+    public function jpegThumbnailLength(): ?int
+    {
+        return $this->document?->jpegThumbnailLength();
     }
 
     /**
@@ -651,12 +673,12 @@ final readonly class ExifTagResolver
      */
     public function referenceBlackWhite(): ?array
     {
-        $values = $this->normalizeRationalList($this->getValue($this->document?->ifd0, ExifTag::REFERENCE_BLACK_WHITE));
-        if (count($values) !== 6) {
+        $values = $this->document?->referenceBlackWhite();
+        if ($values === null || count($values) !== 6) {
             return null;
         }
 
-        return $values;
+        return array_values($values);
     }
 
     /**
@@ -664,7 +686,7 @@ final readonly class ExifTagResolver
      */
     public function copyright(): ?string
     {
-        return $this->stringValue($this->document?->ifd0, ExifTag::COPYRIGHT);
+        return $this->document?->copyright();
     }
 
     /**
@@ -1756,21 +1778,6 @@ final readonly class ExifTagResolver
         }
 
         return [];
-    }
-
-    /**
-     * Normalises integer based lists from EXIF entries.
-     *
-     * @return list<int>|null
-     */
-    private function integerList(?Ifd $ifd, int $tag): ?array
-    {
-        $values = $this->normalizeNumericList($this->getValue($ifd, $tag));
-        if ($values === []) {
-            return null;
-        }
-
-        return array_map(static fn (int|float $value): int => (int) $value, $values);
     }
 
     /**

--- a/src/Model/Exif/ExifDocument.php
+++ b/src/Model/Exif/ExifDocument.php
@@ -203,6 +203,78 @@ final readonly class ExifDocument
     }
 
     /**
+     * Returns the strip offsets defined for the primary or thumbnail image data.
+     *
+     * @return list<int>|null
+     */
+    public function stripOffsets(): ?array
+    {
+        $offsets = $this->numericList($this->ifd0, ExifTag::STRIP_OFFSETS);
+
+        return $offsets ?? $this->numericList($this->ifd1, ExifTag::STRIP_OFFSETS);
+    }
+
+    /**
+     * Returns the strip byte counts for the primary or thumbnail image data.
+     *
+     * @return list<int>|null
+     */
+    public function stripByteCounts(): ?array
+    {
+        $counts = $this->numericList($this->ifd0, ExifTag::STRIP_BYTE_COUNTS);
+
+        return $counts ?? $this->numericList($this->ifd1, ExifTag::STRIP_BYTE_COUNTS);
+    }
+
+    /**
+     * Returns the transfer function lookup table when available.
+     *
+     * @return list<int>|null
+     */
+    public function transferFunction(): ?array
+    {
+        return $this->numericList($this->ifd0, ExifTag::TRANSFER_FUNCTION);
+    }
+
+    /**
+     * Returns the JPEG thumbnail offset, preferring the dedicated thumbnail IFD when present.
+     */
+    public function jpegThumbnailOffset(): ?int
+    {
+        $offset = $this->int($this->ifd1, ExifTag::JPEG_INTERCHANGE_FORMAT);
+
+        return $offset ?? $this->int($this->ifd0, ExifTag::JPEG_INTERCHANGE_FORMAT);
+    }
+
+    /**
+     * Returns the JPEG thumbnail byte length, preferring the dedicated thumbnail IFD when present.
+     */
+    public function jpegThumbnailLength(): ?int
+    {
+        $length = $this->int($this->ifd1, ExifTag::JPEG_INTERCHANGE_FORMAT_LENGTH);
+
+        return $length ?? $this->int($this->ifd0, ExifTag::JPEG_INTERCHANGE_FORMAT_LENGTH);
+    }
+
+    /**
+     * Returns the reference black and white point values as floating point numbers.
+     *
+     * @return list<float>|null
+     */
+    public function referenceBlackWhite(): ?array
+    {
+        return $this->rationalList($this->ifd0, ExifTag::REFERENCE_BLACK_WHITE);
+    }
+
+    /**
+     * Returns the copyright notice string when present.
+     */
+    public function copyright(): ?string
+    {
+        return $this->str($this->ifd0, ExifTag::COPYRIGHT);
+    }
+
+    /**
      * Returns the sequential image number when provided by the camera.
      */
     public function imageNumber(): ?int
@@ -978,6 +1050,46 @@ final readonly class ExifDocument
             }
 
             return $bytes;
+        }
+
+        return null;
+    }
+
+    /**
+     * Converts rational or numeric list values into floating point lists.
+     *
+     * @return list<float>|null
+     */
+    private function rationalList(?Ifd $ifd, int $tag): ?array
+    {
+        $value = $this->value($ifd, $tag);
+
+        if ($value instanceof ExifRationalList) {
+            $result = [];
+            foreach ($value->values as $item) {
+                $float = ValueConverters::rationalToFloat($item);
+                if ($float === null) {
+                    return null;
+                }
+
+                $result[] = $float;
+            }
+
+            return $result;
+        }
+
+        if ($value instanceof ExifRational) {
+            $float = ValueConverters::rationalToFloat($value);
+
+            return $float !== null ? [$float] : null;
+        }
+
+        if ($value instanceof ExifNumericList) {
+            return array_map(static fn ($v): float => (float) $v, $value->values);
+        }
+
+        if (is_int($value) || is_float($value)) {
+            return [(float) $value];
         }
 
         return null;

--- a/tests/Model/Exif/ExifDocumentTest.php
+++ b/tests/Model/Exif/ExifDocumentTest.php
@@ -133,6 +133,56 @@ final class ExifDocumentTest extends TestCase
     }
 
     /**
+     * Ensures EXIF 3.0 table 64 convenience accessors expose normalised values.
+     */
+    #[Test]
+    public function exposesTable64ConvenienceAccessors(): void
+    {
+        $transferFunction = new ExifNumericList([0, 32768, 65535]);
+        $referenceBlackWhite = new ExifRationalList([
+            new ExifRational(0, 1),
+            new ExifRational(255, 1),
+            new ExifRational(0, 1),
+            new ExifRational(255, 1),
+            new ExifRational(0, 1),
+            new ExifRational(255, 1),
+        ]);
+
+        $ifd0 = new Ifd([
+            ExifTag::TRANSFER_FUNCTION     => new IfdEntry(ExifTag::TRANSFER_FUNCTION, 3, 3, $transferFunction),
+            ExifTag::REFERENCE_BLACK_WHITE => new IfdEntry(ExifTag::REFERENCE_BLACK_WHITE, 5, 6, $referenceBlackWhite),
+            ExifTag::COPYRIGHT             => new IfdEntry(ExifTag::COPYRIGHT, 2, 9, "Jane Doe\0"),
+        ]);
+
+        $thumbnailIfd = new Ifd([
+            ExifTag::STRIP_OFFSETS                  => new IfdEntry(
+                ExifTag::STRIP_OFFSETS,
+                4,
+                2,
+                new ExifNumericList([64, 128]),
+            ),
+            ExifTag::STRIP_BYTE_COUNTS              => new IfdEntry(
+                ExifTag::STRIP_BYTE_COUNTS,
+                4,
+                2,
+                new ExifNumericList([256, 512]),
+            ),
+            ExifTag::JPEG_INTERCHANGE_FORMAT        => new IfdEntry(ExifTag::JPEG_INTERCHANGE_FORMAT, 4, 1, 4096),
+            ExifTag::JPEG_INTERCHANGE_FORMAT_LENGTH => new IfdEntry(ExifTag::JPEG_INTERCHANGE_FORMAT_LENGTH, 4, 1, 8192),
+        ]);
+
+        $doc = new ExifDocument($ifd0, null, null, null, $thumbnailIfd);
+
+        self::assertSame([64, 128], $doc->stripOffsets());
+        self::assertSame([256, 512], $doc->stripByteCounts());
+        self::assertSame([0, 32768, 65535], $doc->transferFunction());
+        self::assertSame(4096, $doc->jpegThumbnailOffset());
+        self::assertSame(8192, $doc->jpegThumbnailLength());
+        self::assertSame([0.0, 255.0, 0.0, 255.0, 0.0, 255.0], $doc->referenceBlackWhite());
+        self::assertSame('Jane Doe', $doc->copyright());
+    }
+
+    /**
      * Ensures the GPS helper exposes every decoded field from table 66 including references.
      */
     #[Test]

--- a/tests/Parse/Tiff/TiffExifReaderTest.php
+++ b/tests/Parse/Tiff/TiffExifReaderTest.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace MagicSunday\ImageMeta\Tests\Parse\Tiff;
 
+use MagicSunday\ImageMeta\Curate\Resolver\ExifTagResolver;
 use MagicSunday\ImageMeta\Core\BoundsError;
 use MagicSunday\ImageMeta\Core\Endian;
 use MagicSunday\ImageMeta\Core\ParseError;
@@ -79,6 +80,32 @@ final class TiffExifReaderTest extends TestCase
         $doc    = $reader->parseFromBlob($blob);
 
         call_user_func([self::class, $assertion], $doc);
+    }
+
+    /**
+     * Ensures the TIFF reader exposes EXIF table 64 accessors via the document and resolver.
+     */
+    #[Test]
+    public function surfacesTable64Accessors(): void
+    {
+        $document = (new TiffExifReader())->parseFromBlob(self::buildClassicTiffBlob());
+        $resolver = new ExifTagResolver($document);
+
+        self::assertSame([512], $document->stripOffsets());
+        self::assertSame([1024], $document->stripByteCounts());
+        self::assertSame([0, 32768, 65535], $document->transferFunction());
+        self::assertSame(2048, $document->jpegThumbnailOffset());
+        self::assertSame(4096, $document->jpegThumbnailLength());
+        self::assertSame([0.0, 255.0, 0.0, 255.0, 0.0, 255.0], $document->referenceBlackWhite());
+        self::assertSame('Jane Doe', $document->copyright());
+
+        self::assertSame([512], $resolver->stripOffsets());
+        self::assertSame([1024], $resolver->stripByteCounts());
+        self::assertSame([0, 32768, 65535], $resolver->transferFunction());
+        self::assertSame(2048, $resolver->jpegThumbnailOffset());
+        self::assertSame(4096, $resolver->jpegThumbnailLength());
+        self::assertSame([0.0, 255.0, 0.0, 255.0, 0.0, 255.0], $resolver->referenceBlackWhite());
+        self::assertSame('Jane Doe', $resolver->copyright());
     }
 
     /**


### PR DESCRIPTION
## Summary
- expose EXIF table 64 fields (strip offsets, transfer function, JPEG thumbnail metadata, copyright) via ExifDocument
- update ExifTagResolver to rely on the new document helpers and surface JPEG thumbnail offsets/lengths
- cover the new accessors with unit tests for ExifDocument and TiffExifReader

## Testing
- composer ci:test:php:unit

------
https://chatgpt.com/codex/tasks/task_e_68fb49954460832382424d0aad96bb2f