### PR TITLE
feat: expose extended GPS metadata

### DIFF
--- a/src/Curate/Resolver/GpsResolver.php
+++ b/src/Curate/Resolver/GpsResolver.php
@@ -11,13 +11,24 @@ declare(strict_types=1);
 
 namespace MagicSunday\ImageMeta\Curate\Resolver;
 
+use DateTimeImmutable;
+use DateTimeZone;
+use Exception;
 use MagicSunday\ImageMeta\Model\Exif\ExifDocument;
 use MagicSunday\ImageMeta\Model\Xmp\XmpDocument;
 use MagicSunday\ImageMeta\Value\Gps;
 
 use function array_map;
 use function count;
+use function is_float;
+use function is_int;
+use function is_string;
+use function preg_match;
 use function preg_split;
+use function sprintf;
+use function str_contains;
+use function str_replace;
+use function strtoupper;
 use function trim;
 
 use const PREG_SPLIT_NO_EMPTY;
@@ -36,46 +47,208 @@ final readonly class GpsResolver
      */
     public function resolve(?ExifDocument $exifDocument, ?XmpDocument $xmpDocument): ?Gps
     {
-        $lat   = null;
-        $lon   = null;
-        $alt   = null;
-        $speed = null;
+        $gpsData = $exifDocument instanceof ExifDocument ? $exifDocument->gps() : [];
 
-        if ($exifDocument instanceof ExifDocument) {
-            $gps   = $exifDocument->gps();
-            $lat   = $gps['lat'] ?? null;
-            $lon   = $gps['lon'] ?? null;
-            $alt   = $gps['alt'] ?? null;
-            $speed = $gps['speed_ms'] ?? null;
+        $latitude     = $this->floatValue($gpsData['lat'] ?? null);
+        $longitude    = $this->floatValue($gpsData['lon'] ?? null);
+        $latitudeRef  = $this->uppercase($gpsData['lat_ref'] ?? null);
+        $longitudeRef = $this->uppercase($gpsData['lon_ref'] ?? null);
+        $altitude     = $this->floatValue($gpsData['alt'] ?? null);
+        $altitudeRef  = $this->intValue($gpsData['alt_ref'] ?? null);
+
+        $version      = $this->stringValue($gpsData['version'] ?? null);
+        $satellites   = $this->stringValue($gpsData['satellites'] ?? null);
+        $status       = $this->stringValue($gpsData['status'] ?? null);
+        $measureMode  = $this->stringValue($gpsData['measure_mode'] ?? null);
+        $dop          = $this->floatValue($gpsData['dop'] ?? null);
+        $speedRef     = $this->uppercase($gpsData['speed_ref'] ?? null);
+        $speedMs      = $this->floatValue($gpsData['speed_ms'] ?? null);
+        $trackRef     = $this->uppercase($gpsData['track_ref'] ?? null);
+        $track        = $this->floatValue($gpsData['track'] ?? null);
+        $imgDirRef    = $this->uppercase($gpsData['img_direction_ref'] ?? null);
+        $imgDir       = $this->floatValue($gpsData['img_direction'] ?? null);
+        $mapDatum     = $this->stringValue($gpsData['map_datum'] ?? null);
+
+        $destLatRef    = $this->uppercase($gpsData['dest_lat_ref'] ?? null);
+        $destLat       = $this->floatValue($gpsData['dest_lat'] ?? null);
+        $destLonRef    = $this->uppercase($gpsData['dest_lon_ref'] ?? null);
+        $destLon       = $this->floatValue($gpsData['dest_lon'] ?? null);
+        $destBearRef   = $this->uppercase($gpsData['dest_bearing_ref'] ?? null);
+        $destBear      = $this->floatValue($gpsData['dest_bearing'] ?? null);
+        $destDistRef   = $this->uppercase($gpsData['dest_distance_ref'] ?? null);
+        $destDistMetre = $this->floatValue($gpsData['dest_distance_m'] ?? null);
+
+        $processingMethod = $this->stringValue($gpsData['processing_method'] ?? null);
+        $areaInformation  = $this->stringValue($gpsData['area_information'] ?? null);
+
+        $date = $this->normaliseDate($this->stringValue($gpsData['date'] ?? null));
+        $time = $this->stringValue($gpsData['time'] ?? null);
+
+        $timestamp = $exifDocument?->gpsTimestamp();
+        if (!$timestamp instanceof DateTimeImmutable) {
+            $timestamp = null;
         }
 
-        if ($lat === null || $lon === null) {
-            $latString = $this->xmpString($xmpDocument, self::NS_EXIF, 'GPSLatitude');
-            $latRef    = $this->xmpString($xmpDocument, self::NS_EXIF, 'GPSLatitudeRef');
-            $lonString = $this->xmpString($xmpDocument, self::NS_EXIF, 'GPSLongitude');
-            $lonRef    = $this->xmpString($xmpDocument, self::NS_EXIF, 'GPSLongitudeRef');
-
-            $lat = $lat ?? $this->parseCoordinate($latString, $latRef);
-            $lon = $lon ?? $this->parseCoordinate($lonString, $lonRef);
+        if ($date === null) {
+            $date = $this->normaliseDate($exifDocument?->gpsDateStamp());
         }
 
-        if ($alt === null) {
-            $altitude = $this->xmpFloat($xmpDocument, self::NS_EXIF, 'GPSAltitude');
-            if ($altitude !== null) {
-                $altRef = $this->xmpInt($xmpDocument, self::NS_EXIF, 'GPSAltitudeRef');
+        if ($time === null) {
+            $time = $this->stringValue($exifDocument?->gpsTimeStampString());
+        }
+
+        // Fill from XMP when EXIF values are absent.
+        $xmpLatRef = $this->uppercase($this->xmpString($xmpDocument, self::NS_EXIF, 'GPSLatitudeRef'));
+        if ($latitudeRef === null) {
+            $latitudeRef = $xmpLatRef;
+        }
+
+        if ($latitude === null) {
+            $latitude = $this->parseCoordinate(
+                $this->xmpString($xmpDocument, self::NS_EXIF, 'GPSLatitude'),
+                $xmpLatRef ?? $latitudeRef,
+            );
+        }
+
+        $xmpLonRef = $this->uppercase($this->xmpString($xmpDocument, self::NS_EXIF, 'GPSLongitudeRef'));
+        if ($longitudeRef === null) {
+            $longitudeRef = $xmpLonRef;
+        }
+
+        if ($longitude === null) {
+            $longitude = $this->parseCoordinate(
+                $this->xmpString($xmpDocument, self::NS_EXIF, 'GPSLongitude'),
+                $xmpLonRef ?? $longitudeRef,
+            );
+        }
+
+        if ($altitude === null) {
+            $altitudeXmp = $this->xmpFloat($xmpDocument, self::NS_EXIF, 'GPSAltitude');
+            if ($altitudeXmp !== null) {
+                $altRefXmp = $this->intValue($this->xmpInt($xmpDocument, self::NS_EXIF, 'GPSAltitudeRef'));
+                $altRef    = $altitudeRef ?? $altRefXmp;
+
                 if ($altRef === 1) {
-                    $altitude = -$altitude;
+                    $altitudeXmp = -$altitudeXmp;
                 }
 
-                $alt = $altitude;
+                $altitude = $altitudeXmp;
+
+                if ($altitudeRef === null) {
+                    $altitudeRef = $altRefXmp;
+                }
             }
         }
 
-        if ($lat === null && $lon === null && $alt === null && $speed === null) {
+        if ($speedRef === null) {
+            $speedRef = $this->uppercase($this->xmpString($xmpDocument, self::NS_EXIF, 'GPSSpeedRef'));
+        }
+
+        if ($speedMs === null) {
+            $speedValue = $this->xmpFloat($xmpDocument, self::NS_EXIF, 'GPSSpeed');
+            if ($speedValue !== null && $speedRef !== null) {
+                $speedMs = $this->convertSpeedToMetresPerSecond($speedValue, $speedRef);
+            }
+        }
+
+        if ($date === null) {
+            $date = $this->normaliseDate($this->xmpString($xmpDocument, self::NS_EXIF, 'GPSDateStamp'));
+        }
+
+        if ($time === null) {
+            $time = $this->stringValue($this->xmpString($xmpDocument, self::NS_EXIF, 'GPSTimeStamp'));
+        }
+
+        if (!$timestamp instanceof DateTimeImmutable) {
+            $timestamp = $this->parseXmpTimestamp($xmpDocument);
+        }
+
+        if (!$timestamp instanceof DateTimeImmutable) {
+            $timestamp = $this->combineDateAndTime($date, $time);
+        }
+
+        $differential = $this->intValue($gpsData['differential'] ?? null);
+        $hError       = $this->floatValue($gpsData['h_positioning_error'] ?? null);
+
+        $hasData = false;
+        foreach ([
+            $latitude,
+            $longitude,
+            $altitude,
+            $altitudeRef,
+            $version,
+            $satellites,
+            $status,
+            $measureMode,
+            $dop,
+            $speedRef,
+            $speedMs,
+            $trackRef,
+            $track,
+            $imgDirRef,
+            $imgDir,
+            $mapDatum,
+            $destLatRef,
+            $destLat,
+            $destLonRef,
+            $destLon,
+            $destBearRef,
+            $destBear,
+            $destDistRef,
+            $destDistMetre,
+            $processingMethod,
+            $areaInformation,
+            $date,
+            $time,
+            $timestamp,
+            $differential,
+            $hError,
+        ] as $value) {
+            if ($value !== null) {
+                $hasData = true;
+                break;
+            }
+        }
+
+        if (!$hasData) {
             return null;
         }
 
-        return new Gps($lat, $lon, $alt, $speed);
+        return new Gps(
+            latitude: $latitude,
+            longitude: $longitude,
+            latitudeRef: $latitudeRef,
+            longitudeRef: $longitudeRef,
+            altitude: $altitude,
+            altitudeRef: $altitudeRef,
+            version: $version,
+            satellites: $satellites,
+            status: $status,
+            measureMode: $measureMode,
+            dop: $dop,
+            speedRef: $speedRef,
+            speedMs: $speedMs,
+            trackRef: $trackRef,
+            track: $track,
+            imageDirectionRef: $imgDirRef,
+            imageDirection: $imgDir,
+            mapDatum: $mapDatum,
+            destinationLatitudeRef: $destLatRef,
+            destinationLatitude: $destLat,
+            destinationLongitudeRef: $destLonRef,
+            destinationLongitude: $destLon,
+            destinationBearingRef: $destBearRef,
+            destinationBearing: $destBear,
+            destinationDistanceRef: $destDistRef,
+            destinationDistanceMetres: $destDistMetre,
+            processingMethod: $processingMethod,
+            areaInformation: $areaInformation,
+            date: $date,
+            time: $time,
+            timestamp: $timestamp,
+            differential: $differential,
+            horizontalPositioningError: $hError,
+        );
     }
 
     /**
@@ -134,5 +307,152 @@ final readonly class GpsResolver
         }
 
         return 1.0;
+    }
+
+    /**
+     * Normalises a textual value to uppercase when present.
+     */
+    private function uppercase(?string $value): ?string
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        $trimmed = trim($value);
+        if ($trimmed === '') {
+            return null;
+        }
+
+        return strtoupper($trimmed);
+    }
+
+    /**
+     * Returns the value as string when not empty.
+     */
+    private function stringValue(mixed $value): ?string
+    {
+        if (!is_string($value)) {
+            return null;
+        }
+
+        $trimmed = trim($value);
+
+        return $trimmed === '' ? null : $trimmed;
+    }
+
+    /**
+     * Returns the value as float when numeric.
+     */
+    private function floatValue(mixed $value): ?float
+    {
+        if (is_float($value)) {
+            return $value;
+        }
+
+        if (is_int($value)) {
+            return (float) $value;
+        }
+
+        return null;
+    }
+
+    /**
+     * Returns the value as integer when numeric.
+     */
+    private function intValue(mixed $value): ?int
+    {
+        if (is_int($value)) {
+            return $value;
+        }
+
+        if (is_float($value)) {
+            return (int) round($value);
+        }
+
+        return null;
+    }
+
+    /**
+     * Converts a textual GPS date into ISO format.
+     */
+    private function normaliseDate(?string $value): ?string
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        $trimmed = trim($value);
+        if ($trimmed === '') {
+            return null;
+        }
+
+        if (preg_match('/^\\d{4}:\\d{2}:\\d{2}$/', $trimmed) === 1) {
+            return str_replace(':', '-', $trimmed);
+        }
+
+        return $trimmed;
+    }
+
+    /**
+     * Parses an XMP GPSDateTime value.
+     */
+    private function parseXmpTimestamp(?XmpDocument $document): ?DateTimeImmutable
+    {
+        $value = $this->xmpString($document, self::NS_EXIF, 'GPSDateTime');
+        if ($value === null) {
+            return null;
+        }
+
+        try {
+            $dateTime = new DateTimeImmutable($value);
+        } catch (Exception) {
+            return null;
+        }
+
+        return $dateTime->setTimezone(new DateTimeZone('UTC'));
+    }
+
+    /**
+     * Combines the supplied date and time strings into a UTC timestamp.
+     */
+    private function combineDateAndTime(?string $date, ?string $time): ?DateTimeImmutable
+    {
+        if ($date === null || $time === null) {
+            return null;
+        }
+
+        $time = trim($time);
+        if ($time === '') {
+            return null;
+        }
+
+        $dateTimeString = sprintf('%sT%s', $date, $time);
+        $hasZone        = str_contains($time, 'Z') || str_contains($time, 'z')
+            || str_contains($time, '+') || str_contains($time, '-');
+
+        if (!$hasZone) {
+            $dateTimeString .= 'Z';
+        }
+
+        try {
+            $dateTime = new DateTimeImmutable($dateTimeString);
+        } catch (Exception) {
+            return null;
+        }
+
+        return $dateTime->setTimezone(new DateTimeZone('UTC'));
+    }
+
+    /**
+     * Converts speed in the provided unit to metres per second using GPSSpeedRef semantics.
+     */
+    private function convertSpeedToMetresPerSecond(float $speed, string $speedRef): float
+    {
+        return match ($speedRef) {
+            'K' => $speed / 3.6,
+            'M' => $speed * 0.44704,
+            'N' => $speed * 0.514444,
+            default => $speed,
+        };
     }
 }

--- a/src/Curate/StructuredMetadataBuilder.php
+++ b/src/Curate/StructuredMetadataBuilder.php
@@ -18,6 +18,7 @@ use MagicSunday\ImageMeta\Core\ExifCapabilities;
 use MagicSunday\ImageMeta\Core\ValueConverters;
 use MagicSunday\ImageMeta\Curate\Resolver\CompositeResolver;
 use MagicSunday\ImageMeta\Curate\Resolver\ExifTagResolver;
+use MagicSunday\ImageMeta\Curate\Resolver\GpsResolver;
 use MagicSunday\ImageMeta\Curate\Resolver\QuickTimeResolver;
 use MagicSunday\ImageMeta\Curate\Resolver\XmpResolver;
 use MagicSunday\ImageMeta\Model\Metadata;
@@ -73,6 +74,7 @@ final class StructuredMetadataBuilder
         $xmpDocument       = $metadata->xmpDoc ?? $metadata->selectiveXmpDocument();
         $xmpResolver       = new XmpResolver($xmpDocument);
         $quickTimeResolver = new QuickTimeResolver($metadata->quickTime);
+        $gpsResolver       = new GpsResolver();
 
         $interop = new Interop(index: $exifResolver->interopIndex());
 
@@ -154,13 +156,7 @@ final class StructuredMetadataBuilder
             selfTimerModeSeconds: $exifResolver->selfTimerModeSeconds(),
         );
 
-        $gpsCoords = $exifResolver->gps();
-        $gps       = new Gps(
-            $gpsCoords['lat'],
-            $gpsCoords['lon'],
-            $gpsCoords['alt'],
-            $gpsCoords['speed_ms'] ?? null,
-        );
+        $gps = $gpsResolver->resolve($metadata->exifDoc, $xmpDocument) ?? new Gps();
 
         $device = $this->buildDevice($exifResolver, $quickTimeResolver);
 

--- a/src/Value/Gps.php
+++ b/src/Value/Gps.php
@@ -11,22 +11,82 @@ declare(strict_types=1);
 
 namespace MagicSunday\ImageMeta\Value;
 
+use DateTimeImmutable;
+
 /**
- * Describes the GPS position at capture time.
+ * Describes the GPS position at capture time including navigation details.
  */
 final readonly class Gps
 {
     /**
-     * @param float|null $latitude  Latitude in decimal degrees.
-     * @param float|null $longitude Longitude in decimal degrees.
-     * @param float|null $altitude  Altitude in metres relative to sea level.
-     * @param float|null $speedMs   Ground speed in metres per second when provided.
+     * @param float|null            $latitude                   Latitude in decimal degrees.
+     * @param float|null            $longitude                  Longitude in decimal degrees.
+     * @param string|null           $latitudeRef                Latitude hemisphere reference (N/S).
+     * @param string|null           $longitudeRef               Longitude hemisphere reference (E/W).
+     * @param float|null            $altitude                   Altitude in metres relative to sea level.
+     * @param int|null              $altitudeRef                Altitude reference (0 = above, 1 = below sea level).
+     * @param string|null           $version                    GPS metadata version string.
+     * @param string|null           $satellites                 Satellites used for measurement.
+     * @param string|null           $status                     Receiver status at capture time.
+     * @param string|null           $measureMode                Measurement mode (2 = 2D, 3 = 3D).
+     * @param float|null            $dop                        Dilution of precision.
+     * @param string|null           $speedRef                   Speed reference unit (K/M/N).
+     * @param float|null            $speedMs                    Ground speed in metres per second.
+     * @param string|null           $trackRef                   Course over ground reference (T/M).
+     * @param float|null            $track                      Course over ground in degrees.
+     * @param string|null           $imageDirectionRef          Image direction reference (T/M).
+     * @param float|null            $imageDirection             Image direction in degrees.
+     * @param string|null           $mapDatum                   Geodetic survey data used.
+     * @param string|null           $destinationLatitudeRef     Destination latitude reference.
+     * @param float|null            $destinationLatitude        Destination latitude in decimal degrees.
+     * @param string|null           $destinationLongitudeRef    Destination longitude reference.
+     * @param float|null            $destinationLongitude       Destination longitude in decimal degrees.
+     * @param string|null           $destinationBearingRef      Destination bearing reference (T/M).
+     * @param float|null            $destinationBearing         Destination bearing in degrees.
+     * @param string|null           $destinationDistanceRef     Destination distance reference (K/M/N).
+     * @param float|null            $destinationDistanceMetres  Destination distance in metres.
+     * @param string|null           $processingMethod           GPS processing method description.
+     * @param string|null           $areaInformation            GPS area information description.
+     * @param string|null           $date                       GPS date stamp in ISO 8601 calendar format.
+     * @param string|null           $time                       GPS time stamp in HH:MM:SS(.sss) format.
+     * @param DateTimeImmutable|null $timestamp                 Combined UTC timestamp when available.
+     * @param int|null              $differential               Differential GPS indicator.
+     * @param float|null            $horizontalPositioningError Horizontal positioning error in metres.
      */
     public function __construct(
-        public ?float $latitude,
-        public ?float $longitude,
-        public ?float $altitude,
-        public ?float $speedMs,
+        public ?float $latitude = null,
+        public ?float $longitude = null,
+        public ?string $latitudeRef = null,
+        public ?string $longitudeRef = null,
+        public ?float $altitude = null,
+        public ?int $altitudeRef = null,
+        public ?string $version = null,
+        public ?string $satellites = null,
+        public ?string $status = null,
+        public ?string $measureMode = null,
+        public ?float $dop = null,
+        public ?string $speedRef = null,
+        public ?float $speedMs = null,
+        public ?string $trackRef = null,
+        public ?float $track = null,
+        public ?string $imageDirectionRef = null,
+        public ?float $imageDirection = null,
+        public ?string $mapDatum = null,
+        public ?string $destinationLatitudeRef = null,
+        public ?float $destinationLatitude = null,
+        public ?string $destinationLongitudeRef = null,
+        public ?float $destinationLongitude = null,
+        public ?string $destinationBearingRef = null,
+        public ?float $destinationBearing = null,
+        public ?string $destinationDistanceRef = null,
+        public ?float $destinationDistanceMetres = null,
+        public ?string $processingMethod = null,
+        public ?string $areaInformation = null,
+        public ?string $date = null,
+        public ?string $time = null,
+        public ?DateTimeImmutable $timestamp = null,
+        public ?int $differential = null,
+        public ?float $horizontalPositioningError = null,
     ) {
     }
 }

--- a/tests/Curate/StructuredMetadataBuilderTest.php
+++ b/tests/Curate/StructuredMetadataBuilderTest.php
@@ -16,6 +16,7 @@ use MagicSunday\ImageMeta\Curate\StructuredMetadataBuilder;
 use MagicSunday\ImageMeta\Model\Exif\ExifDocument;
 use MagicSunday\ImageMeta\Model\Exif\ExifNumericList;
 use MagicSunday\ImageMeta\Model\Exif\ExifRational;
+use MagicSunday\ImageMeta\Model\Exif\ExifRationalList;
 use MagicSunday\ImageMeta\Model\Exif\ExifTag;
 use MagicSunday\ImageMeta\Model\Exif\Ifd;
 use MagicSunday\ImageMeta\Model\Exif\IfdEntry;
@@ -743,8 +744,138 @@ final class StructuredMetadataBuilderTest extends TestCase
 
         $structured = (new StructuredMetadataBuilder())->build($metadata);
 
+        self::assertSame('K', $structured->gps->speedRef);
         self::assertEqualsWithDelta(33.3333333, $structured->gps->speedMs, 1e-6);
     }
