### PR TITLE
feat(regions): merge XMP face regions into structured metadata

### DIFF
--- a/src/Curate/Resolver/RegionsResolver.php
+++ b/src/Curate/Resolver/RegionsResolver.php
@@ -1,0 +1,421 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\ImageMeta\Curate\Resolver;
+
+use MagicSunday\ImageMeta\Model\Xmp\XmpDocument;
+use MagicSunday\ImageMeta\Value\Regions;
+use MagicSunday\ImageMeta\Value\Regions\Region;
+use MagicSunday\ImageMeta\Value\Regions\RegionType;
+
+use function abs;
+use function array_values;
+use function count;
+use function is_array;
+use function is_string;
+use function max;
+use function trim;
+
+/**
+ * Resolves structured region annotations from MWG-RS and Apple FaceInfo metadata.
+ */
+final readonly class RegionsResolver
+{
+    use XmpPropertyAccess;
+
+    private const string NS_MWG_REGIONS = 'http://www.metadataworkinggroup.com/schemas/regions/';
+
+    private const string NS_ST_AREA = 'http://ns.adobe.com/xmp/sType/Area#';
+
+    private const string NS_ST_DIMENSIONS = 'http://ns.adobe.com/xmp/sType/Dimensions#';
+
+    private const string NS_APPLE_FACEINFO = 'http://ns.apple.com/faceinfo/1.0/';
+
+    private const float MATCH_THRESHOLD = 0.12;
+
+    /**
+     * Builds a regions aggregate from the supplied XMP document.
+     */
+    public function resolve(?XmpDocument $document): Regions
+    {
+        if (!$document instanceof XmpDocument) {
+            return new Regions([]);
+        }
+
+        $dimensions   = $this->appliedDimensions($document);
+        $mwgRegions   = $this->extractMwgRegions($document, $dimensions);
+        $appleRegions = $this->extractAppleFaceRegions($document, $dimensions);
+
+        foreach ($appleRegions as $appleRegion) {
+            $matchIndex = $this->findMatchingRegionIndex($mwgRegions, $appleRegion);
+            if ($matchIndex !== null) {
+                $mwgRegions[$matchIndex] = $this->mergeRegion($mwgRegions[$matchIndex], $appleRegion);
+                continue;
+            }
+
+            $mwgRegions[] = $appleRegion;
+        }
+
+        return new Regions(array_values($mwgRegions));
+    }
+
+    /**
+     * Extracts MWG-RS region entries.
+     *
+     * @param array{w: float, h: float}|null $dimensions
+     *
+     * @return list<Region>
+     */
+    private function extractMwgRegions(XmpDocument $document, ?array $dimensions): array
+    {
+        $types         = $this->stringValues($document, self::NS_MWG_REGIONS, 'Type');
+        $names         = $this->stringValues($document, self::NS_MWG_REGIONS, 'Name');
+        $displayNames  = $this->stringValues($document, self::NS_MWG_REGIONS, 'PersonDisplayName');
+        $confidences   = $this->floatValues($document, self::NS_MWG_REGIONS, 'Confidence');
+        $rotations     = $this->floatValues($document, self::NS_MWG_REGIONS, 'Rotation');
+        $centersX      = $this->floatValues($document, self::NS_ST_AREA, 'x');
+        $centersY      = $this->floatValues($document, self::NS_ST_AREA, 'y');
+        $widths        = $this->floatValues($document, self::NS_ST_AREA, 'w');
+        $heights       = $this->floatValues($document, self::NS_ST_AREA, 'h');
+        $regionCount   = max(count($centersX), count($centersY), count($widths), count($heights));
+        $resolved      = [];
+
+        for ($index = 0; $index < $regionCount; ++$index) {
+            $centerX = $centersX[$index] ?? null;
+            $centerY = $centersY[$index] ?? null;
+            $width   = $widths[$index] ?? null;
+            $height  = $heights[$index] ?? null;
+
+            if ($centerX === null || $centerY === null || $width === null || $height === null) {
+                continue;
+            }
+
+            $normalised = $this->normalisedBox($centerX, $centerY, $width, $height, $dimensions);
+            if ($normalised === null) {
+                continue;
+            }
+
+            $typeLabel = $types[$index] ?? null;
+            $type      = $typeLabel !== null ? RegionType::fromLabel($typeLabel) : null;
+
+            $person = $displayNames[$index] ?? $names[$index] ?? null;
+            if ($person !== null && $person === '') {
+                $person = null;
+            }
+
+            $resolved[] = new Region(
+                $type,
+                $normalised['x'],
+                $normalised['y'],
+                $normalised['w'],
+                $normalised['h'],
+                $person,
+                $confidences[$index] ?? null,
+                $rotations[$index] ?? null,
+                null,
+            );
+        }
+
+        return array_values($resolved);
+    }
+
+    /**
+     * Extracts Apple FaceInfo face entries.
+     *
+     * @param array{w: float, h: float}|null $dimensions
+     *
+     * @return list<Region>
+     */
+    private function extractAppleFaceRegions(XmpDocument $document, ?array $dimensions): array
+    {
+        $centersX    = $this->floatValues($document, self::NS_APPLE_FACEINFO, 'CenterX');
+        $centersY    = $this->floatValues($document, self::NS_APPLE_FACEINFO, 'CenterY');
+        $widths      = $this->floatValues($document, self::NS_APPLE_FACEINFO, 'Width');
+        $heights     = $this->floatValues($document, self::NS_APPLE_FACEINFO, 'Height');
+        $confidences = $this->floatValues($document, self::NS_APPLE_FACEINFO, 'Confidence');
+        $rolls       = $this->floatValues($document, self::NS_APPLE_FACEINFO, 'Roll');
+        if ($rolls === []) {
+            $rolls = $this->floatValues($document, self::NS_APPLE_FACEINFO, 'Yaw');
+        }
+        $names   = $this->stringValues($document, self::NS_APPLE_FACEINFO, 'Name');
+        if ($names === []) {
+            $names = $this->stringValues($document, self::NS_APPLE_FACEINFO, 'FullName');
+        }
+        $faceIds = $this->stringValues($document, self::NS_APPLE_FACEINFO, 'FaceID');
+        if ($faceIds === []) {
+            $faceIds = $this->stringValues($document, self::NS_APPLE_FACEINFO, 'FaceUUID');
+        }
+
+        $count    = max(count($centersX), count($centersY), count($widths), count($heights));
+        $resolved = [];
+
+        for ($index = 0; $index < $count; ++$index) {
+            $centerX = $centersX[$index] ?? null;
+            $centerY = $centersY[$index] ?? null;
+            $width   = $widths[$index] ?? null;
+            $height  = $heights[$index] ?? null;
+
+            if ($centerX === null || $centerY === null || $width === null || $height === null) {
+                continue;
+            }
+
+            $normalised = $this->normalisedBox($centerX, $centerY, $width, $height, $dimensions);
+            if ($normalised === null) {
+                continue;
+            }
+
+            $resolved[] = new Region(
+                RegionType::FACE,
+                $normalised['x'],
+                $normalised['y'],
+                $normalised['w'],
+                $normalised['h'],
+                $this->stringAt($names, $index),
+                $confidences[$index] ?? null,
+                $rolls[$index] ?? null,
+                $this->stringAt($faceIds, $index),
+            );
+        }
+
+        return array_values($resolved);
+    }
+
+    /**
+     * Attempts to match an Apple face region with an MWG region by spatial overlap.
+     *
+     * @param array<int, Region> $regions
+     */
+    private function findMatchingRegionIndex(array $regions, Region $candidate): ?int
+    {
+        if ($candidate->type !== RegionType::FACE) {
+            return null;
+        }
+
+        $bestIndex = null;
+        $bestScore = null;
+        [$targetCx, $targetCy] = $this->regionCenter($candidate);
+
+        foreach ($regions as $index => $region) {
+            if ($region->type !== RegionType::FACE) {
+                continue;
+            }
+
+            [$cx, $cy] = $this->regionCenter($region);
+            $distance  = abs($cx - $targetCx) + abs($cy - $targetCy);
+            if ($distance > self::MATCH_THRESHOLD) {
+                continue;
+            }
+
+            $sizeDiff = abs($region->w - $candidate->w) + abs($region->h - $candidate->h);
+            $score    = $distance + $sizeDiff;
+            if ($bestScore === null || $score < $bestScore) {
+                $bestScore = $score;
+                $bestIndex = $index;
+            }
+        }
+
+        return $bestIndex;
+    }
+
+    private function mergeRegion(Region $base, Region $supplement): Region
+    {
+        $person = $base->personName ?? $supplement->personName;
+        $confidence = $base->confidence;
+        if ($confidence === null) {
+            $confidence = $supplement->confidence;
+        } elseif ($supplement->confidence !== null) {
+            $confidence = max($confidence, $supplement->confidence);
+        }
+
+        $rotation = $base->rotationDeg ?? $supplement->rotationDeg;
+        $faceId   = $base->faceId ?? $supplement->faceId;
+        $type     = $base->type ?? $supplement->type;
+
+        return new Region(
+            $type,
+            $base->x,
+            $base->y,
+            $base->w,
+            $base->h,
+            $person,
+            $confidence,
+            $rotation,
+            $faceId,
+        );
+    }
+
+    /**
+     * @return array{0: float, 1: float}
+     */
+    private function regionCenter(Region $region): array
+    {
+        return [
+            $region->x + ($region->w / 2.0),
+            $region->y + ($region->h / 2.0),
+        ];
+    }
+
+    /**
+     * @param list<string> $values
+     */
+    private function stringAt(array $values, int $index): ?string
+    {
+        $value = $values[$index] ?? null;
+        if ($value === null) {
+            return null;
+        }
+
+        $trimmed = trim($value);
+
+        return $trimmed === '' ? null : $trimmed;
+    }
+
+    /**
+     * @param array{w: float, h: float}|null $dimensions
+     *
+     * @return array{x: float, y: float, w: float, h: float}|null
+     */
+    private function normalisedBox(float $centerX, float $centerY, float $width, float $height, ?array $dimensions): ?array
+    {
+        if ($width <= 0.0 || $height <= 0.0) {
+            return null;
+        }
+
+        $scaledCenterX = $centerX;
+        $scaledCenterY = $centerY;
+        $scaledWidth   = $width;
+        $scaledHeight  = $height;
+
+        if ($dimensions !== null) {
+            if ($scaledCenterX > 1.0 || $scaledWidth > 1.0) {
+                $scaledCenterX /= $dimensions['w'];
+                $scaledWidth   /= $dimensions['w'];
+            }
+
+            if ($scaledCenterY > 1.0 || $scaledHeight > 1.0) {
+                $scaledCenterY /= $dimensions['h'];
+                $scaledHeight  /= $dimensions['h'];
+            }
+        }
+
+        if (
+            $scaledCenterX > 1.0 || $scaledCenterY > 1.0
+            || $scaledWidth > 1.0 || $scaledHeight > 1.0
+        ) {
+            if (
+                $scaledCenterX <= 100.0 && $scaledCenterY <= 100.0
+                && $scaledWidth <= 100.0 && $scaledHeight <= 100.0
+            ) {
+                $scaledCenterX /= 100.0;
+                $scaledCenterY /= 100.0;
+                $scaledWidth   /= 100.0;
+                $scaledHeight  /= 100.0;
+            }
+        }
+
+        $halfWidth  = $scaledWidth / 2.0;
+        $halfHeight = $scaledHeight / 2.0;
+
+        return [
+            'x' => $this->clamp($scaledCenterX - $halfWidth),
+            'y' => $this->clamp($scaledCenterY - $halfHeight),
+            'w' => $this->clamp($scaledWidth),
+            'h' => $this->clamp($scaledHeight),
+        ];
+    }
+
+    private function clamp(float $value): float
+    {
+        if ($value < 0.0) {
+            return 0.0;
+        }
+
+        if ($value > 1.0) {
+            return 1.0;
+        }
+
+        return $value;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function stringValues(XmpDocument $document, string $namespace, string $localName): array
+    {
+        $raw = $this->xmpValue($document, $namespace, $localName);
+
+        if (is_string($raw)) {
+            $trimmed = trim($raw);
+
+            return $trimmed === '' ? [] : [$trimmed];
+        }
+
+        if (!is_array($raw)) {
+            return [];
+        }
+
+        $values = [];
+        foreach ($raw as $value) {
+            if (!is_string($value)) {
+                continue;
+            }
+
+            $values[] = trim($value);
+        }
+
+        return $values;
+    }
+
+    /**
+     * @return list<float|null>
+     */
+    private function floatValues(XmpDocument $document, string $namespace, string $localName): array
+    {
+        $raw = $this->xmpValue($document, $namespace, $localName);
+
+        if (is_string($raw)) {
+            $raw = [$raw];
+        } elseif (!is_array($raw)) {
+            return [];
+        }
+
+        $values = [];
+        foreach ($raw as $value) {
+            if (!is_string($value)) {
+                $values[] = null;
+                continue;
+            }
+
+            $numeric = $this->parseNumericString($value);
+            $values[] = $numeric;
+        }
+
+        return $values;
+    }
+
+    /**
+     * @return array{w: float, h: float}|null
+     */
+    private function appliedDimensions(XmpDocument $document): ?array
+    {
+        $widths  = $this->floatValues($document, self::NS_ST_DIMENSIONS, 'w');
+        $heights = $this->floatValues($document, self::NS_ST_DIMENSIONS, 'h');
+
+        $width  = $widths[0] ?? null;
+        $height = $heights[0] ?? null;
+
+        if ($width === null || $width <= 0.0 || $height === null || $height <= 0.0) {
+            return null;
+        }
+
+        return ['w' => $width, 'h' => $height];
+    }
+}

--- a/src/Curate/Resolver/XmpResolver.php
+++ b/src/Curate/Resolver/XmpResolver.php
@@ -14,8 +14,10 @@ namespace MagicSunday\ImageMeta\Curate\Resolver;
 use MagicSunday\ImageMeta\Model\Xmp\XmpDocument;
 use MagicSunday\ImageMeta\Value\Xmp;
 
+use function array_filter;
 use function array_map;
 use function array_values;
+use function explode;
 use function is_array;
 use function is_string;
 use function strtolower;
@@ -57,13 +59,19 @@ final readonly class XmpResolver
     {
         $value = $this->document?->get($namespace, $localName);
 
+        if (is_string($value)) {
+            $parts = array_map(static fn (string $item): string => trim($item), explode(',', $value));
+
+            return array_values(array_filter($parts, static fn (string $item): bool => $item !== ''));
+        }
+
         if (!is_array($value)) {
             return [];
         }
 
-        $items = array_values($value);
+        $items = array_map(static fn (string $item): string => trim($item), array_values($value));
 
-        return array_map(static fn (string $item): string => trim($item), $items);
+        return array_values(array_filter($items, static fn (string $item): bool => $item !== ''));
     }
 
     /**

--- a/src/Curate/StructuredMetadataBuilder.php
+++ b/src/Curate/StructuredMetadataBuilder.php
@@ -20,6 +20,7 @@ use MagicSunday\ImageMeta\Curate\Resolver\CompositeResolver;
 use MagicSunday\ImageMeta\Curate\Resolver\ExifTagResolver;
 use MagicSunday\ImageMeta\Curate\Resolver\GpsResolver;
 use MagicSunday\ImageMeta\Curate\Resolver\QuickTimeResolver;
+use MagicSunday\ImageMeta\Curate\Resolver\RegionsResolver;
 use MagicSunday\ImageMeta\Curate\Resolver\XmpResolver;
 use MagicSunday\ImageMeta\Model\Metadata;
 use MagicSunday\ImageMeta\Parse\Icc\IccDecoder;
@@ -47,6 +48,7 @@ use MagicSunday\ImageMeta\Value\Motion;
 use MagicSunday\ImageMeta\Value\Preview;
 use MagicSunday\ImageMeta\Value\ProcessingSettings;
 use MagicSunday\ImageMeta\Value\Regions;
+use MagicSunday\ImageMeta\Value\Regions\RegionType;
 use MagicSunday\ImageMeta\Value\RelatedAssets;
 use MagicSunday\ImageMeta\Value\Rights;
 use MagicSunday\ImageMeta\Value\Scene;
@@ -76,6 +78,7 @@ final class StructuredMetadataBuilder
         $xmpResolver       = new XmpResolver($xmpDocument);
         $quickTimeResolver = new QuickTimeResolver($metadata->quickTime);
         $gpsResolver       = new GpsResolver();
+        $regionsResolver   = new RegionsResolver();
 
         $interop = new Interop(index: $exifResolver->interopIndex());
 
@@ -267,9 +270,13 @@ final class StructuredMetadataBuilder
 
         $motion = new Motion(null, null, null, null, null, null, null, null, null);
 
-        $scene = $this->buildScene($exifResolver, $quickTimeResolver);
+        $regions = $regionsResolver->resolve($xmpDocument);
 
-        $regions = new Regions([]);
+        $scene = $this->buildScene(
+            $exifResolver,
+            $quickTimeResolver,
+            $this->countFaceRegions($regions),
+        );
 
         $flatKeywords         = $xmpResolver->stringList('http://purl.org/dc/elements/1.1/', 'subject');
         $hierarchicalKeywords = $xmpResolver->stringList('http://ns.adobe.com/lightroom/1.0/', 'hierarchicalSubject');
@@ -541,9 +548,25 @@ final class StructuredMetadataBuilder
     }
 
     /**
+     * Counts detected face regions for the scene aggregate.
+     */
+    private function countFaceRegions(Regions $regions): ?int
+    {
+        $count = 0;
+
+        foreach ($regions->items as $region) {
+            if ($region->type === RegionType::FACE) {
+                ++$count;
+            }
+        }
+
+        return $count > 0 ? $count : null;
+    }
+
+    /**
      * Builds the scene value object incorporating EXIF and container hints.
      */
-    private function buildScene(ExifTagResolver $exif, QuickTimeResolver $quickTime): Scene
+    private function buildScene(ExifTagResolver $exif, QuickTimeResolver $quickTime, ?int $faceCount): Scene
     {
         $hdr   = $quickTime->string('HDRImageType');
         $night = $quickTime->bool('NightMode');
@@ -552,7 +575,7 @@ final class StructuredMetadataBuilder
             type: $exif->sceneCaptureType(),
             sceneType: $exif->sceneType()?->value,
             light: $exif->lightSource(),
-            faceCount: null,
+            faceCount: $faceCount,
             hdrScene: $hdr !== null ? true : null,
             nightMode: $night,
             subjectDistanceRange: $exif->subjectDistanceRange(),

--- a/src/Parse/Xmp/XmpParser.php
+++ b/src/Parse/Xmp/XmpParser.php
@@ -16,7 +16,9 @@ use XMLReader;
 
 use function array_filter;
 use function array_key_exists;
+use function array_merge;
 use function array_values;
+use function is_array;
 use function sprintf;
 use function trim;
 
@@ -70,7 +72,11 @@ final class XmpParser
                         if ($namespace !== self::RDF_NAMESPACE) {
                             $value = $this->finalizeValue($listBuffers[$depth], $textBuffers[$depth]);
                             if ($value !== null) {
-                                $data[$this->buildClarkName($namespace, $localName)] = $value;
+                                $this->storeValue(
+                                    $data,
+                                    $this->buildClarkName($namespace, $localName),
+                                    $value,
+                                );
                             }
                         }
 
@@ -111,7 +117,11 @@ final class XmpParser
                     } elseif ($namespace !== self::RDF_NAMESPACE) {
                         $value = $this->finalizeValue($listBuffers[$depth], $textBuffers[$depth]);
                         if ($value !== null) {
-                            $data[$this->buildClarkName($namespace, $localName)] = $value;
+                            $this->storeValue(
+                                $data,
+                                $this->buildClarkName($namespace, $localName),
+                                $value,
+                            );
                         }
                     }
 
@@ -143,6 +153,42 @@ final class XmpParser
         $text = trim($text);
 
         return $text === '' ? null : $text;
+    }
+
+    /**
+     * Stores a value in the result map while merging multiple occurrences.
+     *
+     * @param array<string, string|array<int, string>> $data
+     * @param list<string>|string                      $value
+     */
+    private function storeValue(array &$data, string $key, array|string $value): void
+    {
+        if (!array_key_exists($key, $data)) {
+            $data[$key] = $value;
+
+            return;
+        }
+
+        $existing = $data[$key];
+
+        if (is_array($existing)) {
+            if (is_array($value)) {
+                $data[$key] = array_values([...$existing, ...$value]);
+            } else {
+                $existing[] = $value;
+                $data[$key] = array_values($existing);
+            }
+
+            return;
+        }
+
+        if (is_array($value)) {
+            $data[$key] = array_values(array_merge([$existing], $value));
+
+            return;
+        }
+
+        $data[$key] = [$existing, $value];
     }
 
     /**

--- a/src/Value/Regions/Region.php
+++ b/src/Value/Regions/Region.php
@@ -12,27 +12,31 @@ declare(strict_types=1);
 namespace MagicSunday\ImageMeta\Value\Regions;
 
 /**
- * Represents a rectangular region annotation as defined by XMP MWG-RS metadata.
+ * Represents a rectangular region annotation as defined by XMP metadata.
  */
 final readonly class Region
 {
     /**
-     * @param string      $type       Region type identifier (e.g. face, rect).
-     * @param float       $x          Normalised X coordinate of the top left corner.
-     * @param float       $y          Normalised Y coordinate of the top left corner.
-     * @param float       $w          Normalised width of the region.
-     * @param float       $h          Normalised height of the region.
-     * @param string|null $personName Associated person name when the region marks a face.
-     * @param float|null  $confidence Detection confidence value if provided.
+     * @param RegionType|null $type        Semantic classification of the region (e.g. face, focus).
+     * @param float           $x           Normalised X coordinate of the top left corner.
+     * @param float           $y           Normalised Y coordinate of the top left corner.
+     * @param float           $w           Normalised width of the region.
+     * @param float           $h           Normalised height of the region.
+     * @param string|null     $personName  Associated person name when the region marks a face.
+     * @param float|null      $confidence  Detection confidence value if provided.
+     * @param float|null      $rotationDeg Rotation angle in degrees, positive values rotate clockwise.
+     * @param string|null     $faceId      Optional identifier emitted by face detection engines.
      */
     public function __construct(
-        public string $type,
+        public ?RegionType $type,
         public float $x,
         public float $y,
         public float $w,
         public float $h,
-        public ?string $personName,
-        public ?float $confidence,
+        public ?string $personName = null,
+        public ?float $confidence = null,
+        public ?float $rotationDeg = null,
+        public ?string $faceId = null,
     ) {
     }
 }

