### PR TITLE
feat: parse JPEG SOF sampling for TIFF fallbacks

### DIFF
--- a/src/Curate/StructuredMetadataBuilder.php
+++ b/src/Curate/StructuredMetadataBuilder.php
@@ -104,8 +104,15 @@ final class StructuredMetadataBuilder
 
         $interop = new Interop(index: $exifResolver->interopIndex());
 
+        $bitsPerSample    = $exifResolver->bitsPerSample() ?? $metadata->jpegBitsPerSample;
+        $ycbcrSubSampling = $exifResolver->ycbcrSubSampling();
+        if ($ycbcrSubSampling === null) {
+            $ycbcrSubSampling = $metadata->jpegYCbCrSubSampling;
+        }
+
         $tiff = new TiffData(
             samplesPerPixel: $exifResolver->samplesPerPixel(),
+            bitsPerSample: $bitsPerSample,
             rowsPerStrip: $exifResolver->rowsPerStrip(),
             compression: $exifResolver->compression(),
             photometric: $exifResolver->photometric(),
@@ -114,7 +121,7 @@ final class StructuredMetadataBuilder
             xResolution: $exifResolver->xResolution(),
             yResolution: $exifResolver->yResolution(),
             ycbcrPos: $exifResolver->ycbcrPositioning(),
-            ycbcrSubSampling: $exifResolver->ycbcrSubSampling(),
+            ycbcrSubSampling: $ycbcrSubSampling,
             ycbcrCoefficients: $exifResolver->ycbcrCoefficients(),
             whitePoint: $exifResolver->whitePoint(),
             primaryChromaticities: $exifResolver->primaryChromaticities(),

--- a/src/MetadataReader.php
+++ b/src/MetadataReader.php
@@ -54,11 +54,14 @@ final class MetadataReader
      */
     private function fromJpeg(Stream $stream): Metadata
     {
-        $jpeg       = new JpegExtractor($stream);
-        $exifBlobs  = $jpeg->extractExifBlobs();
-        $xmpBlobs   = $jpeg->extractXmpPackets();
-        $iccProfile = $jpeg->getIccProfile();
+        $jpeg        = new JpegExtractor($stream);
+        $exifBlobs   = $jpeg->extractExifBlobs();
+        $xmpBlobs    = $jpeg->extractXmpPackets();
+        $iccProfile  = $jpeg->getIccProfile();
         $iccSegments = $jpeg->getIccSegments();
+        $bitsPerSample = $jpeg->getFrameSamplePrecision();
+        $sampling      = $jpeg->getFrameComponentSamplingFactors();
+        $subSampling   = $jpeg->getFrameYCbCrSubSampling();
 
         $exifDoc    = null;
         $xmpDoc     = null;
@@ -73,7 +76,19 @@ final class MetadataReader
             $xmpDoc = (new XmpParser())->parse($xmpBlobs[0]);
         }
 
-        return new Metadata($exifBlobs, null, $exifDoc, $xmpBlobs, $xmpDoc, $makerNotes, $iccProfile, $iccSegments);
+        return new Metadata(
+            $exifBlobs,
+            null,
+            $exifDoc,
+            $xmpBlobs,
+            $xmpDoc,
+            $makerNotes,
+            $iccProfile,
+            $iccSegments,
+            $bitsPerSample,
+            $sampling,
+            $subSampling,
+        );
     }
 
     /**

--- a/src/Model/Metadata.php
+++ b/src/Model/Metadata.php
@@ -43,6 +43,14 @@ final class Metadata
      */
     public readonly array $iccSegments;
 
