### PR TITLE
docs: document structured metadata field updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Changelog
+
+## Unreleased
+
+### Added
+- Added `Value\Derived::fovHorizontalDeg` and `Value\Derived::fovVerticalDeg` to expose axis specific angles of view alongside the
+  diagonal `fovDiagonalDeg` helper.
+- Extended `Value\Temporal` with offset tags, a resolved `DateTimeZone` instance and minute level EXIF offsets for reliable
+  capture time reconstruction.
+- Enriched `Value\File` with mime type, file size, extension and SHA-1/MD5 digests so that consumers can correlate assets without
+  re-reading the original payload.
+- Broadened the Apple aggregate with semantic style parameters, colour temperature in Kelvin and Live Photo flags sourced from
+  maker notes and QuickTime metadata.
+- Expanded GPS coverage to include horizontal positioning error and the full destination navigation set from EXIF 2.32 table 66.
+- Introduced dedicated maker note decoders for Apple (`MakerNotes\AppleDecoder`), Canon, Nikon and Sony plus the
+  `Curate\Resolver\AppleResolver` and `Curate\Resolver\MakerNotesResolver` convenience helpers.
+
+### Changed
+- Renamed the diagonal field-of-view helper from `fovDeg` to `fovDiagonalDeg`; consumers should switch to the new property name.
+
+### Removed
+- Dropped the implicit QuickTime video metadata fallback to avoid mixing still-image data with movie track information.
+  Clients that require video track information should rely on the explicit `Video` aggregate.

--- a/README.md
+++ b/README.md
@@ -18,6 +18,14 @@ $structured->temporal->original;
 $structured->keywords->flat;
 $structured->derived->ev100;
 $structured->related->livePhotoPairId;
+$structured->derived->fovDiagonalDeg;     // Diagonal field of view (formerly fovDeg)
+$structured->derived->fovHorizontalDeg;   // Horizontal field of view in degrees
+$structured->derived->fovVerticalDeg;     // Vertical field of view in degrees
+$structured->temporal->tz?->getName();    // Resolved capture time zone source
+$structured->temporal->offsetTimeOriginal;
+$structured->file->fileSize;              // File level metadata (size, digests, extension)
+$structured->apple->flags['livePhotoEnabled'];
+$structured->gps->horizontalPositioningError;
 ```
 
 ### Mapping overview
@@ -68,3 +76,9 @@ $s->standards->exifVersion;         // "3.00"
 ```
 
 The aggregate always instantiates each value object. Consumers therefore never have to deal with tag identifiers or container-specific key names.
+
+The diagonal field of view exposed via `fovDiagonalDeg` corresponds to the value previously documented as `fovDeg`. The new `fovHorizontalDeg` and `fovVerticalDeg` helpers provide axis-specific angles so clients can present per-dimension compositions without additional trigonometry.
+
+The expanded temporal aggregate surfaces raw EXIF offset tags alongside a resolved `DateTimeZone` instance. This makes it possible to reconstruct original capture times even when the offset varies between creation, digitisation and modification steps. File level metadata now reports size, extension and cryptographic digests to help consumers correlate assets or detect tampering.
+
+Apple maker note data now includes semantic style parameters, colour temperature and Live Photo flags from both maker notes and QuickTime metadata. GPS coverage has been widened with horizontal positioning error and full destination navigation metrics from EXIF 2.32 table 66.

--- a/docs/fields.md
+++ b/docs/fields.md
@@ -1,0 +1,32 @@
+# Structured field semantics
+
+This document summarises the physical units attached to selected value objects and explains the
+circle of confusion (CoC) model used by the derived metrics helper.
+
+## Units
+
+* **Metres (m)**
+  * `Derived::hyperfocalM`
+  * `Capture::waterDepthM`
+  * `Gps::altitude`, `Gps::destinationDistanceMetres`, `Gps::horizontalPositioningError`
+* **Kelvin (K)**
+  * `Apple::colorTemperature` reports the device supplied white balance as an absolute colour temperature.
+* **Degrees (°)**
+  * `Derived::fovDiagonalDeg`, `Derived::fovHorizontalDeg`, `Derived::fovVerticalDeg`
+  * `Motion::rollDeg`, `Motion::pitchDeg`, `Motion::yawDeg`
+  * `Capture::cameraElevationAngleDeg`
+  * `Gps::track`, `Gps::imageDirection`, `Gps::destinationBearing`
+* **Metres per second squared (m/s²)**
+  * `Capture::accelerationMs2`
+  * `Motion::accelX`, `Motion::accelY`, `Motion::accelZ`
+
+Unless stated otherwise, temperatures recorded via EXIF tags (for example `Capture::temperatureC`) remain in Celsius.
+Time zone offsets in `Temporal` are expressed as raw EXIF strings and minutes (`timeZoneOffsetMinutes`). GPS speed values
+(`Gps::speedMs`) are normalised to metres per second.
+
+## Circle of confusion model
+
+`ValueConverters::calcCircleOfConfusionMm()` assumes a full-frame reference circle of confusion of 0.029&nbsp;mm. When a crop
+factor is available, the constant is divided by the crop factor to approximate the effective CoC for the captured format. If no
+crop factor can be derived the function keeps the 0.029&nbsp;mm baseline, and it returns `null` whenever an invalid (zero or
+negative) crop factor is encountered. This value feeds into the hyperfocal distance calculator and the three field-of-view helpers.


### PR DESCRIPTION
## Summary
- extend the README with examples for the new field-of-view, temporal, file, Apple and GPS properties
- add a fields reference that records the units used by key value objects and documents the circle of confusion model
- record the API-visible field additions, decoder/resolver introductions and the video fallback removal in the changelog

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68fbd16b236c832384a3066722f4277d