### PR TITLE
Align EXIF textual tag accessors with EXIF 3.0 IDs

### DIFF
--- a/src/Model/Exif/ExifDocument.php
+++ b/src/Model/Exif/ExifDocument.php
@@ -196,7 +196,19 @@ final readonly class ExifDocument
      */
     public function imageTitle(): ?string
     {
-        return $this->str($this->ifd0, ExifTag::IMAGE_TITLE);
+        $value = $this->str($this->exifIfd, ExifTag::IMAGE_TITLE);
+
+        if ($value !== null) {
+            return $value;
+        }
+
+        $value = $this->str($this->ifd0, ExifTag::IMAGE_TITLE);
+
+        if ($value !== null) {
+            return $value;
+        }
+
+        return $this->str($this->ifd0, ExifTag::IMAGE_DESCRIPTION);
     }
 
     /**
@@ -204,7 +216,19 @@ final readonly class ExifDocument
      */
     public function photographer(): ?string
     {
-        return $this->str($this->ifd0, ExifTag::PHOTOGRAPHER);
+        $value = $this->str($this->exifIfd, ExifTag::PHOTOGRAPHER);
+
+        if ($value !== null) {
+            return $value;
+        }
+
+        $value = $this->str($this->ifd0, ExifTag::PHOTOGRAPHER);
+
+        if ($value !== null) {
+            return $value;
+        }
+
+        return $this->str($this->ifd0, ExifTag::ARTIST);
     }
 
     /**
@@ -212,7 +236,9 @@ final readonly class ExifDocument
      */
     public function imageEditor(): ?string
     {
-        return $this->str($this->ifd0, ExifTag::IMAGE_EDITOR);
+        $value = $this->str($this->exifIfd, ExifTag::IMAGE_EDITOR);
+
+        return $value ?? $this->str($this->ifd0, ExifTag::IMAGE_EDITOR);
     }
 
     /**

--- a/tests/Curate/Resolver/ExifTagResolverTest.php
+++ b/tests/Curate/Resolver/ExifTagResolverTest.php
@@ -260,8 +260,7 @@ final class ExifTagResolverTest extends TestCase
     public function resolvesSceneDescriptorsAndSoftwareMetadata(): void
     {
         $ifd0 = new Ifd([
-            ExifTag::IMAGE_TITLE  => new IfdEntry(ExifTag::IMAGE_TITLE, 2, 1, 'Evening scene'),
-            ExifTag::PHOTOGRAPHER => new IfdEntry(ExifTag::PHOTOGRAPHER, 2, 1, 'Jamie Doe'),
+            ExifTag::IMAGE_DESCRIPTION => new IfdEntry(ExifTag::IMAGE_DESCRIPTION, 2, 1, 'Evening scene'),
         ]);
 
         $exifIfd = new Ifd([
@@ -269,6 +268,9 @@ final class ExifTagResolverTest extends TestCase
             ExifTag::SCENE_TYPE                 => new IfdEntry(ExifTag::SCENE_TYPE, 7, 1, chr(1)),
             ExifTag::CFA_PATTERN                => new IfdEntry(ExifTag::CFA_PATTERN, 7, 4, "\x00\x01\x02\x03"),
             ExifTag::CUSTOM_RENDERED            => new IfdEntry(ExifTag::CUSTOM_RENDERED, 3, 1, 1),
+            ExifTag::IMAGE_TITLE                => new IfdEntry(ExifTag::IMAGE_TITLE, 2, 1, 'Evening Glow'),
+            ExifTag::PHOTOGRAPHER               => new IfdEntry(ExifTag::PHOTOGRAPHER, 2, 1, 'Jamie Doe'),
+            ExifTag::IMAGE_EDITOR               => new IfdEntry(ExifTag::IMAGE_EDITOR, 2, 1, 'Casey Edit'),
             ExifTag::CAMERA_FIRMWARE            => new IfdEntry(ExifTag::CAMERA_FIRMWARE, 2, 1, 'FW Main'),
             ExifTag::RAW_DEVELOPING_SOFTWARE    => new IfdEntry(ExifTag::RAW_DEVELOPING_SOFTWARE, 2, 1, 'Raw Studio'),
             ExifTag::IMAGE_EDITING_SOFTWARE     => new IfdEntry(ExifTag::IMAGE_EDITING_SOFTWARE, 2, 1, 'Pixel Edit'),
@@ -288,6 +290,9 @@ final class ExifTagResolverTest extends TestCase
             CfaPatternColor::CYAN,
         ], $resolver->cfaPatternColors());
         self::assertSame(CustomRendered::CUSTOM_PROCESS, $resolver->customRendered());
+        self::assertSame('Evening Glow', $resolver->imageTitle());
+        self::assertSame('Jamie Doe', $resolver->photographer());
+        self::assertSame('Casey Edit', $resolver->imageEditor());
         self::assertSame('FW Main', $resolver->cameraFirmware());
         self::assertSame('Raw Studio', $resolver->rawDevelopingSoftware());
         self::assertSame('Pixel Edit', $resolver->imageEditingSoftware());

--- a/tests/Model/Exif/ExifDocumentTest.php
+++ b/tests/Model/Exif/ExifDocumentTest.php
@@ -419,9 +419,6 @@ final class ExifDocumentTest extends TestCase
     {
         $ifd0 = new Ifd([
             ExifTag::IMAGE_DESCRIPTION => new IfdEntry(ExifTag::IMAGE_DESCRIPTION, 2, 1, 'Coastal cliffs'),
-            ExifTag::IMAGE_TITLE       => new IfdEntry(ExifTag::IMAGE_TITLE, 2, 1, 'Cliffside Dusk'),
-            ExifTag::PHOTOGRAPHER      => new IfdEntry(ExifTag::PHOTOGRAPHER, 2, 1, 'Alex Light'),
-            ExifTag::IMAGE_EDITOR      => new IfdEntry(ExifTag::IMAGE_EDITOR, 2, 1, 'Chris Edit'),
         ]);
 
         $exifIfd = new Ifd([
@@ -454,6 +451,9 @@ final class ExifDocumentTest extends TestCase
             ExifTag::CFA_PATTERN                => new IfdEntry(ExifTag::CFA_PATTERN, 7, 4, "\x02\x01\x01\x02"),
             ExifTag::CUSTOM_RENDERED            => new IfdEntry(ExifTag::CUSTOM_RENDERED, 3, 1, 1),
             ExifTag::DEVICE_SETTING_DESCRIPTION => new IfdEntry(ExifTag::DEVICE_SETTING_DESCRIPTION, 7, 1, 'Neutral profile'),
+            ExifTag::IMAGE_TITLE                => new IfdEntry(ExifTag::IMAGE_TITLE, 2, 1, 'Cliffside Dusk'),
+            ExifTag::PHOTOGRAPHER               => new IfdEntry(ExifTag::PHOTOGRAPHER, 2, 1, 'Alex Light'),
+            ExifTag::IMAGE_EDITOR               => new IfdEntry(ExifTag::IMAGE_EDITOR, 2, 1, 'Chris Edit'),
             ExifTag::CAMERA_FIRMWARE            => new IfdEntry(ExifTag::CAMERA_FIRMWARE, 2, 1, 'FW 2.0'),
             ExifTag::RAW_DEVELOPING_SOFTWARE    => new IfdEntry(ExifTag::RAW_DEVELOPING_SOFTWARE, 2, 1, 'RawLab'),
             ExifTag::IMAGE_EDITING_SOFTWARE     => new IfdEntry(ExifTag::IMAGE_EDITING_SOFTWARE, 2, 1, 'EditLab'),

--- a/tests/Parse/Tiff/TiffExifReaderTest.php
+++ b/tests/Parse/Tiff/TiffExifReaderTest.php
@@ -184,10 +184,13 @@ final class TiffExifReaderTest extends TestCase
         } else {
             self::assertSame("\x00\x01\x02\x03", $cfaPattern);
         }
-        self::assertSame('FW', rtrim($exifIfd->get(ExifTag::CAMERA_FIRMWARE)?->value ?? ''));
-        self::assertSame('RAW', rtrim($exifIfd->get(ExifTag::RAW_DEVELOPING_SOFTWARE)?->value ?? ''));
-        self::assertSame('IMG', rtrim($exifIfd->get(ExifTag::IMAGE_EDITING_SOFTWARE)?->value ?? ''));
-        self::assertSame('META', rtrim($exifIfd->get(ExifTag::METADATA_EDITING_SOFTWARE)?->value ?? ''));
+        self::assertSame('Cliffside Dusk', rtrim($exifIfd->get(ExifTag::IMAGE_TITLE)?->value ?? ''));
+        self::assertSame('Alex Light', rtrim($exifIfd->get(ExifTag::PHOTOGRAPHER)?->value ?? ''));
+        self::assertSame('Chris Edit', rtrim($exifIfd->get(ExifTag::IMAGE_EDITOR)?->value ?? ''));
+        self::assertSame('Firmware 2.0', rtrim($exifIfd->get(ExifTag::CAMERA_FIRMWARE)?->value ?? ''));
+        self::assertSame('RawLab Studio', rtrim($exifIfd->get(ExifTag::RAW_DEVELOPING_SOFTWARE)?->value ?? ''));
+        self::assertSame('EditLab Pro', rtrim($exifIfd->get(ExifTag::IMAGE_EDITING_SOFTWARE)?->value ?? ''));
+        self::assertSame('MetaLab Suite', rtrim($exifIfd->get(ExifTag::METADATA_EDITING_SOFTWARE)?->value ?? ''));
     }
 
     /**
@@ -579,20 +582,89 @@ final class TiffExifReaderTest extends TestCase
         ];
         $ifd0 = pack('v', count($ifd0Entries)) . implode('', $ifd0Entries) . pack('V', 0);
 
-        $exifEntries = [
-            self::packClassicEntry(ExifTag::SCENE_TYPE, 7, 1, self::inlineAsciiToInt("\x01", 4)),
-            self::packClassicEntry(ExifTag::CUSTOM_RENDERED, 3, 1, 1),
-            self::packClassicEntry(ExifTag::CFA_PATTERN, 7, 4, self::inlineAsciiToInt("\x00\x01\x02\x03", 4)),
-            self::packClassicEntry(ExifTag::COMPONENTS_CONFIGURATION, 7, 4, self::inlineAsciiToInt("\x01\x02\x03\x00", 4)),
-            self::packClassicEntry(ExifTag::CAMERA_FIRMWARE, 2, 4, self::inlineAsciiToInt('FW', 4)),
-            self::packClassicEntry(ExifTag::RAW_DEVELOPING_SOFTWARE, 2, 4, self::inlineAsciiToInt('RAW', 4)),
-            self::packClassicEntry(ExifTag::IMAGE_EDITING_SOFTWARE, 2, 4, self::inlineAsciiToInt('IMG', 4)),
-            self::packClassicEntry(ExifTag::METADATA_EDITING_SOFTWARE, 2, 4, self::inlineAsciiToInt('META', 4)),
+        $entries = [
+            [
+                'tag'   => ExifTag::SCENE_TYPE,
+                'type'  => 7,
+                'count' => 1,
+                'value' => self::inlineAsciiToInt("\x01", 4),
+            ],
+            [
+                'tag'   => ExifTag::CUSTOM_RENDERED,
+                'type'  => 3,
+                'count' => 1,
+                'value' => 1,
+            ],
+            [
+                'tag'   => ExifTag::CFA_PATTERN,
+                'type'  => 7,
+                'count' => 4,
+                'value' => self::inlineAsciiToInt("\x00\x01\x02\x03", 4),
+            ],
+            [
+                'tag'   => ExifTag::COMPONENTS_CONFIGURATION,
+                'type'  => 7,
+                'count' => 4,
+                'value' => self::inlineAsciiToInt("\x01\x02\x03\x00", 4),
+            ],
         ];
+
+        $asciiTags = [
+            ExifTag::IMAGE_TITLE               => 'Cliffside Dusk',
+            ExifTag::PHOTOGRAPHER              => 'Alex Light',
+            ExifTag::IMAGE_EDITOR              => 'Chris Edit',
+            ExifTag::CAMERA_FIRMWARE           => 'Firmware 2.0',
+            ExifTag::RAW_DEVELOPING_SOFTWARE   => 'RawLab Studio',
+            ExifTag::IMAGE_EDITING_SOFTWARE    => 'EditLab Pro',
+            ExifTag::METADATA_EDITING_SOFTWARE => 'MetaLab Suite',
+        ];
+
+        $entryCount       = count($entries) + count($asciiTags);
+        $exifIfdSize      = 2 + ($entryCount * 12) + 4;
+        $nextDataOffset   = $exifIfdOffset + $exifIfdSize;
+        $stringDataBuffer = '';
+
+        foreach ($asciiTags as $tag => $value) {
+            $encoded = $value . "\0";
+            $length  = strlen($encoded);
+
+            if ($length <= 4) {
+                $entries[] = [
+                    'tag'   => $tag,
+                    'type'  => 2,
+                    'count' => $length,
+                    'value' => self::inlineAsciiToInt($encoded, 4),
+                ];
+
+                continue;
+            }
+
+            $entries[] = [
+                'tag'   => $tag,
+                'type'  => 2,
+                'count' => $length,
+                'value' => $nextDataOffset,
+            ];
+
+            $stringDataBuffer .= $encoded;
+            $nextDataOffset   += $length;
+        }
+
+        usort($entries, static fn (array $left, array $right): int => $left['tag'] <=> $right['tag']);
+
+        $exifEntries = array_map(
+            static fn (array $entry): string => self::packClassicEntry(
+                $entry['tag'],
+                $entry['type'],
+                $entry['count'],
+                $entry['value'],
+            ),
+            $entries,
+        );
 
         $exifIfd = pack('v', count($exifEntries)) . implode('', $exifEntries) . pack('V', 0);
 
-        return $header . $ifd0 . $exifIfd;
+        return $header . $ifd0 . $exifIfd . $stringDataBuffer;
     }
 
     /**


### PR DESCRIPTION
## Summary
- update the document and resolver accessors to prefer the EXIF 3.0 textual tag IDs while keeping legacy fallbacks
- refresh the document and resolver tests to source 0xA436–0xA43C data from the EXIF IFD
- rebuild the TIFF fixture helper and assertions to emit realistic strings for the new textual tags

## Testing
- composer ci:test:php:unit

------
https://chatgpt.com/codex/tasks/task_e_68fb5d3592c48323bfe691bdbc330db2