### PR TITLE
feat: expose file metadata and optional digests

### DIFF
--- a/src/Curate/StructuredMetadataBuilder.php
+++ b/src/Curate/StructuredMetadataBuilder.php
@@ -189,7 +189,13 @@ final class StructuredMetadataBuilder
         $apple = $this->buildApple($appleMakerNotes, $quickTimeResolver, $metadata->quickTime);
         $xmp   = $xmpResolver->value();
 
-        $file = new File(null, null, null, null, null);
+        $file = new File(
+            $metadata->mimeType,
+            $metadata->fileSize,
+            $metadata->extension,
+            $metadata->digestSha1,
+            $metadata->digestMd5,
+        );
 
         $container = new Container(
             format: $quickTimeResolver->string('MajorBrand'),

--- a/src/MetadataReader.php
+++ b/src/MetadataReader.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace MagicSunday\ImageMeta;
 
+use MagicSunday\ImageMeta\Core\ParseError;
 use MagicSunday\ImageMeta\Core\Stream;
 use MagicSunday\ImageMeta\Detect\ContainerType;
 use MagicSunday\ImageMeta\Detect\FormatDetector;
@@ -22,6 +23,23 @@ use MagicSunday\ImageMeta\Parse\Jpeg\JpegExtractor;
 use MagicSunday\ImageMeta\Parse\Tiff\TiffExifReader;
 use MagicSunday\ImageMeta\Parse\Xmp\XmpParser;
 
+use const FILEINFO_MIME_TYPE;
+use const PATHINFO_EXTENSION;
+use function fclose;
+use function feof;
+use function finfo_close;
+use function finfo_file;
+use function finfo_open;
+use function filesize;
+use function fopen;
+use function fread;
+use function hash_final;
+use function hash_init;
+use function hash_update;
+use function is_string;
+use function pathinfo;
+use function strtolower;
+
 /**
  * Coordinates format detection and metadata extraction for supported containers.
  */
@@ -30,18 +48,75 @@ final class MetadataReader
     /**
      * Reads metadata from the given file path by delegating to the appropriate parser.
      *
-     * @param string $path Path to the image or media file being inspected.
+     * @param string $path              Path to the image or media file being inspected.
+     * @param bool   $calculateDigests  When true SHA-1 and MD5 digests are streamed from disk.
      *
      * @return Metadata
      */
-    public function read(string $path): Metadata
+    public function read(string $path, bool $calculateDigests = false): Metadata
     {
+        $mimeType = null;
+        $finfo    = finfo_open(FILEINFO_MIME_TYPE);
+        if ($finfo !== false) {
+            $detected = finfo_file($finfo, $path);
+            if (is_string($detected) && $detected !== '') {
+                $mimeType = $detected;
+            }
+
+            finfo_close($finfo);
+        }
+
+        $fileSize = filesize($path);
+        if ($fileSize === false) {
+            $fileSize = null;
+        }
+
+        $extension = pathinfo($path, PATHINFO_EXTENSION);
+        if ($extension === '') {
+            $extension = null;
+        } else {
+            $extension = strtolower($extension);
+        }
+
+        $digestSha1 = null;
+        $digestMd5  = null;
+        if ($calculateDigests) {
+            $handle = fopen($path, 'rb');
+            if ($handle === false) {
+                throw new ParseError('Cannot open for digest: ' . $path);
+            }
+
+            $sha1 = hash_init('sha1');
+            $md5  = hash_init('md5');
+
+            try {
+                while (!feof($handle)) {
+                    $chunk = fread($handle, 8192);
+                    if ($chunk === false) {
+                        throw new ParseError('Digest read failure: ' . $path);
+                    }
+
+                    if ($chunk === '') {
+                        continue;
+                    }
+
+                    hash_update($sha1, $chunk);
+                    hash_update($md5, $chunk);
+                }
+            } finally {
+                fclose($handle);
+            }
+
+            $digestSha1 = hash_final($sha1);
+            $digestMd5  = hash_final($md5);
+        }
+
         $stream = Stream::fromPath($path);
         $type   = FormatDetector::detect($stream);
 
         return match ($type) {
-            ContainerType::JPEG    => $this->fromJpeg($stream),
-            ContainerType::ISOBMFF => $this->fromIsoBmff($stream),
+            ContainerType::JPEG    => $this->fromJpeg($stream, $mimeType, $fileSize, $extension, $digestSha1, $digestMd5),
+            ContainerType::ISOBMFF => $this->fromIsoBmff($stream, $mimeType, $fileSize, $extension, $digestSha1, $digestMd5),
         };
     }
 
@@ -52,7 +127,14 @@ final class MetadataReader
      *
      * @return Metadata
      */
-    private function fromJpeg(Stream $stream): Metadata
+    private function fromJpeg(
+        Stream $stream,
+        ?string $mimeType,
+        ?int $fileSize,
+        ?string $extension,
+        ?string $digestSha1,
+        ?string $digestMd5,
+    ): Metadata
     {
         $jpeg       = new JpegExtractor($stream);
         $exifBlobs  = $jpeg->extractExifBlobs();
@@ -73,7 +155,21 @@ final class MetadataReader
             $xmpDoc = (new XmpParser())->parse($xmpBlobs[0]);
         }
 
-        return new Metadata($exifBlobs, null, $exifDoc, $xmpBlobs, $xmpDoc, $makerNotes, $iccProfile, $iccSegments);
+        return new Metadata(
+            $exifBlobs,
+            null,
+            $exifDoc,
+            $xmpBlobs,
+            $xmpDoc,
+            $makerNotes,
+            $iccProfile,
+            $iccSegments,
+            $mimeType,
+            $fileSize,
+            $extension,
+            $digestSha1,
+            $digestMd5,
+        );
     }
 
     /**
@@ -83,7 +179,14 @@ final class MetadataReader
      *
      * @return Metadata
      */
