### PR TITLE
feat: capture file metadata and optional digests

### DIFF
--- a/src/Curate/StructuredMetadataBuilder.php
+++ b/src/Curate/StructuredMetadataBuilder.php
@@ -196,7 +196,13 @@ final class StructuredMetadataBuilder
         $apple = $this->buildApple($appleMakerNotes, $quickTimeResolver, $metadata->quickTime);
         $xmp   = $xmpResolver->value();
 
-        $file = new File(null, null, null, null, null);
+        $file = new File(
+            $metadata->mimeType,
+            $metadata->fileSize,
+            $metadata->extension,
+            $metadata->digestSha1,
+            $metadata->digestMd5,
+        );
 
         $container = new Container(
             format: $quickTimeResolver->string('MajorBrand'),

--- a/src/MetadataReader.php
+++ b/src/MetadataReader.php
@@ -22,6 +22,14 @@ use MagicSunday\ImageMeta\Parse\Jpeg\JpegExtractor;
 use MagicSunday\ImageMeta\Parse\Tiff\TiffExifReader;
 use MagicSunday\ImageMeta\Parse\Xmp\XmpParser;
 
+use const FILEINFO_MIME_TYPE;
+use const PATHINFO_EXTENSION;
+use function filesize;
+use function hash_file;
+use function is_string;
+use function pathinfo;
+use function strtolower;
+
 /**
  * Coordinates format detection and metadata extraction for supported containers.
  */
@@ -30,18 +38,26 @@ final class MetadataReader
     /**
      * Reads metadata from the given file path by delegating to the appropriate parser.
      *
-     * @param string $path Path to the image or media file being inspected.
+     * @param string $path        Path to the image or media file being inspected.
+     * @param bool   $withDigests When true the SHA-1 and MD5 digests are calculated as part of the
+     *                            returned metadata aggregate.
      *
      * @return Metadata
      */
-    public function read(string $path): Metadata
+    public function read(string $path, bool $withDigests = false): Metadata
     {
+        $mimeType  = $this->detectMimeType($path);
+        $fileSize  = $this->detectFileSize($path);
+        $extension = $this->detectExtension($path);
+
+        [$sha1, $md5] = $withDigests ? $this->calculateDigests($path) : [null, null];
+
         $stream = Stream::fromPath($path);
         $type   = FormatDetector::detect($stream);
 
         return match ($type) {
-            ContainerType::JPEG    => $this->fromJpeg($stream),
-            ContainerType::ISOBMFF => $this->fromIsoBmff($stream),
+            ContainerType::JPEG    => $this->fromJpeg($stream, $mimeType, $fileSize, $extension, $sha1, $md5),
+            ContainerType::ISOBMFF => $this->fromIsoBmff($stream, $mimeType, $fileSize, $extension, $sha1, $md5),
         };
     }
 
@@ -52,7 +68,14 @@ final class MetadataReader
      *
      * @return Metadata
      */
-    private function fromJpeg(Stream $stream): Metadata
+    private function fromJpeg(
+        Stream $stream,
+        ?string $mimeType,
+        ?int $fileSize,
+        ?string $extension,
+        ?string $digestSha1,
+        ?string $digestMd5,
+    ): Metadata
     {
         $jpeg        = new JpegExtractor($stream);
         $exifBlobs   = $jpeg->extractExifBlobs();
@@ -88,6 +111,11 @@ final class MetadataReader
             $bitsPerSample,
             $sampling,
             $subSampling,
+            $mimeType,
+            $fileSize,
+            $extension,
+            $digestSha1,
+            $digestMd5,
         );
     }
 
@@ -98,7 +126,14 @@ final class MetadataReader
      *
      * @return Metadata
      */
-    private function fromIsoBmff(Stream $stream): Metadata
+    private function fromIsoBmff(
+        Stream $stream,
+        ?string $mimeType,
+        ?int $fileSize,
+        ?string $extension,
+        ?string $digestSha1,
+        ?string $digestMd5,
+    ): Metadata
     {
         [$exifBlobs, $xmpBlobs, $qt] = (new IsoBmffExtractor($stream))->extract();
 
@@ -115,7 +150,83 @@ final class MetadataReader
             $xmpDoc = (new XmpParser())->parse($xmpBlobs[0]);
         }
 