--- a/src/Value/Regions/RegionType.php
+++ b/src/Value/Regions/RegionType.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\ImageMeta\Value\Regions;
+
+/**
+ * Describes the semantic classification of an annotated region.
+ */
+enum RegionType: string
+{
+    case FACE = 'Face';
+    case FOCUS = 'Focus';
+    case OBJECT = 'Object';
+    case UNKNOWN = 'Unknown';
+
+    /**
+     * Attempts to create a RegionType enum from a free-form label.
+     */
+    public static function fromLabel(?string $label): ?self
+    {
+        if ($label === null) {
+            return null;
+        }
+
+        $normalized = strtolower(trim($label));
+        if ($normalized === '') {
+            return null;
+        }
+
+        return match ($normalized) {
+            'face' => self::FACE,
+            'focus' => self::FOCUS,
+            'object', 'pet', 'subject', 'rectangle', 'rect' => self::OBJECT,
+            default => self::UNKNOWN,
+        };
+    }
+}

--- a/tests/Curate/Resolver/RegionsResolverTest.php
+++ b/tests/Curate/Resolver/RegionsResolverTest.php
@@ -1,0 +1,125 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\ImageMeta\Tests\Curate\Resolver;
+
+use MagicSunday\ImageMeta\Curate\Resolver\RegionsResolver;
+use MagicSunday\ImageMeta\Model\Xmp\XmpDocument;
+use MagicSunday\ImageMeta\Value\Regions\RegionType;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \MagicSunday\ImageMeta\Curate\Resolver\RegionsResolver
+ */
+final class RegionsResolverTest extends TestCase
+{
+    private const string NS_MWG = 'http://www.metadataworkinggroup.com/schemas/regions/';
+
+    private const string NS_ST_AREA = 'http://ns.adobe.com/xmp/sType/Area#';
+
+    private const string NS_ST_DIM = 'http://ns.adobe.com/xmp/sType/Dimensions#';
+
+    private const string NS_APPLE = 'http://ns.apple.com/faceinfo/1.0/';
+
+    #[Test]
+    public function resolvesAndMergesRegionSources(): void
+    {
+        $document = new XmpDocument([
+            '{' . self::NS_ST_AREA . '}x'          => ['0.4', '0.75'],
+            '{' . self::NS_ST_AREA . '}y'          => ['0.45', '0.60'],
+            '{' . self::NS_ST_AREA . '}w'          => ['0.2', '0.10'],
+            '{' . self::NS_ST_AREA . '}h'          => ['0.25', '0.08'],
+            '{' . self::NS_MWG . '}Type'           => ['Face', 'Focus'],
+            '{' . self::NS_MWG . '}Name'           => ['Alice', ''],
+            '{' . self::NS_MWG . '}Confidence'     => ['0.91', '0.5'],
+            '{' . self::NS_MWG . '}Rotation'       => ['12.5', '0'],
+            '{' . self::NS_APPLE . '}CenterX'      => ['0.4', '0.72'],
+            '{' . self::NS_APPLE . '}CenterY'      => ['0.45', '0.61'],
+            '{' . self::NS_APPLE . '}Width'        => ['0.2', '0.12'],
+            '{' . self::NS_APPLE . '}Height'       => ['0.25', '0.09'],
+            '{' . self::NS_APPLE . '}Confidence'   => ['0.88', '0.42'],
+            '{' . self::NS_APPLE . '}Roll'         => ['2.0', '-5.0'],
+            '{' . self::NS_APPLE . '}Name'         => ['Alice', 'Bob'],
+            '{' . self::NS_APPLE . '}FaceID'       => ['101', '202'],
+        ]);
+
+        $resolver = new RegionsResolver();
+        $regions  = $resolver->resolve($document);
+
+        self::assertCount(3, $regions->items);
+
+        $faceRegion = $regions->items[0];
+        self::assertSame(RegionType::FACE, $faceRegion->type);
+        self::assertEqualsWithDelta(0.3, $faceRegion->x, 0.0001);
+        self::assertEqualsWithDelta(0.325, $faceRegion->y, 0.0001);
+        self::assertEqualsWithDelta(0.2, $faceRegion->w, 0.0001);
+        self::assertEqualsWithDelta(0.25, $faceRegion->h, 0.0001);
+        self::assertSame('Alice', $faceRegion->personName);
+        self::assertNotNull($faceRegion->confidence);
+        self::assertEqualsWithDelta(0.91, $faceRegion->confidence, 0.0001);
+        self::assertNotNull($faceRegion->rotationDeg);
+        self::assertEqualsWithDelta(12.5, $faceRegion->rotationDeg, 0.0001);
+        self::assertSame('101', $faceRegion->faceId);
+
+        $focusRegion = $regions->items[1];
+        self::assertSame(RegionType::FOCUS, $focusRegion->type);
+        self::assertEqualsWithDelta(0.7, $focusRegion->x, 0.0001);
+        self::assertEqualsWithDelta(0.56, $focusRegion->y, 0.0001);
+        self::assertEqualsWithDelta(0.1, $focusRegion->w, 0.0001);
+        self::assertEqualsWithDelta(0.08, $focusRegion->h, 0.0001);
+        self::assertNull($focusRegion->personName);
+        self::assertNotNull($focusRegion->confidence);
+        self::assertEqualsWithDelta(0.5, $focusRegion->confidence, 0.0001);
+        self::assertNotNull($focusRegion->rotationDeg);
+        self::assertEqualsWithDelta(0.0, $focusRegion->rotationDeg, 0.0001);
+        self::assertNull($focusRegion->faceId);
+
+        $appleOnlyRegion = $regions->items[2];
+        self::assertSame(RegionType::FACE, $appleOnlyRegion->type);
+        self::assertEqualsWithDelta(0.66, $appleOnlyRegion->x, 0.0001);
+        self::assertEqualsWithDelta(0.565, $appleOnlyRegion->y, 0.0001);
+        self::assertEqualsWithDelta(0.12, $appleOnlyRegion->w, 0.0001);
+        self::assertEqualsWithDelta(0.09, $appleOnlyRegion->h, 0.0001);
+        self::assertSame('Bob', $appleOnlyRegion->personName);
+        self::assertNotNull($appleOnlyRegion->confidence);
+        self::assertEqualsWithDelta(0.42, $appleOnlyRegion->confidence, 0.0001);
+        self::assertNotNull($appleOnlyRegion->rotationDeg);
+        self::assertEqualsWithDelta(-5.0, $appleOnlyRegion->rotationDeg, 0.0001);
+        self::assertSame('202', $appleOnlyRegion->faceId);
+    }
+
+    #[Test]
+    public function normalisesPixelCoordinatesUsingAppliedDimensions(): void
+    {
+        $document = new XmpDocument([
+            '{' . self::NS_ST_DIM . '}w' => ['4000'],
+            '{' . self::NS_ST_DIM . '}h' => ['3000'],
+            '{' . self::NS_ST_AREA . '}x' => ['2000'],
+            '{' . self::NS_ST_AREA . '}y' => ['1500'],
+            '{' . self::NS_ST_AREA . '}w' => ['800'],
+            '{' . self::NS_ST_AREA . '}h' => ['600'],
+            '{' . self::NS_MWG . '}Type' => ['Face'],
+        ]);
+
+        $resolver = new RegionsResolver();
+        $regions  = $resolver->resolve($document);
+
+        self::assertCount(1, $regions->items);
+        $region = $regions->items[0];
+
+        self::assertSame(RegionType::FACE, $region->type);
+        self::assertEqualsWithDelta(0.4, $region->x, 0.0001);
+        self::assertEqualsWithDelta(0.4, $region->y, 0.0001);
+        self::assertEqualsWithDelta(0.2, $region->w, 0.0001);
+        self::assertEqualsWithDelta(0.2, $region->h, 0.0001);
+    }
+}

