### PR TITLE
feat: derive EXIF capability profiles from version markers

### DIFF
--- a/src/Core/ExifCapabilities.php
+++ b/src/Core/ExifCapabilities.php
@@ -1,0 +1,67 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\ImageMeta\Core;
+
+use function preg_match;
+use function sprintf;
+use function trim;
+
+/**
+ * Maps raw EXIF version identifiers to capability profiles defined by the specification.
+ */
+final class ExifCapabilities
+{
+    private const DEFAULT_PROFILE = '2.2';
+
+    /**
+     * Derives the EXIF capability profile name from a raw version marker.
+     */
+    public static function fromVersion(?string $version): string
+    {
+        if ($version === null) {
+            return self::DEFAULT_PROFILE;
+        }
+
+        $normalized = trim($version, "\0\t\n\r \v");
+        if ($normalized === '') {
+            return self::DEFAULT_PROFILE;
+        }
+
+        $map = [
+            '0220' => '2.2',
+            '0221' => '2.2',
+            '0230' => '2.3',
+            '0231' => '2.3',
+            '0300' => '3.0',
+        ];
+
+        if (isset($map[$normalized])) {
+            return $map[$normalized];
+        }
+
+        if (preg_match('/^(\d)\.(\d)(\d)$/', $normalized, $matches) === 1) {
+            $candidate = sprintf('0%d%d%d', (int) $matches[1], (int) $matches[2], (int) $matches[3]);
+            if (isset($map[$candidate])) {
+                return $map[$candidate];
+            }
+        }
+
+        if (preg_match('/^(\d)\.(\d)$/', $normalized, $matches) === 1) {
+            $candidate = sprintf('0%d%d0', (int) $matches[1], (int) $matches[2]);
+            if (isset($map[$candidate])) {
+                return $map[$candidate];
+            }
+        }
+
+        return self::DEFAULT_PROFILE;
+    }
+}

--- a/src/Curate/StructuredMetadataBuilder.php
+++ b/src/Curate/StructuredMetadataBuilder.php
@@ -14,6 +14,7 @@ namespace MagicSunday\ImageMeta\Curate;
 use DateTimeImmutable;
 use DateTimeZone;
 use Exception;
+use MagicSunday\ImageMeta\Core\ExifCapabilities;
 use MagicSunday\ImageMeta\Core\ValueConverters;
 use MagicSunday\ImageMeta\Curate\Resolver\CompositeResolver;
 use MagicSunday\ImageMeta\Curate\Resolver\ExifTagResolver;
@@ -107,8 +108,12 @@ final class StructuredMetadataBuilder
             exposureTimesTotal: $exifResolver->sourceExposureTimesOfCompositeImage(),
         );
 
+        $exifVersion = $exifResolver->exifVersion();
+        $profile     = ExifCapabilities::fromVersion($exifVersion);
+
         $standards = new Standards(
-            exifVersion: $exifResolver->exifVersion(),
+            exifVersion: $exifVersion,
+            profile: $profile,
             flashpixVersion: $exifResolver->flashpixVersion(),
             tiffEpStandardId: $exifResolver->tiffEpStandardId(),
         );

--- a/src/Value/Standards.php
+++ b/src/Value/Standards.php
@@ -12,17 +12,19 @@ declare(strict_types=1);
 namespace MagicSunday\ImageMeta\Value;
 
 /**
- * Captures version identifiers for the embedded metadata standards.
+ * Captures version identifiers and derived capability information for metadata standards.
  */
 final readonly class Standards
 {
     /**
      * @param string|null $exifVersion       Normalised EXIF specification version (e.g. "3.00").
+     * @param string|null $profile           Derived EXIF capability profile (e.g. "3.0").
      * @param string|null $flashpixVersion   FlashPix specification version string.
      * @param list<int>|null $tiffEpStandardId TIFF/EP identifier bytes.
      */
     public function __construct(
         public ?string $exifVersion,
+        public ?string $profile,
         public ?string $flashpixVersion,
         public ?array $tiffEpStandardId,
     ) {

--- a/tests/Curate/StructuredMetadataBuilderTest.php
+++ b/tests/Curate/StructuredMetadataBuilderTest.php
@@ -262,6 +262,7 @@ final class StructuredMetadataBuilderTest extends TestCase
         self::assertSame(SubjectDistanceRange::DISTANT, $structured->scene->subjectDistanceRange);
 
         self::assertSame('3.00', $structured->standards->exifVersion);
+        self::assertSame('3.0', $structured->standards->profile);
         self::assertSame('0100', $structured->standards->flashpixVersion);
         self::assertSame([1, 0, 0, 0], $structured->standards->tiffEpStandardId);
 
@@ -361,9 +362,51 @@ final class StructuredMetadataBuilderTest extends TestCase
         self::assertTrue($structured->scene->hdrScene);
         self::assertTrue($structured->scene->nightMode);
 
+        self::assertSame('3.0', $structured->standards->profile);
+
         self::assertSame('OffsetTimeOriginal', $structured->temporal->tzSource);
         self::assertInstanceOf(DateTimeImmutable::class, $structured->temporal->original);
         self::assertSame('+01:00', $structured->temporal->original?->format('P'));
+    }
+
+    /**
+     * Ensures EXIF 2.2 markers derive the legacy profile identifier.
+     */
+    #[Test]
+    public function derivesProfileForExif22(): void
+    {
+        $ifd0 = new Ifd([]);
+        $exifIfd = new Ifd([
+            ExifTag::EXIF_VERSION => new IfdEntry(ExifTag::EXIF_VERSION, 7, 4, '0220'),
+        ]);
+
+        $exifDocument = new ExifDocument($ifd0, $exifIfd, null, null, null);
+        $metadata     = new Metadata(['primary'], null, $exifDocument);
+
+        $structured = (new StructuredMetadataBuilder())->build($metadata);
+
+        self::assertSame('2.20', $structured->standards->exifVersion);
+        self::assertSame('2.2', $structured->standards->profile);
+    }
+
+    /**
+     * Ensures EXIF 2.3 markers derive the enhanced profile identifier.
+     */
+    #[Test]
+    public function derivesProfileForExif23(): void
+    {
+        $ifd0 = new Ifd([]);
+        $exifIfd = new Ifd([
+            ExifTag::EXIF_VERSION => new IfdEntry(ExifTag::EXIF_VERSION, 7, 4, '0231'),
+        ]);
+
+        $exifDocument = new ExifDocument($ifd0, $exifIfd, null, null, null);
+        $metadata     = new Metadata(['primary'], null, $exifDocument);
+
+        $structured = (new StructuredMetadataBuilder())->build($metadata);
+
+        self::assertSame('2.31', $structured->standards->exifVersion);
+        self::assertSame('2.3', $structured->standards->profile);
     }
 
     /**
@@ -379,6 +422,7 @@ final class StructuredMetadataBuilderTest extends TestCase
         self::assertSame(['index' => null], get_object_vars($structured->interop));
         self::assertNull($structured->tiff->compression);
         self::assertNull($structured->camera->make);
+        self::assertSame('2.2', $structured->standards->profile);
     }
 
     /**


### PR DESCRIPTION
## Summary
- add an ExifCapabilities helper that maps version bytes to EXIF capability profiles
- store the derived profile on the Standards value object and wire it into the builder
- extend structured metadata tests to cover EXIF 2.2, 2.3, and 3.0 profile derivation

## Testing
- composer ci:test:php:unit


------
https://chatgpt.com/codex/tasks/task_e_68fb70081094832387540990e10ac6ad