### PR TITLE
fix: normalise EXIF TimeZoneOffset parsing

### DIFF
--- a/src/Model/Exif/ExifDocument.php
+++ b/src/Model/Exif/ExifDocument.php
@@ -19,6 +19,7 @@ use MagicSunday\ImageMeta\Value\Enum\CfaPatternColor;
 use MagicSunday\ImageMeta\Value\Enum\CustomRendered;
 use MagicSunday\ImageMeta\Value\Enum\SceneType;
 
+use function array_key_exists;
 use function array_map;
 use function iconv;
 use function is_float;
@@ -941,7 +942,23 @@ final readonly class ExifDocument
     {
         $values = $this->numericList($this->exifIfd, ExifTag::TIME_ZONE_OFFSET);
 
-        return $values;
+        if ($values === null || $values === []) {
+            return null;
+        }
+
+        $minutes = [];
+
+        foreach ($values as $value) {
+            $converted = ValueConverters::offsetToMinutes($value);
+
+            if ($converted === null) {
+                return null;
+            }
+
+            $minutes[] = $converted;
+        }
+
+        return $minutes;
     }
 
     /**
@@ -1269,19 +1286,27 @@ final readonly class ExifDocument
      */
     public function captureDateTime(): ?DateTimeImmutable
     {
-        $offsetOriginal = $this->offsetTimeOriginal();
+        $offsetOriginal  = $this->offsetTimeOriginal();
         $offsetDigitized = $this->offsetTimeDigitized();
-        $offset = $this->offsetTime();
-        $fallbackOffset = null;
+        $offset          = $this->offsetTime();
+
+        $fallbackOriginal  = null;
+        $fallbackDigitized = null;
+        $fallbackModify    = null;
 
         if ($offsetOriginal === null && $offsetDigitized === null && $offset === null) {
-            $fallbackOffset = $this->derivedOffsetFromTimeZoneOffset();
+            $primaryOffset   = $this->derivedOffsetFromTimeZoneOffset(0);
+            $secondaryOffset = $this->derivedOffsetFromTimeZoneOffset(1);
+
+            $fallbackOriginal  = $primaryOffset;
+            $fallbackDigitized = $secondaryOffset ?? $primaryOffset;
+            $fallbackModify    = $primaryOffset;
         }
 
         $attempts = [
-            [$this->dateTimeOriginalRaw(), $offsetOriginal ?? $fallbackOffset, $this->subSecTimeOriginal()],
-            [$this->dateTimeDigitizedRaw(), $offsetDigitized ?? $fallbackOffset, $this->subSecTimeDigitized()],
-            [$this->dateTimeRaw(), $offset ?? $fallbackOffset, $this->subSecTime()],
+            [$this->dateTimeOriginalRaw(), $offsetOriginal ?? $fallbackOriginal, $this->subSecTimeOriginal()],
+            [$this->dateTimeDigitizedRaw(), $offsetDigitized ?? $fallbackDigitized, $this->subSecTimeDigitized()],
+            [$this->dateTimeRaw(), $offset ?? $fallbackModify, $this->subSecTime()],
         ];
 
         foreach ($attempts as [$raw, $rawOffset, $subSeconds]) {
@@ -1560,22 +1585,15 @@ final readonly class ExifDocument
     /**
      * Derives a canonical offset string from the legacy TimeZoneOffset tag when available.
      */
-    private function derivedOffsetFromTimeZoneOffset(): ?string
+    private function derivedOffsetFromTimeZoneOffset(int $component = 0): ?string
     {
-        $offsets = $this->timeZoneOffsetMinutes();
+        $values = $this->numericList($this->exifIfd, ExifTag::TIME_ZONE_OFFSET);
 
-        if ($offsets === null || $offsets === []) {
+        if ($values === null || !array_key_exists($component, $values)) {
             return null;
         }
 
-        $minutes = $offsets[0];
-        $sign = $minutes < 0 ? '-' : '+';
-        $absolute = abs($minutes);
-        $hours = intdiv($absolute, 60);
-        $remainingMinutes = $absolute % 60;
-        $composed = sprintf('%s%02d:%02d', $sign, $hours, $remainingMinutes);
-
-        return ValueConverters::parseOffsetString($composed);
+        return ValueConverters::parseOffsetString($values[$component]);
     }
 
     /**

--- a/tests/Curate/Resolver/ExifTagResolverTest.php
+++ b/tests/Curate/Resolver/ExifTagResolverTest.php
@@ -234,7 +234,7 @@ final class ExifTagResolverTest extends TestCase
             ExifTag::OFFSET_TIME            => new IfdEntry(ExifTag::OFFSET_TIME, 2, 6, '+00:30'),
             ExifTag::OFFSET_TIME_ORIGINAL   => new IfdEntry(ExifTag::OFFSET_TIME_ORIGINAL, 2, 6, '-01:30'),
             ExifTag::OFFSET_TIME_DIGITIZED  => new IfdEntry(ExifTag::OFFSET_TIME_DIGITIZED, 2, 6, '+01:45'),
-            ExifTag::TIME_ZONE_OFFSET       => new IfdEntry(ExifTag::TIME_ZONE_OFFSET, 8, 2, new ExifNumericList([-90, 120])),
+            ExifTag::TIME_ZONE_OFFSET       => new IfdEntry(ExifTag::TIME_ZONE_OFFSET, 8, 2, new ExifNumericList([-1, 2])),
             ExifTag::SELF_TIMER_MODE        => new IfdEntry(ExifTag::SELF_TIMER_MODE, 3, 1, 7),
             ExifTag::INTERLACE              => new IfdEntry(ExifTag::INTERLACE, 3, 1, 1),
         ]);
@@ -248,7 +248,7 @@ final class ExifTagResolverTest extends TestCase
         self::assertSame('+00:30', $resolver->offsetTime());
         self::assertSame('-01:30', $resolver->offsetTimeOriginal());
         self::assertSame('+01:45', $resolver->offsetTimeDigitized());
-        self::assertSame([-90, 120], $resolver->timeZoneOffsetMinutes());
+        self::assertSame([-60, 120], $resolver->timeZoneOffsetMinutes());
         self::assertSame(7, $resolver->selfTimerModeSeconds());
         self::assertSame(1, $resolver->interlace());
     }

--- a/tests/Curate/StructuredMetadataBuilderTest.php
+++ b/tests/Curate/StructuredMetadataBuilderTest.php
@@ -135,7 +135,7 @@ final class StructuredMetadataBuilderTest extends TestCase
             ExifTag::OFFSET_TIME_ORIGINAL        => new IfdEntry(ExifTag::OFFSET_TIME_ORIGINAL, 2, 6, '+01:30'),
             ExifTag::OFFSET_TIME_DIGITIZED       => new IfdEntry(ExifTag::OFFSET_TIME_DIGITIZED, 2, 6, '+01:30'),
             ExifTag::OFFSET_TIME                 => new IfdEntry(ExifTag::OFFSET_TIME, 2, 6, '+01:30'),
-            ExifTag::TIME_ZONE_OFFSET            => new IfdEntry(ExifTag::TIME_ZONE_OFFSET, 8, 2, new ExifNumericList([-90, -60])),
+            ExifTag::TIME_ZONE_OFFSET            => new IfdEntry(ExifTag::TIME_ZONE_OFFSET, 8, 2, new ExifNumericList([-2, -1])),
             ExifTag::SELF_TIMER_MODE             => new IfdEntry(ExifTag::SELF_TIMER_MODE, 3, 1, 10),
             ExifTag::TEMPERATURE                 => new IfdEntry(ExifTag::TEMPERATURE, 10, 1, new ExifRational(215, 10)),
             ExifTag::HUMIDITY                    => new IfdEntry(ExifTag::HUMIDITY, 10, 1, new ExifRational(600, 10)),
@@ -309,7 +309,7 @@ final class StructuredMetadataBuilderTest extends TestCase
         self::assertSame('+01:30', $structured->temporal->offsetTime);
         self::assertSame('+01:30', $structured->temporal->offsetTimeOriginal);
         self::assertSame('+01:30', $structured->temporal->offsetTimeDigitized);
-        self::assertSame([-90, -60], $structured->temporal->timeZoneOffsetMinutes);
+        self::assertSame([-120, -60], $structured->temporal->timeZoneOffsetMinutes);
         self::assertSame('OffsetTimeOriginal', $structured->temporal->tzSource);
     }
 
@@ -515,7 +515,7 @@ final class StructuredMetadataBuilderTest extends TestCase
 
         $exifIfd = new Ifd([
             ExifTag::DATETIME_ORIGINAL => new IfdEntry(ExifTag::DATETIME_ORIGINAL, 2, 1, '2024:05:02 12:00:00'),
-            ExifTag::TIME_ZONE_OFFSET  => new IfdEntry(ExifTag::TIME_ZONE_OFFSET, 8, 1, new ExifNumericList([-120])),
+            ExifTag::TIME_ZONE_OFFSET  => new IfdEntry(ExifTag::TIME_ZONE_OFFSET, 8, 1, new ExifNumericList([-2])),
         ]);
 
         $exifDocument = new ExifDocument($ifd0, $exifIfd, null, null, null);
@@ -627,7 +627,7 @@ final class StructuredMetadataBuilderTest extends TestCase
             ExifTag::EXIF_VERSION      => new IfdEntry(ExifTag::EXIF_VERSION, 7, 4, '0230'),
             ExifTag::ISO_SPEED         => new IfdEntry(ExifTag::ISO_SPEED, 4, 1, 320),
             ExifTag::DATETIME_ORIGINAL => new IfdEntry(ExifTag::DATETIME_ORIGINAL, 2, 1, '2024:03:10 10:15:30'),
-            ExifTag::TIME_ZONE_OFFSET  => new IfdEntry(ExifTag::TIME_ZONE_OFFSET, 8, 1, new ExifNumericList([-90])),
+            ExifTag::TIME_ZONE_OFFSET  => new IfdEntry(ExifTag::TIME_ZONE_OFFSET, 8, 1, new ExifNumericList([-130])),
         ]);
 
         $exifDocument = new ExifDocument(new Ifd([]), $exifIfd, null, null, null);

--- a/tests/Model/Exif/ExifDocumentTest.php
+++ b/tests/Model/Exif/ExifDocumentTest.php
@@ -175,7 +175,7 @@ final class ExifDocumentTest extends TestCase
                 ExifTag::TIME_ZONE_OFFSET,
                 3,
                 1,
-                new ExifNumericList([90]),
+                new ExifNumericList([9]),
             ),
         ]);
 
@@ -183,7 +183,30 @@ final class ExifDocumentTest extends TestCase
 
         $capture = $doc->captureDateTime();
         self::assertNotNull($capture);
-        self::assertSame('2021-02-03T04:05:06.789+01:30', $capture->format(self::ISO_8601_MILLISECONDS));
+        self::assertSame('2021-02-03T04:05:06.789+09:00', $capture->format(self::ISO_8601_MILLISECONDS));
+    }
+
+    #[Test]
+    public function usesSecondTimeZoneOffsetComponentForDigitizedFallback(): void
+    {
+        $ifd0 = new Ifd([]);
+
+        $exifIfd = new Ifd([
+            ExifTag::DATETIME_DIGITIZED     => new IfdEntry(ExifTag::DATETIME_DIGITIZED, 2, 1, '2022:08:09 10:11:12'),
+            ExifTag::SUB_SEC_TIME_DIGITIZED => new IfdEntry(ExifTag::SUB_SEC_TIME_DIGITIZED, 2, 1, '321'),
+            ExifTag::TIME_ZONE_OFFSET       => new IfdEntry(
+                ExifTag::TIME_ZONE_OFFSET,
+                3,
+                2,
+                new ExifNumericList([9, -3]),
+            ),
+        ]);
+
+        $doc = new ExifDocument($ifd0, $exifIfd, null, null, null);
+
+        $capture = $doc->captureDateTime();
+        self::assertNotNull($capture);
+        self::assertSame('2022-08-09T10:11:12.321-03:00', $capture->format(self::ISO_8601_MILLISECONDS));
     }
 
     /**
@@ -432,7 +455,7 @@ final class ExifDocumentTest extends TestCase
             ExifTag::OFFSET_TIME_DIGITIZED     => new IfdEntry(ExifTag::OFFSET_TIME_DIGITIZED, 2, 1, '+01:30'),
             ExifTag::OFFSET_TIME               => new IfdEntry(ExifTag::OFFSET_TIME, 2, 1, '+01:30'),
             ExifTag::SUB_SEC_TIME              => new IfdEntry(ExifTag::SUB_SEC_TIME, 2, 1, '500'),
-            ExifTag::TIME_ZONE_OFFSET          => new IfdEntry(ExifTag::TIME_ZONE_OFFSET, 8, 1, new ExifNumericList([-90])),
+            ExifTag::TIME_ZONE_OFFSET          => new IfdEntry(ExifTag::TIME_ZONE_OFFSET, 8, 1, new ExifNumericList([-130])),
             ExifTag::SELF_TIMER_MODE           => new IfdEntry(ExifTag::SELF_TIMER_MODE, 3, 1, 10),
         ]);
 


### PR DESCRIPTION
## Summary
- normalise EXIF TimeZoneOffset handling to parse hour-based values and derive component-specific fallbacks
- update captureDateTime to reuse the parsed offsets for original, digitised, and modify timestamps
- refresh EXIF resolver and builder tests to cover hour-based offsets, including two-value TimeZoneOffset inputs

## Testing
- composer ci:test:php:unit

------
https://chatgpt.com/codex/tasks/task_e_68fbc4086c6883239a13d7bad52b93b9