--- a/tests/Curate/Resolver/XmpResolverTest.php
+++ b/tests/Curate/Resolver/XmpResolverTest.php
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\ImageMeta\Tests\Curate\Resolver;
+
+use MagicSunday\ImageMeta\Curate\Resolver\XmpResolver;
+use MagicSunday\ImageMeta\Model\Xmp\XmpDocument;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \MagicSunday\ImageMeta\Curate\Resolver\XmpResolver
+ */
+final class XmpResolverTest extends TestCase
+{
+    private const string DC_NAMESPACE = 'http://purl.org/dc/elements/1.1/';
+
+    #[Test]
+    public function stringListHandlesCommaSeparatedValues(): void
+    {
+        $document = new XmpDocument([
+            '{' . self::DC_NAMESPACE . '}subject' => 'Alpha, Beta , ,Gamma',
+        ]);
+
+        $resolver = new XmpResolver($document);
+
+        self::assertSame(['Alpha', 'Beta', 'Gamma'], $resolver->stringList(self::DC_NAMESPACE, 'subject'));
+    }
+
+    #[Test]
+    public function stringListTrimsArrayValues(): void
+    {
+        $document = new XmpDocument([
+            '{' . self::DC_NAMESPACE . '}subject' => ['First', ' Second ', ''],
+        ]);
+
+        $resolver = new XmpResolver($document);
+
+        self::assertSame(['First', 'Second'], $resolver->stringList(self::DC_NAMESPACE, 'subject'));
+    }
+}

