### PR TITLE
feat: enhance Apple maker note decoding and metadata curation

### DIFF
--- a/src/Curate/Resolver/AppleResolver.php
+++ b/src/Curate/Resolver/AppleResolver.php
@@ -14,11 +14,29 @@ namespace MagicSunday\ImageMeta\Curate\Resolver;
 use MagicSunday\ImageMeta\Model\QuickTimeMeta;
 use MagicSunday\ImageMeta\Value\Apple;
 
+use function is_numeric;
+use function preg_split;
+
 /**
  * Resolves Apple specific metadata from QuickTime containers.
  */
 final readonly class AppleResolver
 {
+    /**
+     * @var array<string, string>
+     */
+    private const FLAG_KEYS = [
+        'LivePhotoAuto'         => 'livePhotoAuto',
+        'LivePhotoEnabled'      => 'livePhotoEnabled',
+        'LivePhotoActive'       => 'livePhotoActive',
+        'LivePhotoLongExposure' => 'livePhotoLongExposure',
+        'LivePhoto'             => 'livePhoto',
+        'HdrAuto'               => 'hdrAuto',
+        'HdrEnabled'            => 'hdrEnabled',
+        'NightMode'             => 'nightMode',
+        'LongExposure'          => 'longExposure',
+    ];
+
     /**
      * Builds an Apple value object from available metadata.
      */
@@ -29,10 +47,101 @@ final readonly class AppleResolver
         }
 
         $identifier = $quickTimeMeta->contentIdentifier();
-        if ($identifier === null) {
+        $resolver   = new QuickTimeResolver($quickTimeMeta);
+
+        $cameraType       = $resolver->string('CameraType');
+        $hdrHeadroom      = $resolver->float('HdrHeadroom') ?? $resolver->float('HDRHeadroom');
+        $hdrGain          = $this->floatList($resolver, 'HdrGain', 'HDRGain');
+        $snr              = $resolver->float('SNRSetting') ?? $resolver->float('SNR');
+        $focusPosition    = $resolver->float('FocusPosition');
+        $livePhotoIndex   = $resolver->int('LivePhotoVideoIndex');
+        $colorTemperature = $resolver->int('ColorTemperature');
+        $semanticPreset   = $resolver->string('SemanticStylePreset');
+        $semanticWarmth   = $resolver->float('SemanticStyleWarmth');
+        $semanticTone     = $resolver->float('SemanticStyleTone');
+        $flags            = $this->flags($resolver);
+
+        if (
+            $identifier === null
+            && $cameraType === null
+            && $hdrHeadroom === null
+            && $hdrGain === null
+            && $snr === null
+            && $focusPosition === null
+            && $livePhotoIndex === null
+            && $colorTemperature === null
+            && $semanticPreset === null
+            && $semanticWarmth === null
+            && $semanticTone === null
+            && $flags === []
+        ) {
             return null;
         }
 
-        return new Apple($identifier);
+        return new Apple(
+            $identifier,
+            $cameraType,
+            $hdrHeadroom,
+            $hdrGain,
+            $snr,
+            $focusPosition,
+            $livePhotoIndex,
+            $colorTemperature,
+            $semanticPreset,
+            $semanticWarmth,
+            $semanticTone,
+            $flags,
+        );
+    }
+
+    /**
+     * @return list<float>|null
+     */
+    private function floatList(QuickTimeResolver $resolver, string ...$keys): ?array
+    {
+        foreach ($keys as $key) {
+            $raw = $resolver->string($key);
+            if ($raw === null) {
+                continue;
+            }
+
+            $parts = preg_split('/[\\s,]+/', $raw);
+            if ($parts === false) {
+                continue;
+            }
+
+            $values = [];
+            foreach ($parts as $part) {
+                if ($part === '') {
+                    continue;
+                }
+
+                if (is_numeric($part)) {
+                    $values[] = (float) $part;
+                }
+            }
+
+            if ($values !== []) {
+                return $values;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @return array<string, bool>
+     */
+    private function flags(QuickTimeResolver $resolver): array
+    {
+        $flags = [];
+        foreach (self::FLAG_KEYS as $key => $normalized) {
+            $value = $resolver->bool($key);
+            if ($value !== null) {
+                $flags[$normalized] = $value;
+            }
+        }
+
+        return $flags;
     }
 }

--- a/src/Curate/StructuredMetadataBuilder.php
+++ b/src/Curate/StructuredMetadataBuilder.php
@@ -21,7 +21,9 @@ use MagicSunday\ImageMeta\Curate\Resolver\ExifTagResolver;
 use MagicSunday\ImageMeta\Curate\Resolver\GpsResolver;
 use MagicSunday\ImageMeta\Curate\Resolver\QuickTimeResolver;
 use MagicSunday\ImageMeta\Curate\Resolver\XmpResolver;
+use MagicSunday\ImageMeta\MakerNotes\Apple\AppleMakerNotes;
 use MagicSunday\ImageMeta\Model\Metadata;
+use MagicSunday\ImageMeta\Model\QuickTimeMeta;
 use MagicSunday\ImageMeta\Parse\Icc\IccDecoder;
 use MagicSunday\ImageMeta\Value\Apple;
 use MagicSunday\ImageMeta\Value\Audio;
@@ -59,6 +61,10 @@ use MagicSunday\ImageMeta\Value\Video;
 use MagicSunday\ImageMeta\Value\WhiteBalanceDetails;
 use MagicSunday\ImageMeta\Value\Xmp;
 
+use function array_key_exists;
+use function array_is_list;
+use function is_numeric;
+use function preg_split;
 use function strtoupper;
 
 /**
@@ -66,6 +72,21 @@ use function strtoupper;
  */
 final class StructuredMetadataBuilder
 {
+    /**
+     * @var array<string, string>
+     */
+    private const APPLE_FLAG_KEYS = [
+        'LivePhotoAuto'         => 'livePhotoAuto',
+        'LivePhotoEnabled'      => 'livePhotoEnabled',
+        'LivePhotoActive'       => 'livePhotoActive',
+        'LivePhotoLongExposure' => 'livePhotoLongExposure',
+        'LivePhoto'             => 'livePhoto',
+        'HdrAuto'               => 'hdrAuto',
+        'HdrEnabled'            => 'hdrEnabled',
+        'NightMode'             => 'nightMode',
+        'LongExposure'          => 'longExposure',
+    ];
+
     /**
      * Builds the structured metadata aggregate from the supplied metadata container.
      */
@@ -75,6 +96,7 @@ final class StructuredMetadataBuilder
         $xmpDocument       = $metadata->xmpDoc ?? $metadata->selectiveXmpDocument();
         $xmpResolver       = new XmpResolver($xmpDocument);
         $quickTimeResolver = new QuickTimeResolver($metadata->quickTime);
+        $appleMakerNotes   = $metadata->makerNotes?->apple();
         $gpsResolver       = new GpsResolver();
 
         $interop = new Interop(index: $exifResolver->interopIndex());
@@ -161,7 +183,7 @@ final class StructuredMetadataBuilder
 
         $device = $this->buildDevice($exifResolver, $quickTimeResolver);
 
-        $apple = new Apple($metadata->quickTime?->contentIdentifier());
+        $apple = $this->buildApple($appleMakerNotes, $quickTimeResolver, $metadata->quickTime);
         $xmp   = $xmpResolver->value();
 
         $file = new File(null, null, null, null, null);
@@ -237,9 +259,14 @@ final class StructuredMetadataBuilder
             deviceSettingDescription: $exifResolver->deviceSettingDescription(),
         );
 
+        $whiteBalanceKelvin = $apple->colorTemperature;
+        if ($whiteBalanceKelvin === null) {
+            $whiteBalanceKelvin = $this->quickTimeInt($quickTimeResolver, 'ColorTemperature');
+        }
+
         $whiteBalanceDetails = new WhiteBalanceDetails(
             mode: $exifResolver->whiteBalance(),
-            kelvin: null,
+            kelvin: $whiteBalanceKelvin,
             rgGain: null,
             bgGain: null,
         );
@@ -265,7 +292,7 @@ final class StructuredMetadataBuilder
             afMode: null,
         );
 
-        $motion = new Motion(null, null, null, null, null, null, null, null, null);
+        $motion = $this->buildMotion($appleMakerNotes);
 
         $scene = $this->buildScene($exifResolver, $quickTimeResolver);
 
@@ -557,6 +584,145 @@ final class StructuredMetadataBuilder
             nightMode: $night,
             subjectDistanceRange: $exif->subjectDistanceRange(),
         );
