### PR TITLE
test: replace binary ICC fixture with synthetic profile

### DIFF
--- a/src/Curate/StructuredMetadataBuilder.php
+++ b/src/Curate/StructuredMetadataBuilder.php
@@ -21,6 +21,7 @@ use MagicSunday\ImageMeta\Curate\Resolver\ExifTagResolver;
 use MagicSunday\ImageMeta\Curate\Resolver\QuickTimeResolver;
 use MagicSunday\ImageMeta\Curate\Resolver\XmpResolver;
 use MagicSunday\ImageMeta\Model\Metadata;
+use MagicSunday\ImageMeta\Parse\Icc\IccDecoder;
 use MagicSunday\ImageMeta\Value\Apple;
 use MagicSunday\ImageMeta\Value\Audio;
 use MagicSunday\ImageMeta\Value\Author;
@@ -215,12 +216,18 @@ final class StructuredMetadataBuilder
             bitDepth: $quickTimeResolver->int('AudioBitsPerSample'),
         );
 
+        $iccData = null;
+        if ($metadata->iccProfile !== null || $metadata->iccSegments !== []) {
+            $iccData = (new IccDecoder())->decode($metadata->iccProfile, $metadata->iccSegments);
+        }
+
         $colorProfile = new ColorProfile(
-            profileName: null,
-            profileVersion: null,
-            pcs: null,
-            renderingIntent: null,
+            profileName: $iccData['description'] ?? null,
+            profileVersion: $iccData['version'] ?? null,
+            pcs: $iccData['pcs'] ?? null,
+            renderingIntent: $iccData['renderingIntent'] ?? null,
             gamma: $exifResolver->gamma(),
+            profileId: $iccData['profileId'] ?? null,
         );
 
         $processing = new ProcessingSettings(

--- a/src/MetadataReader.php
+++ b/src/MetadataReader.php
@@ -54,9 +54,11 @@ final class MetadataReader
      */
     private function fromJpeg(Stream $stream): Metadata
     {
-        $jpeg      = new JpegExtractor($stream);
-        $exifBlobs = $jpeg->extractExifBlobs();
-        $xmpBlobs  = $jpeg->extractXmpPackets();
+        $jpeg       = new JpegExtractor($stream);
+        $exifBlobs  = $jpeg->extractExifBlobs();
+        $xmpBlobs   = $jpeg->extractXmpPackets();
+        $iccProfile = $jpeg->getIccProfile();
+        $iccSegments = $jpeg->getIccSegments();
 
         $exifDoc    = null;
         $xmpDoc     = null;
@@ -71,7 +73,7 @@ final class MetadataReader
             $xmpDoc = (new XmpParser())->parse($xmpBlobs[0]);
         }
 
-        return new Metadata($exifBlobs, null, $exifDoc, $xmpBlobs, $xmpDoc, $makerNotes);
+        return new Metadata($exifBlobs, null, $exifDoc, $xmpBlobs, $xmpDoc, $makerNotes, $iccProfile, $iccSegments);
     }
 
     /**

--- a/src/Model/Metadata.php
+++ b/src/Model/Metadata.php
@@ -36,6 +36,13 @@ final class Metadata
     public readonly ?XmpDocument $xmpDoc;
     public readonly ?MakerNotesMetadata $makerNotes;
 
+    public readonly ?string $iccProfile;
+
+    /**
+     * @var list<string>
+     */
+    public readonly array $iccSegments;
+
     private ?StructuredMetadata $structured = null;
 
     /**
@@ -45,6 +52,8 @@ final class Metadata
      * @param list<string>            $xmpBlobs   XMP packets (RDF/XML), first is primary
      * @param XmpDocument|null        $xmpDoc     Parsed representation of the primary XMP packet.
      * @param MakerNotesMetadata|null $makerNotes Decoded maker notes metadata for the primary EXIF blob.
+     * @param string|null             $iccProfile Binary ICC profile when available.
+     * @param list<string>            $iccSegments Raw ICC APP2 segments in encounter order.
      */
     public function __construct(
         array $exifBlobs,
@@ -53,13 +62,17 @@ final class Metadata
         array $xmpBlobs = [],
         ?XmpDocument $xmpDoc = null,
         ?MakerNotesMetadata $makerNotes = null,
+        ?string $iccProfile = null,
+        array $iccSegments = [],
     ) {
-        $this->exifBlobs  = $exifBlobs;
-        $this->quickTime  = $quickTime;
-        $this->exifDoc    = $exifDoc;
-        $this->xmpBlobs   = $xmpBlobs;
-        $this->xmpDoc     = $xmpDoc;
-        $this->makerNotes = $makerNotes;
+        $this->exifBlobs   = $exifBlobs;
+        $this->quickTime   = $quickTime;
+        $this->exifDoc     = $exifDoc;
+        $this->xmpBlobs    = $xmpBlobs;
+        $this->xmpDoc      = $xmpDoc;
+        $this->makerNotes  = $makerNotes;
+        $this->iccProfile  = $iccProfile;
+        $this->iccSegments = $iccSegments;
     }
 
     /**

--- a/src/Parse/Icc/IccDecoder.php
+++ b/src/Parse/Icc/IccDecoder.php
@@ -1,0 +1,357 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\ImageMeta\Parse\Icc;
+
+use function array_key_exists;
+use function bin2hex;
+use function class_exists;
+use function function_exists;
+use function iconv;
+use function mb_convert_encoding;
+use function min;
+use function ord;
+use function rtrim;
+use function sprintf;
+use function str_repeat;
+use function str_starts_with;
+use function strlen;
+use function substr;
+use function strtoupper;
+use function unpack;
+
+/**
+ * Decodes ICC profiles to expose header information and human readable tags.
+ */
+final class IccDecoder
+{
+    private const int HEADER_LENGTH = 128;
+
+    private const int TAG_RECORD_LENGTH = 12;
+
+    private const string ICC_SIGNATURE = 'ICC_PROFILE\0';
+
+    /**
+     * Mapping of ICC rendering intent enumerations to descriptive strings.
+     */
+    private const array RENDERING_INTENT_MAP = [
+        0 => 'Perceptual',
+        1 => 'Media-Relative Colorimetric',
+        2 => 'Saturation',
+        3 => 'ICC-Absolute Colorimetric',
+    ];
+
+    /**
+     * Decodes the ICC profile payload by extracting header fields and well known tags.
+     *
+     * @param string|null       $profileData Raw ICC profile data when a complete payload is available.
+     * @param array<int, string> $segments    ICC segments collected from APP2 markers ordered by appearance.
+     *
+     * @return array{
+     *     description: string|null,
+     *     version: string|null,
+     *     pcs: string|null,
+     *     renderingIntent: string|null,
+     *     profileId: string|null,
+     * }|null
+     */
+    public function decode(?string $profileData, array $segments = []): ?array
+    {
+        $data = $profileData;
+        if ($data === null || strlen($data) < self::HEADER_LENGTH) {
+            $data = $this->combineSegments($segments);
+        }
+
+        if ($data === null || strlen($data) < self::HEADER_LENGTH) {
+            return null;
+        }
+
+        $profileSize = $this->uInt32Be(substr($data, 0, 4));
+        $length      = strlen($data);
+        if ($profileSize > $length) {
+            return null; // truncated payload
+        }
+
+        $version         = $this->extractVersion($data);
+        $pcs             = $this->extractSignature(substr($data, 20, 4));
+        $renderingIntent = $this->extractRenderingIntent($data);
+        $profileId       = $this->extractProfileId($data);
+        $description     = $this->extractDescription($data, $profileSize);
+
+        return [
+            'description' => $description,
+            'version' => $version,
+            'pcs' => $pcs,
+            'renderingIntent' => $renderingIntent,
+            'profileId' => $profileId,
+        ];
+    }
+
+    /**
+     * Attempts to reconstruct the ICC payload from APP2 ICC segments.
+     *
+     * @param array<int, string> $segments Ordered ICC segments as extracted from the JPEG stream.
+     */
+    private function combineSegments(array $segments): ?string
+    {
+        if ($segments === []) {
+            return null;
+        }
+
+        $sequence      = [];
+        $expectedCount = null;
+
+        foreach ($segments as $payload) {
+            if (!str_starts_with($payload, self::ICC_SIGNATURE)) {
+                continue;
+            }
+
+            $minLength = strlen(self::ICC_SIGNATURE) + 2;
+            if (strlen($payload) <= $minLength) {
+                continue;
+            }
+
+            $sequenceNumber = ord($payload[strlen(self::ICC_SIGNATURE)]);
+            $sequenceCount  = ord($payload[strlen(self::ICC_SIGNATURE) + 1]);
+
+            if ($sequenceCount === 0) {
+                return null;
+            }
+
+            if ($expectedCount === null) {
+                $expectedCount = $sequenceCount;
+            } elseif ($expectedCount !== $sequenceCount) {
+                return null; // conflicting counts
+            }
+
+            $sequence[$sequenceNumber] = substr($payload, $minLength);
+        }
+
+        if ($expectedCount === null) {
+            return null;
+        }
+
+        $iccData = '';
+        for ($i = 1; $i <= $expectedCount; $i++) {
+            if (!array_key_exists($i, $sequence)) {
+                return null;
+            }
+
+            $iccData .= $sequence[$i];
+        }
+
+        return $iccData;
+    }
+
+    private function extractVersion(string $data): ?string
+    {
+        $majorMinor = ord($data[8]);
+        $bugfix     = ord($data[9]);
+
+        $major = $majorMinor >> 4;
+        $minor = $majorMinor & 0x0F;
+        $bug   = $bugfix >> 4;
+
+        if ($major === 0 && $minor === 0 && $bug === 0) {
+            return null;
+        }
+
+        return $bug > 0
+            ? sprintf('%d.%d.%d', $major, $minor, $bug)
+            : sprintf('%d.%d', $major, $minor);
+    }
+
+    private function extractSignature(string $signature): ?string
+    {
+        if ($signature === '' || strlen($signature) < 4) {
+            return null;
+        }
+
+        return strtoupper($signature);
+    }
+
+    private function extractRenderingIntent(string $data): ?string
+    {
+        $intent = $this->uInt32Be(substr($data, 64, 4));
+
+        return self::RENDERING_INTENT_MAP[$intent] ?? null;
+    }
+
+    private function extractProfileId(string $data): ?string
+    {
+        $profileId = substr($data, 84, 16);
+        if ($profileId === str_repeat("\0", 16)) {
+            return null;
+        }
+
+        return strtoupper(bin2hex($profileId));
+    }
+
+    private function extractDescription(string $data, int $profileSize): ?string
+    {
+        if ($profileSize < self::HEADER_LENGTH + 4) {
+            return null;
+        }
+
+        $length         = min(strlen($data), $profileSize);
+        $tagCountOffset = self::HEADER_LENGTH;
+        if ($tagCountOffset + 4 > $length) {
+            return null;
+        }
+
+        $tagCount = $this->uInt32Be(substr($data, $tagCountOffset, 4));
+        $cursor   = $tagCountOffset + 4;
+
+        for ($i = 0; $i < $tagCount; $i++) {
+            if ($cursor + self::TAG_RECORD_LENGTH > $length) {
+                break;
+            }
+
+            $signature = substr($data, $cursor, 4);
+            $offset    = $this->uInt32Be(substr($data, $cursor + 4, 4));
+            $size      = $this->uInt32Be(substr($data, $cursor + 8, 4));
+            $cursor   += self::TAG_RECORD_LENGTH;
+
+            if ($signature !== 'desc') {
+                continue;
+            }
+
+            if ($offset < self::HEADER_LENGTH || $size === 0) {
+                continue;
+            }
+
+            if ($offset + $size > $length) {
+                continue;
+            }
+
+            $tagData = substr($data, $offset, $size);
+            $type    = substr($tagData, 0, 4);
+
+            if ($type === 'desc') {
+                return $this->parseDescTag($tagData);
+            }
+
+            if ($type === 'mluc') {
+                $value = $this->parseMlucTag($tagData);
+                if ($value !== null) {
+                    return $value;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private function parseDescTag(string $data): ?string
+    {
+        if (strlen($data) < 12) {
+            return null;
+        }
+
+        $asciiLength = $this->uInt32Be(substr($data, 8, 4));
+        if ($asciiLength === 0) {
+            return null;
+        }
+
+        $available = strlen($data) - 12;
+        $length    = min($asciiLength, $available);
+        if ($length <= 0) {
+            return null;
+        }
+
+        $text = substr($data, 12, $length);
+
+        return rtrim($text, "\0");
+    }
+
+    private function parseMlucTag(string $data): ?string
+    {
+        if (strlen($data) < 16) {
+            return null;
+        }
+
+        $recordCount = $this->uInt32Be(substr($data, 8, 4));
+        $recordSize  = $this->uInt32Be(substr($data, 12, 4));
+        if ($recordCount === 0 || $recordSize < 12) {
+            return null;
+        }
+
+        $cursor = 16;
+        for ($i = 0; $i < $recordCount; $i++) {
+            if ($cursor + $recordSize > strlen($data)) {
+                break;
+            }
+
+            $stringLength = $this->uInt32Be(substr($data, $cursor + 4, 4));
+            $stringOffset = $this->uInt32Be(substr($data, $cursor + 8, 4));
+            $cursor      += $recordSize;
+
+            if ($stringLength === 0) {
+                continue;
+            }
+
+            if ($stringOffset + $stringLength > strlen($data)) {
+                continue;
+            }
+
+            $raw = substr($data, $stringOffset, $stringLength);
+            $utf = $this->decodeUtf16Be($raw);
+            if ($utf !== null && $utf !== '') {
+                return $utf;
+            }
+        }
+
+        return null;
+    }
+
+    private function decodeUtf16Be(string $data): ?string
+    {
+        if ($data === '') {
+            return null;
+        }
+
+        if (function_exists('mb_convert_encoding')) {
+            return mb_convert_encoding($data, 'UTF-8', 'UTF-16BE');
+        }
+
+        if (function_exists('iconv')) {
+            $converted = iconv('UTF-16BE', 'UTF-8//IGNORE', $data);
+
+            return $converted === false ? null : $converted;
+        }
+
+        if (class_exists('Imagick') && class_exists('ImagickPixel')) {
+            try {
+                $imagick = new \Imagick();
+                $imagick->newImage(1, 1, new \ImagickPixel('white'));
+                $imagick->setImageFormat('png');
+                $imagick->setImageProperty('icc:text', $data);
+                $text = $imagick->getImageProperty('icc:text');
+                if ($text !== '') {
+                    return $text;
+                }
+            } catch (\Throwable) {
+                // ignore - fall through to null
+            }
+        }
+
+        return null;
+    }
+
+    private function uInt32Be(string $bytes): int
+    {
+        $bytes = substr($bytes . "\0\0\0\0", 0, 4);
+
+        $unpacked = unpack('Nvalue', $bytes);
+
+        return isset($unpacked['value']) ? (int) $unpacked['value'] : 0;
+    }
+}

--- a/src/Value/ColorProfile.php
+++ b/src/Value/ColorProfile.php
@@ -22,6 +22,7 @@ final readonly class ColorProfile
      * @param string|null $pcs             Profile connection space.
      * @param string|null $renderingIntent Rendering intent description.
      * @param float|null  $gamma           Scene gamma value when provided by EXIF.
+     * @param string|null $profileId       Optional profile identifier (MD5) when available.
      */
     public function __construct(
         public ?string $profileName,
@@ -29,6 +30,7 @@ final readonly class ColorProfile
         public ?string $pcs,
         public ?string $renderingIntent,
         public ?float $gamma,
+        public ?string $profileId = null,
     ) {
     }
 }

--- a/tests/Curate/StructuredMetadataBuilderTest.php
+++ b/tests/Curate/StructuredMetadataBuilderTest.php
@@ -23,6 +23,7 @@ use MagicSunday\ImageMeta\Model\Metadata;
 use MagicSunday\ImageMeta\Model\QuickTimeMeta;
 use MagicSunday\ImageMeta\Model\Xmp\XmpDocument;
 use MagicSunday\ImageMeta\Parse\Tiff\TiffExifReader;
+use MagicSunday\ImageMeta\Tests\Fixtures\Icc\IccFixtures;
 use MagicSunday\ImageMeta\Value\Enum\ColorSpace;
 use MagicSunday\ImageMeta\Value\Enum\CompositeImage;
 use MagicSunday\ImageMeta\Value\Enum\Compression;
@@ -725,6 +726,26 @@ final class StructuredMetadataBuilderTest extends TestCase
 
         self::assertNotNull($structured->lens->maxApertureFNumber);
         self::assertEqualsWithDelta(4.0, $structured->lens->maxApertureFNumber, 0.0001);
+    }
+
+    /**
+     * Ensures ICC colour profile data from JPEG metadata is mapped onto the structured aggregate.
+     */
+    #[Test]
+    public function populatesColorProfileFromIccMetadata(): void
+    {
+        $icc = IccFixtures::minimalProfile();
+
+        $metadata   = new Metadata([], null, null, [], null, null, $icc, []);
+        $structured = (new StructuredMetadataBuilder())->build($metadata);
+
+        $profile = $structured->colorProfile;
+        self::assertSame('Test Profile', $profile->profileName);
+        self::assertSame('4.2.1', $profile->profileVersion);
+        self::assertSame('XYZ ', $profile->pcs);
+        self::assertSame('Media-Relative Colorimetric', $profile->renderingIntent);
+        self::assertSame('00112233445566778899AABBCCDDEEFF', $profile->profileId);
+        self::assertNull($profile->gamma);
     }
 
     /**

--- a/tests/Fixtures/Icc/IccFixtures.php
+++ b/tests/Fixtures/Icc/IccFixtures.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\ImageMeta\Tests\Fixtures\Icc;
+
+use function pack;
+
+/**
+ * Provides synthetic ICC profile fixtures for unit tests.
+ */
+final class IccFixtures
+{
+    private const string MINIMAL_PROFILE_HEX = '000000f1000000004210000000000000'
+        . '5247422058595a200000000000000000'
+        . '00000000616373700000000000000000'
+        . '00000000000000000000000000000000'
+        . '00000001000000000000000000000000'
+        . '0000000000112233445566778899aabb'
+        . 'ccddeeff000000000000000000000000'
+        . '00000000000000000000000000000000'
+        . '00000001646573630000009000000061'
+        . '64657363000000000000000d54657374'
+        . '2050726f66696c650000000000000000'
+        . '00000000000000000000000000000000'
+        . '00000000000000000000000000000000'
+        . '00000000000000000000000000000000'
+        . '00000000000000000000000000000000'
+        . '00';
+
+    /**
+     * Returns a minimal ICC profile with description and rendering intent tags.
+     */
+    public static function minimalProfile(): string
+    {
+        return pack('H*', self::MINIMAL_PROFILE_HEX);
+    }
+}

--- a/tests/MetadataReader/MetadataReaderTest.php
+++ b/tests/MetadataReader/MetadataReaderTest.php
@@ -80,6 +80,8 @@ final class MetadataReaderTest extends TestCase
         self::assertSame('Nikon', $metadata->makerNotes->vendor());
         self::assertSame(strlen($makerNote), $metadata->makerNotes->length());
         self::assertSame(sha1($makerNote), $metadata->makerNotes->sha1());
+        self::assertNull($metadata->iccProfile);
+        self::assertSame([], $metadata->iccSegments);
     }
 
     /**
@@ -121,6 +123,8 @@ final class MetadataReaderTest extends TestCase
         self::assertSame('Sony', $metadata->makerNotes->vendor());
         self::assertSame(strlen($makerNote), $metadata->makerNotes->length());
         self::assertSame(sha1($makerNote), $metadata->makerNotes->sha1());
+        self::assertNull($metadata->iccProfile);
+        self::assertSame([], $metadata->iccSegments);
     }
 
     /**

--- a/tests/Parse/Icc/IccDecoderTest.php
+++ b/tests/Parse/Icc/IccDecoderTest.php
@@ -1,0 +1,87 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\ImageMeta\Tests\Parse\Icc;
+
+use MagicSunday\ImageMeta\Parse\Icc\IccDecoder;
+use MagicSunday\ImageMeta\Tests\Fixtures\Icc\IccFixtures;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+use function chr;
+use function intdiv;
+use function strlen;
+use function substr;
+
+/**
+ * @covers \MagicSunday\ImageMeta\Parse\Icc\IccDecoder
+ */
+#[CoversClass(IccDecoder::class)]
+final class IccDecoderTest extends TestCase
+{
+    #[Test]
+    public function testDecodeExtractsHeaderFields(): void
+    {
+        $profile = IccFixtures::minimalProfile();
+
+        $decoder = new IccDecoder();
+        $result  = $decoder->decode($profile);
+
+        self::assertNotNull($result);
+        self::assertSame('Test Profile', $result['description']);
+        self::assertSame('4.2.1', $result['version']);
+        self::assertSame('XYZ ', $result['pcs']);
+        self::assertSame('Media-Relative Colorimetric', $result['renderingIntent']);
+        self::assertSame('00112233445566778899AABBCCDDEEFF', $result['profileId']);
+    }
+
+    #[Test]
+    public function testDecodeReassemblesSegments(): void
+    {
+        $profile = IccFixtures::minimalProfile();
+
+        $half = intdiv(strlen($profile) + 1, 2);
+        $segments = [
+            $this->createSegment(1, 2, substr($profile, 0, $half)),
+            $this->createSegment(2, 2, substr($profile, $half)),
+        ];
+
+        $decoder = new IccDecoder();
+        $result  = $decoder->decode(null, $segments);
+
+        self::assertNotNull($result);
+        self::assertSame('Test Profile', $result['description']);
+        self::assertSame('4.2.1', $result['version']);
+        self::assertSame('XYZ ', $result['pcs']);
+        self::assertSame('Media-Relative Colorimetric', $result['renderingIntent']);
+        self::assertSame('00112233445566778899AABBCCDDEEFF', $result['profileId']);
+    }
+
+    #[Test]
+    public function testDecodeReturnsNullForTruncatedData(): void
+    {
+        $decoder = new IccDecoder();
+
+        self::assertNull($decoder->decode('short'));
+        self::assertNull($decoder->decode(null, [$this->createSegment(1, 2, 'payload')]));
+    }
+
+    /**
+     * @param int    $sequence Sequence index of the ICC fragment.
+     * @param int    $count    Total number of ICC fragments.
+     * @param string $payload  Raw ICC fragment payload.
+     */
+    private function createSegment(int $sequence, int $count, string $payload): string
+    {
+        return 'ICC_PROFILE\0' . chr($sequence) . chr($count) . $payload;
+    }
+}


### PR DESCRIPTION
## Summary
- replace the binary ICC fixture with a PHP fixture that synthesises the profile data
- update ICC decoder and structured metadata tests to use the shared fixture helper

## Testing
- composer ci:test:php:unit

------
https://chatgpt.com/codex/tasks/task_e_68fbc44094348323891423067c3312c8