-        return new Metadata($exifBlobs, $qt, $exifDoc, $xmpBlobs, $xmpDoc, $makerNotes);
+        return new Metadata(
+            $exifBlobs,
+            $qt,
+            $exifDoc,
+            $xmpBlobs,
+            $xmpDoc,
+            $makerNotes,
+            null,
+            [],
+            null,
+            null,
+            null,
+            $mimeType,
+            $fileSize,
+            $extension,
+            $digestSha1,
+            $digestMd5,
+        );
+    }
+
+    /**
+     * Attempts to detect the mime type of the provided path using the file information extension.
+     */
+    private function detectMimeType(string $path): ?string
+    {
+        $finfo = new \finfo(FILEINFO_MIME_TYPE);
+        $mime  = $finfo->file($path);
+
+        if (!is_string($mime) || $mime === '') {
+            return null;
+        }
+
+        return $mime;
+    }
+
+    /**
+     * Returns the filesize in bytes or null when not available.
+     */
+    private function detectFileSize(string $path): ?int
+    {
+        $size = filesize($path);
+
+        if ($size === false) {
+            return null;
+        }
+
+        return $size;
+    }
+
+    /**
+     * Extracts the file extension from the provided path.
+     */
+    private function detectExtension(string $path): ?string
+    {
+        $extension = pathinfo($path, PATHINFO_EXTENSION);
+
+        if ($extension === '') {
+            return null;
+        }
+
+        return strtolower($extension);
+    }
+
+    /**
+     * Calculates the SHA-1 and MD5 digests for the provided path.
+     *
+     * @return array{0:?string,1:?string}
+     */
+    private function calculateDigests(string $path): array
+    {
+        $sha1 = hash_file('sha1', $path);
+        $md5  = hash_file('md5', $path);
+
+        return [
+            is_string($sha1) ? $sha1 : null,
+            is_string($md5) ? $md5 : null,
+        ];
     }
 
     /**

--- a/src/Model/Metadata.php
+++ b/src/Model/Metadata.php
@@ -51,6 +51,16 @@ final class Metadata
     /** @var array{0:int,1:int}|null */
     public readonly ?array $jpegYCbCrSubSampling;
 