+    public readonly ?int $jpegBitsPerSample;
+
+    /** @var array<int, array{horizontal:int, vertical:int}>|null */
+    public readonly ?array $jpegFrameSamplingFactors;
+
+    /** @var array{0:int,1:int}|null */
+    public readonly ?array $jpegYCbCrSubSampling;
+
     private ?StructuredMetadata $structured = null;
 
     /**
@@ -54,6 +62,10 @@ final class Metadata
      * @param MakerNotesMetadata|null $makerNotes Decoded maker notes metadata for the primary EXIF blob.
      * @param string|null             $iccProfile Binary ICC profile when available.
      * @param list<string>            $iccSegments Raw ICC APP2 segments in encounter order.
+     * @param int|null                $jpegBitsPerSample Sample precision reported by the JPEG frame header.
+     * @param array<int, array{horizontal:int, vertical:int}>|null $jpegFrameSamplingFactors Component sampling factors by
+     *                                                                                       identifier.
+     * @param array{0:int,1:int}|null $jpegYCbCrSubSampling Derived YCbCr subsampling from the JPEG frame header.
      */
     public function __construct(
         array $exifBlobs,
@@ -64,6 +76,9 @@ final class Metadata
         ?MakerNotesMetadata $makerNotes = null,
         ?string $iccProfile = null,
         array $iccSegments = [],
+        ?int $jpegBitsPerSample = null,
+        ?array $jpegFrameSamplingFactors = null,
+        ?array $jpegYCbCrSubSampling = null,
     ) {
         $this->exifBlobs   = $exifBlobs;
         $this->quickTime   = $quickTime;
@@ -73,6 +88,9 @@ final class Metadata
         $this->makerNotes  = $makerNotes;
         $this->iccProfile  = $iccProfile;
         $this->iccSegments = $iccSegments;
+        $this->jpegBitsPerSample        = $jpegBitsPerSample;
+        $this->jpegFrameSamplingFactors = $jpegFrameSamplingFactors;
+        $this->jpegYCbCrSubSampling     = $jpegYCbCrSubSampling;
     }
 
     /**

--- a/src/Parse/Jpeg/JpegExtractor.php
+++ b/src/Parse/Jpeg/JpegExtractor.php
@@ -48,6 +48,10 @@ final class JpegExtractor
 
     private const int MARKER_APP13 = 0xED;
 
+    private const int MARKER_SOF0 = 0xC0;
+
+    private const int MARKER_SOF2 = 0xC2;
+
     /**
      * Signatures identifying metadata-bearing APP segments.
      */
@@ -89,6 +93,14 @@ final class JpegExtractor
 
     /** @var list<string> */
     private array $iptcPayloads = [];
+
+    private ?int $frameBitsPerSample = null;
+
+    /** @var array<int, array{horizontal: int, vertical: int}>|null */
+    private ?array $frameComponentSampling = null;
+
+    /** @var array{0:int,1:int}|null */
+    private ?array $frameYCbCrSubSampling = null;
 
     /**
      * Initialises the extractor with a seekable stream.
@@ -160,6 +172,40 @@ final class JpegExtractor
     }
 
     /**
+     * Returns the precision in bits reported by the primary start of frame segment.
+     */
+    public function getFrameSamplePrecision(): ?int
+    {
+        $this->parseIfNeeded();
+
+        return $this->frameBitsPerSample;
+    }
+
+    /**
+     * Returns the horizontal and vertical sampling factors for components identified in the SOF.
+     *
+     * @return array<int, array{horizontal:int, vertical:int}>|null
+     */
+    public function getFrameComponentSamplingFactors(): ?array
+    {
+        $this->parseIfNeeded();
+
+        return $this->frameComponentSampling;
+    }
+
+    /**
+     * Returns the derived YCbCr subsampling factors inferred from the SOF component sampling.
+     *
+     * @return array{0:int,1:int}|null
+     */
+    public function getFrameYCbCrSubSampling(): ?array
+    {
+        $this->parseIfNeeded();
+
+        return $this->frameYCbCrSubSampling;
+    }
+
+    /**
      * Lazily scans the JPEG structure the first time metadata is requested.
      */
     private function parseIfNeeded(): void
@@ -181,6 +227,9 @@ final class JpegExtractor
         $this->iccProfile       = null;
         $this->iptcPayloads     = [];
         $this->xmpPacketHashes  = [];
