### PR TITLE
fix: harmonise temporal fractional seconds fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ $structured->related->livePhotoPairId;
 | `temporal.original` | EXIF `DateTimeOriginal` + `OffsetTimeOriginal` | XMP `exif:DateTimeOriginal` | `ValueConverters::parseOffset()` |
 | `derived.ev100` | Calculated from exposure values | – | `ValueConverters::calcEv100()` |
 
+### Temporal fractional seconds harmonisation
+
+ImageMeta mirrors fractional seconds from `SubSecTimeOriginal` or `SubSecTimeDigitized` into the generic EXIF `SubSecTime` slot when the latter is missing. This display-only harmonisation keeps `temporal.subSecTime`, `temporal.subSecTimeOriginal` and `temporal.subSecTimeDigitized` aligned without altering the underlying capture timestamps.
+
 ### GPS metadata coverage
 
 ImageMeta normalises every entry from the EXIF 2.32 table 66 GPS IFD. The decoded data is exposed through

--- a/src/Curate/StructuredMetadataBuilder.php
+++ b/src/Curate/StructuredMetadataBuilder.php
@@ -454,6 +454,9 @@ final class StructuredMetadataBuilder
 
     /**
      * Builds the temporal value object derived from EXIF, QuickTime and XMP data.
+     *
+     * Fractional seconds are mirrored into the generic field to keep display values consistent
+     * whenever only the original or digitized timestamp carries sub-second precision.
      */
     private function buildTemporal(ExifTagResolver $resolver, QuickTimeResolver $quickTime, XmpResolver $xmp): Temporal
     {
@@ -483,6 +486,10 @@ final class StructuredMetadataBuilder
         $subSecTime         = $this->sanitizeSubSeconds($resolver->string('SubSecTime'));
         $subSecDigitizedRaw = $this->sanitizeSubSeconds($resolver->string('SubSecTimeDigitized'));
         $subSecOriginal     = $this->sanitizeSubSeconds($subOriginalRaw);
+
+        if ($subSecTime === null) {
+            $subSecTime = $subSecOriginal ?? $subSecDigitizedRaw;
+        }
 
         $timeZoneOffsets = $resolver->ints('TimeZoneOffset');
 

--- a/tests/Curate/StructuredMetadataBuilderTest.php
+++ b/tests/Curate/StructuredMetadataBuilderTest.php
@@ -777,6 +777,47 @@ final class StructuredMetadataBuilderTest extends TestCase
     }
 
     /**
+     * Ensures fractional seconds mirror into the generic field when the original precision is available.
+     */
+    #[Test]
+    public function mirrorsFractionalSecondsFromOriginalIntoGenericField(): void
+    {
+        $exifIfd = new Ifd([
+            ExifTag::SUB_SEC_TIME_ORIGINAL  => new IfdEntry(ExifTag::SUB_SEC_TIME_ORIGINAL, 2, 3, '957'),
+            ExifTag::SUB_SEC_TIME_DIGITIZED => new IfdEntry(ExifTag::SUB_SEC_TIME_DIGITIZED, 2, 3, '957'),
+        ]);
+
+        $exifDocument = new ExifDocument(new Ifd([]), $exifIfd, null, null, null);
+        $metadata     = new Metadata(['primary'], null, $exifDocument);
+
+        $structured = (new StructuredMetadataBuilder())->build($metadata);
+
+        self::assertSame('957', $structured->temporal->subSecTimeOriginal);
+        self::assertSame('957', $structured->temporal->subSecTimeDigitized);
+        self::assertSame('957', $structured->temporal->subSecTime);
+    }
+
+    /**
+     * Ensures fractional seconds mirror into the generic field when only digitized precision is present.
+     */
+    #[Test]
+    public function mirrorsFractionalSecondsFromDigitizedIntoGenericField(): void
+    {
+        $exifIfd = new Ifd([
+            ExifTag::SUB_SEC_TIME_DIGITIZED => new IfdEntry(ExifTag::SUB_SEC_TIME_DIGITIZED, 2, 3, '957'),
+        ]);
+
+        $exifDocument = new ExifDocument(new Ifd([]), $exifIfd, null, null, null);
+        $metadata     = new Metadata(['primary'], null, $exifDocument);
+
+        $structured = (new StructuredMetadataBuilder())->build($metadata);
+
+        self::assertNull($structured->temporal->subSecTimeOriginal);
+        self::assertSame('957', $structured->temporal->subSecTimeDigitized);
+        self::assertSame('957', $structured->temporal->subSecTime);
+    }
+
+    /**
      * Verifies that the color space upgrades to Adobe RGB when tagged as uncalibrated with an R03 interop index.
      */
     #[Test]


### PR DESCRIPTION
## Summary
- mirror fractional seconds from original or digitized EXIF slots into the generic temporal field
- document the display-only sub-second harmonisation in the README and StructuredMetadataBuilder PHPDoc
- add PHPUnit coverage to assert consistent sub-second values across temporal fields

## Testing
- composer ci:test:php:unit

------
https://chatgpt.com/codex/tasks/task_e_68fbd16095088323a93a994f2b2359f7