### PR TITLE
Refactor composite resolver fallbacks for ISO, dimensions, and capture date

### DIFF
--- a/src/Curate/Resolver/CompositeResolver.php
+++ b/src/Curate/Resolver/CompositeResolver.php
@@ -14,10 +14,16 @@ namespace MagicSunday\ImageMeta\Curate\Resolver;
 use Closure;
 use DateTimeImmutable;
 use DateTimeZone;
+use MagicSunday\ImageMeta\Core\ValueConverters;
 
+use function abs;
+use function intdiv;
 use function is_array;
+use function is_float;
+use function is_int;
 use function is_numeric;
 use function is_string;
+use function sprintf;
 
 /**
  * Selects the first non-null value from a list of resolver callables.
@@ -45,93 +51,270 @@ final readonly class CompositeResolver
     }
 
     /**
-     * Resolves an integer ISO value from the provided candidate callbacks.
+     * Resolves the ISO sensitivity using the EXIF resolver and optional fallback providers.
      *
-     * @param list<Closure():int|string|null> $candidates
+     * @param Closure():(int|float|string|null) ...$fallbacks
      */
-    public static function intISO(array $candidates): ?int
+    public static function intISO(ExifTagResolver $exif, Closure ...$fallbacks): ?int
     {
-        $value = self::first($candidates);
-
-        if ($value === null) {
-            return null;
+        $iso = $exif->iso();
+        if (is_int($iso)) {
+            return $iso;
         }
 
-        if (is_int($value)) {
-            return $value;
+        foreach ($fallbacks as $fallback) {
+            $candidate  = $fallback();
+            $normalized = self::normalizeInteger($candidate);
+
+            if ($normalized !== null) {
+                return $normalized;
+            }
         }
 
-        return is_numeric($value) ? (int) $value : null;
+        return null;
     }
 
     /**
-     * Resolves image dimensions through deferred callbacks.
+     * Resolves image dimensions falling back to optional providers when EXIF lacks values.
      *
-     * @param Closure():int|string|null $widthResolver
-     * @param Closure():int|string|null $heightResolver
+     * @param Closure():(array{width:int|string|null,height:int|string|null}|null) ...$fallbacks
      *
      * @return array{width:?int,height:?int}
      */
-    public static function dimensions(Closure $widthResolver, Closure $heightResolver): array
+    public static function dimensions(ExifTagResolver $exif, Closure ...$fallbacks): array
     {
-        $widthValue  = $widthResolver();
-        $heightValue = $heightResolver();
+        $width  = $exif->imageWidth();
+        $height = $exif->imageHeight();
 
-        $width = is_int($widthValue)
-            ? $widthValue
-            : (is_numeric($widthValue) ? (int) $widthValue : null);
+        if ($width !== null || $height !== null) {
+            return ['width' => $width, 'height' => $height];
+        }
 
-        $height = is_int($heightValue)
-            ? $heightValue
-            : (is_numeric($heightValue) ? (int) $heightValue : null);
-
-        return ['width' => $width, 'height' => $height];
-    }
-
-    /**
-     * Resolves the original capture date from the provided callbacks.
-     *
-     * @param array<string,Closure():array{date:?DateTimeImmutable,tz:?DateTimeZone,subSec:?string}> $candidates
-     *
-     * @return array{date:?DateTimeImmutable,tz:?DateTimeZone,subSec:?string,source:?string}
-     */
-    public static function dateOriginal(array $candidates): array
-    {
-        foreach ($candidates as $source => $resolver) {
-            $value = $resolver();
-
+        foreach ($fallbacks as $fallback) {
+            $value = $fallback();
             if (!is_array($value)) {
                 continue;
             }
 
-            $date = $value['date'] ?? null;
-            if (!$date instanceof DateTimeImmutable) {
+            $widthCandidate  = self::normalizeInteger($value['width'] ?? null);
+            $heightCandidate = self::normalizeInteger($value['height'] ?? null);
+
+            if ($widthCandidate !== null || $heightCandidate !== null) {
+                return ['width' => $widthCandidate, 'height' => $heightCandidate];
+            }
+        }
+
+        return ['width' => null, 'height' => null];
+    }
+
+    /**
+     * Resolves the primary capture date along with timezone metadata and fractional seconds.
+     *
+     * Each fallback closure may return either {@see DateTimeImmutable} directly or an associative
+     * array containing the keys `date`, `tz`, `subSec`, `source`, and `tzSource`.
+     *
+     * @param Closure():(DateTimeImmutable|array{
+     *     date:?DateTimeImmutable,
+     *     tz:?DateTimeZone,
+     *     subSec:?string,
+     *     source?:string,
+     *     tzSource?:string
+     * }|null) ...$fallbacks
+     *
+     * @return array{
+     *     date:?DateTimeImmutable,
+     *     tz:?DateTimeZone,
+     *     subSec:?string,
+     *     source:?string,
+     *     tzSource:?string
+     * }
+     */
+    public static function dateOriginal(ExifTagResolver $exif, Closure ...$fallbacks): array
+    {
+        $offsetTimeOriginal  = $exif->offsetTimeOriginal();
+        $offsetTimeDigitized = $exif->offsetTimeDigitized();
+        $offsetTime          = $exif->offsetTime();
+
+        $subSecOriginal  = self::normalizeSubSeconds($exif->subSecTimeOriginal());
+        $subSecDigitized = self::normalizeSubSeconds($exif->subSecTimeDigitized());
+        $subSec          = self::normalizeSubSeconds($exif->subSecTime());
+
+        $candidates = [
+            [
+                'source'   => 'DateTimeOriginal',
+                'date'     => $exif->captureDateTime(),
+                'tz'       => ValueConverters::parseOffset($offsetTimeOriginal),
+                'subSec'   => $subSecOriginal,
+                'tzSource' => 'OffsetTimeOriginal',
+            ],
+            [
+                'source'   => 'DateTimeDigitized',
+                'date'     => $exif->digitizedDateTime(),
+                'tz'       => ValueConverters::parseOffset($offsetTimeDigitized),
+                'subSec'   => $subSecDigitized,
+                'tzSource' => 'OffsetTimeDigitized',
+            ],
+            [
+                'source'   => 'DateTime',
+                'date'     => $exif->fileDateTime(),
+                'tz'       => ValueConverters::parseOffset($offsetTime),
+                'subSec'   => $subSec,
+                'tzSource' => 'OffsetTime',
+            ],
+        ];
+
+        $position = 0;
+        foreach ($fallbacks as $fallback) {
+            $position++;
+            $value = $fallback();
+            if ($value === null) {
                 continue;
             }
 
-            $tz = $value['tz'] ?? null;
-            if (!$tz instanceof DateTimeZone) {
-                $tz = null;
+            if ($value instanceof DateTimeImmutable) {
+                $candidates[] = [
+                    'source'   => sprintf('fallback-%d', $position),
+                    'date'     => $value,
+                    'tz'       => $value->getTimezone(),
+                    'subSec'   => null,
+                    'tzSource' => sprintf('fallback-%d', $position),
+                ];
+
+                continue;
             }
 
-            $subSec = $value['subSec'] ?? null;
-            if (!is_string($subSec) || $subSec === '') {
-                $subSec = null;
-            }
+            $date = $value['date'] ?? null;
+            $tz   = $value['tz'] ?? null;
+            $sub  = $value['subSec'] ?? null;
+            $src  = $value['source'] ?? null;
+            $tzSrc = $value['tzSource'] ?? null;
+            $label = sprintf('fallback-%d', $position);
 
-            return [
-                'date' => $date,
-                'tz' => $tz,
-                'subSec' => $subSec,
-                'source' => $source,
+            $candidates[] = [
+                'source'   => is_string($src) && $src !== '' ? $src : $label,
+                'date'     => $date instanceof DateTimeImmutable ? $date : null,
+                'tz'       => $tz instanceof DateTimeZone ? $tz : null,
+                'subSec'   => is_string($sub) ? self::normalizeSubSeconds($sub) : null,
+                'tzSource' => is_string($tzSrc) && $tzSrc !== ''
+                    ? $tzSrc
+                    : (is_string($src) && $src !== '' ? $src : $label),
             ];
         }
 
+        $selected = null;
+        foreach ($candidates as $candidate) {
+            if ($candidate['date'] instanceof DateTimeImmutable) {
+                $selected = $candidate;
+                break;
+            }
+        }
+
+        if ($selected === null) {
+            $selected = [
+                'source'   => null,
+                'date'     => null,
+                'tz'       => null,
+                'subSec'   => null,
+                'tzSource' => null,
+            ];
+        }
+
+        $tz       = $selected['tz'] instanceof DateTimeZone ? $selected['tz'] : null;
+        $tzSource = $selected['tz'] instanceof DateTimeZone ? $selected['tzSource'] : null;
+
+        if (!$tz instanceof DateTimeZone) {
+            $offsetCandidates = [
+                'OffsetTimeOriginal'  => $offsetTimeOriginal,
+                'OffsetTimeDigitized' => $offsetTimeDigitized,
+                'OffsetTime'          => $offsetTime,
+            ];
+
+            foreach ($offsetCandidates as $source => $offset) {
+                $candidateTz = ValueConverters::parseOffset($offset);
+                if ($candidateTz instanceof DateTimeZone) {
+                    $tz       = $candidateTz;
+                    $tzSource = $source;
+                    break;
+                }
+            }
+        }
+
+        if (!$tz instanceof DateTimeZone) {
+            $minutes = $exif->timeZoneOffsetMinutes();
+            if (is_array($minutes) && isset($minutes[0])) {
+                $candidateTz = self::timeZoneFromMinutes($minutes[0]);
+                if ($candidateTz instanceof DateTimeZone) {
+                    $tz       = $candidateTz;
+                    $tzSource = 'TimeZoneOffset';
+                }
+            }
+        }
+
+        if (!$tz instanceof DateTimeZone && $selected['date'] instanceof DateTimeImmutable) {
+            $tz       = $selected['date']->getTimezone();
+            $tzSource = $selected['tzSource'];
+        }
+
+        $date = $selected['date'];
+        if ($date instanceof DateTimeImmutable && $tz instanceof DateTimeZone) {
+            $date = $date->setTimezone($tz);
+        }
+
         return [
-            'date' => null,
-            'tz' => null,
-            'subSec' => null,
-            'source' => null,
+            'date'     => $date instanceof DateTimeImmutable ? $date : null,
+            'tz'       => $tz instanceof DateTimeZone ? $tz : null,
+            'subSec'   => $selected['subSec'] ?? $subSecOriginal,
+            'source'   => $selected['source'],
+            'tzSource' => $tzSource,
         ];
+    }
+
+    /**
+     * Normalizes integer candidates coming from various metadata sources.
+     */
+    private static function normalizeInteger(int|float|string|null $value): ?int
+    {
+        if (is_int($value)) {
+            return $value;
+        }
+
+        if (is_float($value)) {
+            return (int) $value;
+        }
+
+        if (is_string($value) && $value !== '' && is_numeric($value)) {
+            return (int) $value;
+        }
+
+        return null;
+    }
+
+    /**
+     * Converts empty fractional second strings to null.
+     */
+    private static function normalizeSubSeconds(?string $value): ?string
+    {
+        return $value === null || $value === '' ? null : $value;
+    }
+
+    /**
+     * Converts a minute offset into a timezone object while validating its bounds.
+     */
+    private static function timeZoneFromMinutes(?int $minutes): ?DateTimeZone
+    {
+        if (!is_int($minutes)) {
+            return null;
+        }
+
+        if ($minutes < -14 * 60 || $minutes > 14 * 60) {
+            return null;
+        }
+
+        $absolute = abs($minutes);
+        $hours    = intdiv($absolute, 60);
+        $mins     = $absolute % 60;
+        $prefix   = $minutes < 0 ? '-' : '+';
+
+        return ValueConverters::parseOffset(sprintf('%s%02d:%02d', $prefix, $hours, $mins));
     }
 }

--- a/src/Curate/StructuredMetadataBuilder.php
+++ b/src/Curate/StructuredMetadataBuilder.php
@@ -12,7 +12,6 @@ declare(strict_types=1);
 namespace MagicSunday\ImageMeta\Curate;
 
 use DateTimeImmutable;
-use DateTimeZone;
 use Exception;
 use MagicSunday\ImageMeta\Core\ExifCapabilities;
 use MagicSunday\ImageMeta\Core\ValueConverters;
@@ -131,9 +130,11 @@ final class StructuredMetadataBuilder
         $image  = $this->buildImage($exifResolver, $xmpResolver, $quickTimeResolver, $interop);
 
         $exposure = new Exposure(
-            iso: CompositeResolver::intISO([
-                fn () => $exifResolver->iso(),
-            ]),
+            iso: CompositeResolver::intISO(
+                $exifResolver,
+                fn () => $xmpResolver->string('http://ns.adobe.com/exif/1.0/', 'ISOSpeedRatings'),
+                fn () => $xmpResolver->string('http://ns.adobe.com/exif/1.0/aux/', 'ISOSpeedRatings'),
+            ),
             exposureTimeSec: $exifResolver->exposureTime(),
             fNumber: $exifResolver->fNumber(),
             exposureBiasEv: $exifResolver->exposureBias(),
@@ -430,132 +431,67 @@ final class StructuredMetadataBuilder
         $exifCreate = $resolver->digitizedDateTime();
         $exifModify = $resolver->fileDateTime();
 
+        $xmpCreate       = $this->parseFlexibleDate($xmp->string('http://ns.adobe.com/xap/1.0/', 'CreateDate'));
+        $xmpModify       = $this->parseFlexibleDate($xmp->string('http://ns.adobe.com/xap/1.0/', 'ModifyDate'));
+        $xmpDateCreated  = $this->parseFlexibleDate($xmp->string('http://ns.adobe.com/photoshop/1.0/', 'DateCreated'));
+        $quickTimeCreate = $this->parseFlexibleDate($quickTime->string('CreationDate'));
+        $quickTimeModify = $this->parseFlexibleDate($quickTime->string('ModifyDate'));
+
+        $create = $exifCreate ?? $xmpCreate ?? $quickTimeCreate;
+        $modify = $exifModify ?? $xmpModify ?? $quickTimeModify;
+
         $offsetTime          = $resolver->offsetTime();
         $offsetTimeOriginal  = $resolver->offsetTimeOriginal();
         $offsetTimeDigitized = $resolver->offsetTimeDigitized();
 
-        $subSecTime = $resolver->subSecTime();
-        if ($subSecTime === '') {
-            $subSecTime = null;
-        }
+        $subSecTime         = $this->sanitizeSubSeconds($resolver->subSecTime());
+        $subSecOriginalRaw  = $this->sanitizeSubSeconds($resolver->subSecTimeOriginal());
+        $subSecDigitizedRaw = $this->sanitizeSubSeconds($resolver->subSecTimeDigitized());
 
-        $subSecOriginalRaw = $resolver->subSecTimeOriginal();
-        if ($subSecOriginalRaw === '') {
-            $subSecOriginalRaw = null;
-        }
+        $timeZoneOffsets = $resolver->timeZoneOffsetMinutes();
 
-        $subSecDigitizedRaw = $resolver->subSecTimeDigitized();
-        if ($subSecDigitizedRaw === '') {
-            $subSecDigitizedRaw = null;
-        }
-        $timeZoneOffsets     = $resolver->timeZoneOffsetMinutes();
-
-        $exifOriginal = CompositeResolver::dateOriginal([
-            'DateTimeOriginal' => fn () => [
-                'date'   => $resolver->captureDateTime(),
-                'tz'     => ValueConverters::parseOffset($offsetTimeOriginal),
-                'subSec' => $subSecOriginalRaw,
+        $exifOriginal = CompositeResolver::dateOriginal(
+            $resolver,
+            fn () => [
+                'date' => $xmpDateCreated,
+                'tz' => null,
+                'subSec' => null,
+                'source' => 'XMP',
+                'tzSource' => 'XMP',
             ],
-            'DateTimeDigitized' => fn () => [
-                'date'   => $exifCreate,
-                'tz'     => ValueConverters::parseOffset($offsetTimeDigitized),
-                'subSec' => $subSecDigitizedRaw,
+            fn () => [
+                'date' => $quickTimeCreate,
+                'tz' => null,
+                'subSec' => null,
+                'source' => 'QuickTime',
+                'tzSource' => 'QuickTime',
             ],
-            'DateTime' => fn () => [
-                'date'   => $exifModify,
-                'tz'     => ValueConverters::parseOffset($offsetTime),
-                'subSec' => $subSecTime,
-            ],
-        ]);
+            fn () => $exifCreate === null
+                && ($xmpCreate instanceof DateTimeImmutable || $quickTimeCreate instanceof DateTimeImmutable)
+                ? [
+                    'date' => $xmpCreate ?? $quickTimeCreate,
+                    'tz' => null,
+                    'subSec' => $subSecDigitizedRaw,
+                    'source' => 'DateTimeDigitized',
+                    'tzSource' => 'DateTimeDigitized',
+                ]
+                : null,
+            fn () => $exifModify === null
+                && ($xmpModify instanceof DateTimeImmutable || $quickTimeModify instanceof DateTimeImmutable)
+                ? [
+                    'date' => $xmpModify ?? $quickTimeModify,
+                    'tz' => null,
+                    'subSec' => $subSecTime,
+                    'source' => 'DateTime',
+                    'tzSource' => 'DateTime',
+                ]
+                : null,
+        );
 
         $original           = $exifOriginal['date'];
-        $subSecTimeOriginal = $exifOriginal['subSec'] ?? $subSecOriginalRaw;
         $tz                 = $exifOriginal['tz'];
-        $tzSource           = null;
-
-        if ($tz instanceof DateTimeZone) {
-            $source   = $exifOriginal['source'] ?? null;
-            $tzSource = match ($source) {
-                'DateTimeOriginal' => 'OffsetTimeOriginal',
-                'DateTimeDigitized' => 'OffsetTimeDigitized',
-                'DateTime' => 'OffsetTime',
-                default => $source,
-            };
-        } else {
-            $tz = null;
-        }
-
-        $fallbackTz       = $original instanceof DateTimeImmutable ? $original->getTimezone() : null;
-        $fallbackTzSource = $original !== null ? ($exifOriginal['source'] ?? null) : null;
-
-        $create = $exifCreate ?? $this->parseFlexibleDate($xmp->string('http://ns.adobe.com/xap/1.0/', 'CreateDate'));
-        $create = $create ?? $this->parseFlexibleDate($quickTime->string('CreationDate'));
-
-        $modify = $exifModify ?? $this->parseFlexibleDate($xmp->string('http://ns.adobe.com/xap/1.0/', 'ModifyDate'));
-        $modify = $modify ?? $this->parseFlexibleDate($quickTime->string('ModifyDate'));
-
-        if ($original === null) {
-            $original = $this->parseFlexibleDate($xmp->string('http://ns.adobe.com/photoshop/1.0/', 'DateCreated'));
-            if ($original instanceof DateTimeImmutable) {
-                $fallbackTz       = $original->getTimezone();
-                $fallbackTzSource = 'XMP';
-            }
-        }
-
-        if ($original === null) {
-            $quickTimeDate = $this->parseFlexibleDate($quickTime->string('CreationDate'));
-            if ($quickTimeDate instanceof DateTimeImmutable) {
-                $original        = $quickTimeDate;
-                $fallbackTz       = $quickTimeDate->getTimezone();
-                $fallbackTzSource = 'QuickTime';
-            }
-        }
-
-        if ($original === null && $create instanceof DateTimeImmutable) {
-            $original         = $create;
-            $fallbackTz       = $create->getTimezone();
-            $fallbackTzSource = 'DateTimeDigitized';
-        }
-
-        if ($original === null && $modify instanceof DateTimeImmutable) {
-            $original         = $modify;
-            $fallbackTz       = $modify->getTimezone();
-            $fallbackTzSource = 'DateTime';
-        }
-
-        if ($tz === null) {
-            $offsetCandidates = [
-                'OffsetTimeOriginal'  => $offsetTimeOriginal,
-                'OffsetTimeDigitized' => $offsetTimeDigitized,
-                'OffsetTime'          => $offsetTime,
-            ];
-
-            foreach ($offsetCandidates as $source => $offset) {
-                $candidate = ValueConverters::parseOffset($offset);
-                if ($candidate instanceof DateTimeZone) {
-                    $tz       = $candidate;
-                    $tzSource = $source;
-                    break;
-                }
-            }
-        }
-
-        if ($tz === null && is_array($timeZoneOffsets) && $timeZoneOffsets !== []) {
-            $candidate = $this->timeZoneFromMinutes($timeZoneOffsets[0]);
-            if ($candidate instanceof DateTimeZone) {
-                $tz       = $candidate;
-                $tzSource = 'TimeZoneOffset';
-            }
-        }
-
-        if ($tz === null && $fallbackTz instanceof DateTimeZone) {
-            $tz       = $fallbackTz;
-            $tzSource = $fallbackTzSource;
-        }
-
-        if ($tz instanceof DateTimeZone && $original instanceof DateTimeImmutable) {
-            $original = $original->setTimezone($tz);
-        }
+        $tzSource           = $exifOriginal['tzSource'] ?? null;
+        $subSecTimeOriginal = $exifOriginal['subSec'] ?? $subSecOriginalRaw;
 
         return new Temporal(
             create: $create,
@@ -647,17 +583,15 @@ final class StructuredMetadataBuilder
     private function buildImage(ExifTagResolver $exif, XmpResolver $xmp, QuickTimeResolver $quickTime, Interop $interop): Image
     {
         $dimensions = CompositeResolver::dimensions(
-            fn () => $exif->imageWidth(),
-            fn () => $exif->imageHeight(),
+            $exif,
+            fn () => [
+                'width' => $quickTime->int('ImageWidth'),
+                'height' => $quickTime->int('ImageHeight'),
+            ],
         );
 
         $width  = $dimensions['width'];
         $height = $dimensions['height'];
-
-        if ($width === null && $height === null) {
-            $width  = $quickTime->int('ImageWidth');
-            $height = $quickTime->int('ImageHeight');
-        }
 
         $documentName = CompositeResolver::first([
             fn () => $xmp->string('http://ns.adobe.com/tiff/1.0/', 'DocumentName'),
@@ -736,24 +670,11 @@ final class StructuredMetadataBuilder
     }
 
     /**
-     * Converts an EXIF TimeZoneOffset value expressed in minutes to a DateTimeZone.
+     * Normalises EXIF fractional second strings.
      */
-    private function timeZoneFromMinutes(?int $minutes): ?DateTimeZone
+    private function sanitizeSubSeconds(?string $value): ?string
     {
-        if (!is_int($minutes)) {
-            return null;
-        }
-
-        if ($minutes < -14 * 60 || $minutes > 14 * 60) {
-            return null;
-        }
-
-        $absolute = abs($minutes);
-        $hours    = intdiv($absolute, 60);
-        $mins     = $absolute % 60;
-        $prefix   = $minutes < 0 ? '-' : '+';
-
-        return ValueConverters::parseOffset(sprintf('%s%02d:%02d', $prefix, $hours, $mins));
+        return $value === null || $value === '' ? null : $value;
     }
 
     /**


### PR DESCRIPTION
## Summary
- introduce ExifTagResolver-aware helpers in CompositeResolver for ISO values, dimensions, and original capture dates with centralised fallback handling
- update StructuredMetadataBuilder to rely on the new helpers and streamline temporal/timezone derivation including EXIF/XMP/QuickTime fallbacks
- add a sanitiser for EXIF sub-second strings while removing redundant timezone conversion helpers

## Testing
- composer ci:test:php:unit
- composer ci:test:php:phpstan *(fails: existing warnings in ValueConverters and ExifTagResolver about redundant checks)*

------
https://chatgpt.com/codex/tasks/task_e_68fb8024db7c83238094a6b5e13c8d15