### PR TITLE
fix: avoid video dimensions for JPEG metadata

### DIFF
--- a/src/Curate/StructuredMetadataBuilder.php
+++ b/src/Curate/StructuredMetadataBuilder.php
@@ -213,14 +213,8 @@ final class StructuredMetadataBuilder
         $video = new Video(
             durationSec: $quickTimeResolver->float('Duration'),
             frameRate: $quickTimeResolver->float('VideoFrameRate'),
-            width: CompositeResolver::first([
-                fn () => $quickTimeResolver->int('ImageWidth'),
-                fn () => $image->width,
-            ]),
-            height: CompositeResolver::first([
-                fn () => $quickTimeResolver->int('ImageHeight'),
-                fn () => $image->height,
-            ]),
+            width: $quickTimeResolver->int('ImageWidth'),
+            height: $quickTimeResolver->int('ImageHeight'),
             codec: $quickTimeResolver->string('CompressorID'),
             hdr: $quickTimeResolver->bool('HDRFormat'),
             transferFunction: $quickTimeResolver->string('TransferFunction'),

--- a/tests/Curate/StructuredMetadataBuilderTest.php
+++ b/tests/Curate/StructuredMetadataBuilderTest.php
@@ -653,6 +653,28 @@ final class StructuredMetadataBuilderTest extends TestCase
     }
 
     /**
+     * Ensures JPEG containers (ContainerType::JPEG) do not populate video dimensions without QuickTime metadata.
+     */
+    #[Test]
+    public function doesNotExposeVideoDimensionsForJpegContainers(): void
+    {
+        $ifd0 = new Ifd([
+            ExifTag::IMAGE_WIDTH  => new IfdEntry(ExifTag::IMAGE_WIDTH, 4, 1, 5472),
+            ExifTag::IMAGE_HEIGHT => new IfdEntry(ExifTag::IMAGE_HEIGHT, 4, 1, 3648),
+        ]);
+
+        $exifDocument = new ExifDocument($ifd0, new Ifd([]), null, null, null);
+        $metadata     = new Metadata(['primary'], null, $exifDocument);
+
+        $structured = (new StructuredMetadataBuilder())->build($metadata);
+
+        self::assertSame(5472, $structured->image->width);
+        self::assertSame(3648, $structured->image->height);
+        self::assertNull($structured->video->width);
+        self::assertNull($structured->video->height);
+    }
+
+    /**
      * Ensures legacy PhotographicSensitivity data stored in IFD0 is used when EXIF tags are absent.
      */
     #[Test]


### PR DESCRIPTION
## Summary
- remove the StructuredMetadataBuilder fallback that reused image dimensions for the video block
- cover JPEG containers with a regression test to ensure video width/height stay null without QuickTime metadata

## Testing
- composer ci:test:php:unit

------
https://chatgpt.com/codex/tasks/task_e_68fbcec18188832391dec20de64a1c61