+        $this->frameBitsPerSample      = null;
+        $this->frameComponentSampling  = null;
+        $this->frameYCbCrSubSampling   = null;
 
         while (true) {
             [$marker, $offset] = $this->nextMarkerWithOffset();
@@ -208,6 +257,8 @@ final class JpegExtractor
                 $this->handleApp2($payload, $offset);
             } elseif ($marker === self::MARKER_APP13) {
                 $this->handleApp13($payload);
+            } elseif ($marker === self::MARKER_SOF0 || $marker === self::MARKER_SOF2) {
+                $this->handleStartOfFrame($marker, $payload, $offset);
             }
         }
 
@@ -389,5 +440,112 @@ final class JpegExtractor
         if (str_starts_with($payload, self::IPTC_SIGNATURE)) {
             $this->iptcPayloads[] = $payload;
         }
+    }
+
+    /**
+     * Parses baseline or progressive start of frame markers to obtain sampling information.
+     *
+     * @param int    $marker  Marker code (SOF0 or SOF2).
+     * @param string $payload Raw SOF payload excluding the marker and length field.
+     * @param int    $offset  Offset where the SOF marker begins.
+     */
+    private function handleStartOfFrame(int $marker, string $payload, int $offset): void
+    {
+        if ($this->frameBitsPerSample !== null) {
+            return;
+        }
+
+        $length = strlen($payload);
+        if ($length < 6) {
+            throw new ParseError(sprintf('SOF marker 0x%02X at offset %d is too short', $marker, $offset));
+        }
+
+        $componentCount = ord($payload[5]);
+        if ($componentCount === 0) {
+            throw new ParseError(sprintf('SOF marker 0x%02X at offset %d reports zero components', $marker, $offset));
+        }
+
+        $expectedLength = 6 + ($componentCount * 3);
+        if ($length < $expectedLength) {
+            throw new ParseError(sprintf('SOF marker 0x%02X at offset %d is truncated', $marker, $offset));
+        }
+
+        $components = [];
+        $index      = 6;
+
+        for ($i = 0; $i < $componentCount; ++$i) {
+            $componentId     = ord($payload[$index]);
+            $samplingFactors = ord($payload[$index + 1]);
+            $horizontal      = $samplingFactors >> 4;
+            $vertical        = $samplingFactors & 0x0F;
+
+            if ($horizontal === 0 || $vertical === 0) {
+                throw new ParseError(
+                    sprintf('SOF marker 0x%02X at offset %d contains zero sampling factor', $marker, $offset)
+                );
+            }
+
+            $components[$componentId] = [
+                'horizontal' => $horizontal,
+                'vertical'   => $vertical,
+            ];
+
+            $index += 3;
+        }
+
+        $this->frameBitsPerSample     = ord($payload[0]);
+        $this->frameComponentSampling = $components;
+        $this->frameYCbCrSubSampling  = $this->deriveYCbCrSubSampling($components);
+    }
+
+    /**
+     * Derives YCbCr subsampling factors from component sampling values.
+     *
+     * @param array<int, array{horizontal:int, vertical:int}> $components
+     *
+     * @return array{0:int,1:int}|null
+     */
+    private function deriveYCbCrSubSampling(array $components): ?array
+    {
+        $luma = $components[1] ?? null;
+        if ($luma === null) {
+            return null;
+        }
+
+        $chromas = [];
+        foreach ($components as $id => $component) {
+            if ($id === 1) {
+                continue;
+            }
+
+            $chromas[] = $component;
+        }
+
+        if ($chromas === []) {
+            return null;
+        }
+
+        $horizontal = $chromas[0]['horizontal'];
+        $vertical   = $chromas[0]['vertical'];
+
+        if ($horizontal === 0 || $vertical === 0) {
+            return null;
+        }
+
+        $count = count($chromas);
+        for ($i = 1; $i < $count; ++$i) {
+            $component = $chromas[$i];
+            $horizontal = min($horizontal, $component['horizontal']);
+            $vertical   = min($vertical, $component['vertical']);
+        }
+
+        if ($luma['horizontal'] % $horizontal !== 0 || $luma['vertical'] % $vertical !== 0) {
+            return null;
+        }
+
+        return [
+            (int) ($luma['horizontal'] / $horizontal),
+            (int) ($luma['vertical'] / $vertical),
+        ];
     }
 }