+    public readonly ?string $mimeType;
+
+    public readonly ?int $fileSize;
+
+    public readonly ?string $extension;
+
+    public readonly ?string $digestSha1;
+
+    public readonly ?string $digestMd5;
+
     private ?StructuredMetadata $structured = null;
 
     /**
@@ -66,6 +76,11 @@ final class Metadata
      * @param array<int, array{horizontal:int, vertical:int}>|null $jpegFrameSamplingFactors Component sampling factors by
      *                                                                                       identifier.
      * @param array{0:int,1:int}|null $jpegYCbCrSubSampling Derived YCbCr subsampling from the JPEG frame header.
+     * @param string|null             $mimeType Detected mime type for the source file.
+     * @param int|null                $fileSize Size of the source file in bytes.
+     * @param string|null             $extension Lowercase file extension extracted from the path.
+     * @param string|null             $digestSha1 Lowercase hexadecimal SHA-1 digest of the payload.
+     * @param string|null             $digestMd5 Lowercase hexadecimal MD5 digest of the payload.
      */
     public function __construct(
         array $exifBlobs,
@@ -79,6 +94,11 @@ final class Metadata
         ?int $jpegBitsPerSample = null,
         ?array $jpegFrameSamplingFactors = null,
         ?array $jpegYCbCrSubSampling = null,
+        ?string $mimeType = null,
+        ?int $fileSize = null,
+        ?string $extension = null,
+        ?string $digestSha1 = null,
+        ?string $digestMd5 = null,
     ) {
         $this->exifBlobs   = $exifBlobs;
         $this->quickTime   = $quickTime;
@@ -91,6 +111,11 @@ final class Metadata
         $this->jpegBitsPerSample        = $jpegBitsPerSample;
         $this->jpegFrameSamplingFactors = $jpegFrameSamplingFactors;
         $this->jpegYCbCrSubSampling     = $jpegYCbCrSubSampling;
+        $this->mimeType  = $mimeType;
+        $this->fileSize  = $fileSize;
+        $this->extension = $extension;
+        $this->digestSha1 = $digestSha1;
+        $this->digestMd5  = $digestMd5;
     }
 
     /**

--- a/tests/Curate/StructuredMetadataBuilderTest.php
+++ b/tests/Curate/StructuredMetadataBuilderTest.php
@@ -320,6 +320,41 @@ final class StructuredMetadataBuilderTest extends TestCase
         self::assertSame('OffsetTimeOriginal', $structured->temporal->tzSource);
     }
 
+
+    /**
+     * Ensures file level metadata is propagated to the structured representation.
+     */
+    #[Test]
+    public function propagatesFileInformationFromMetadataAggregate(): void
+    {
+        $metadata = new Metadata(
+            [],
+            null,
+            null,
+            [],
+            null,
+            null,
+            null,
+            [],
+            null,
+            null,
+            null,
+            'image/jpeg',
+            54321,
+            'jpg',
+            'sha1-digest',
+            'md5-digest',
+        );
+
+        $structured = (new StructuredMetadataBuilder())->build($metadata);
+
+        self::assertSame('image/jpeg', $structured->file->mimeType);
+        self::assertSame(54321, $structured->file->fileSize);
+        self::assertSame('jpg', $structured->file->extension);
+        self::assertSame('sha1-digest', $structured->file->digestSha1);
+        self::assertSame('md5-digest', $structured->file->digestMd5);
+    }
+
     /**
      * Ensures printable UNDEFINED EXIF values parsed from a TIFF blob map to structured standards metadata.
      */

--- a/tests/MetadataReader/MetadataReaderTest.php
+++ b/tests/MetadataReader/MetadataReaderTest.php
@@ -23,7 +23,10 @@ use PHPUnit\Framework\TestCase;
 
 use function chr;
 use function file_put_contents;
+use function ltrim;
+use function md5;
 use function pack;
+use function rename;
 use function sha1;
 use function strlen;
 use function sys_get_temp_dir;
@@ -62,7 +65,7 @@ final class MetadataReaderTest extends TestCase
             . $this->segment(self::MARKER_APP1, self::XMP_SIGNATURE . $xmp)
             . "\xFF\xD9";
 
-        $path = $this->writeTempFile($jpeg);
+        $path = $this->writeTempFile($jpeg, 'jpg');
 
         try {
             $metadata = (new MetadataReader())->read($path);
@@ -82,6 +85,50 @@ final class MetadataReaderTest extends TestCase
         self::assertSame(sha1($makerNote), $metadata->makerNotes->sha1());
         self::assertNull($metadata->iccProfile);
         self::assertSame([], $metadata->iccSegments);
+        self::assertSame('image/jpeg', $metadata->mimeType);
+        self::assertSame(strlen($jpeg), $metadata->fileSize);
+        self::assertSame('jpg', $metadata->extension);
+        self::assertNull($metadata->digestSha1);
+        self::assertNull($metadata->digestMd5);
+
+        $structured = $metadata->structured();
+        self::assertSame('image/jpeg', $structured->file->mimeType);
+        self::assertSame(strlen($jpeg), $structured->file->fileSize);
+        self::assertSame('jpg', $structured->file->extension);
+        self::assertNull($structured->file->digestSha1);
+        self::assertNull($structured->file->digestMd5);
+    }
+
+    /**
+     * Ensures optional digest calculation provides SHA-1 and MD5 for JPEG payloads.
+     */
+    #[Test]
+    public function testReadJpegWithDigestsPopulatesChecksums(): void
+    {
+        $makerNote = 'digest-maker-note';
+        $tiff      = $this->littleEndianTiffWithMakerNote('Canon', 'EOS R6', $makerNote);
+
+        $jpeg = "\xFF\xD8"
+            . $this->segment(self::MARKER_APP1, self::EXIF_SIGNATURE . $tiff)
+            . "\xFF\xD9";
+
+        $path = $this->writeTempFile($jpeg, 'jpeg');
+
+        try {
+            $metadata = (new MetadataReader())->read($path, true);
+        } finally {
+            @unlink($path);
+        }
+
+        $expectedSha1 = sha1($jpeg);
+        $expectedMd5  = md5($jpeg);
+
+        self::assertSame($expectedSha1, $metadata->digestSha1);
+        self::assertSame($expectedMd5, $metadata->digestMd5);
+
+        $structured = $metadata->structured();
+        self::assertSame($expectedSha1, $structured->file->digestSha1);
+        self::assertSame($expectedMd5, $structured->file->digestMd5);
     }
 
     /**
@@ -134,7 +181,7 @@ final class MetadataReaderTest extends TestCase
      *
      * @return string Absolute path to the temporary file containing the payload.
      */
