### PR TITLE
feat: enhance GPS metadata helpers and coverage

### DIFF
--- a/src/Curate/Resolver/ExifTagResolver.php
+++ b/src/Curate/Resolver/ExifTagResolver.php
@@ -49,6 +49,7 @@ use function is_float;
 use function is_int;
 use function is_string;
 use function ord;
+use function round;
 use function trim;
 
 /**
@@ -1104,9 +1105,7 @@ final readonly class ExifTagResolver
      */
     public function gpsDate(): ?string
     {
-        $value = $this->gpsField('date');
-
-        return is_string($value) ? $value : null;
+        return $this->document?->gpsDateStamp();
     }
 
     /**
@@ -1114,9 +1113,7 @@ final readonly class ExifTagResolver
      */
     public function gpsTime(): ?string
     {
-        $value = $this->gpsField('time');
-
-        return is_string($value) ? $value : null;
+        return $this->document?->gpsTimeStampString();
     }
 
     /**
@@ -1124,9 +1121,7 @@ final readonly class ExifTagResolver
      */
     public function gpsTimestamp(): ?DateTimeImmutable
     {
-        $value = $this->gpsField('timestamp');
-
-        return $value instanceof DateTimeImmutable ? $value : null;
+        return $this->document?->gpsTimestamp();
     }
 
     /**
@@ -1184,9 +1179,7 @@ final readonly class ExifTagResolver
      */
     public function gpsSpeedRef(): ?string
     {
-        $value = $this->gpsField('speed_ref');
-
-        return is_string($value) ? $value : null;
+        return $this->document?->gpsSpeedRef();
     }
 
     /**
@@ -1194,9 +1187,7 @@ final readonly class ExifTagResolver
      */
     public function gpsSpeed(): ?float
     {
-        $value = $this->gpsField('speed_ms');
-
-        return is_float($value) ? $value : (is_int($value) ? (float) $value : null);
+        return $this->document?->gpsSpeedMetresPerSecond();
     }
 
     /**
@@ -1204,9 +1195,7 @@ final readonly class ExifTagResolver
      */
     public function gpsTrackRef(): ?string
     {
-        $value = $this->gpsField('track_ref');
-
-        return is_string($value) ? $value : null;
+        return $this->document?->gpsTrackRef();
     }
 
     /**
@@ -1214,9 +1203,7 @@ final readonly class ExifTagResolver
      */
     public function gpsTrack(): ?float
     {
-        $value = $this->gpsField('track');
-
-        return is_float($value) ? $value : (is_int($value) ? (float) $value : null);
+        return $this->document?->gpsTrack();
     }
 
     /**
@@ -1224,9 +1211,7 @@ final readonly class ExifTagResolver
      */
     public function gpsImgDirectionRef(): ?string
     {
-        $value = $this->gpsField('img_direction_ref');
-
-        return is_string($value) ? $value : null;
+        return $this->document?->gpsImgDirectionRef();
     }
 
     /**
@@ -1234,9 +1219,7 @@ final readonly class ExifTagResolver
      */
     public function gpsImgDirection(): ?float
     {
-        $value = $this->gpsField('img_direction');
-
-        return is_float($value) ? $value : (is_int($value) ? (float) $value : null);
+        return $this->document?->gpsImgDirection();
     }
 
     /**
@@ -1294,9 +1277,7 @@ final readonly class ExifTagResolver
      */
     public function gpsDestinationBearingRef(): ?string
     {
-        $value = $this->gpsField('dest_bearing_ref');
-
-        return is_string($value) ? $value : null;
+        return $this->document?->gpsDestinationBearingRef();
     }
 
     /**
@@ -1304,9 +1285,7 @@ final readonly class ExifTagResolver
      */
     public function gpsDestinationBearing(): ?float
     {
-        $value = $this->gpsField('dest_bearing');
-
-        return is_float($value) ? $value : (is_int($value) ? (float) $value : null);
+        return $this->document?->gpsDestinationBearing();
     }
 
     /**
@@ -1314,9 +1293,7 @@ final readonly class ExifTagResolver
      */
     public function gpsDestinationDistanceRef(): ?string
     {
-        $value = $this->gpsField('dest_distance_ref');
-
-        return is_string($value) ? $value : null;
+        return $this->document?->gpsDestinationDistanceRef();
     }
 
     /**
@@ -1324,9 +1301,7 @@ final readonly class ExifTagResolver
      */
     public function gpsDestinationDistance(): ?float
     {
-        $value = $this->gpsField('dest_distance_m');
-
-        return is_float($value) ? $value : (is_int($value) ? (float) $value : null);
+        return $this->document?->gpsDestinationDistanceMetres();
     }
 
     /**
@@ -1354,17 +1329,7 @@ final readonly class ExifTagResolver
      */
     public function gpsDifferential(): ?int
     {
-        $value = $this->gpsField('differential');
-
-        if (is_int($value)) {
-            return $value;
-        }
-
-        if (is_float($value)) {
-            return (int) round($value);
-        }
-
-        return null;
+        return $this->document?->gpsDifferential();
     }
 
     /**
@@ -1372,9 +1337,7 @@ final readonly class ExifTagResolver
      */
     public function gpsHorizontalPositioningError(): ?float
     {
-        $value = $this->gpsField('h_positioning_error');
-
-        return is_float($value) ? $value : (is_int($value) ? (float) $value : null);
+        return $this->document?->gpsHorizontalPositioningError();
     }
 
     /**

--- a/src/Model/Exif/ExifDocument.php
+++ b/src/Model/Exif/ExifDocument.php
@@ -27,6 +27,7 @@ use function is_string;
 use function ord;
 use function preg_replace;
 use function rtrim;
+use function round;
 use function str_pad;
 use function str_replace;
 use function strlen;
@@ -822,6 +823,222 @@ final readonly class ExifDocument
         }
 
         return ValueConverters::gpsFromIfd($this->gpsIfd);
+    }
+
+    /**
+     * Returns the recorded GPS date stamp in ISO calendar format.
+     */
+    public function gpsDateStamp(): ?string
+    {
+        $value = $this->gpsValue('date');
+
+        return is_string($value) ? $value : null;
+    }
+
+    /**
+     * Returns the recorded GPS time stamp in HH:MM:SS(.sss) format.
+     */
+    public function gpsTimeStampString(): ?string
+    {
+        $value = $this->gpsValue('time');
+
+        return is_string($value) ? $value : null;
+    }
+
+    /**
+     * Returns the combined GPS timestamp in UTC when both date and time are available.
+     */
+    public function gpsTimestamp(): ?DateTimeImmutable
+    {
+        $value = $this->gpsValue('timestamp');
+
+        return $value instanceof DateTimeImmutable ? $value : null;
+    }
+
+    /**
+     * Returns the GPSSpeedRef value indicating the source units (K, M, N).
+     */
+    public function gpsSpeedRef(): ?string
+    {
+        $value = $this->gpsValue('speed_ref');
+
+        return is_string($value) ? $value : null;
+    }
+
+    /**
+     * Returns the GPS speed converted to metres per second.
+     */
+    public function gpsSpeedMetresPerSecond(): ?float
+    {
+        $value = $this->gpsValue('speed_ms');
+
+        if (is_float($value)) {
+            return $value;
+        }
+
+        if (is_int($value)) {
+            return (float) $value;
+        }
+
+        return null;
+    }
+
+    /**
+     * Returns the GPSTrackRef value (T for true, M for magnetic).
+     */
+    public function gpsTrackRef(): ?string
+    {
+        $value = $this->gpsValue('track_ref');
+
+        return is_string($value) ? $value : null;
+    }
+
+    /**
+     * Returns the normalised course over ground in degrees within [0, 360).
+     */
+    public function gpsTrack(): ?float
+    {
+        $value = $this->gpsValue('track');
+
+        if (is_float($value)) {
+            return $value;
+        }
+
+        if (is_int($value)) {
+            return (float) $value;
+        }
+
+        return null;
+    }
+
+    /**
+     * Returns the GPSImgDirectionRef value.
+     */
+    public function gpsImgDirectionRef(): ?string
+    {
+        $value = $this->gpsValue('img_direction_ref');
+
+        return is_string($value) ? $value : null;
+    }
+
+    /**
+     * Returns the normalised image direction in degrees within [0, 360).
+     */
+    public function gpsImgDirection(): ?float
+    {
+        $value = $this->gpsValue('img_direction');
+
+        if (is_float($value)) {
+            return $value;
+        }
+
+        if (is_int($value)) {
+            return (float) $value;
+        }
+
+        return null;
+    }
+
+    /**
+     * Returns the GPSDestBearingRef value (true or magnetic).
+     */
+    public function gpsDestinationBearingRef(): ?string
+    {
+        $value = $this->gpsValue('dest_bearing_ref');
+
+        return is_string($value) ? $value : null;
+    }
+
+    /**
+     * Returns the normalised destination bearing in degrees within [0, 360).
+     */
+    public function gpsDestinationBearing(): ?float
+    {
+        $value = $this->gpsValue('dest_bearing');
+
+        if (is_float($value)) {
+            return $value;
+        }
+
+        if (is_int($value)) {
+            return (float) $value;
+        }
+
+        return null;
+    }
+
+    /**
+     * Returns the GPSDestDistanceRef value (kilometres, miles or nautical miles).
+     */
+    public function gpsDestinationDistanceRef(): ?string
+    {
+        $value = $this->gpsValue('dest_distance_ref');
+
+        return is_string($value) ? $value : null;
+    }
+
+    /**
+     * Returns the destination distance converted to metres.
+     */
+    public function gpsDestinationDistanceMetres(): ?float
+    {
+        $value = $this->gpsValue('dest_distance_m');
+
+        if (is_float($value)) {
+            return $value;
+        }
+
+        if (is_int($value)) {
+            return (float) $value;
+        }
+
+        return null;
+    }
+
+    /**
+     * Returns the GPS differential correction indicator.
+     */
+    public function gpsDifferential(): ?int
+    {
+        $value = $this->gpsValue('differential');
+
+        if (is_int($value)) {
+            return $value;
+        }
+
+        if (is_float($value)) {
+            return (int) round($value);
+        }
+
+        return null;
+    }
+
+    /**
+     * Returns the horizontal positioning error in metres when provided.
+     */
+    public function gpsHorizontalPositioningError(): ?float
+    {
+        $value = $this->gpsValue('h_positioning_error');
+
+        if (is_float($value)) {
+            return $value;
+        }
+
+        if (is_int($value)) {
+            return (float) $value;
+        }
+
+        return null;
+    }
+
+    /**
+     * Returns a single value from the cached GPS metadata map.
+     */
+    private function gpsValue(string $key): mixed
+    {
+        $gps = $this->gps();
+
+        return $gps[$key] ?? null;
     }
 
     /**

--- a/src/Model/Exif/ExifTag.php
+++ b/src/Model/Exif/ExifTag.php
@@ -265,7 +265,7 @@ final readonly class ExifTag
 
     public const int DEVICE_SETTING_DESCRIPTION = 0xA40B;
 
-    // GPS sub IFD (Table 66 – EXIF 2.32)
+    // GPS sub IFD (Table 66 – EXIF 3.0)
     public const int GPS_VERSION_ID = 0x0000;
 
     public const int GPS_LATITUDE_REF = 0x0001;

--- a/src/Model/Exif/ValueConverters.php
+++ b/src/Model/Exif/ValueConverters.php
@@ -21,6 +21,7 @@ use function count;
 use function ctype_digit;
 use function explode;
 use function floor;
+use function fmod;
 use function implode;
 use function is_float;
 use function is_int;
@@ -170,6 +171,32 @@ final readonly class ValueConverters
             'N'     => $numeric * 1852.0,
             default => null,
         };
+    }
+
+    /**
+     * Normalises a compass bearing to the [0, 360) interval.
+     */
+    public static function normalizeBearing(int|float|null $value): ?float
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        $bearing = fmod((float) $value, 360.0);
+
+        if ($bearing < 0.0) {
+            $bearing += 360.0;
+        }
+
+        if ($bearing < 0.0 || $bearing >= 360.0) {
+            $bearing = fmod($bearing, 360.0);
+
+            if ($bearing < 0.0) {
+                $bearing += 360.0;
+            }
+        }
+
+        return $bearing;
     }
 
     /**
@@ -452,11 +479,13 @@ final readonly class ValueConverters
 
         $trackRefValue       = $trackRefEntry?->value;
         $result['track_ref'] = is_string($trackRefValue) ? strtoupper(trim($trackRefValue)) : null;
-        $result['track']     = self::rationalToFloat($trackEntry?->value);
+        $trackValue          = self::rationalToFloat($trackEntry?->value);
+        $result['track']     = self::normalizeBearing($trackValue);
 
         $imgDirRefValue             = $imgDirRefEntry?->value;
         $result['img_direction_ref'] = is_string($imgDirRefValue) ? strtoupper(trim($imgDirRefValue)) : null;
-        $result['img_direction']     = self::rationalToFloat($imgDirEntry?->value);
+        $imgDirectionValue           = self::rationalToFloat($imgDirEntry?->value);
+        $result['img_direction']     = self::normalizeBearing($imgDirectionValue);
 
         $result['map_datum'] = self::sanitizeString($mapDatumEntry?->value);
 
@@ -474,7 +503,8 @@ final readonly class ValueConverters
 
         $destBearingRefValue        = $destBearRefEntry?->value;
         $result['dest_bearing_ref'] = is_string($destBearingRefValue) ? strtoupper(trim($destBearingRefValue)) : null;
-        $result['dest_bearing']     = self::rationalToFloat($destBearEntry?->value);
+        $destBearingValue           = self::rationalToFloat($destBearEntry?->value);
+        $result['dest_bearing']     = self::normalizeBearing($destBearingValue);
 
         $destDistanceRefValue        = $destDistRefEntry?->value;
         $result['dest_distance_ref'] = is_string($destDistanceRefValue) ? strtoupper(trim($destDistanceRefValue)) : null;

--- a/tests/Curate/Resolver/ExifTagResolverTest.php
+++ b/tests/Curate/Resolver/ExifTagResolverTest.php
@@ -20,6 +20,8 @@ use MagicSunday\ImageMeta\Model\Exif\ExifRationalList;
 use MagicSunday\ImageMeta\Model\Exif\ExifTag;
 use MagicSunday\ImageMeta\Model\Exif\Ifd;
 use MagicSunday\ImageMeta\Model\Exif\IfdEntry;
+use MagicSunday\ImageMeta\Parse\Tiff\TiffExifReader;
+use MagicSunday\ImageMeta\Tests\Support\GpsTiffBuilder;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\Attributes\UsesClass;
@@ -35,6 +37,8 @@ use PHPUnit\Framework\TestCase;
 #[UsesClass(ExifRational::class)]
 #[UsesClass(ExifRationalList::class)]
 #[UsesClass(ExifNumericList::class)]
+#[UsesClass(TiffExifReader::class)]
+#[UsesClass(GpsTiffBuilder::class)]
 final class ExifTagResolverTest extends TestCase
 {
     /**
@@ -166,6 +170,49 @@ final class ExifTagResolverTest extends TestCase
         self::assertInstanceOf(DateTimeImmutable::class, $timestamp);
         self::assertSame('2024-05-06T12:34:56+00:00', $timestamp->format(DATE_ATOM));
         self::assertSame('12:34:56.789000', $timestamp->format('H:i:s.u'));
+
+        self::assertSame(2, $resolver->gpsDifferential());
+        self::assertEqualsWithDelta(1.5, $resolver->gpsHorizontalPositioningError(), 0.000001);
+    }
+
+    /**
+     * Ensures GPS data parsed from a TIFF blob is normalised and exposed via resolver helpers.
+     */
+    #[Test]
+    public function resolvesGpsMetadataFromSyntheticTiff(): void
+    {
+        $document = (new TiffExifReader())->parseFromBlob(GpsTiffBuilder::buildClassicGpsTiff());
+        $resolver = new ExifTagResolver($document);
+
+        $gps = $resolver->gps();
+
+        self::assertSame('N', $gps['lat_ref']);
+        self::assertEqualsWithDelta(51.5, $gps['lat'], 0.000001);
+        self::assertSame('E', $gps['lon_ref']);
+        self::assertEqualsWithDelta(8.5, $gps['lon'], 0.000001);
+        self::assertSame(0, $gps['alt_ref']);
+        self::assertEqualsWithDelta(150.0, $gps['alt'], 0.000001);
+        self::assertEqualsWithDelta(90.0, $gps['track'], 0.000001);
+        self::assertEqualsWithDelta(45.0, $gps['img_direction'], 0.000001);
+        self::assertEqualsWithDelta(45.0, $gps['dest_bearing'], 0.000001);
+        self::assertEqualsWithDelta(42000.0, $gps['dest_distance_m'], 0.000001);
+
+        self::assertSame('K', $resolver->gpsSpeedRef());
+        self::assertEqualsWithDelta(20.0, $resolver->gpsSpeed(), 0.000001);
+        self::assertSame('T', $resolver->gpsTrackRef());
+        self::assertEqualsWithDelta(90.0, $resolver->gpsTrack(), 0.000001);
+        self::assertSame('M', $resolver->gpsImgDirectionRef());
+        self::assertEqualsWithDelta(45.0, $resolver->gpsImgDirection(), 0.000001);
+        self::assertSame('T', $resolver->gpsDestinationBearingRef());
+        self::assertEqualsWithDelta(45.0, $resolver->gpsDestinationBearing(), 0.000001);
+        self::assertSame('K', $resolver->gpsDestinationDistanceRef());
+        self::assertEqualsWithDelta(42000.0, $resolver->gpsDestinationDistance(), 0.000001);
+        self::assertSame('2024-05-06', $resolver->gpsDate());
+        self::assertSame('12:34:56.789', $resolver->gpsTime());
+
+        $timestamp = $resolver->gpsTimestamp();
+        self::assertInstanceOf(DateTimeImmutable::class, $timestamp);
+        self::assertSame('2024-05-06T12:34:56+00:00', $timestamp->format(DATE_ATOM));
 
         self::assertSame(2, $resolver->gpsDifferential());
         self::assertEqualsWithDelta(1.5, $resolver->gpsHorizontalPositioningError(), 0.000001);

--- a/tests/Model/Exif/ExifDocumentTest.php
+++ b/tests/Model/Exif/ExifDocumentTest.php
@@ -20,6 +20,8 @@ use MagicSunday\ImageMeta\Model\Exif\ExifTag;
 use MagicSunday\ImageMeta\Model\Exif\Ifd;
 use MagicSunday\ImageMeta\Model\Exif\IfdEntry;
 use MagicSunday\ImageMeta\Model\Exif\ValueConverters;
+use MagicSunday\ImageMeta\Parse\Tiff\TiffExifReader;
+use MagicSunday\ImageMeta\Tests\Support\GpsTiffBuilder;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\Attributes\UsesClass;
@@ -34,6 +36,8 @@ use PHPUnit\Framework\TestCase;
 #[UsesClass(Ifd::class)]
 #[UsesClass(IfdEntry::class)]
 #[UsesClass(ValueConverters::class)]
+#[UsesClass(TiffExifReader::class)]
+#[UsesClass(GpsTiffBuilder::class)]
 final class ExifDocumentTest extends TestCase
 {
     private const string ISO_8601_MILLISECONDS = 'Y-m-d\TH:i:s.vP';
@@ -237,7 +241,7 @@ final class ExifDocumentTest extends TestCase
         self::assertSame('N', $gps['speed_ref']);
         self::assertEqualsWithDelta(6.3508166667, $gps['speed_ms'], 0.000001);
         self::assertSame('M', $gps['track_ref']);
-        self::assertEqualsWithDelta(543.21, $gps['track'], 0.000001);
+        self::assertEqualsWithDelta(183.21, $gps['track'], 0.000001);
         self::assertSame('T', $gps['img_direction_ref']);
         self::assertEqualsWithDelta(90.0, $gps['img_direction'], 0.000001);
         self::assertSame('WGS-84', $gps['map_datum']);
@@ -480,5 +484,47 @@ final class ExifDocumentTest extends TestCase
 
         $docWithoutExif = new ExifDocument($ifd0, null, null, null, null);
         self::assertSame(200, $docWithoutExif->iso());
+    }
+
+    /**
+     * Ensures GPS metadata parsed via the TIFF reader is normalised and exposed via dedicated helpers.
+     */
+    #[Test]
+    public function parsesGpsMetadataFromSyntheticTiff(): void
+    {
+        $document = (new TiffExifReader())->parseFromBlob(GpsTiffBuilder::buildClassicGpsTiff());
+
+        $gps = $document->gps();
+
+        self::assertSame('N', $gps['lat_ref']);
+        self::assertEqualsWithDelta(51.5, $gps['lat'], 0.000001);
+        self::assertSame('E', $gps['lon_ref']);
+        self::assertEqualsWithDelta(8.5, $gps['lon'], 0.000001);
+        self::assertSame(0, $gps['alt_ref']);
+        self::assertEqualsWithDelta(150.0, $gps['alt'], 0.000001);
+        self::assertEqualsWithDelta(90.0, $gps['track'], 0.000001);
+        self::assertEqualsWithDelta(45.0, $gps['img_direction'], 0.000001);
+        self::assertEqualsWithDelta(45.0, $gps['dest_bearing'], 0.000001);
+        self::assertEqualsWithDelta(42000.0, $gps['dest_distance_m'], 0.000001);
+
+        self::assertSame('K', $document->gpsSpeedRef());
+        self::assertEqualsWithDelta(20.0, $document->gpsSpeedMetresPerSecond(), 0.000001);
+        self::assertSame('T', $document->gpsTrackRef());
+        self::assertEqualsWithDelta(90.0, $document->gpsTrack(), 0.000001);
+        self::assertSame('M', $document->gpsImgDirectionRef());
+        self::assertEqualsWithDelta(45.0, $document->gpsImgDirection(), 0.000001);
+        self::assertSame('T', $document->gpsDestinationBearingRef());
+        self::assertEqualsWithDelta(45.0, $document->gpsDestinationBearing(), 0.000001);
+        self::assertSame('K', $document->gpsDestinationDistanceRef());
+        self::assertEqualsWithDelta(42000.0, $document->gpsDestinationDistanceMetres(), 0.000001);
+        self::assertSame('2024-05-06', $document->gpsDateStamp());
+        self::assertSame('12:34:56.789', $document->gpsTimeStampString());
+
+        $timestamp = $document->gpsTimestamp();
+        self::assertInstanceOf(DateTimeImmutable::class, $timestamp);
+        self::assertSame('2024-05-06T12:34:56+00:00', $timestamp->format(DATE_ATOM));
+
+        self::assertSame(2, $document->gpsDifferential());
+        self::assertEqualsWithDelta(1.5, $document->gpsHorizontalPositioningError(), 0.000001);
     }
 }