--- a/src/Value/TiffData.php
+++ b/src/Value/TiffData.php
@@ -24,6 +24,7 @@ final readonly class TiffData
 {
     /**
      * @param int|null                                                    $samplesPerPixel             Number of samples per pixel.
+     * @param int|null                                                    $bitsPerSample               Bits per sample reported for the image.
      * @param int|null                                                    $rowsPerStrip                Number of rows per TIFF strip.
      * @param Compression|null                                            $compression                 Compression method used for pixel data.
      * @param Photometric|null                                            $photometric                 Photometric interpretation of the samples.
@@ -46,6 +47,7 @@ final readonly class TiffData
      */
     public function __construct(
         public ?int $samplesPerPixel,
+        public ?int $bitsPerSample,
         public ?int $rowsPerStrip,
         public ?Compression $compression,
         public ?Photometric $photometric,

--- a/tests/Curate/StructuredMetadataBuilderTest.php
+++ b/tests/Curate/StructuredMetadataBuilderTest.php
@@ -1049,6 +1049,36 @@ final class StructuredMetadataBuilderTest extends TestCase
     }
 
     /**
+     * Ensures JPEG frame metadata backfills TIFF characteristics when EXIF is absent.
+     */
+    #[Test]
+    public function backfillsTiffDataFromJpegFrameWhenExifMissing(): void
+    {
+        $metadata = new Metadata(
+            [],
+            null,
+            null,
+            [],
+            null,
+            null,
+            null,
+            [],
+            8,
+            [
+                1 => ['horizontal' => 2, 'vertical' => 2],
+                2 => ['horizontal' => 1, 'vertical' => 1],
+                3 => ['horizontal' => 1, 'vertical' => 1],
+            ],
+            [2, 2],
+        );
+
+        $structured = (new StructuredMetadataBuilder())->build($metadata);
+
+        self::assertSame(8, $structured->tiff->bitsPerSample);
+        self::assertSame([2, 2], $structured->tiff->ycbcrSubSampling);
+    }
+
+    /**
      * Builds a Classic TIFF blob with EXIF/Flashpix version tags encoded as printable UNDEFINED values.
      */
     private function buildClassicVersionBlob(): string

--- a/tests/Model/Metadata/MetadataTest.php
+++ b/tests/Model/Metadata/MetadataTest.php
@@ -67,13 +67,37 @@ final class MetadataTest extends TestCase
             '{http://ns.adobe.com/photoshop/1.0/}DateCreated' => '2024-05-01',
         ]);
 
-        $metadata = new Metadata($exifBlobs, $quickTime, $exifDoc, $xmpBlobs, $xmpDoc);
+        $iccProfile  = 'icc-profile';
+        $iccSegments = ['seg-1', 'seg-2'];
+        $sampling    = [
+            1 => ['horizontal' => 2, 'vertical' => 2],
+            2 => ['horizontal' => 1, 'vertical' => 1],
+        ];
+
+        $metadata = new Metadata(
+            $exifBlobs,
+            $quickTime,
+            $exifDoc,
+            $xmpBlobs,
+            $xmpDoc,
+            null,
+            $iccProfile,
+            $iccSegments,
+            12,
+            $sampling,
+            [2, 1],
+        );
 
         self::assertSame($exifBlobs, $metadata->exifBlobs);
         self::assertSame($quickTime, $metadata->quickTime);
         self::assertSame($exifDoc, $metadata->exifDoc);
         self::assertSame($xmpBlobs, $metadata->xmpBlobs);
         self::assertSame($xmpDoc, $metadata->xmpDoc);
