### PR TITLE
Fix timezone fallback when EXIF offsets are missing

### DIFF
--- a/src/Curate/Resolver/CompositeResolver.php
+++ b/src/Curate/Resolver/CompositeResolver.php
@@ -283,8 +283,21 @@ final readonly class CompositeResolver
         }
 
         if (!$tz instanceof DateTimeZone && $selected['date'] instanceof DateTimeImmutable) {
-            $tz       = $selected['date']->getTimezone();
-            $tzSource = $selected['tzSource'];
+            $candidateTz     = $selected['date']->getTimezone();
+            $selectedTzSource = is_string($selected['tzSource']) && $selected['tzSource'] !== ''
+                ? $selected['tzSource']
+                : null;
+
+            $offsetSources = ['OffsetTimeOriginal', 'OffsetTimeDigitized', 'OffsetTime', 'TimeZoneOffset'];
+
+            if (
+                $candidateTz instanceof DateTimeZone
+                && ($selectedTzSource === null || !in_array($selectedTzSource, $offsetSources, true))
+            ) {
+                $tz       = $candidateTz;
+                $tzSource = $selectedTzSource
+                    ?? (is_string($selected['source']) && $selected['source'] !== '' ? $selected['source'] : null);
+            }
         }
 
         $date = $selected['date'];

--- a/tests/Curate/StructuredMetadataBuilderTest.php
+++ b/tests/Curate/StructuredMetadataBuilderTest.php
@@ -502,6 +502,30 @@ final class StructuredMetadataBuilderTest extends TestCase
     }
 
     /**
+     * Ensures DateTimeOriginal does not leak the PHP default timezone when offset metadata is missing.
+     */
+    #[Test]
+    public function leavesTimezoneUnsetWhenOffsetTagsMissing(): void
+    {
+        $ifd0 = new Ifd([
+            ExifTag::DATETIME_ORIGINAL => new IfdEntry(ExifTag::DATETIME_ORIGINAL, 2, 1, '2024:05:02 12:34:56'),
+        ]);
+
+        $exifIfd = new Ifd([
+            ExifTag::DATETIME_ORIGINAL => new IfdEntry(ExifTag::DATETIME_ORIGINAL, 2, 1, '2024:05:02 12:34:56'),
+        ]);
+
+        $exifDocument = new ExifDocument($ifd0, $exifIfd, null, null, null);
+        $metadata     = new Metadata(['primary'], null, $exifDocument);
+
+        $structured = (new StructuredMetadataBuilder())->build($metadata);
+
+        self::assertInstanceOf(DateTimeImmutable::class, $structured->temporal->original);
+        self::assertNull($structured->temporal->tz);
+        self::assertNull($structured->temporal->tzSource);
+    }
+
+    /**
      * Validates that EXIF 2.2 style payloads populate ISO and dimensions while leaving the timezone unset.
      */
     #[Test]


### PR DESCRIPTION
## Summary
- guard the CompositeResolver fallback so DateTimeOriginal does not inherit the PHP default timezone when no offset tags resolve
- cover the behaviour with a StructuredMetadataBuilder test that omits all offset-related tags

## Testing
- composer ci:test:php:unit

------
https://chatgpt.com/codex/tasks/task_e_68fb8d7b7144832384da93d9a19d2f3a