--- a/tests/Support/GpsTiffBuilder.php
+++ b/tests/Support/GpsTiffBuilder.php
@@ -1,0 +1,159 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\ImageMeta\Tests\Support;
+
+use MagicSunday\ImageMeta\Model\Exif\ExifTag;
+
+use function array_map;
+use function array_pad;
+use function pack;
+use function strlen;
+use function str_split;
+use function unpack;
+use function ord;
+
+/**
+ * Builds synthetic Classic TIFF payloads containing EXIF GPS metadata for integration tests.
+ */
+final class GpsTiffBuilder
+{
+    /**
+     * Creates a Classic TIFF blob with a populated GPS IFD exercising EXIF 3.0 tags.
+     */
+    public static function buildClassicGpsTiff(): string
+    {
+        $header = 'II' . pack('v', 0x002A) . pack('V', 8);
+
+        $ifd0EntryCount = 1;
+        $ifd0Size       = 2 + ($ifd0EntryCount * 12) + 4;
+        $gpsIfdOffset   = 8 + $ifd0Size;
+
+        $ifd0 = pack('v', $ifd0EntryCount)
+            . self::packClassicEntry(ExifTag::GPS_IFD_POINTER, 4, 1, $gpsIfdOffset)
+            . pack('V', 0);
+
+        $definitions = [
+            [ExifTag::GPS_VERSION_ID, 1, 4, 'bytes', [3, 0, 0, 0]],
+            [ExifTag::GPS_LATITUDE_REF, 2, 2, 'string', "N\0"],
+            [ExifTag::GPS_LATITUDE, 5, 3, 'rationals', [[51, 1], [30, 1], [0, 1]]],
+            [ExifTag::GPS_LONGITUDE_REF, 2, 2, 'string', "E\0"],
+            [ExifTag::GPS_LONGITUDE, 5, 3, 'rationals', [[8, 1], [30, 1], [0, 1]]],
+            [ExifTag::GPS_ALTITUDE_REF, 1, 1, 'inline', 0],
+            [ExifTag::GPS_ALTITUDE, 5, 1, 'rationals', [[150, 1]]],
+            [ExifTag::GPS_TIME_STAMP, 5, 3, 'rationals', [[12, 1], [34, 1], [56789, 1000]]],
+            [ExifTag::GPS_DATE_STAMP, 2, 11, 'string', "2024:05:06\0"],
+            [ExifTag::GPS_SPEED_REF, 2, 2, 'string', "K\0"],
+            [ExifTag::GPS_SPEED, 5, 1, 'rationals', [[72000, 1000]]],
+            [ExifTag::GPS_TRACK_REF, 2, 2, 'string', "T\0"],
+            [ExifTag::GPS_TRACK, 5, 1, 'rationals', [[450, 1]]],
+            [ExifTag::GPS_IMG_DIRECTION_REF, 2, 2, 'string', "M\0"],
+            [ExifTag::GPS_IMG_DIRECTION, 5, 1, 'rationals', [[405, 1]]],
+            [ExifTag::GPS_DEST_LATITUDE_REF, 2, 2, 'string', "N\0"],
+            [ExifTag::GPS_DEST_LATITUDE, 5, 3, 'rationals', [[41, 1], [0, 1], [0, 1]]],
+            [ExifTag::GPS_DEST_LONGITUDE_REF, 2, 2, 'string', "E\0"],
+            [ExifTag::GPS_DEST_LONGITUDE, 5, 3, 'rationals', [[8, 1], [30, 1], [0, 1]]],
+            [ExifTag::GPS_DEST_BEARING_REF, 2, 2, 'string', "T\0"],
+            [ExifTag::GPS_DEST_BEARING, 5, 1, 'rationals', [[765, 1]]],
+            [ExifTag::GPS_DEST_DISTANCE_REF, 2, 2, 'string', "K\0"],
+            [ExifTag::GPS_DEST_DISTANCE, 5, 1, 'rationals', [[42, 1]]],
+            [ExifTag::GPS_DIFFERENTIAL, 3, 1, 'inline', 2],
+            [ExifTag::GPS_H_POSITIONING_ERROR, 5, 1, 'rationals', [[15, 10]]],
+        ];
+
+        $gpsEntryCount = count($definitions);
+        $gpsIfdSize    = 2 + ($gpsEntryCount * 12) + 4;
+        $dataBase      = $gpsIfdOffset + $gpsIfdSize;
+
+        $gpsEntries = [];
+        $gpsData    = '';
+
+        $addData = static function (string $value) use (&$gpsData, $dataBase): int {
+            $offset  = $dataBase + strlen($gpsData);
+            $gpsData .= $value;
+
+            return $offset;
+        };
+
+        foreach ($definitions as [$tag, $type, $count, $mode, $payload]) {
+            switch ($mode) {
+                case 'bytes':
+                    $value = self::inlineBytes($payload);
+                    $gpsEntries[] = self::packClassicEntry($tag, $type, $count, $value);
+                    break;
+                case 'string':
+                    if (strlen($payload) <= 4) {
+                        $gpsEntries[] = self::packClassicEntry($tag, $type, $count, self::inlineString($payload));
+                        break;
+                    }
+
+                    $offset = $addData($payload);
+                    $gpsEntries[] = self::packClassicEntry($tag, $type, $count, $offset);
+                    break;
+                case 'rationals':
+                    $buffer = '';
+                    foreach ($payload as [$numerator, $denominator]) {
+                        $buffer .= self::packRational($numerator, $denominator);
+                    }
+
+                    $offset = $addData($buffer);
+                    $gpsEntries[] = self::packClassicEntry($tag, $type, $count, $offset);
+                    break;
+                case 'inline':
+                    $gpsEntries[] = self::packClassicEntry($tag, $type, $count, (int) $payload);
+                    break;
+            }
+        }
+
+        $gpsIfd = pack('v', $gpsEntryCount) . implode('', $gpsEntries) . pack('V', 0);
+
+        return $header . $ifd0 . $gpsIfd . $gpsData;
+    }
+
+    /**
+     * Packs a Classic TIFF directory entry.
+     */
+    private static function packClassicEntry(int $tag, int $type, int $count, int $valueOrOffset): string
+    {
+        return pack('v', $tag)
+            . pack('v', $type)
+            . pack('V', $count)
+            . pack('V', $valueOrOffset);
+    }
+
+    /**
+     * Packs a rational number into TIFF numerator/denominator format.
+     */
+    private static function packRational(int $numerator, int $denominator): string
+    {
+        return pack('V', $numerator) . pack('V', $denominator);
+    }
+
+    /**
+     * Converts a string containing up to four bytes into an inline DWORD value.
+     */
+    private static function inlineString(string $value): int
+    {
+        return self::inlineBytes(array_map(static fn (string $c): int => ord($c), str_split($value)));
+    }
+
+    /**
+     * Converts up to four bytes into an inline DWORD representation.
+     *
+     * @param array<int> $bytes
+     */
+    private static function inlineBytes(array $bytes): int
+    {
+        $bytes = array_pad($bytes, 4, 0);
+
+        return unpack('V', pack('C4', $bytes[0], $bytes[1], $bytes[2], $bytes[3]))[1];
+    }
+}


### PR DESCRIPTION
## Summary
- add EXIF 3.0 GPS helper accessors to ExifDocument and expose them through ExifTagResolver
- normalise GPS bearings and speed conversions while updating tag constants to match the latest spec
- add synthetic Classic TIFF GPS fixtures and PHPUnit coverage for document and resolver helpers

## Testing
- composer ci:test:php:unit

------
https://chatgpt.com/codex/tasks/task_e_68fb49974bcc83239c4eb478db6d5449