+        self::assertSame($iccProfile, $metadata->iccProfile);
+        self::assertSame($iccSegments, $metadata->iccSegments);
+        self::assertSame(12, $metadata->jpegBitsPerSample);
+        self::assertSame($sampling, $metadata->jpegFrameSamplingFactors);
+        self::assertSame([2, 1], $metadata->jpegYCbCrSubSampling);
     }
 
     /**
@@ -89,6 +113,9 @@ final class MetadataTest extends TestCase
         self::assertNull($metadata->exifDoc);
         self::assertSame([], $metadata->xmpBlobs);
         self::assertNull($metadata->xmpDoc);
+        self::assertNull($metadata->jpegBitsPerSample);
+        self::assertNull($metadata->jpegFrameSamplingFactors);
+        self::assertNull($metadata->jpegYCbCrSubSampling);
     }
 
     /**

--- a/tests/Parse/Jpeg/JpegExtractorTest.php
+++ b/tests/Parse/Jpeg/JpegExtractorTest.php
@@ -48,6 +48,10 @@ final class JpegExtractorTest extends TestCase
 
     private const int MARKER_APP13 = 0xED;
 
+    private const int MARKER_SOF0 = 0xC0;
+
+    private const int MARKER_SOF2 = 0xC2;
+
     /**
      * Verifies APP1 segments yield EXIF and XMP payloads regardless of ordering.
      *
@@ -182,6 +186,44 @@ final class JpegExtractorTest extends TestCase
         $extractor = $this->createExtractor($jpeg);
 
         self::assertSame([$iptcOne, $iptcTwo], $extractor->getIptcPayloads());
+    }
+
+    /**
+     * Ensures SOF markers expose precision and component sampling factors.
+     *
+     * @param int $marker
+     */
+    #[Test]
+    #[DataProvider('provideSofMarkers')]
+    public function parsesPrecisionAndSamplingFromSof(int $marker): void
+    {
+        $framePayload = "\x08" . pack('n', 32) . pack('n', 64) . "\x03"
+            . "\x01\x22\x00"
+            . "\x02\x11\x01"
+            . "\x03\x11\x01";
+
+        $jpeg      = $this->jpeg(self::segment($marker, $framePayload));
+        $extractor = $this->createExtractor($jpeg);
+
+        self::assertSame(8, $extractor->getFrameSamplePrecision());
+        self::assertSame(
+            [
+                1 => ['horizontal' => 2, 'vertical' => 2],
+                2 => ['horizontal' => 1, 'vertical' => 1],
+                3 => ['horizontal' => 1, 'vertical' => 1],
+            ],
+            $extractor->getFrameComponentSamplingFactors(),
+        );
+        self::assertSame([2, 2], $extractor->getFrameYCbCrSubSampling());
+    }
+
+    /**
+     * @return iterable<string, array{0:int}>
+     */
+    public static function provideSofMarkers(): iterable
+    {
+        yield 'baseline-dct' => [self::MARKER_SOF0];
+        yield 'progressive-dct' => [self::MARKER_SOF2];
     }
 
     /**


### PR DESCRIPTION
## Summary
- parse SOF0/SOF2 frame segments to capture sample precision and component sampling in the JPEG extractor
- surface the captured frame data through Metadata and populate TIFF bitsPerSample and YCbCrSubSampling when EXIF omits them
- extend unit tests to cover JPEG frame parsing and fallback population in structured metadata

## Testing
- composer ci:test:php:unit
- .build/bin/phpstan analyse src/Parse/Jpeg/JpegExtractor.php src/Model/Metadata.php src/MetadataReader.php src/Value/TiffData.php src/Curate/StructuredMetadataBuilder.php -c .build/phpstan.neon --memory-limit=-1 *(fails: existing nullsafe warnings in StructuredMetadataBuilder outside the touched area)*

------
https://chatgpt.com/codex/tasks/task_e_68fbceaae66083238ce3d072d39859e8