### PR TITLE
feat: adopt EXIF 3.0 attribution identifiers

### DIFF
--- a/src/Model/Exif/ExifDocument.php
+++ b/src/Model/Exif/ExifDocument.php
@@ -184,7 +184,12 @@ final readonly class ExifDocument
      */
     public function imageTitle(): ?string
     {
-        return $this->str($this->ifd0, ExifTag::IMAGE_TITLE);
+        return $this->strWithFallback(
+            $this->exifIfd,
+            ExifTag::IMAGE_TITLE,
+            $this->ifd0,
+            ExifTag::LEGACY_IMAGE_TITLE,
+        );
     }
 
     /**
@@ -192,7 +197,12 @@ final readonly class ExifDocument
      */
     public function photographer(): ?string
     {
-        return $this->str($this->ifd0, ExifTag::PHOTOGRAPHER);
+        return $this->strWithFallback(
+            $this->exifIfd,
+            ExifTag::PHOTOGRAPHER,
+            $this->ifd0,
+            ExifTag::LEGACY_PHOTOGRAPHER,
+        );
     }
 
     /**
@@ -200,7 +210,12 @@ final readonly class ExifDocument
      */
     public function imageEditor(): ?string
     {
-        return $this->str($this->ifd0, ExifTag::IMAGE_EDITOR);
+        return $this->strWithFallback(
+            $this->exifIfd,
+            ExifTag::IMAGE_EDITOR,
+            $this->ifd0,
+            ExifTag::LEGACY_IMAGE_EDITOR,
+        );
     }
 
     /**
@@ -702,7 +717,12 @@ final readonly class ExifDocument
      */
     public function cameraFirmware(): ?string
     {
-        return $this->str($this->exifIfd, ExifTag::CAMERA_FIRMWARE);
+        return $this->strWithFallback(
+            $this->exifIfd,
+            ExifTag::CAMERA_FIRMWARE,
+            $this->exifIfd,
+            ExifTag::LEGACY_CAMERA_FIRMWARE,
+        );
     }
 
     /**
@@ -710,7 +730,12 @@ final readonly class ExifDocument
      */
     public function rawDevelopingSoftware(): ?string
     {
-        return $this->str($this->exifIfd, ExifTag::RAW_DEVELOPING_SOFTWARE);
+        return $this->strWithFallback(
+            $this->exifIfd,
+            ExifTag::RAW_DEVELOPING_SOFTWARE,
+            $this->exifIfd,
+            ExifTag::LEGACY_RAW_DEVELOPING_SOFTWARE,
+        );
     }
 
     /**
@@ -718,7 +743,12 @@ final readonly class ExifDocument
      */
     public function imageEditingSoftware(): ?string
     {
-        return $this->str($this->exifIfd, ExifTag::IMAGE_EDITING_SOFTWARE);
+        return $this->strWithFallback(
+            $this->exifIfd,
+            ExifTag::IMAGE_EDITING_SOFTWARE,
+            $this->exifIfd,
+            ExifTag::LEGACY_IMAGE_EDITING_SOFTWARE,
+        );
     }
 
     /**
@@ -726,7 +756,12 @@ final readonly class ExifDocument
      */
     public function metadataEditingSoftware(): ?string
     {
-        return $this->str($this->exifIfd, ExifTag::METADATA_EDITING_SOFTWARE);
+        return $this->strWithFallback(
+            $this->exifIfd,
+            ExifTag::METADATA_EDITING_SOFTWARE,
+            $this->exifIfd,
+            ExifTag::LEGACY_METADATA_EDITING_SOFTWARE,
+        );
     }
 
     /**
@@ -1153,6 +1188,22 @@ final readonly class ExifDocument
             $this->offsetTime(),
             $this->subSecTime(),
         );
+    }
+
+    /**
+     * Returns a string value using a fallback tag when the primary tag is not present.
+     *
+     * @return string|null
+     */
+    private function strWithFallback(?Ifd $primaryIfd, int $primaryTag, ?Ifd $fallbackIfd, int $fallbackTag): ?string
+    {
+        $value = $this->str($primaryIfd, $primaryTag);
+
+        if ($value !== null) {
+            return $value;
+        }
+
+        return $this->str($fallbackIfd, $fallbackTag);
     }
 
     /**

--- a/src/Model/Exif/ExifTag.php
+++ b/src/Model/Exif/ExifTag.php
@@ -29,7 +29,7 @@ final readonly class ExifTag
 
     public const int IMAGE_DESCRIPTION = 0x010E;
 
-    public const int IMAGE_TITLE = 0x0320;
+    public const int IMAGE_TITLE = 0xA436;
 
     public const int MAKE = 0x010F;
 
@@ -61,9 +61,9 @@ final readonly class ExifTag
 
     public const int ARTIST = 0x013B;
 
-    public const int PHOTOGRAPHER = 0xE92D;
+    public const int PHOTOGRAPHER = 0xA437;
 
-    public const int IMAGE_EDITOR = 0xE92E;
+    public const int IMAGE_EDITOR = 0xA438;
 
     public const int WHITE_POINT = 0x013E;
 
@@ -342,13 +342,27 @@ final readonly class ExifTag
 
     public const int CAMERA_ELEVATION_ANGLE = 0x9405;
 
-    public const int CAMERA_FIRMWARE = 0xE92F;
+    public const int CAMERA_FIRMWARE = 0xA439;
 
-    public const int RAW_DEVELOPING_SOFTWARE = 0xE930;
+    public const int RAW_DEVELOPING_SOFTWARE = 0xA43A;
 
-    public const int IMAGE_EDITING_SOFTWARE = 0xE931;
+    public const int IMAGE_EDITING_SOFTWARE = 0xA43B;
 
-    public const int METADATA_EDITING_SOFTWARE = 0xE932;
+    public const int METADATA_EDITING_SOFTWARE = 0xA43C;
+
+    public const int LEGACY_IMAGE_TITLE = 0x0320;
+
+    public const int LEGACY_PHOTOGRAPHER = 0xE92D;
+
+    public const int LEGACY_IMAGE_EDITOR = 0xE92E;
+
+    public const int LEGACY_CAMERA_FIRMWARE = 0xE92F;
+
+    public const int LEGACY_RAW_DEVELOPING_SOFTWARE = 0xE930;
+
+    public const int LEGACY_IMAGE_EDITING_SOFTWARE = 0xE931;
+
+    public const int LEGACY_METADATA_EDITING_SOFTWARE = 0xE932;
 
     // Interoperability IFD
     public const int INTEROPERABILITY_INDEX = 0x0001;

--- a/tests/Curate/StructuredMetadataBuilderTest.php
+++ b/tests/Curate/StructuredMetadataBuilderTest.php
@@ -81,9 +81,6 @@ final class StructuredMetadataBuilderTest extends TestCase
             ExifTag::MODEL                      => new IfdEntry(ExifTag::MODEL, 2, 8, 'EOS R6 II'),
             ExifTag::SOFTWARE                   => new IfdEntry(ExifTag::SOFTWARE, 2, 8, 'Firmware1'),
             ExifTag::IMAGE_DESCRIPTION          => new IfdEntry(ExifTag::IMAGE_DESCRIPTION, 2, 16, 'Sunset over Alps'),
-            ExifTag::IMAGE_TITLE                => new IfdEntry(ExifTag::IMAGE_TITLE, 2, 12, 'Sunset Title'),
-            ExifTag::PHOTOGRAPHER               => new IfdEntry(ExifTag::PHOTOGRAPHER, 2, 22, 'Jane D. Photographer'),
-            ExifTag::IMAGE_EDITOR               => new IfdEntry(ExifTag::IMAGE_EDITOR, 2, 12, 'John Editor'),
             ExifTag::ORIENTATION                => new IfdEntry(ExifTag::ORIENTATION, 3, 1, Orientation::RIGHT_TOP->value),
             ExifTag::ARTIST                     => new IfdEntry(ExifTag::ARTIST, 2, 12, 'Jane Doe'),
         ]);
@@ -102,6 +99,9 @@ final class StructuredMetadataBuilderTest extends TestCase
             ExifTag::IMAGE_NUMBER              => new IfdEntry(ExifTag::IMAGE_NUMBER, 4, 1, 128),
             ExifTag::SECURITY_CLASSIFICATION   => new IfdEntry(ExifTag::SECURITY_CLASSIFICATION, 2, 1, 'Restricted'),
             ExifTag::IMAGE_HISTORY             => new IfdEntry(ExifTag::IMAGE_HISTORY, 2, 1, 'Developed in Raw Studio'),
+            ExifTag::IMAGE_TITLE               => new IfdEntry(ExifTag::IMAGE_TITLE, 2, 12, 'Sunset Title'),
+            ExifTag::PHOTOGRAPHER              => new IfdEntry(ExifTag::PHOTOGRAPHER, 2, 22, 'Jane D. Photographer'),
+            ExifTag::IMAGE_EDITOR              => new IfdEntry(ExifTag::IMAGE_EDITOR, 2, 12, 'John Editor'),
             ExifTag::INTERLACE                 => new IfdEntry(ExifTag::INTERLACE, 3, 1, 1),
             ExifTag::EXPOSURE_BIAS_VALUE       => new IfdEntry(ExifTag::EXPOSURE_BIAS_VALUE, 10, 1, [[-2, 1]]),
             ExifTag::METERING_MODE             => new IfdEntry(ExifTag::METERING_MODE, 3, 1, MeteringMode::PATTERN->value),
@@ -305,6 +305,40 @@ final class StructuredMetadataBuilderTest extends TestCase
         self::assertSame('+01:30', $structured->temporal->offsetTimeDigitized);
         self::assertSame([-90, -60], $structured->temporal->timeZoneOffsetMinutes);
         self::assertSame('OffsetTimeOriginal', $structured->temporal->tzSource);
+    }
+
+    /**
+     * Ensures the builder falls back to legacy attribution tags when EXIF 3.0 tags are not present.
+     */
+    #[Test]
+    public function usesLegacyExifAttributionWhenNewTagsMissing(): void
+    {
+        $ifd0 = new Ifd([
+            ExifTag::LEGACY_IMAGE_TITLE  => new IfdEntry(ExifTag::LEGACY_IMAGE_TITLE, 2, 1, 'Legacy Title'),
+            ExifTag::LEGACY_PHOTOGRAPHER => new IfdEntry(ExifTag::LEGACY_PHOTOGRAPHER, 2, 1, 'Legacy Photographer'),
+            ExifTag::LEGACY_IMAGE_EDITOR => new IfdEntry(ExifTag::LEGACY_IMAGE_EDITOR, 2, 1, 'Legacy Editor'),
+        ]);
+
+        $exifIfd = new Ifd([
+            ExifTag::LEGACY_CAMERA_FIRMWARE           => new IfdEntry(ExifTag::LEGACY_CAMERA_FIRMWARE, 2, 1, 'Legacy Firmware'),
+            ExifTag::LEGACY_RAW_DEVELOPING_SOFTWARE   => new IfdEntry(ExifTag::LEGACY_RAW_DEVELOPING_SOFTWARE, 2, 1, 'Legacy Raw'),
+            ExifTag::LEGACY_IMAGE_EDITING_SOFTWARE    => new IfdEntry(ExifTag::LEGACY_IMAGE_EDITING_SOFTWARE, 2, 1, 'Legacy Edit'),
+            ExifTag::LEGACY_METADATA_EDITING_SOFTWARE => new IfdEntry(ExifTag::LEGACY_METADATA_EDITING_SOFTWARE, 2, 1, 'Legacy Metadata'),
+        ]);
+
+        $exifDocument = new ExifDocument($ifd0, $exifIfd, null, null, null);
+
+        $metadata = new Metadata(['primary'], null, $exifDocument, [], null);
+
+        $structured = (new StructuredMetadataBuilder())->build($metadata);
+
+        self::assertSame('Legacy Title', $structured->image->title);
+        self::assertSame('Legacy Photographer', $structured->author->photographer);
+        self::assertSame('Legacy Editor', $structured->author->imageEditor);
+        self::assertSame('Legacy Firmware', $structured->camera->firmware);
+        self::assertSame('Legacy Raw', $structured->device->rawDevelopingSoftware);
+        self::assertSame('Legacy Edit', $structured->device->imageEditingSoftware);
+        self::assertSame('Legacy Metadata', $structured->device->metadataEditingSoftware);
     }
 
     /**

--- a/tests/Model/Exif/ExifDocumentTest.php
+++ b/tests/Model/Exif/ExifDocumentTest.php
@@ -416,9 +416,6 @@ final class ExifDocumentTest extends TestCase
     {
         $ifd0 = new Ifd([
             ExifTag::IMAGE_DESCRIPTION => new IfdEntry(ExifTag::IMAGE_DESCRIPTION, 2, 1, 'Coastal cliffs'),
-            ExifTag::IMAGE_TITLE       => new IfdEntry(ExifTag::IMAGE_TITLE, 2, 1, 'Cliffside Dusk'),
-            ExifTag::PHOTOGRAPHER      => new IfdEntry(ExifTag::PHOTOGRAPHER, 2, 1, 'Alex Light'),
-            ExifTag::IMAGE_EDITOR      => new IfdEntry(ExifTag::IMAGE_EDITOR, 2, 1, 'Chris Edit'),
         ]);
 
         $exifIfd = new Ifd([
@@ -432,6 +429,9 @@ final class ExifDocumentTest extends TestCase
             ExifTag::IMAGE_NUMBER               => new IfdEntry(ExifTag::IMAGE_NUMBER, 3, 1, 512),
             ExifTag::SECURITY_CLASSIFICATION    => new IfdEntry(ExifTag::SECURITY_CLASSIFICATION, 2, 1, 'Confidential'),
             ExifTag::IMAGE_HISTORY              => new IfdEntry(ExifTag::IMAGE_HISTORY, 2, 1, 'Processed in RawLab'),
+            ExifTag::IMAGE_TITLE               => new IfdEntry(ExifTag::IMAGE_TITLE, 2, 1, 'Cliffside Dusk'),
+            ExifTag::PHOTOGRAPHER              => new IfdEntry(ExifTag::PHOTOGRAPHER, 2, 1, 'Alex Light'),
+            ExifTag::IMAGE_EDITOR              => new IfdEntry(ExifTag::IMAGE_EDITOR, 2, 1, 'Chris Edit'),
             ExifTag::TEMPERATURE                => new IfdEntry(ExifTag::TEMPERATURE, 10, 1, new ExifRational(200, 10)),
             ExifTag::HUMIDITY                   => new IfdEntry(ExifTag::HUMIDITY, 10, 1, new ExifRational(550, 10)),
             ExifTag::PRESSURE                   => new IfdEntry(ExifTag::PRESSURE, 10, 1, new ExifRational(100000, 100)),
@@ -495,6 +495,36 @@ final class ExifDocumentTest extends TestCase
         self::assertSame('RawLab', $doc->rawDevelopingSoftware());
         self::assertSame('EditLab', $doc->imageEditingSoftware());
         self::assertSame('MetaLab', $doc->metadataEditingSoftware());
+    }
+
+    /**
+     * Ensures Table 65 extension getters fall back to legacy identifiers when new tags are absent.
+     */
+    #[Test]
+    public function table65ExtensionsFallbackToLegacyIdentifiers(): void
+    {
+        $ifd0 = new Ifd([
+            ExifTag::LEGACY_IMAGE_TITLE  => new IfdEntry(ExifTag::LEGACY_IMAGE_TITLE, 2, 1, 'Legacy Title'),
+            ExifTag::LEGACY_PHOTOGRAPHER => new IfdEntry(ExifTag::LEGACY_PHOTOGRAPHER, 2, 1, 'Legacy Photographer'),
+            ExifTag::LEGACY_IMAGE_EDITOR => new IfdEntry(ExifTag::LEGACY_IMAGE_EDITOR, 2, 1, 'Legacy Editor'),
+        ]);
+
+        $exifIfd = new Ifd([
+            ExifTag::LEGACY_CAMERA_FIRMWARE           => new IfdEntry(ExifTag::LEGACY_CAMERA_FIRMWARE, 2, 1, 'FW Legacy'),
+            ExifTag::LEGACY_RAW_DEVELOPING_SOFTWARE   => new IfdEntry(ExifTag::LEGACY_RAW_DEVELOPING_SOFTWARE, 2, 1, 'Raw Legacy'),
+            ExifTag::LEGACY_IMAGE_EDITING_SOFTWARE    => new IfdEntry(ExifTag::LEGACY_IMAGE_EDITING_SOFTWARE, 2, 1, 'Edit Legacy'),
+            ExifTag::LEGACY_METADATA_EDITING_SOFTWARE => new IfdEntry(ExifTag::LEGACY_METADATA_EDITING_SOFTWARE, 2, 1, 'Meta Legacy'),
+        ]);
+
+        $doc = new ExifDocument($ifd0, $exifIfd, null, null, null);
+
+        self::assertSame('Legacy Title', $doc->imageTitle());
+        self::assertSame('Legacy Photographer', $doc->photographer());
+        self::assertSame('Legacy Editor', $doc->imageEditor());
+        self::assertSame('FW Legacy', $doc->cameraFirmware());
+        self::assertSame('Raw Legacy', $doc->rawDevelopingSoftware());
+        self::assertSame('Edit Legacy', $doc->imageEditingSoftware());
+        self::assertSame('Meta Legacy', $doc->metadataEditingSoftware());
     }
 
     /**

--- a/tests/Model/Exif/ExifTagTest.php
+++ b/tests/Model/Exif/ExifTagTest.php
@@ -69,7 +69,7 @@ final class ExifTagTest extends TestCase
             'COMPRESSION'                    => 0x0103,
             'PHOTOMETRIC_INTERPRETATION'     => 0x0106,
             'IMAGE_DESCRIPTION'              => 0x010E,
-            'IMAGE_TITLE'                    => 0x0320,
+            'IMAGE_TITLE'                    => 0xA436,
             'MAKE'                           => 0x010F,
             'MODEL'                          => 0x0110,
             'STRIP_OFFSETS'                  => 0x0111,
@@ -94,8 +94,8 @@ final class ExifTagTest extends TestCase
             'YCBCR_POSITIONING'              => 0x0213,
             'REFERENCE_BLACK_WHITE'          => 0x0214,
             'COPYRIGHT'                      => 0x8298,
-            'PHOTOGRAPHER'                   => 0xE92D,
-            'IMAGE_EDITOR'                   => 0xE92E,
+            'PHOTOGRAPHER'                   => 0xA437,
+            'IMAGE_EDITOR'                   => 0xA438,
 
             // Pointer tags
             'EXIF_IFD_POINTER'               => 0x8769,
@@ -195,10 +195,18 @@ final class ExifTagTest extends TestCase
             'WATER_DEPTH'                    => 0x9403,
             'ACCELERATION'                   => 0x9404,
             'CAMERA_ELEVATION_ANGLE'         => 0x9405,
-            'CAMERA_FIRMWARE'                => 0xE92F,
-            'RAW_DEVELOPING_SOFTWARE'        => 0xE930,
-            'IMAGE_EDITING_SOFTWARE'         => 0xE931,
-            'METADATA_EDITING_SOFTWARE'      => 0xE932,
+            'CAMERA_FIRMWARE'                => 0xA439,
+            'RAW_DEVELOPING_SOFTWARE'        => 0xA43A,
+            'IMAGE_EDITING_SOFTWARE'         => 0xA43B,
+            'METADATA_EDITING_SOFTWARE'      => 0xA43C,
+
+            'LEGACY_CAMERA_FIRMWARE'         => 0xE92F,
+            'LEGACY_IMAGE_EDITING_SOFTWARE'  => 0xE931,
+            'LEGACY_IMAGE_EDITOR'            => 0xE92E,
+            'LEGACY_IMAGE_TITLE'             => 0x0320,
+            'LEGACY_METADATA_EDITING_SOFTWARE' => 0xE932,
+            'LEGACY_PHOTOGRAPHER'            => 0xE92D,
+            'LEGACY_RAW_DEVELOPING_SOFTWARE' => 0xE930,
 
             // Interoperability IFD
             'INTEROPERABILITY_INDEX'         => 0x0001,


### PR DESCRIPTION
## Summary
- update EXIF attribution constants to the EXIF 3.0 identifiers and keep the legacy values for fallback
- teach the EXIF document helpers to read the new tags with legacy fallbacks and update structured metadata fixtures accordingly
- extend the unit tests to cover the new identifiers and verify the legacy fallback path

## Testing
- composer ci:test:php:unit

------
https://chatgpt.com/codex/tasks/task_e_68fb55cb585c8323b37877d5c3c949e9