### PR TITLE
Fix EXIF 2.2 profile derivation in structured metadata

### DIFF
--- a/src/Curate/StructuredMetadataBuilder.php
+++ b/src/Curate/StructuredMetadataBuilder.php
@@ -110,13 +110,7 @@ final class StructuredMetadataBuilder
         );
 
         $exifVersion = $exifResolver->exifVersion();
-        $profile = null;
-        if ($exifVersion !== null) {
-            $derived = ExifCapabilities::fromVersion($exifVersion);
-            if ($derived !== '2.2') {
-                $profile = $derived;
-            }
-        }
+        $profile     = $exifVersion !== null ? ExifCapabilities::fromVersion($exifVersion) : null;
 
         $standards = new Standards(
             exifVersion: $exifVersion,

--- a/tests/Curate/StructuredMetadataBuilderTest.php
+++ b/tests/Curate/StructuredMetadataBuilderTest.php
@@ -386,7 +386,7 @@ final class StructuredMetadataBuilderTest extends TestCase
         $structured = (new StructuredMetadataBuilder())->build($metadata);
 
         self::assertSame('2.20', $structured->standards->exifVersion);
-        self::assertNull($structured->standards->profile);
+        self::assertSame('2.2', $structured->standards->profile);
     }
 
     /**


### PR DESCRIPTION
## Summary
- ensure StructuredMetadataBuilder keeps the capability profile returned for EXIF 2.2 markers
- update the StructuredMetadataBuilder test to expect the baseline "2.2" profile for EXIF 2.2 inputs

## Testing
- composer ci:test:php:unit

------
https://chatgpt.com/codex/tasks/task_e_68fb85071e788323a3c8a687b80cbb8c