### PR TITLE
feat: add ModifyDate alias for EXIF DateTime tag

### DIFF
--- a/src/Curate/Resolver/ExifTagResolver.php
+++ b/src/Curate/Resolver/ExifTagResolver.php
@@ -1142,7 +1142,7 @@ final readonly class ExifTagResolver
     }
 
     /**
-     * Returns the image datetime when available.
+     * Returns the ModifyDate/DateTime timestamp when available.
      */
     public function fileDateTime(): ?DateTimeImmutable
     {
@@ -1174,7 +1174,7 @@ final readonly class ExifTagResolver
     }
 
     /**
-     * Returns the fractional seconds associated with the DateTime tag.
+     * Returns the fractional seconds associated with the ModifyDate/DateTime tag.
      */
     public function subSecTime(): ?string
     {

--- a/src/Model/Exif/ExifDocument.php
+++ b/src/Model/Exif/ExifDocument.php
@@ -904,7 +904,7 @@ final readonly class ExifDocument
     }
 
     /**
-     * Returns the raw DateTime tag value from IFD0.
+     * Returns the raw ModifyDate (legacy DateTime) tag value from IFD0.
      *
      * @return string|null
      */
@@ -914,7 +914,7 @@ final readonly class ExifDocument
     }
 
     /**
-     * Returns the fractional seconds for the DateTime tag.
+     * Returns the fractional seconds for the ModifyDate/DateTime tag.
      */
     public function subSecTime(): ?string
     {
@@ -950,7 +950,7 @@ final readonly class ExifDocument
     }
 
     /**
-     * Returns the normalized offset time for the IFD0 DateTime tag.
+     * Returns the normalized offset time for the IFD0 ModifyDate/DateTime tag.
      */
     public function offsetTime(): ?string
     {
@@ -978,7 +978,7 @@ final readonly class ExifDocument
     }
 
     /**
-     * Returns the raw offset time for the DateTime tag.
+     * Returns the raw offset time for the ModifyDate/DateTime tag.
      *
      * @return string|null
      */
@@ -1280,7 +1280,7 @@ final readonly class ExifDocument
     }
 
     /**
-     * Returns the DateTime tag combined with its optional offset.
+     * Returns the ModifyDate/DateTime tag combined with its optional offset.
      *
      * @return DateTimeImmutable|null
      */

--- a/src/Model/Exif/ExifTag.php
+++ b/src/Model/Exif/ExifTag.php
@@ -65,7 +65,17 @@ final readonly class ExifTag
 
     public const int SOFTWARE = 0x0131;
 
+    /**
+     * Legacy EXIF 2.x identifier retained for backwards compatibility.
+     *
+     * EXIF 3.0 renames the tag to ModifyDate, exposed via the MODIFY_DATE alias.
+     */
     public const int DATETIME = 0x0132;
+
+    /**
+     * Preferred alias that matches the EXIF 3.0 ModifyDate tag name.
+     */
+    public const int MODIFY_DATE = 0x0132;
 
     public const int ARTIST = 0x013B;
 

--- a/tests/Model/Exif/ExifTagTest.php
+++ b/tests/Model/Exif/ExifTagTest.php
@@ -85,6 +85,7 @@ final class ExifTagTest extends TestCase
             'TRANSFER_FUNCTION'              => 0x012D,
             'SOFTWARE'                       => 0x0131,
             'DATETIME'                       => 0x0132,
+            'MODIFY_DATE'                    => 0x0132,
             'ARTIST'                         => 0x013B,
             'WHITE_POINT'                    => 0x013E,
             'PRIMARY_CHROMATICITIES'         => 0x013F,
@@ -231,4 +232,13 @@ final class ExifTagTest extends TestCase
         self::assertArrayNotHasKey(0x013C, $constants);
         self::assertArrayNotHasKey(0xA20D, $constants);
     }
+
+    /**
+     * Ensures the ModifyDate alias shares the DateTime identifier.
+     */
+    public function testModifyDateAliasMatchesDateTime(): void
+    {
+        self::assertSame(ExifTag::DATETIME, ExifTag::MODIFY_DATE);
+    }
+
 }


### PR DESCRIPTION
## Summary
- add the EXIF 3.0 ModifyDate alias alongside the existing DateTime constant
- update docblocks that reference the tag so they prefer the ModifyDate naming
- extend the Exif tag test fixture and add an assertion that the alias and legacy identifier match

## Testing
- composer ci:test:php:unit *(fails: StructuredMetadataBuilderTest expects "2.32" while runtime reports "2.3" – pre-existing outside this change)*
- ./.build/bin/phpunit tests/Model/Exif/ExifTagTest.php


------
https://chatgpt.com/codex/tasks/task_e_68fbba3a21ec8323a68664efe9c90099