-    private function fromIsoBmff(Stream $stream): Metadata
+    private function fromIsoBmff(
+        Stream $stream,
+        ?string $mimeType,
+        ?int $fileSize,
+        ?string $extension,
+        ?string $digestSha1,
+        ?string $digestMd5,
+    ): Metadata
     {
         [$exifBlobs, $xmpBlobs, $qt] = (new IsoBmffExtractor($stream))->extract();
 
@@ -100,7 +203,21 @@ final class MetadataReader
             $xmpDoc = (new XmpParser())->parse($xmpBlobs[0]);
         }
 
-        return new Metadata($exifBlobs, $qt, $exifDoc, $xmpBlobs, $xmpDoc, $makerNotes);
+        return new Metadata(
+            $exifBlobs,
+            $qt,
+            $exifDoc,
+            $xmpBlobs,
+            $xmpDoc,
+            $makerNotes,
+            null,
+            [],
+            $mimeType,
+            $fileSize,
+            $extension,
+            $digestSha1,
+            $digestMd5,
+        );
     }
 
     /**

--- a/src/Model/Metadata.php
+++ b/src/Model/Metadata.php
@@ -43,6 +43,12 @@ final class Metadata
      */
     public readonly array $iccSegments;
 
+    public readonly ?string $mimeType;
+    public readonly ?int $fileSize;
+    public readonly ?string $extension;
+    public readonly ?string $digestSha1;
+    public readonly ?string $digestMd5;
+
     private ?StructuredMetadata $structured = null;
 
     /**
@@ -54,6 +60,11 @@ final class Metadata
      * @param MakerNotesMetadata|null $makerNotes Decoded maker notes metadata for the primary EXIF blob.
      * @param string|null             $iccProfile Binary ICC profile when available.
      * @param list<string>            $iccSegments Raw ICC APP2 segments in encounter order.
+     * @param string|null             $mimeType    Detected mime type for the inspected file.
+     * @param int|null                $fileSize    File size in bytes when available.
+     * @param string|null             $extension   Lowercase file extension derived from the path.
+     * @param string|null             $digestSha1  Hexadecimal SHA-1 digest when computed.
+     * @param string|null             $digestMd5   Hexadecimal MD5 digest when computed.
      */
     public function __construct(
         array $exifBlobs,
@@ -64,6 +75,11 @@ final class Metadata
         ?MakerNotesMetadata $makerNotes = null,
         ?string $iccProfile = null,
         array $iccSegments = [],
+        ?string $mimeType = null,
+        ?int $fileSize = null,
+        ?string $extension = null,
+        ?string $digestSha1 = null,
+        ?string $digestMd5 = null,
     ) {
         $this->exifBlobs   = $exifBlobs;
         $this->quickTime   = $quickTime;
@@ -73,6 +89,11 @@ final class Metadata
         $this->makerNotes  = $makerNotes;
         $this->iccProfile  = $iccProfile;
         $this->iccSegments = $iccSegments;
+        $this->mimeType    = $mimeType;
+        $this->fileSize    = $fileSize;
+        $this->extension   = $extension;
+        $this->digestSha1  = $digestSha1;
+        $this->digestMd5   = $digestMd5;
     }
 
     /**

--- a/tests/Curate/StructuredMetadataBuilderTest.php
+++ b/tests/Curate/StructuredMetadataBuilderTest.php
@@ -1048,6 +1048,34 @@ final class StructuredMetadataBuilderTest extends TestCase
         self::assertEqualsWithDelta(-5.0, $third->rotationDeg, 0.0001);
     }
 
+    #[Test]
+    public function testBuildsFileMetadataFromAggregate(): void
+    {
+        $metadata = new Metadata(
+            [],
+            null,
+            null,
+            [],
+            null,
+            null,
+            null,
+            [],
+            'image/jpeg',
+            2048,
+            'jpg',
+            'sha1-digest',
+            'md5-digest',
+        );
+
+        $structured = (new StructuredMetadataBuilder())->build($metadata);
+
+        self::assertSame('image/jpeg', $structured->file->mimeType);
+        self::assertSame(2048, $structured->file->fileSize);
+        self::assertSame('jpg', $structured->file->extension);
+        self::assertSame('sha1-digest', $structured->file->digestSha1);
+        self::assertSame('md5-digest', $structured->file->digestMd5);
+    }
+
     /**
      * Builds a Classic TIFF blob with EXIF/Flashpix version tags encoded as printable UNDEFINED values.
      */

