### PR TITLE
feat: expose derived crop factor and fov metrics

### DIFF
--- a/src/Core/ValueConverters.php
+++ b/src/Core/ValueConverters.php
@@ -59,6 +59,11 @@ use const JSON_THROW_ON_ERROR;
  */
 final readonly class ValueConverters
 {
+    private const FULL_FRAME_WIDTH_MM = 36.0;
+    private const FULL_FRAME_HEIGHT_MM = 24.0;
+    private const FULL_FRAME_DIAGONAL_MM = 43.2666153056;
+    private const FULL_FRAME_CIRCLE_OF_CONFUSION_MM = 0.029;
+
     /**
      * Converts a rational or numeric EXIF representation into a floating point value.
      *
@@ -260,20 +265,104 @@ final readonly class ValueConverters
     }
 
     /**
-     * Approximates the diagonal field of view in degrees.
+     * Calculates the crop factor from focal lengths.
      */
-    public static function calcFovDeg(?int $focalLength35mm, ?float $cropFactor): ?float
+    public static function calcCropFactor(?int $focalLength35mm, ?float $focalLengthMm): ?float
     {
-        if ($focalLength35mm !== null && $focalLength35mm > 0) {
-            // 35mm full frame diagonal is approximately 43.2666153056 mm.
-            return rad2deg(2.0 * atan(43.2666153056 / (2.0 * (float) $focalLength35mm)));
+        if ($focalLength35mm === null || $focalLength35mm <= 0 || $focalLengthMm === null || $focalLengthMm <= 0.0) {
+            return null;
+        }
+
+        return (float) $focalLength35mm / $focalLengthMm;
+    }
+
+    /**
+     * Calculates the circle of confusion in millimetres based on the crop factor.
+     */
+    public static function calcCircleOfConfusionMm(?float $cropFactor): ?float
+    {
+        if ($cropFactor === null) {
+            return self::FULL_FRAME_CIRCLE_OF_CONFUSION_MM;
+        }
+
+        if ($cropFactor <= 0.0) {
+            return null;
+        }
+
+        return self::FULL_FRAME_CIRCLE_OF_CONFUSION_MM / $cropFactor;
+    }
+
+    /**
+     * Approximates the diagonal field of view in degrees.
+     *
+     * The result reflects the diagonal angle of view of the recorded frame.
+     */
+    public static function calcFovDeg(?int $focalLength35mm, ?float $cropFactor, ?float $focalLengthMm = null): ?float
+    {
+        $fov = self::calcFovFromSensorDimension(
+            self::FULL_FRAME_DIAGONAL_MM,
+            $focalLengthMm,
+            $focalLength35mm,
+            $cropFactor,
+        );
+
+        if ($fov !== null) {
+            return $fov;
         }
 
         if ($cropFactor !== null && $cropFactor > 0.0) {
-            // Assume a 50mm lens equivalent on full frame to derive an estimate.
+            // Assume a 50mm lens equivalent on full frame to derive an estimate when only the crop factor is known.
             $equivalent = 50.0 * $cropFactor;
 
-            return rad2deg(2.0 * atan(43.2666153056 / (2.0 * $equivalent)));
+            return rad2deg(2.0 * atan(self::FULL_FRAME_DIAGONAL_MM / (2.0 * $equivalent)));
+        }
+
+        return null;
+    }
+
+    /**
+     * Approximates the horizontal field of view in degrees.
+     */
+    public static function calcHorizontalFovDeg(?int $focalLength35mm, ?float $cropFactor, ?float $focalLengthMm = null): ?float
+    {
+        return self::calcFovFromSensorDimension(
+            self::FULL_FRAME_WIDTH_MM,
+            $focalLengthMm,
+            $focalLength35mm,
+            $cropFactor,
+        );
+    }
+
+    /**
+     * Approximates the vertical field of view in degrees.
+     */
+    public static function calcVerticalFovDeg(?int $focalLength35mm, ?float $cropFactor, ?float $focalLengthMm = null): ?float
+    {
+        return self::calcFovFromSensorDimension(
+            self::FULL_FRAME_HEIGHT_MM,
+            $focalLengthMm,
+            $focalLength35mm,
+            $cropFactor,
+        );
+    }
+
+    /**
+     * Calculates the field of view for the supplied sensor dimension.
+     */
+    private static function calcFovFromSensorDimension(
+        float $fullFrameDimensionMm,
+        ?float $focalLengthMm,
+        ?int $focalLength35mm,
+        ?float $cropFactor
+    ): ?float {
+        if ($focalLengthMm !== null && $focalLengthMm > 0.0 && $cropFactor !== null && $cropFactor > 0.0) {
+            $sensorDimension = $fullFrameDimensionMm / $cropFactor;
+
+            return rad2deg(2.0 * atan($sensorDimension / (2.0 * $focalLengthMm)));
+        }
+
+        if ($focalLength35mm !== null && $focalLength35mm > 0) {
+            return rad2deg(2.0 * atan($fullFrameDimensionMm / (2.0 * (float) $focalLength35mm)));
         }
 
         return null;

--- a/src/Curate/StructuredMetadataBuilder.php
+++ b/src/Curate/StructuredMetadataBuilder.php
@@ -302,6 +302,9 @@ final class StructuredMetadataBuilder
 
         $temporal = $this->buildTemporal($exifResolver, $quickTimeResolver, $xmpResolver);
 
+        $cropFactor = ValueConverters::calcCropFactor($lens->focalLengthIn35mm, $lens->focalLengthMm);
+        $circleOfConfusionMm = ValueConverters::calcCircleOfConfusionMm($cropFactor);
+
         $derived = new Derived(
             ev100: ValueConverters::calcEv100(
                 $exposure->exposureTimeSec,
@@ -311,11 +314,13 @@ final class StructuredMetadataBuilder
             hyperfocalM: ValueConverters::calcHyperfocalM(
                 $lens->focalLengthMm,
                 $exposure->fNumber,
-                0.029,
+                $circleOfConfusionMm,
             ),
-            fovDeg: ValueConverters::calcFovDeg($lens->focalLengthIn35mm, null),
+            fovDiagonalDeg: ValueConverters::calcFovDeg($lens->focalLengthIn35mm, $cropFactor, $lens->focalLengthMm),
+            fovHorizontalDeg: ValueConverters::calcHorizontalFovDeg($lens->focalLengthIn35mm, $cropFactor, $lens->focalLengthMm),
+            fovVerticalDeg: ValueConverters::calcVerticalFovDeg($lens->focalLengthIn35mm, $cropFactor, $lens->focalLengthMm),
             focalLength35mm: $lens->focalLengthIn35mm,
-            cropFactor: null,
+            cropFactor: $cropFactor,
         );
 
         $panoramaFlag = $xmpResolver->bool('http://ns.google.com/photos/1.0/panorama/', 'UsePanoramaViewer');

--- a/src/Value/Derived.php
+++ b/src/Value/Derived.php
@@ -17,16 +17,20 @@ namespace MagicSunday\ImageMeta\Value;
 final readonly class Derived
 {
     /**
-     * @param float|null $ev100           Exposure value normalised to ISO 100.
-     * @param float|null $hyperfocalM     Hyperfocal distance in metres.
-     * @param float|null $fovDeg          Approximate diagonal field of view in degrees.
-     * @param int|null   $focalLength35mm Equivalent focal length in 35mm terms.
-     * @param float|null $cropFactor      Estimated crop factor.
+     * @param float|null $ev100              Exposure value normalised to ISO 100.
+     * @param float|null $hyperfocalM        Hyperfocal distance in metres.
+     * @param float|null $fovDiagonalDeg     Diagonal field of view in degrees.
+     * @param float|null $fovHorizontalDeg   Horizontal field of view in degrees.
+     * @param float|null $fovVerticalDeg     Vertical field of view in degrees.
+     * @param int|null   $focalLength35mm    Equivalent focal length in 35mm terms.
+     * @param float|null $cropFactor         Estimated crop factor.
      */
     public function __construct(
         public ?float $ev100,
         public ?float $hyperfocalM,
-        public ?float $fovDeg,
+        public ?float $fovDiagonalDeg,
+        public ?float $fovHorizontalDeg,
+        public ?float $fovVerticalDeg,
         public ?int $focalLength35mm,
         public ?float $cropFactor,
     ) {

--- a/tests/Core/ValueConvertersTest.php
+++ b/tests/Core/ValueConvertersTest.php
@@ -119,4 +119,23 @@ final class ValueConvertersTest extends TestCase
         self::assertNull(ValueConverters::toEnumOrNull(ResolutionUnit::class, 99));
         self::assertNull(ValueConverters::toEnumOrNull(ResolutionUnit::class, null));
     }
+
+    #[Test]
+    public function calculatesFieldOfViewAndHyperfocalMetrics(): void
+    {
+        $cropFactor = ValueConverters::calcCropFactor(75, 50.0);
+        self::assertEqualsWithDelta(1.5, $cropFactor, 1e-12);
+
+        $circleOfConfusion = ValueConverters::calcCircleOfConfusionMm($cropFactor);
+        self::assertEqualsWithDelta(0.019333333333333334, $circleOfConfusion, 1e-12);
+        self::assertEqualsWithDelta(0.029, ValueConverters::calcCircleOfConfusionMm(null), 1e-12);
+        self::assertNull(ValueConverters::calcCircleOfConfusionMm(0.0));
+
+        $hyperfocal = ValueConverters::calcHyperfocalM(50.0, 8.0, $circleOfConfusion);
+        self::assertEqualsWithDelta(16.213793103448276, $hyperfocal, 1e-12);
+
+        self::assertEqualsWithDelta(32.179788109672, ValueConverters::calcFovDeg(75, $cropFactor, 50.0), 1e-12);
+        self::assertEqualsWithDelta(26.991466561592, ValueConverters::calcHorizontalFovDeg(75, $cropFactor, 50.0), 1e-12);
+        self::assertEqualsWithDelta(18.180553841645, ValueConverters::calcVerticalFovDeg(75, $cropFactor, 50.0), 1e-12);
+    }
 }

--- a/tests/Curate/StructuredMetadataBuilderTest.php
+++ b/tests/Curate/StructuredMetadataBuilderTest.php
@@ -222,6 +222,13 @@ final class StructuredMetadataBuilderTest extends TestCase
         self::assertSame([35.0, 4.0, 150.0, 5.6], $structured->lens->lensSpecification);
         self::assertEqualsWithDelta(1.9965, $structured->lens->maxApertureFNumber, 0.001);
 
+        self::assertEqualsWithDelta(44.573916, $structured->derived->hyperfocalM, 1e-6);
+        self::assertEqualsWithDelta(28.558322, $structured->derived->fovDiagonalDeg, 1e-6);
+        self::assertEqualsWithDelta(23.913168, $structured->derived->fovHorizontalDeg, 1e-6);
+        self::assertEqualsWithDelta(16.071421, $structured->derived->fovVerticalDeg, 1e-6);
+        self::assertSame(85, $structured->derived->focalLength35mm);
+        self::assertEqualsWithDelta(1.0, $structured->derived->cropFactor, 1e-6);
+
         self::assertSame(6720, $structured->image->width);
         self::assertSame(4480, $structured->image->height);
         self::assertSame(Orientation::RIGHT_TOP, $structured->image->orientation);


### PR DESCRIPTION
## Summary
- add crop factor, circle of confusion and orientation-specific field-of-view helpers to the value converters
- extend the derived metadata aggregate with diagonal, horizontal and vertical FOV plus crop factor
- populate the new metrics during structured metadata building and cover them with updated unit tests

## Testing
- composer ci:test:php:unit

------
https://chatgpt.com/codex/tasks/task_e_68fbbcf5ce78832381807c1acb0b04ac