--- a/tests/Curate/StructuredMetadataBuilderTest.php
+++ b/tests/Curate/StructuredMetadataBuilderTest.php
@@ -43,6 +43,7 @@ use MagicSunday\ImageMeta\Value\Enum\SensingMethod;
 use MagicSunday\ImageMeta\Value\Enum\SubjectDistanceRange;
 use MagicSunday\ImageMeta\Value\Enum\WhiteBalance;
 use MagicSunday\ImageMeta\Value\Enum\YCbCrPositioning;
+use MagicSunday\ImageMeta\Value\Regions\RegionType;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
@@ -927,6 +928,54 @@ final class StructuredMetadataBuilderTest extends TestCase
                 self::fail(sprintf('%s::%s expected null/empty, got %s', $name, $field, var_export($fieldValue, true)));
             }
         }
+    }
+
+    /**
+     * Ensures XMP region metadata is propagated to the structured output including face counts.
+     */
+    #[Test]
+    public function mergesFaceRegionsFromXmp(): void
+    {
+        $xmpDocument = new XmpDocument([
+            '{http://ns.adobe.com/xmp/sType/Area#}x'        => ['0.4', '0.75'],
+            '{http://ns.adobe.com/xmp/sType/Area#}y'        => ['0.45', '0.60'],
+            '{http://ns.adobe.com/xmp/sType/Area#}w'        => ['0.2', '0.10'],
+            '{http://ns.adobe.com/xmp/sType/Area#}h'        => ['0.25', '0.08'],
+            '{http://www.metadataworkinggroup.com/schemas/regions/}Type'       => ['Face', 'Focus'],
+            '{http://www.metadataworkinggroup.com/schemas/regions/}Name'       => ['Alice', ''],
+            '{http://www.metadataworkinggroup.com/schemas/regions/}Confidence' => ['0.91', '0.5'],
+            '{http://www.metadataworkinggroup.com/schemas/regions/}Rotation'   => ['12.5', '0'],
+            '{http://ns.apple.com/faceinfo/1.0/}CenterX'    => ['0.4', '0.72'],
+            '{http://ns.apple.com/faceinfo/1.0/}CenterY'    => ['0.45', '0.61'],
+            '{http://ns.apple.com/faceinfo/1.0/}Width'      => ['0.2', '0.12'],
+            '{http://ns.apple.com/faceinfo/1.0/}Height'     => ['0.25', '0.09'],
+            '{http://ns.apple.com/faceinfo/1.0/}Confidence' => ['0.88', '0.42'],
+            '{http://ns.apple.com/faceinfo/1.0/}Roll'       => ['1.0', '-5.0'],
+            '{http://ns.apple.com/faceinfo/1.0/}Name'       => ['Alice', 'Bob'],
+            '{http://ns.apple.com/faceinfo/1.0/}FaceID'     => ['101', '202'],
+        ]);
+
+        $metadata   = new Metadata([], null, null, [], $xmpDocument);
+        $structured = (new StructuredMetadataBuilder())->build($metadata);
+
+        self::assertSame(2, $structured->scene->faceCount);
+        self::assertCount(3, $structured->regions->items);
+
+        $first = $structured->regions->items[0];
+        self::assertSame(RegionType::FACE, $first->type);
+        self::assertSame('Alice', $first->personName);
+        self::assertSame('101', $first->faceId);
+        self::assertNotNull($first->confidence);
+        self::assertEqualsWithDelta(0.91, $first->confidence, 0.0001);
+        self::assertNotNull($first->rotationDeg);
+        self::assertEqualsWithDelta(12.5, $first->rotationDeg, 0.0001);
+
+        $third = $structured->regions->items[2];
+        self::assertSame(RegionType::FACE, $third->type);
+        self::assertSame('Bob', $third->personName);
+        self::assertSame('202', $third->faceId);
+        self::assertNotNull($third->rotationDeg);
+        self::assertEqualsWithDelta(-5.0, $third->rotationDeg, 0.0001);
     }
 
     /**

--- a/tests/Model/Xmp/XmpDocumentTest.php
+++ b/tests/Model/Xmp/XmpDocumentTest.php
@@ -127,4 +127,30 @@ XML;
         self::assertArrayNotHasKey($subjectKey, $document->data);
         self::assertNull($document->find('subject'));
     }
+
+    /**
+     * Multiple occurrences of identical properties are returned as ordered lists.
+     */
+    #[Test]
+    public function testDocumentMergesRepeatedValues(): void
+    {
+        $xml = <<<XML
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+         xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <rdf:Description>
+    <dc:subject>Alpha</dc:subject>
+  </rdf:Description>
+  <rdf:Description>
+    <dc:subject>Beta</dc:subject>
+  </rdf:Description>
+</rdf:RDF>
+XML;
+
+        $document = (new XmpParser())->parse($xml);
+
+        $subjects = $document->get(self::DC_NAMESPACE, 'subject');
+
+        self::assertIsArray($subjects);
+        self::assertSame(['Alpha', 'Beta'], $subjects);
+    }
 }


### PR DESCRIPTION
## Summary
- add a RegionsResolver that merges MWG-RS regions with Apple FaceInfo metadata and normalises bounding boxes
- extend region value objects with typed metadata for face id, rotation and semantic type and wire the resolver into the structured builder
- teach the XMP parser/resolver to expose repeated and comma separated values as proper lists
- cover the new resolver, builder integration and string list behaviour with dedicated tests

## Testing
- composer ci:test:php:unit

------
https://chatgpt.com/codex/tasks/task_e_68fbc8bee9c08323a1bd6ffea51ca863