### PR TITLE
fix: harden metadata value converters

### DIFF
--- a/src/Core/ValueConverters.php
+++ b/src/Core/ValueConverters.php
@@ -30,7 +30,6 @@ use function array_filter;
 use function array_slice;
 use function array_values;
 use function atan;
-use function bin2hex;
 use function count;
 use function ctype_digit;
 use function ctype_print;
@@ -44,11 +43,11 @@ use function is_string;
 use function json_encode;
 use function log;
 use function pow;
+use function preg_match;
 use function rad2deg;
 use function sprintf;
 use function str_replace;
 use function strlen;
-use function strtoupper;
 use function trim;
 
 use const JSON_PRESERVE_ZERO_FRACTION;
@@ -125,12 +124,32 @@ final readonly class ValueConverters
      */
     public static function parseOffset(?string $offset): ?DateTimeZone
     {
-        if ($offset === null || $offset === '') {
+        if ($offset === null) {
             return null;
         }
 
+        $trimmed = trim($offset);
+        if ($trimmed === '') {
+            return null;
+        }
+
+        if ($trimmed === 'Z') {
+            $trimmed = '+00:00';
+        }
+
+        if (preg_match('/^([+-])(\d{1,2})(?::?(\d{2}))?$/', $trimmed, $matches) === 1) {
+            $hours   = (int) $matches[2];
+            $minutes = isset($matches[3]) ? (int) $matches[3] : 0;
+
+            if ($hours > 14 || $minutes >= 60 || ($hours === 14 && $minutes !== 0)) {
+                return null;
+            }
+
+            $trimmed = sprintf('%s%02d:%02d', $matches[1], $hours, $minutes);
+        }
+
         try {
-            return new DateTimeZone($offset);
+            return new DateTimeZone($trimmed);
         } catch (Exception) {
             return null;
         }
@@ -141,13 +160,18 @@ final readonly class ValueConverters
      *
      * @param array<int, int|float> $values Subject area values as extracted from metadata.
      *
-     * @return array{x:?int,y:?int,w:?int,h:?int}
+     * @return array{x:?int,y:?int,w:?int,h:?int}|null
      */
-    public static function subjectAreaToRect(array $values): array
+    public static function subjectAreaToRect(array $values): ?array
     {
         $values = array_values($values);
+        $count  = count($values);
 
-        if (count($values) >= 4) {
+        if ($count >= 4) {
+            if (!is_numeric($values[0]) || !is_numeric($values[1]) || !is_numeric($values[2]) || !is_numeric($values[3])) {
+                return null;
+            }
+
             return [
                 'x' => (int) $values[0],
                 'y' => (int) $values[1],
@@ -156,8 +180,16 @@ final readonly class ValueConverters
             ];
         }
 
-        if (count($values) === 3) {
+        if ($count === 3) {
+            if (!is_numeric($values[0]) || !is_numeric($values[1]) || !is_numeric($values[2])) {
+                return null;
+            }
+
             $radius = (int) $values[2];
+
+            if ($radius < 0) {
+                return null;
+            }
 
             return [
                 'x' => (int) $values[0] - $radius,
@@ -167,7 +199,15 @@ final readonly class ValueConverters
             ];
         }
 
-        return ['x' => null, 'y' => null, 'w' => null, 'h' => null];
+        if ($count === 2) {
+            if (!is_numeric($values[0]) || !is_numeric($values[1])) {
+                return null;
+            }
+
+            return ['x' => (int) $values[0], 'y' => (int) $values[1], 'w' => null, 'h' => null];
+        }
+
+        return null;
     }
 
     /**
@@ -234,17 +274,19 @@ final readonly class ValueConverters
         }
 
         if (ctype_digit($trimmed) && strlen($trimmed) === 4) {
-            $major = (int) substr($trimmed, 0, 2);
-            $minor = (int) substr($trimmed, 2, 2);
-
-            return sprintf('%d.%02d', $major, $minor);
+            return match ($trimmed) {
+                '0220' => '2.20',
+                '0231' => '2.31',
+                '0300' => '3.00',
+                default => null,
+            };
         }
 
         if (ctype_print($trimmed)) {
             return $trimmed;
         }
 
-        return strtoupper(bin2hex($trimmed));
+        return null;
     }
 
     /**

--- a/src/Curate/StructuredMetadataBuilder.php
+++ b/src/Curate/StructuredMetadataBuilder.php
@@ -234,10 +234,13 @@ final class StructuredMetadataBuilder
             bgGain: null,
         );
 
+        $rect      = null;
         $focusRect = $exifResolver->subjectArea();
         if ($focusRect !== null) {
             $rect = ValueConverters::subjectAreaToRect($focusRect);
-        } else {
+        }
+
+        if ($rect === null) {
             $location = $exifResolver->subjectLocation();
             $rect     = ($location !== null && count($location) >= 2)
                 ? ['x' => $location[0], 'y' => $location[1], 'w' => null, 'h' => null]

--- a/tests/Core/ValueConvertersTest.php
+++ b/tests/Core/ValueConvertersTest.php
@@ -35,11 +35,43 @@ final class ValueConvertersTest extends TestCase
     #[Test]
     public function normalisesExifVersionAndFlash(): void
     {
+        self::assertSame('2.20', ValueConverters::toExifVersion('0220'));
+        self::assertSame('2.31', ValueConverters::toExifVersion('0231'));
         self::assertSame('3.00', ValueConverters::toExifVersion('0300'));
+        self::assertSame('Exif', ValueConverters::toExifVersion("Exif\0\0"));
+        self::assertNull(ValueConverters::toExifVersion('0240'));
+        self::assertNull(ValueConverters::toExifVersion("\x01\x02\x03\x04"));
         $flash = ValueConverters::flashFromShort(0x59);
         self::assertTrue($flash->fired);
         self::assertSame(FlashMode::AUTO, $flash->mode);
         self::assertSame(FlashReturn::NO_STROBE_DETECTION, $flash->returnDetection);
+    }
+
+    #[Test]
+    public function normalisesOffsetsAndSubjectAreas(): void
+    {
+        self::assertSame('+01:00', ValueConverters::parseOffset('+01:00')?->getName());
+        self::assertSame('+01:00', ValueConverters::parseOffset('+0100')?->getName());
+        self::assertSame('+01:00', ValueConverters::parseOffset('+1')?->getName());
+        self::assertSame('UTC', ValueConverters::parseOffset('UTC')?->getName());
+        self::assertNull(ValueConverters::parseOffset('+15:00'));
+        self::assertNull(ValueConverters::parseOffset('+01:61'));
+
+        self::assertSame(
+            ['x' => 10, 'y' => 20, 'w' => null, 'h' => null],
+            ValueConverters::subjectAreaToRect([10, 20]),
+        );
+        self::assertSame(
+            ['x' => 75, 'y' => 95, 'w' => 50, 'h' => 50],
+            ValueConverters::subjectAreaToRect([100, 120, 25]),
+        );
+        self::assertSame(
+            ['x' => 10, 'y' => 20, 'w' => 30, 'h' => 40],
+            ValueConverters::subjectAreaToRect([10, 20, 30, 40]),
+        );
+        self::assertNull(ValueConverters::subjectAreaToRect([10]));
+        self::assertNull(ValueConverters::subjectAreaToRect([10, 20, -5]));
+        self::assertNull(ValueConverters::subjectAreaToRect(['a', 'b']));
     }
 
     #[Test]


### PR DESCRIPTION
## Summary
- normalise timezone offsets and tighten EXIF version parsing
- return null for malformed subject area payloads and fall back to subject locations
- extend the value converter unit tests to cover offsets, subject areas, and EXIF versions

## Testing
- composer ci:test:php:unit

------
https://chatgpt.com/codex/tasks/task_e_68fb703c92048323bfa4b172eaa6e8cd