+    }
+
+    private function buildApple(
+        ?AppleMakerNotes $makerNotes,
+        QuickTimeResolver $quickTimeResolver,
+        ?QuickTimeMeta $quickTimeMeta,
+    ): Apple {
+        $contentIdentifier = $makerNotes?->contentIdentifier ?? $quickTimeMeta?->contentIdentifier();
+        $cameraType        = $makerNotes?->cameraType ?? $this->quickTimeString($quickTimeResolver, 'CameraType');
+        $hdrHeadroom       = $makerNotes?->hdrHeadroom ?? $this->quickTimeFloat($quickTimeResolver, 'HdrHeadroom', 'HDRHeadroom');
+        $hdrGain           = $makerNotes?->hdrGain ?? $this->quickTimeFloatList($quickTimeResolver, 'HdrGain', 'HDRGain');
+        $snr               = $makerNotes?->snr ?? $this->quickTimeFloat($quickTimeResolver, 'SNRSetting', 'SNR');
+        $focusPosition     = $makerNotes?->focusPosition ?? $this->quickTimeFloat($quickTimeResolver, 'FocusPosition');
+        $livePhotoIndex    = $makerNotes?->livePhotoIndex ?? $this->quickTimeInt($quickTimeResolver, 'LivePhotoVideoIndex');
+        $colorTemperature  = $makerNotes?->colorTemperature ?? $this->quickTimeInt($quickTimeResolver, 'ColorTemperature');
+        $semanticPreset    = $makerNotes?->semanticStylePreset ?? $this->quickTimeString($quickTimeResolver, 'SemanticStylePreset');
+        $semanticWarmth    = $makerNotes?->semanticStyleWarmth ?? $this->quickTimeFloat($quickTimeResolver, 'SemanticStyleWarmth');
+        $semanticTone      = $makerNotes?->semanticStyleTone ?? $this->quickTimeFloat($quickTimeResolver, 'SemanticStyleTone');
+
+        $flags         = $makerNotes?->flags ?? [];
+        $quickTimeFlags = $this->quickTimeFlags($quickTimeResolver);
+        foreach ($quickTimeFlags as $key => $value) {
+            if (!array_key_exists($key, $flags)) {
+                $flags[$key] = $value;
+            }
+        }
+
+        return new Apple(
+            $contentIdentifier,
+            $cameraType,
+            $hdrHeadroom,
+            $hdrGain,
+            $snr,
+            $focusPosition,
+            $livePhotoIndex,
+            $colorTemperature,
+            $semanticPreset,
+            $semanticWarmth,
+            $semanticTone,
+            $flags,
+        );
+    }
+
+    private function buildMotion(?AppleMakerNotes $makerNotes): Motion
+    {
+        $vector = $makerNotes?->accelerationVector;
+
+        $accelX = null;
+        $accelY = null;
+        $accelZ = null;
+
+        if ($vector !== null && array_is_list($vector)) {
+            $accelX = $vector[0] ?? null;
+            $accelY = $vector[1] ?? null;
+            $accelZ = $vector[2] ?? null;
+        }
+
+        return new Motion(null, null, null, $accelX, $accelY, $accelZ, null, null, null);
+    }
+
+    private function quickTimeString(QuickTimeResolver $resolver, string ...$keys): ?string
+    {
+        foreach ($keys as $key) {
+            $value = $resolver->string($key);
+            if ($value !== null && $value !== '') {
+                return $value;
+            }
+        }
+
+        return null;
+    }
+
+    private function quickTimeFloat(QuickTimeResolver $resolver, string ...$keys): ?float
+    {
+        foreach ($keys as $key) {
+            $value = $resolver->float($key);
+            if ($value !== null) {
+                return $value;
+            }
+        }
+
+        return null;
+    }
+
+    private function quickTimeInt(QuickTimeResolver $resolver, string ...$keys): ?int
+    {
+        foreach ($keys as $key) {
+            $value = $resolver->int($key);
+            if ($value !== null) {
+                return $value;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @return list<float>|null
+     */
+    private function quickTimeFloatList(QuickTimeResolver $resolver, string ...$keys): ?array
+    {
+        $raw = $this->quickTimeString($resolver, ...$keys);
+        if ($raw === null) {
+            return null;
+        }
+
+        $parts = preg_split('/[\\s,]+/', $raw);
+        if ($parts === false) {
+            return null;
+        }
+
+        $values = [];
+        foreach ($parts as $part) {
+            if ($part === '') {
+                continue;
+            }
+
+            if (is_numeric($part)) {
+                $values[] = (float) $part;
+            }
+        }
+
+        return $values !== [] ? $values : null;
+    }
+
+    /**
+     * @return array<string, bool>
+     */
+    private function quickTimeFlags(QuickTimeResolver $resolver): array
+    {
+        $flags = [];
+        foreach (self::APPLE_FLAG_KEYS as $key => $normalized) {
+            $value = $resolver->bool($key);
+            if ($value !== null) {
+                $flags[$normalized] = $value;
+            }
+        }
+
+        return $flags;
     }
 
     /**

--- a/src/MakerNotes/Apple/AppleMakerNotes.php
+++ b/src/MakerNotes/Apple/AppleMakerNotes.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\ImageMeta\MakerNotes\Apple;
+
+/**
+ * Represents curated maker note data extracted from Apple devices.
+ */
+final readonly class AppleMakerNotes
+{
+    /**
+     * @param string|null $contentIdentifier   Unique content identifier assigned by Apple platforms.
+     * @param string|null $cameraType          Describes the hardware camera (e.g. "Wide", "Tele").
+     * @param float|null  $hdrHeadroom         HDR headroom value reported by the device.
+     * @param list<float>|null $hdrGain        HDR gain values per colour channel.
+     * @param float|null  $snr                 Signal-to-noise ratio setting.
+     * @param float|null  $focusPosition       Lens focus position in the native scale.
+     * @param int|null    $livePhotoIndex      Index of the representative frame in a Live Photo sequence.
+     * @param int|null    $colorTemperature    White balance colour temperature in Kelvin.
+     * @param string|null $semanticStylePreset Selected semantic style preset name.
+     * @param float|null  $semanticStyleWarmth Semantic style warmth adjustment.
+     * @param float|null  $semanticStyleTone   Semantic style tone adjustment.
+     * @param array<string, bool> $flags       Boolean flags derived from maker note keys.
+     * @param list<float>|null $accelerationVector  Acceleration vector recorded during capture.
+     */
+    public function __construct(
+        public ?string $contentIdentifier,
+        public ?string $cameraType,
+        public ?float $hdrHeadroom,
+        public ?array $hdrGain,
+        public ?float $snr,
+        public ?float $focusPosition,
+        public ?int $livePhotoIndex,
+        public ?int $colorTemperature,
+        public ?string $semanticStylePreset,
+        public ?float $semanticStyleWarmth,
+        public ?float $semanticStyleTone,
+        public array $flags,
+        public ?array $accelerationVector,
+    ) {
+    }
+}

--- a/src/MakerNotes/Apple/BinaryPlistDecoder.php
+++ b/src/MakerNotes/Apple/BinaryPlistDecoder.php
@@ -1,0 +1,364 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\ImageMeta\MakerNotes\Apple;
+
+use MagicSunday\ImageMeta\Core\ParseError;
+
+use function array_key_exists;
+use function iconv;
+use function is_int;
+use function is_string;
+use function ord;
+use function strlen;
+use function str_starts_with;
+use function substr;
+
+/**
+ * Minimal decoder for Apple's binary property list format used inside maker notes.
+ */
+final class BinaryPlistDecoder
+{
+    private string $data = '';
+
+    /**
+     * @var list<int>
+     */
+    private array $offsetTable = [];
+
+    private int $objectRefSize = 0;
+
+    private int $length = 0;
+
+    private int $topObjectIndex = 0;
+
+    /**
+     * Decodes the supplied binary property list and returns the top level value.
+     *
+     * @return array<int, string|int|float|bool|array|null>|array<string, string|int|float|bool|array|null>|string|int|float|bool|null
+     */
+    public function decode(string $data): array|string|int|float|bool|null
+    {
+        if ($data === '') {
+            throw new ParseError('The property list data must not be empty.');
+        }
+
+        if (!str_starts_with($data, 'bplist00')) {
+            throw new ParseError('Unsupported property list format.');
+        }
+
+        if (strlen($data) < 40) {
+            throw new ParseError('The property list payload is too small.');
+        }
+
+        $this->data          = $data;
+        $this->length        = strlen($data);
+        $this->offsetTable   = [];
+        $this->objectRefSize = 0;
+        $this->decodeTrailer();
+
+        if ($this->offsetTable === []) {
+            throw new ParseError('The property list does not contain any objects.');
+        }
+
+        $topIndex = $this->topObjectIndex;
+        if ($topIndex < 0) {
+            throw new ParseError('Missing top level object index.');
+        }
+
+        return $this->parseObject($topIndex);
+    }
+
+    private function decodeTrailer(): void
+    {
+        $trailer = substr($this->data, -32);
+        if ($trailer === false || strlen($trailer) !== 32) {
+            throw new ParseError('Invalid property list trailer.');
+        }
+
+        $offsetIntSize    = ord($trailer[6]);
+        $objectRefSize    = ord($trailer[7]);
+        $numObjects       = $this->readUint64($trailer, 8);
+        $topObject        = $this->readUint64($trailer, 16);
+        $offsetTableStart = $this->readUint64($trailer, 24);
+
+        if ($offsetIntSize < 1 || $objectRefSize < 1) {
+            throw new ParseError('Invalid property list integer sizing.');
+        }
+
+        if ($numObjects < 1) {
+            throw new ParseError('The property list does not contain any objects.');
+        }
+
+        if ($offsetTableStart >= $this->length) {
+            throw new ParseError('The offset table is located outside of the payload.');
+        }
+
+        $this->objectRefSize = $objectRefSize;
+
+        $entries = [];
+        $cursor  = $offsetTableStart;
+        for ($idx = 0; $idx < $numObjects; $idx++) {
+            $offset = $this->readUint($cursor, $offsetIntSize);
+            $entries[] = $offset;
+            $cursor   += $offsetIntSize;
+        }
+
+        $this->offsetTable   = $entries;
+        $this->topObjectIndex = (int) $topObject;
+    }
+
+    private function parseObject(int $index): array|string|int|float|bool|null
+    {
+        if (!array_key_exists($index, $this->offsetTable)) {
+            throw new ParseError('The property list object reference is invalid.');
+        }
+
+        $offset = $this->offsetTable[$index];
+        if ($offset >= $this->length) {
+            throw new ParseError('The property list object offset is invalid.');
+        }
+
+        $marker = ord($this->data[$offset]);
+        $type   = $marker >> 4;
+        $info   = $marker & 0x0F;
+
+        return match ($type) {
+            0x0 => $this->parseSimple($info),
+            0x1 => $this->parseInteger($offset, $info),
+            0x2 => $this->parseReal($offset, $info),
+            0x4 => $this->parseData($offset, $info),
+            0x5 => $this->parseAscii($offset, $info),
+            0x6 => $this->parseUnicode($offset, $info),
+            0xA => $this->parseArray($offset, $info),
+            0xD => $this->parseDictionary($offset, $info),
+            default => throw new ParseError('Unsupported property list object type.'),
+        };
+    }
+
+    private function parseSimple(int $info): bool|null
+    {
+        return match ($info) {
+            0x0 => null,
+            0x8 => false,
+            0x9 => true,
+            default => throw new ParseError('Unsupported simple property list object.'),
+        };
+    }
+
+    private function parseInteger(int $offset, int $info): int
+    {
+        $size = 1 << $info;
+        if ($size === 0) {
+            throw new ParseError('Integer object without payload.');
+        }
+
+        $value = $this->readUint($offset + 1, $size);
+
+        return $value;
+    }
+
+    private function parseReal(int $offset, int $info): float
+    {
+        $size = 1 << $info;
+        if ($size === 4) {
+            $bytes = substr($this->data, $offset + 1, 4);
+            if ($bytes === false || strlen($bytes) !== 4) {
+                throw new ParseError('Incomplete real payload.');
+            }
+
+            $value = unpack('G', $bytes);
+
+            return (float) $value[1];
+        }
+
+        if ($size === 8) {
+            $bytes = substr($this->data, $offset + 1, 8);
+            if ($bytes === false || strlen($bytes) !== 8) {
+                throw new ParseError('Incomplete double payload.');
+            }
+
+            $value = unpack('E', $bytes);
+
+            return (float) $value[1];
+        }
+
+        throw new ParseError('Unsupported floating point width.');
+    }
+
+    private function parseData(int $offset, int $info): string
+    {
+        [$size, $header] = $this->readLength($offset, $info);
+
+        $payload = substr($this->data, $offset + $header, $size);
+        if ($payload === false || strlen($payload) !== $size) {
+            throw new ParseError('Incomplete data payload.');
+        }
+
+        return $payload;
+    }
+
+    private function parseAscii(int $offset, int $info): string
+    {
+        [$size, $header] = $this->readLength($offset, $info);
+
+        $payload = substr($this->data, $offset + $header, $size);
+        if ($payload === false || strlen($payload) !== $size) {
+            throw new ParseError('Incomplete ASCII string payload.');
+        }
+
+        return $payload;
+    }
+
+    private function parseUnicode(int $offset, int $info): string
+    {
+        [$size, $header] = $this->readLength($offset, $info);
+
+        $byteLength = $size * 2;
+        $payload    = substr($this->data, $offset + $header, $byteLength);
+        if ($payload === false || strlen($payload) !== $byteLength) {
+            throw new ParseError('Incomplete Unicode string payload.');
+        }
+
+        $decoded = iconv('UTF-16BE', 'UTF-8', $payload);
+        if ($decoded === false) {
+            throw new ParseError('Failed to decode Unicode string payload.');
+        }
+
+        return $decoded;
+    }
+
+    /**
+     * @return array<int, string|int|float|bool|array|null>
+     */
+    private function parseArray(int $offset, int $info): array
+    {
+        [$count, $header] = $this->readLength($offset, $info);
+        if ($count === 0) {
+            return [];
+        }
+
+        $refsOffset = $offset + $header;
+        $bytes      = $count * $this->objectRefSize;
+        if ($refsOffset + $bytes > $this->length) {
+            throw new ParseError('Array references exceed payload bounds.');
+        }
+
+        $result = [];
+        for ($idx = 0; $idx < $count; $idx++) {
+            $reference = $this->readUint($refsOffset + ($idx * $this->objectRefSize), $this->objectRefSize);
+            $result[]  = $this->parseObject($reference);
+        }
+
+        return $result;
+    }
+
+    /**
+     * @return array<string, string|int|float|bool|array|null>
+     */
+    private function parseDictionary(int $offset, int $info): array
+    {
+        [$count, $header] = $this->readLength($offset, $info);
+        if ($count === 0) {
+            return [];
+        }
+
+        $refsOffset = $offset + $header;
+        $bytes      = $count * $this->objectRefSize * 2;
+        if ($refsOffset + $bytes > $this->length) {
+            throw new ParseError('Dictionary references exceed payload bounds.');
+        }
+
+        $keys   = [];
+        $values = [];
+        for ($idx = 0; $idx < $count; $idx++) {
+            $keyRef = $this->readUint($refsOffset + ($idx * $this->objectRefSize), $this->objectRefSize);
+            $valRef = $this->readUint(
+                $refsOffset + ($count * $this->objectRefSize) + ($idx * $this->objectRefSize),
+                $this->objectRefSize
+            );
+
+            $keys[]   = $this->parseObject($keyRef);
+            $values[] = $this->parseObject($valRef);
+        }
+
+        $result = [];
+        foreach ($keys as $idx => $key) {
+            if (!is_string($key)) {
+                throw new ParseError('Dictionary keys must be strings.');
+            }
+
+            $result[$key] = $values[$idx];
+        }
+
+        return $result;
+    }
+
+    /**
+     * @return array{0:int,1:int}
+     */
+    private function readLength(int $offset, int $info): array
+    {
+        if ($info !== 0x0F) {
+            return [$info, 1];
+        }
+
+        $sizeMarkerOffset = $offset + 1;
+        if ($sizeMarkerOffset >= $this->length) {
+            throw new ParseError('The property list size marker exceeds the payload.');
+        }
+
+        $marker = ord($this->data[$sizeMarkerOffset]);
+        $type   = $marker >> 4;
+        $info   = $marker & 0x0F;
+        if ($type !== 0x1) {
+            throw new ParseError('Size marker does not encode an integer.');
+        }
+
+        $sizeBytes = 1 << $info;
+        $value     = $this->readUint($sizeMarkerOffset + 1, $sizeBytes);
+
+        return [$value, 2 + $sizeBytes];
+    }
+
+    private function readUint(int $offset, int $length): int
+    {
+        if ($length < 1) {
+            throw new ParseError('Cannot read zero length integers.');
+        }
+
+        if ($offset < 0 || $offset + $length > $this->length) {
+            throw new ParseError('Attempted to read outside of the payload.');
+        }
+
+        $value = 0;
+        for ($idx = 0; $idx < $length; $idx++) {
+            $value = ($value << 8) | ord($this->data[$offset + $idx]);
+        }
+
+        return $value;
+    }
+
+    private function readUint64(string $data, int $offset): int
+    {
+        $slice = substr($data, $offset, 8);
+        if ($slice === false || strlen($slice) !== 8) {
+            throw new ParseError('Failed to read 64-bit integer.');
+        }
+
+        $parts = unpack('Nhigh/Nlow', $slice);
+        if ($parts === false) {
+            throw new ParseError('Failed to unpack 64-bit integer.');
+        }
+
+        return ((int) $parts['high'] << 32) | (int) $parts['low'];
+    }
+}

--- a/src/MakerNotes/AppleDecoder.php
+++ b/src/MakerNotes/AppleDecoder.php
@@ -11,14 +11,43 @@ declare(strict_types=1);
 
 namespace MagicSunday\ImageMeta\MakerNotes;
 
+use MagicSunday\ImageMeta\MakerNotes\Apple\AppleMakerNotes;
+use MagicSunday\ImageMeta\MakerNotes\Apple\BinaryPlistDecoder;
+
+use function array_is_list;
+use function array_key_exists;
+use function is_array;
+use function is_bool;
+use function is_float;
+use function is_int;
+use function is_numeric;
+use function is_string;
 use function sha1;
 use function strlen;
+use function trim;
 
 /**
- * Decoder that returns basic metadata about the raw maker notes produced by Apple devices.
+ * Decoder that extracts structured metadata from Apple maker note payloads.
  */
 final class AppleDecoder implements MakerNotesDecoderInterface
 {
+    /**
+     * Maps maker note keys to normalised flag identifiers.
+     *
+     * @var array<string, string>
+     */
+    private const FLAG_MAP = [
+        'LivePhotoAuto'         => 'livePhotoAuto',
+        'LivePhotoEnabled'      => 'livePhotoEnabled',
+        'LivePhotoActive'       => 'livePhotoActive',
+        'LivePhotoLongExposure' => 'livePhotoLongExposure',
+        'LivePhoto'             => 'livePhoto',
+        'HdrAuto'               => 'hdrAuto',
+        'HdrEnabled'            => 'hdrEnabled',
+        'NightMode'             => 'nightMode',
+        'LongExposure'          => 'longExposure',
+    ];
+
     /**
      * Creates a metadata value object describing the Apple maker note payload.
      *
@@ -28,10 +57,241 @@ final class AppleDecoder implements MakerNotesDecoderInterface
      */
     public function decode(string $raw, string $make, ?string $model): MakerNotesMetadata
     {
+        $appleData = $this->parseAppleData($raw);
+
         return new MakerNotesMetadata(
             'Apple',
             strlen($raw),
-            sha1($raw)
+            sha1($raw),
+            $appleData
         );
+    }
+
+    private function parseAppleData(string $raw): ?AppleMakerNotes
+    {
+        $decoded = (new BinaryPlistDecoder())->decode($raw);
+        if (!is_array($decoded) || array_is_list($decoded)) {
+            return null;
+        }
+
+        return $this->buildAppleMakerNotes($decoded);
+    }
+
+    /**
+     * @param array<string, string|int|float|bool|array|null> $dictionary
+     */
+    private function buildAppleMakerNotes(array $dictionary): ?AppleMakerNotes
+    {
+        $contentIdentifier   = $this->stringValue($dictionary, 'ContentIdentifier');
+        $cameraType          = $this->stringValue($dictionary, 'CameraType');
+        $hdrHeadroom         = $this->floatValue($dictionary, 'HdrHeadroom', 'HDRHeadroom');
+        $hdrGain             = $this->floatList($dictionary, 'HdrGain', 'HDRGain');
+        $snr                 = $this->floatValue($dictionary, 'SNRSetting', 'SNR');
+        $focusPosition       = $this->floatValue($dictionary, 'FocusPosition');
+        $livePhotoIndex      = $this->intValue($dictionary, 'LivePhotoVideoIndex');
+        $colorTemperature    = $this->intValue($dictionary, 'ColorTemperature');
+        $semanticStylePreset = $this->stringValue($dictionary, 'SemanticStylePreset');
+        $semanticStyleWarmth = $this->floatValue($dictionary, 'SemanticStyleWarmth');
+        $semanticStyleTone   = $this->floatValue($dictionary, 'SemanticStyleTone');
+        $accelerationVector  = $this->floatList($dictionary, 'AccelerationVector');
+        $flags               = $this->extractFlags($dictionary);
+
+        if (
+            $contentIdentifier === null
+            && $cameraType === null
+            && $hdrHeadroom === null
+            && $hdrGain === null
+            && $snr === null
+            && $focusPosition === null
+            && $livePhotoIndex === null
+            && $colorTemperature === null
+            && $semanticStylePreset === null
+            && $semanticStyleWarmth === null
+            && $semanticStyleTone === null
+            && $flags === []
+            && $accelerationVector === null
+        ) {
+            return null;
+        }
+
+        return new AppleMakerNotes(
+            $contentIdentifier,
+            $cameraType,
+            $hdrHeadroom,
+            $hdrGain,
+            $snr,
+            $focusPosition,
+            $livePhotoIndex,
+            $colorTemperature,
+            $semanticStylePreset,
+            $semanticStyleWarmth,
+            $semanticStyleTone,
+            $flags,
+            $accelerationVector,
+        );
+    }
+
+    /**
+     * @param array<string, string|int|float|bool|array|null> $dictionary
+     */
+    private function stringValue(array $dictionary, string $key): ?string
+    {
+        if (!array_key_exists($key, $dictionary)) {
+            return null;
+        }
+
+        $value = $dictionary[$key];
+        if (!is_string($value)) {
+            return null;
+        }
+
+        $trimmed = trim($value);
+
+        return $trimmed !== '' ? $trimmed : null;
+    }
+
+    /**
+     * @param array<string, string|int|float|bool|array|null> $dictionary
+     */
+    private function floatValue(array $dictionary, string ...$keys): ?float
+    {
+        foreach ($keys as $key) {
+            if (!array_key_exists($key, $dictionary)) {
+                continue;
+            }
+
+            $value = $dictionary[$key];
+            if (is_float($value)) {
+                return $value;
+            }
+
+            if (is_int($value) || is_numeric($value)) {
+                return (float) $value;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param array<string, string|int|float|bool|array|null> $dictionary
+     */
+    private function intValue(array $dictionary, string ...$keys): ?int
+    {
+        foreach ($keys as $key) {
+            if (!array_key_exists($key, $dictionary)) {
+                continue;
+            }
+
+            $value = $dictionary[$key];
+            if (is_int($value)) {
+                return $value;
+            }
+
+            if (is_numeric($value)) {
+                return (int) $value;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param array<string, string|int|float|bool|array|null> $dictionary
+     *
+     * @return list<float>|null
+     */
+    private function floatList(array $dictionary, string ...$keys): ?array
+    {
+        foreach ($keys as $key) {
+            if (!array_key_exists($key, $dictionary)) {
+                continue;
+            }
+
+            $value = $dictionary[$key];
+            if (!is_array($value)) {
+                continue;
+            }
+
+            if (!array_is_list($value) && array_key_exists('values', $value) && is_array($value['values'])) {
+                $value = $value['values'];
+            }
+
+            if (!array_is_list($value)) {
+                continue;
+            }
+
+            $result = [];
+            foreach ($value as $entry) {
+                if (is_float($entry)) {
+                    $result[] = $entry;
+                } elseif (is_int($entry) || is_numeric($entry)) {
+                    $result[] = (float) $entry;
+                }
+            }
+
+            if ($result !== []) {
+                return $result;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param array<string, string|int|float|bool|array|null> $dictionary
+     *
+     * @return array<string, bool>
+     */
+    private function extractFlags(array $dictionary): array
+    {
+        $flags = [];
+        foreach (self::FLAG_MAP as $makerKey => $normalized) {
+            if (!array_key_exists($makerKey, $dictionary)) {
+                continue;
+            }
+
+            $value = $dictionary[$makerKey];
+            $bool  = $this->boolValue($value);
+            if ($bool === null) {
+                continue;
+            }
+
+            $flags[$normalized] = $bool;
+        }
+
+        return $flags;
+    }
+
+    private function boolValue(string|int|float|bool|null|array $value): ?bool
+    {
+        if (is_bool($value)) {
+            return $value;
+        }
+
+        if (is_int($value)) {
+            return $value !== 0;
+        }
+
+        if (is_float($value)) {
+            return $value !== 0.0;
+        }
+
+        if (is_string($value)) {
+            $normalized = trim($value);
+            if ($normalized === '') {
+                return null;
+            }
+
+            if ($normalized === '1' || $normalized === 'true' || $normalized === 'TRUE') {
+                return true;
+            }
+
+            if ($normalized === '0' || $normalized === 'false' || $normalized === 'FALSE') {
+                return false;
+            }
+        }
+
+        return null;
     }
 }

--- a/src/MakerNotes/MakerNotesMetadata.php
+++ b/src/MakerNotes/MakerNotesMetadata.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 namespace MagicSunday\ImageMeta\MakerNotes;
 
 use InvalidArgumentException;
+use MagicSunday\ImageMeta\MakerNotes\Apple\AppleMakerNotes;
 
 use function preg_match;
 
@@ -24,11 +25,13 @@ final readonly class MakerNotesMetadata
      * @param string $vendor Vendor responsible for the maker note payload. Must not be empty.
      * @param int    $length Number of bytes contained in the payload. Must be zero or positive.
      * @param string $sha1   Lowercase hexadecimal SHA-1 digest of the payload. Must be 40 characters long.
+     * @param AppleMakerNotes|null $apple Additional Apple specific maker note data.
      */
     public function __construct(
         private string $vendor,
         private int $length,
         private string $sha1,
+        private ?AppleMakerNotes $apple = null,
     ) {
         if ($vendor === '') {
             throw new InvalidArgumentException('The vendor must not be empty.');
@@ -65,5 +68,13 @@ final readonly class MakerNotesMetadata
     public function sha1(): string
     {
         return $this->sha1;
+    }
+
+    /**
+     * Returns Apple specific maker note data when available.
+     */
+    public function apple(): ?AppleMakerNotes
+    {
+        return $this->apple;
     }
 }

--- a/src/Value/Apple.php
+++ b/src/Value/Apple.php
@@ -12,14 +12,37 @@ declare(strict_types=1);
 namespace MagicSunday\ImageMeta\Value;
 
 /**
- * Holds Apple specific metadata coming from QuickTime containers.
+ * Holds Apple specific metadata aggregated from maker notes and QuickTime sources.
  */
 final readonly class Apple
 {
     /**
-     * @param string|null $contentIdentifier Unique content identifier assigned by Apple platforms.
+     * @param string|null $contentIdentifier   Unique content identifier assigned by Apple platforms.
+     * @param string|null $cameraType          Reported hardware camera type (e.g. "Wide", "Tele").
+     * @param float|null  $hdrHeadroom         HDR headroom value reported by the capture pipeline.
+     * @param list<float>|null $hdrGain        HDR gain values per colour channel.
+     * @param float|null  $snr                 Signal-to-noise ratio setting applied during capture.
+     * @param float|null  $focusPosition       Focus position within the device specific range.
+     * @param int|null    $livePhotoIndex      Index of the still frame for Live Photo sequences.
+     * @param int|null    $colorTemperature    White balance colour temperature in Kelvin.
+     * @param string|null $semanticStylePreset Semantic style preset name.
+     * @param float|null  $semanticStyleWarmth Semantic style warmth value.
+     * @param float|null  $semanticStyleTone   Semantic style tone value.
+     * @param array<string, bool> $flags       Boolean flags derived from maker notes or QuickTime metadata.
      */
-    public function __construct(public ?string $contentIdentifier)
-    {
+    public function __construct(
+        public ?string $contentIdentifier,
+        public ?string $cameraType,
+        public ?float $hdrHeadroom,
+        public ?array $hdrGain,
+        public ?float $snr,
+        public ?float $focusPosition,
+        public ?int $livePhotoIndex,
+        public ?int $colorTemperature,
+        public ?string $semanticStylePreset,
+        public ?float $semanticStyleWarmth,
+        public ?float $semanticStyleTone,
+        public array $flags,
+    ) {
     }
 }

--- a/tests/Curate/StructuredMetadataBuilderTest.php
+++ b/tests/Curate/StructuredMetadataBuilderTest.php
@@ -13,6 +13,8 @@ namespace MagicSunday\ImageMeta\Tests\Curate;
 
 use DateTimeImmutable;
 use MagicSunday\ImageMeta\Curate\StructuredMetadataBuilder;
+use MagicSunday\ImageMeta\MakerNotes\Apple\AppleMakerNotes;
+use MagicSunday\ImageMeta\MakerNotes\MakerNotesMetadata;
 use MagicSunday\ImageMeta\Model\Exif\ExifDocument;
 use MagicSunday\ImageMeta\Model\Exif\ExifNumericList;
 use MagicSunday\ImageMeta\Model\Exif\ExifRational;
@@ -45,6 +47,8 @@ use MagicSunday\ImageMeta\Value\Enum\WhiteBalance;
 use MagicSunday\ImageMeta\Value\Enum\YCbCrPositioning;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
+
+use function str_repeat;
 
 /**
  * @covers \MagicSunday\ImageMeta\Curate\StructuredMetadataBuilder
@@ -395,6 +399,72 @@ final class StructuredMetadataBuilderTest extends TestCase
         self::assertSame('OffsetTimeOriginal', $structured->temporal->tzSource);
         self::assertInstanceOf(DateTimeImmutable::class, $structured->temporal->original);
         self::assertSame('+01:00', $structured->temporal->original?->format('P'));
+    }
+
+    /**
+     * Ensures maker notes Apple data is preferred over QuickTime metadata and propagates to white balance and motion.
+     */
+    #[Test]
+    public function prefersMakerNotesAppleData(): void
+    {
+        $appleMakerNotes = new AppleMakerNotes(
+            contentIdentifier: 'maker-content',
+            cameraType: 'Maker Wide',
+            hdrHeadroom: 3.0,
+            hdrGain: [2.1, 2.2, 2.3],
+            snr: 18.5,
+            focusPosition: 0.5,
+            livePhotoIndex: 4,
+            colorTemperature: 4300,
+            semanticStylePreset: 'MakerPreset',
+            semanticStyleWarmth: 0.3,
+            semanticStyleTone: -0.2,
+            flags: ['livePhotoAuto' => false, 'nightMode' => true],
+            accelerationVector: [0.05, 0.1, -0.1],
+        );
+
+        $makerNotes = new MakerNotesMetadata('Apple', 64, str_repeat('a', 40), $appleMakerNotes);
+
+        $ifd0         = new Ifd([]);
+        $exifDocument = new ExifDocument($ifd0, null, null, null, null, $makerNotes);
+
+        $quickTime = new QuickTimeMeta([
+            QuickTimeMeta::CONTENT_IDENTIFIER_KEY => 'qt-content',
+            'CameraType'                          => 'QuickTime Camera',
+            'HdrHeadroom'                         => 1.0,
+            'HdrGain'                             => '0.5 0.6 0.7',
+            'SNRSetting'                          => 9.0,
+            'FocusPosition'                       => 0.2,
+            'LivePhotoVideoIndex'                 => 1,
+            'ColorTemperature'                    => 6500,
+            'SemanticStylePreset'                 => 'QuickPreset',
+            'SemanticStyleWarmth'                 => 0.1,
+            'SemanticStyleTone'                   => 0.15,
+            'LivePhotoAuto'                       => 1,
+            'NightMode'                           => 0,
+        ]);
+
+        $metadata   = new Metadata(['primary'], $quickTime, $exifDocument, [], null, $makerNotes);
+        $structured = (new StructuredMetadataBuilder())->build($metadata);
+
+        self::assertSame('maker-content', $structured->apple->contentIdentifier);
+        self::assertSame('Maker Wide', $structured->apple->cameraType);
+        self::assertSame([2.1, 2.2, 2.3], $structured->apple->hdrGain);
+        self::assertEqualsWithDelta(3.0, $structured->apple->hdrHeadroom, 1e-12);
+        self::assertEqualsWithDelta(18.5, $structured->apple->snr, 1e-12);
+        self::assertEqualsWithDelta(0.5, $structured->apple->focusPosition, 1e-12);
+        self::assertSame(4, $structured->apple->livePhotoIndex);
+        self::assertSame(4300, $structured->apple->colorTemperature);
+        self::assertSame('MakerPreset', $structured->apple->semanticStylePreset);
+        self::assertEqualsWithDelta(0.3, $structured->apple->semanticStyleWarmth, 1e-12);
+        self::assertEqualsWithDelta(-0.2, $structured->apple->semanticStyleTone, 1e-12);
+        self::assertFalse($structured->apple->flags['livePhotoAuto']);
+        self::assertTrue($structured->apple->flags['nightMode']);
+
+        self::assertSame(4300, $structured->whiteBalanceDetails->kelvin);
+        self::assertEqualsWithDelta(0.05, $structured->motion->accelX, 1e-12);
+        self::assertEqualsWithDelta(0.1, $structured->motion->accelY, 1e-12);
+        self::assertEqualsWithDelta(-0.1, $structured->motion->accelZ, 1e-12);
     }
 
     /**

--- a/tests/MakerNotes/AppleDecoder/AppleDecoderTest.php
+++ b/tests/MakerNotes/AppleDecoder/AppleDecoderTest.php
@@ -11,11 +11,13 @@ declare(strict_types=1);
 
 namespace MagicSunday\ImageMeta\Tests\MakerNotes\AppleDecoder;
 
+use MagicSunday\ImageMeta\MakerNotes\Apple\AppleMakerNotes;
 use MagicSunday\ImageMeta\MakerNotes\AppleDecoder;
 use MagicSunday\ImageMeta\MakerNotes\MakerNotesMetadata;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
+use function hex2bin;
 use function sha1;
 use function strlen;
 
@@ -27,12 +29,12 @@ use function strlen;
 final class AppleDecoderTest extends TestCase
 {
     /**
-     * Ensures the decoder returns the expected metadata value object including vendor, length, and SHA-1 hash.
+     * Ensures the decoder extracts structured Apple maker note data from a representative payload.
      */
     #[Test]
-    public function decodeReturnsExpectedMetadata(): void
+    public function decodeParsesAppleMakerNotes(): void
     {
-        $raw     = "\x01\x02example";
+        $raw     = $this->buildMakerNotesBlob();
         $decoder = new AppleDecoder();
 
         $metadata = $decoder->decode($raw, 'Apple', 'iPhone');
@@ -41,5 +43,31 @@ final class AppleDecoderTest extends TestCase
         self::assertSame('Apple', $metadata->vendor());
         self::assertSame(strlen($raw), $metadata->length());
         self::assertSame(sha1($raw), $metadata->sha1());
+
+        $apple = $metadata->apple();
+        self::assertInstanceOf(AppleMakerNotes::class, $apple);
+        self::assertSame('photo-uuid', $apple->contentIdentifier);
+        self::assertSame('Tele', $apple->cameraType);
+        self::assertEqualsWithDelta(2.5, $apple->hdrHeadroom, 1e-12);
+        self::assertSame([1.0, 1.2, 1.3], $apple->hdrGain);
+        self::assertEqualsWithDelta(24.5, $apple->snr, 1e-12);
+        self::assertEqualsWithDelta(0.62, $apple->focusPosition, 1e-12);
+        self::assertSame(2, $apple->livePhotoIndex);
+        self::assertSame(5000, $apple->colorTemperature);
+        self::assertSame('Warm', $apple->semanticStylePreset);
+        self::assertEqualsWithDelta(0.15, $apple->semanticStyleWarmth, 1e-12);
+        self::assertEqualsWithDelta(-0.05, $apple->semanticStyleTone, 1e-12);
+        self::assertSame([0.1, -0.2, 0.3], $apple->accelerationVector);
+
+        self::assertTrue($apple->flags['livePhotoAuto']);
+        self::assertArrayHasKey('nightMode', $apple->flags);
+        self::assertFalse($apple->flags['nightMode']);
+    }
+
+    private function buildMakerNotesBlob(): string
+    {
+        $hex = '62706c6973743030de0102030405060708090a0b0c0d0e0f13141516171b1c1d1e1f2021225f1012416363656c65726174696f6e566563746f725a43616d657261547970655f1010436f6c6f7254656d70657261747572655f1011436f6e74656e744964656e7469666965725d466f637573506f736974696f6e574864724761696e5b48647248656164726f6f6d5d4c69766550686f746f4175746f5f10134c69766550686f746f566964656f496e646578594e696768744d6f64655a534e5253657474696e675f101353656d616e7469635374796c655072657365745f101153656d616e7469635374796c65546f6e655f101353656d616e7469635374796c655761726d7468a3101112233fb999999999999a23bfc999999999999a233fd33333333333335454656c651113885a70686f746f2d75756964233fe3d70a3d70a3d7a318191a233ff0000000000000233ff3333333333333233ff4cccccccccccd23400400000000000009100208234038800000000000545761726d23bfa999999999999a233fc333333333333300080025003a00450058006c007a0082008e009c00b200bc00c700dd00f10107010b0114011d0126012b012e013901420146014f01580161016a016b016d016e0177017c0185000000000000020100000000000000230000000000000000000000000000018e';
+
+        return (string) hex2bin($hex);
     }
 }

--- a/tests/MakerNotes/MakerNotesMetadata/MakerNotesMetadataTest.php
+++ b/tests/MakerNotes/MakerNotesMetadata/MakerNotesMetadataTest.php
@@ -35,6 +35,7 @@ final class MakerNotesMetadataTest extends TestCase
         self::assertSame('Contoso', $metadata->vendor());
         self::assertSame(123, $metadata->length());
         self::assertSame('0123456789abcdef0123456789abcdef01234567', $metadata->sha1());
+        self::assertNull($metadata->apple());
     }
 
     /**


### PR DESCRIPTION
## Summary
- add a binary property list decoder and value objects to expose rich Apple maker note metadata such as camera type, HDR, focus, and semantic styles
- prioritise maker note data when building structured metadata, propagate Kelvin temperatures and motion vectors, and merge QuickTime flags as a fallback
- expand PHPUnit coverage for Apple maker notes decoding and structured metadata aggregation

## Testing
- composer ci:test:php:unit

------
https://chatgpt.com/codex/tasks/task_e_68fbc8c0d2908323973f3c2312d8f794