--- a/tests/MetadataReader/MetadataReaderTest.php
+++ b/tests/MetadataReader/MetadataReaderTest.php
@@ -23,11 +23,13 @@ use PHPUnit\Framework\TestCase;
 
 use function chr;
 use function file_put_contents;
+use function md5;
 use function pack;
 use function sha1;
 use function strlen;
 use function sys_get_temp_dir;
 use function tempnam;
+use function rename;
 use function unlink;
 
 /**
@@ -128,6 +130,86 @@ final class MetadataReaderTest extends TestCase
     }
 
     /**
+     * Ensures JPEG file level metadata is exposed without computing digests by default.
+     */
+    #[Test]
+    public function testReadJpegPopulatesFileMetadataWithoutDigests(): void
+    {
+        $makerNote = 'file-metadata-maker-note';
+        $tiff      = $this->littleEndianTiffWithMakerNote('Canon', 'EOS R5', $makerNote);
+        $xmp       = '<x:xmpmeta xmlns:x="adobe:ns:meta/">'
+            . '<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">'
+            . '<rdf:Description xmlns:dc="http://purl.org/dc/elements/1.1/" dc:description="File metadata" />'
+            . '</rdf:RDF>'
+            . '</x:xmpmeta>';
+
+        $jpeg = "\xFF\xD8"
+            . $this->segment(self::MARKER_APP1, self::EXIF_SIGNATURE . $tiff)
+            . $this->segment(self::MARKER_APP1, self::XMP_SIGNATURE . $xmp)
+            . "\xFF\xD9";
+
+        $path = $this->writeTempFileWithExtension($jpeg, 'JPG');
+
+        try {
+            $metadata   = (new MetadataReader())->read($path);
+            $structured = $metadata->structured();
+        } finally {
+            @unlink($path);
+        }
+
+        $size = strlen($jpeg);
+
+        self::assertSame('image/jpeg', $metadata->mimeType);
+        self::assertSame($size, $metadata->fileSize);
+        self::assertSame('jpg', $metadata->extension);
+        self::assertNull($metadata->digestSha1);
+        self::assertNull($metadata->digestMd5);
+
+        self::assertSame('image/jpeg', $structured->file->mimeType);
+        self::assertSame($size, $structured->file->fileSize);
+        self::assertSame('jpg', $structured->file->extension);
+        self::assertNull($structured->file->digestSha1);
+        self::assertNull($structured->file->digestMd5);
+    }
+
+    /**
+     * Ensures optional digest calculation populates SHA-1 and MD5 values.
+     */
+    #[Test]
+    public function testReadJpegComputesDigestsWhenEnabled(): void
+    {
+        $makerNote = 'file-digest-maker-note';
+        $tiff      = $this->littleEndianTiffWithMakerNote('Fujifilm', 'X-T5', $makerNote);
+        $xmp       = '<x:xmpmeta xmlns:x="adobe:ns:meta/">'
+            . '<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">'
+            . '<rdf:Description xmlns:dc="http://purl.org/dc/elements/1.1/" dc:creator="Digest" />'
+            . '</rdf:RDF>'
+            . '</x:xmpmeta>';
+
+        $jpeg = "\xFF\xD8"
+            . $this->segment(self::MARKER_APP1, self::EXIF_SIGNATURE . $tiff)
+            . $this->segment(self::MARKER_APP1, self::XMP_SIGNATURE . $xmp)
+            . "\xFF\xD9";
+
+        $path = $this->writeTempFileWithExtension($jpeg, 'jpg');
+
+        try {
+            $metadata   = (new MetadataReader())->read($path, true);
+            $structured = $metadata->structured();
+        } finally {
+            @unlink($path);
+        }
+
+        $expectedSha1 = sha1($jpeg);
+        $expectedMd5  = md5($jpeg);
+
+        self::assertSame($expectedSha1, $metadata->digestSha1);
+        self::assertSame($expectedMd5, $metadata->digestMd5);
+        self::assertSame($expectedSha1, $structured->file->digestSha1);
+        self::assertSame($expectedMd5, $structured->file->digestMd5);
+    }
+
+    /**
      * Writes the provided binary payload to a temporary file and returns its path.
      *
      * @param string $payload Binary payload to persist on disk.
@@ -144,6 +226,22 @@ final class MetadataReaderTest extends TestCase
         file_put_contents($path, $payload);
 
         return $path;
+    }
+
+    /**
+     * Persists the payload and renames the file to include the desired extension.
+     */
+    private function writeTempFileWithExtension(string $payload, string $extension): string
+    {
+        $path   = $this->writeTempFile($payload);
+        $target = $path . '.' . $extension;
+
+        if (!rename($path, $target)) {
+            @unlink($path);
+            self::fail('Unable to rename temporary file');
+        }
+
+        return $target;
     }
 
     /**


### PR DESCRIPTION
## Summary
- collect mime type, size, extension, and optional SHA-1/MD5 digests during metadata reads
- persist file-level details on the Metadata aggregate and surface them through StructuredMetadataBuilder
- add coverage for JPEG file metadata propagation and digest toggling

## Testing
- composer ci:test:php:unit
- composer ci:test:php:phpstan *(fails with existing analysis findings in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68fbcec85c84832383c5eec6b9d5efc8