-    private function writeTempFile(string $payload): string
+    private function writeTempFile(string $payload, ?string $extension = null): string
     {
         $path = tempnam(sys_get_temp_dir(), 'meta');
         if ($path === false) {
@@ -142,6 +189,17 @@ final class MetadataReaderTest extends TestCase
         }
 
         file_put_contents($path, $payload);
+
+        if ($extension !== null) {
+            $suffix = ltrim($extension, '.');
+            $target = $path . '.' . $suffix;
+            if (!rename($path, $target)) {
+                @unlink($path);
+                self::fail('Unable to rename temporary file');
+            }
+
+            $path = $target;
+        }
 
         return $path;
     }

--- a/tests/Model/Metadata/MetadataTest.php
+++ b/tests/Model/Metadata/MetadataTest.php
@@ -86,6 +86,11 @@ final class MetadataTest extends TestCase
             12,
             $sampling,
             [2, 1],
+            'image/heic',
+            987_654,
+            'heic',
+            'abc123',
+            'def456',
         );
 
         self::assertSame($exifBlobs, $metadata->exifBlobs);
@@ -98,6 +103,11 @@ final class MetadataTest extends TestCase
         self::assertSame(12, $metadata->jpegBitsPerSample);
         self::assertSame($sampling, $metadata->jpegFrameSamplingFactors);
         self::assertSame([2, 1], $metadata->jpegYCbCrSubSampling);
+        self::assertSame('image/heic', $metadata->mimeType);
+        self::assertSame(987_654, $metadata->fileSize);
+        self::assertSame('heic', $metadata->extension);
+        self::assertSame('abc123', $metadata->digestSha1);
+        self::assertSame('def456', $metadata->digestMd5);
     }
 
     /**
@@ -116,6 +126,11 @@ final class MetadataTest extends TestCase
         self::assertNull($metadata->jpegBitsPerSample);
         self::assertNull($metadata->jpegFrameSamplingFactors);
         self::assertNull($metadata->jpegYCbCrSubSampling);
+        self::assertNull($metadata->mimeType);
+        self::assertNull($metadata->fileSize);
+        self::assertNull($metadata->extension);
+        self::assertNull($metadata->digestSha1);
+        self::assertNull($metadata->digestMd5);
     }
 
     /**


### PR DESCRIPTION
## Summary
- detect mime type, file size and extension when reading metadata and optionally compute SHA-1/MD5 digests
- expose the collected file attributes on the metadata aggregate and propagate them to the structured File value
- exercise the new behaviour with integration and unit coverage for JPEG ingestion

## Testing
- composer ci:test:php:unit
- composer ci:test:php:phpstan *(fails: pre-existing phpstan warnings in unrelated modules)*

------
https://chatgpt.com/codex/tasks/task_e_68fbd159db488323ac224e4a298f4755