+
+
+    /**
+     * Ensures complex EXIF GPS metadata is fully represented in the structured aggregate.
+     */
+    #[Test]
+    public function buildsCompleteGpsDatasetFromExifMetadata(): void
+    {
+        $gpsIfd = new Ifd([
+            ExifTag::GPS_VERSION_ID   => new IfdEntry(ExifTag::GPS_VERSION_ID, 1, 4, [3, 0, 0, 0]),
+            ExifTag::GPS_LATITUDE_REF => new IfdEntry(ExifTag::GPS_LATITUDE_REF, 2, 2, 'N'),
+            ExifTag::GPS_LATITUDE     => new IfdEntry(
+                ExifTag::GPS_LATITUDE,
+                5,
+                3,
+                new ExifRationalList([
+                    new ExifRational(51, 1),
+                    new ExifRational(30, 1),
+                    new ExifRational(0, 1),
+                ]),
+            ),
+            ExifTag::GPS_LONGITUDE_REF => new IfdEntry(ExifTag::GPS_LONGITUDE_REF, 2, 2, 'E'),
+            ExifTag::GPS_LONGITUDE     => new IfdEntry(
+                ExifTag::GPS_LONGITUDE,
+                5,
+                3,
+                new ExifRationalList([
+                    new ExifRational(8, 1),
+                    new ExifRational(30, 1),
+                    new ExifRational(0, 1),
+                ]),
+            ),
+            ExifTag::GPS_ALTITUDE_REF => new IfdEntry(ExifTag::GPS_ALTITUDE_REF, 1, 1, 0),
+            ExifTag::GPS_ALTITUDE     => new IfdEntry(ExifTag::GPS_ALTITUDE, 5, 1, new ExifRational(150, 1)),
+            ExifTag::GPS_TIME_STAMP   => new IfdEntry(
+                ExifTag::GPS_TIME_STAMP,
+                5,
+                3,
+                new ExifRationalList([
+                    new ExifRational(12, 1),
+                    new ExifRational(34, 1),
+                    new ExifRational(56789, 1000),
+                ]),
+            ),
+            ExifTag::GPS_DATE_STAMP        => new IfdEntry(ExifTag::GPS_DATE_STAMP, 2, 10, '2024:05:06'),
+            ExifTag::GPS_SATELLITES        => new IfdEntry(ExifTag::GPS_SATELLITES, 2, 2, '05'),
+            ExifTag::GPS_STATUS            => new IfdEntry(ExifTag::GPS_STATUS, 2, 1, 'A'),
+            ExifTag::GPS_MEASURE_MODE      => new IfdEntry(ExifTag::GPS_MEASURE_MODE, 2, 1, '3'),
+            ExifTag::GPS_DOP               => new IfdEntry(ExifTag::GPS_DOP, 5, 1, new ExifRational(25, 10)),
+            ExifTag::GPS_SPEED_REF         => new IfdEntry(ExifTag::GPS_SPEED_REF, 2, 1, 'K'),
+            ExifTag::GPS_SPEED             => new IfdEntry(ExifTag::GPS_SPEED, 5, 1, new ExifRational(72000, 1000)),
+            ExifTag::GPS_TRACK_REF         => new IfdEntry(ExifTag::GPS_TRACK_REF, 2, 1, 'T'),
+            ExifTag::GPS_TRACK             => new IfdEntry(ExifTag::GPS_TRACK, 5, 1, new ExifRational(12345, 100)),
+            ExifTag::GPS_IMG_DIRECTION_REF => new IfdEntry(ExifTag::GPS_IMG_DIRECTION_REF, 2, 1, 'M'),
+            ExifTag::GPS_IMG_DIRECTION     => new IfdEntry(ExifTag::GPS_IMG_DIRECTION, 5, 1, new ExifRational(2500, 10)),
+            ExifTag::GPS_MAP_DATUM         => new IfdEntry(ExifTag::GPS_MAP_DATUM, 2, 6, 'WGS-84'),
+            ExifTag::GPS_DEST_LATITUDE_REF => new IfdEntry(ExifTag::GPS_DEST_LATITUDE_REF, 2, 1, 'N'),
+            ExifTag::GPS_DEST_LATITUDE     => new IfdEntry(
+                ExifTag::GPS_DEST_LATITUDE,
+                5,
+                3,
+                new ExifRationalList([
+                    new ExifRational(41, 1),
+                    new ExifRational(0, 1),
+                    new ExifRational(0, 1),
+                ]),
+            ),
+            ExifTag::GPS_DEST_LONGITUDE_REF => new IfdEntry(ExifTag::GPS_DEST_LONGITUDE_REF, 2, 1, 'E'),
+            ExifTag::GPS_DEST_LONGITUDE     => new IfdEntry(
+                ExifTag::GPS_DEST_LONGITUDE,
+                5,
+                3,
+                new ExifRationalList([
+                    new ExifRational(8, 1),
+                    new ExifRational(30, 1),
+                    new ExifRational(0, 1),
+                ]),
+            ),
+            ExifTag::GPS_DEST_BEARING_REF    => new IfdEntry(ExifTag::GPS_DEST_BEARING_REF, 2, 1, 'T'),
+            ExifTag::GPS_DEST_BEARING        => new IfdEntry(ExifTag::GPS_DEST_BEARING, 5, 1, new ExifRational(123, 1)),
+            ExifTag::GPS_DEST_DISTANCE_REF   => new IfdEntry(ExifTag::GPS_DEST_DISTANCE_REF, 2, 1, 'K'),
+            ExifTag::GPS_DEST_DISTANCE       => new IfdEntry(ExifTag::GPS_DEST_DISTANCE, 5, 1, new ExifRational(42, 1)),
+            ExifTag::GPS_PROCESSING_METHOD   => new IfdEntry(ExifTag::GPS_PROCESSING_METHOD, 7, 11, "ASCII\0\0\0NETWORK"),
+            ExifTag::GPS_AREA_INFORMATION    => new IfdEntry(ExifTag::GPS_AREA_INFORMATION, 7, 13, "ASCII\0\0\0AreaName"),
+            ExifTag::GPS_DIFFERENTIAL        => new IfdEntry(ExifTag::GPS_DIFFERENTIAL, 3, 1, 2),
+            ExifTag::GPS_H_POSITIONING_ERROR => new IfdEntry(ExifTag::GPS_H_POSITIONING_ERROR, 5, 1, new ExifRational(15, 10)),
+        ]);
+
+        $exifDocument = new ExifDocument(new Ifd([]), null, $gpsIfd, null, null);
+        $metadata     = new Metadata(['primary'], null, $exifDocument);
+
+        $structured = (new StructuredMetadataBuilder())->build($metadata);
+
+        self::assertSame('N', $structured->gps->latitudeRef);
+        self::assertEqualsWithDelta(51.5, $structured->gps->latitude, 1e-6);
+        self::assertSame('E', $structured->gps->longitudeRef);
+        self::assertEqualsWithDelta(8.5, $structured->gps->longitude, 1e-6);
+        self::assertSame(0, $structured->gps->altitudeRef);
+        self::assertEqualsWithDelta(150.0, $structured->gps->altitude, 1e-6);
+        self::assertSame('3.0.0.0', $structured->gps->version);
+        self::assertSame('05', $structured->gps->satellites);
+        self::assertSame('A', $structured->gps->status);
+        self::assertSame('3', $structured->gps->measureMode);
+        self::assertEqualsWithDelta(2.5, $structured->gps->dop, 1e-6);
+        self::assertSame('K', $structured->gps->speedRef);
+        self::assertEqualsWithDelta(20.0, $structured->gps->speedMs, 1e-6);
+        self::assertSame('T', $structured->gps->trackRef);
+        self::assertEqualsWithDelta(123.45, $structured->gps->track, 1e-6);
+        self::assertSame('M', $structured->gps->imageDirectionRef);
+        self::assertEqualsWithDelta(250.0, $structured->gps->imageDirection, 1e-6);
+        self::assertSame('WGS-84', $structured->gps->mapDatum);
+        self::assertSame('N', $structured->gps->destinationLatitudeRef);
+        self::assertEqualsWithDelta(41.0, $structured->gps->destinationLatitude, 1e-6);
+        self::assertSame('E', $structured->gps->destinationLongitudeRef);
+        self::assertEqualsWithDelta(8.5, $structured->gps->destinationLongitude, 1e-6);
+        self::assertSame('T', $structured->gps->destinationBearingRef);
+        self::assertEqualsWithDelta(123.0, $structured->gps->destinationBearing, 1e-6);
+        self::assertSame('K', $structured->gps->destinationDistanceRef);
+        self::assertEqualsWithDelta(42000.0, $structured->gps->destinationDistanceMetres, 1e-6);
+        self::assertSame('NETWORK', $structured->gps->processingMethod);
+        self::assertSame('AreaName', $structured->gps->areaInformation);
+        self::assertSame('2024-05-06', $structured->gps->date);
+        self::assertSame('12:34:56.789', $structured->gps->time);
+        self::assertInstanceOf(DateTimeImmutable::class, $structured->gps->timestamp);
+        self::assertSame('2024-05-06T12:34:56+00:00', $structured->gps->timestamp?->format(DATE_ATOM));
+        self::assertSame(2, $structured->gps->differential);
+        self::assertEqualsWithDelta(1.5, $structured->gps->horizontalPositioningError, 1e-6);
+    }
+
 
     /**
      * Verifies that empty metadata still instantiates every value object with null/default state.


### PR DESCRIPTION
## Summary
- expand the GPS value object so altitude references, navigation bearings, timestamps, accuracy, and processing metadata are available to consumers
- update the GPS resolver to merge EXIF/XMP data, convert units (including GPSSpeedRef), and populate the extended fields
- plug the resolver into StructuredMetadataBuilder and extend the unit tests to cover full GPS datasets

## Testing
- composer ci:test:php:unit

------
https://chatgpt.com/codex/tasks/task_e_68fbc447e710832388e6ef34b9c706c0