### PR TITLE
Fix EXIF profile fallback to helper default

### DIFF
--- a/src/Curate/StructuredMetadataBuilder.php
+++ b/src/Curate/StructuredMetadataBuilder.php
@@ -105,7 +105,7 @@ final class StructuredMetadataBuilder
         );
 
         $exifVersion = $exifResolver->exifVersion();
-        $profile     = $exifVersion !== null ? ExifCapabilities::fromVersion($exifVersion) : null;
+        $profile     = ExifCapabilities::fromVersion($exifVersion);
 
         $standards = new Standards(
             exifVersion: $exifVersion,

--- a/tests/Curate/StructuredMetadataBuilderTest.php
+++ b/tests/Curate/StructuredMetadataBuilderTest.php
@@ -422,7 +422,7 @@ final class StructuredMetadataBuilderTest extends TestCase
         self::assertSame(['index' => null], get_object_vars($structured->interop));
         self::assertNull($structured->tiff->compression);
         self::assertNull($structured->camera->make);
-        self::assertNull($structured->standards->profile);
+        self::assertSame('2.2', $structured->standards->profile);
     }
 
     /**
@@ -709,6 +709,11 @@ final class StructuredMetadataBuilderTest extends TestCase
 
             foreach (get_object_vars($value) as $field => $fieldValue) {
                 if ($fieldValue === null) {
+                    continue;
+                }
+
+                if ($name === 'standards' && $field === 'profile') {
+                    self::assertSame('2.2', $fieldValue, 'standards::profile should fall back to the default EXIF capability profile');
                     continue;
                 }
 


### PR DESCRIPTION
## Summary
- always resolve the structured standards profile via `ExifCapabilities::fromVersion`
- update structured metadata builder expectations to assert the default EXIF profile fallback
- adjust missing metadata coverage to allow the default capability profile while keeping other null checks

## Testing
- composer ci:test:php:unit

------
https://chatgpt.com/codex/tasks/task_e_68fb8d6ea9348323b1714e984f2dc61b