### PR TITLE
fix(exif): extend iso fallbacks to EXIF 3.0 sensitivity tags

### DIFF
--- a/src/Model/Exif/ExifDocument.php
+++ b/src/Model/Exif/ExifDocument.php
@@ -433,6 +433,16 @@ final readonly class ExifDocument
             return $iso;
         }
 
+        $iso = $this->int($this->exifIfd, ExifTag::STANDARD_OUTPUT_SENSITIVITY);
+        if ($iso !== null) {
+            return $iso;
+        }
+
+        $iso = $this->int($this->exifIfd, ExifTag::RECOMMENDED_EXPOSURE_INDEX);
+        if ($iso !== null) {
+            return $iso;
+        }
+
         $iso = $this->int($this->exifIfd, ExifTag::PHOTOGRAPHIC_SENSITIVITY);
         if ($iso !== null) {
             return $iso;

--- a/tests/Model/Exif/ExifDocumentTest.php
+++ b/tests/Model/Exif/ExifDocumentTest.php
@@ -571,6 +571,41 @@ final class ExifDocumentTest extends TestCase
     }
 
     /**
+     * Ensures the ISO getter prefers EXIF 3.0 sensitivity tags before falling back to photographic sensitivity.
+     */
+    #[Test]
+    public function isoPrefersStandardOutputAndRecommendedIndices(): void
+    {
+        $ifd0 = new Ifd([
+            ExifTag::PHOTOGRAPHIC_SENSITIVITY => new IfdEntry(ExifTag::PHOTOGRAPHIC_SENSITIVITY, 3, 1, 100),
+        ]);
+
+        $exifIfd = new Ifd([
+            ExifTag::STANDARD_OUTPUT_SENSITIVITY => new IfdEntry(ExifTag::STANDARD_OUTPUT_SENSITIVITY, 3, 1, 160),
+            ExifTag::RECOMMENDED_EXPOSURE_INDEX => new IfdEntry(ExifTag::RECOMMENDED_EXPOSURE_INDEX, 3, 1, 320),
+            ExifTag::PHOTOGRAPHIC_SENSITIVITY   => new IfdEntry(ExifTag::PHOTOGRAPHIC_SENSITIVITY, 3, 1, 640),
+        ]);
+
+        $doc = new ExifDocument($ifd0, $exifIfd, null, null, null);
+        self::assertSame(160, $doc->iso());
+
+        $recommendedExifIfd = new Ifd([
+            ExifTag::RECOMMENDED_EXPOSURE_INDEX => new IfdEntry(ExifTag::RECOMMENDED_EXPOSURE_INDEX, 3, 1, 320),
+            ExifTag::PHOTOGRAPHIC_SENSITIVITY   => new IfdEntry(ExifTag::PHOTOGRAPHIC_SENSITIVITY, 3, 1, 640),
+        ]);
+
+        $docWithRecommended = new ExifDocument($ifd0, $recommendedExifIfd, null, null, null);
+        self::assertSame(320, $docWithRecommended->iso());
+
+        $photographicExifIfd = new Ifd([
+            ExifTag::PHOTOGRAPHIC_SENSITIVITY => new IfdEntry(ExifTag::PHOTOGRAPHIC_SENSITIVITY, 3, 1, 640),
+        ]);
+
+        $docWithPhotographic = new ExifDocument($ifd0, $photographicExifIfd, null, null, null);
+        self::assertSame(640, $docWithPhotographic->iso());
+    }
+
+    /**
      * Ensures the ISO getter falls back to legacy tags when the ISO speed tag is missing.
      */
     #[Test]


### PR DESCRIPTION
## Summary
- prefer StandardOutputSensitivity and RecommendedExposureIndex when deriving the ISO sensitivity
- cover the extended fallback order in ExifDocumentTest while keeping existing behaviour intact

## Testing
- composer ci:test:php:unit *(fails: StructuredMetadataBuilderTest::buildsStandardsFromPrintableUndefinedBlob expects '2.32' but receives '2.3')*

------
https://chatgpt.com/codex/tasks/task_e_68fbba240b84832398d1894585bc99a7