### PR TITLE
Add coverage for optics, GPS resolver, and metadata handling

### DIFF
--- a/tests/Core/ValueConvertersTest.php
+++ b/tests/Core/ValueConvertersTest.php
@@ -17,6 +17,7 @@ use MagicSunday\ImageMeta\Model\Exif\ExifRationalList;
 use MagicSunday\ImageMeta\Value\Enum\FlashMode;
 use MagicSunday\ImageMeta\Value\Enum\FlashReturn;
 use MagicSunday\ImageMeta\Value\Enum\ResolutionUnit;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
@@ -137,5 +138,108 @@ final class ValueConvertersTest extends TestCase
         self::assertEqualsWithDelta(32.179788109672, ValueConverters::calcFovDeg(75, $cropFactor, 50.0), 1e-12);
         self::assertEqualsWithDelta(26.991466561592, ValueConverters::calcHorizontalFovDeg(75, $cropFactor, 50.0), 1e-12);
         self::assertEqualsWithDelta(18.180553841645, ValueConverters::calcVerticalFovDeg(75, $cropFactor, 50.0), 1e-12);
+    }
+
+    #[Test]
+    #[DataProvider('opticalDatasetProvider')]
+    public function calculatesOpticalMetricsAcrossSensorFormats(
+        int $focalLength35mm,
+        float $focalLengthMm,
+        float $fNumber,
+        float $expectedCropFactor,
+        float $expectedCircleOfConfusion,
+        float $expectedHyperfocal,
+        float $expectedFovDiagonal,
+        float $expectedFovHorizontal,
+        float $expectedFovVertical,
+    ): void {
+        $cropFactor = ValueConverters::calcCropFactor($focalLength35mm, $focalLengthMm);
+        self::assertEqualsWithDelta($expectedCropFactor, $cropFactor, 1e-9);
+
+        $circleOfConfusion = ValueConverters::calcCircleOfConfusionMm($cropFactor);
+        self::assertEqualsWithDelta($expectedCircleOfConfusion, $circleOfConfusion, 1e-9);
+
+        $hyperfocal = ValueConverters::calcHyperfocalM($focalLengthMm, $fNumber, $circleOfConfusion);
+        self::assertEqualsWithDelta($expectedHyperfocal, $hyperfocal, 1e-6);
+
+        self::assertEqualsWithDelta(
+            $expectedFovDiagonal,
+            ValueConverters::calcFovDeg($focalLength35mm, $cropFactor, $focalLengthMm),
+            1e-6,
+        );
+        self::assertEqualsWithDelta(
+            $expectedFovHorizontal,
+            ValueConverters::calcHorizontalFovDeg($focalLength35mm, $cropFactor, $focalLengthMm),
+            1e-6,
+        );
+        self::assertEqualsWithDelta(
+            $expectedFovVertical,
+            ValueConverters::calcVerticalFovDeg($focalLength35mm, $cropFactor, $focalLengthMm),
+            1e-6,
+        );
+    }
+
+    /**
+     * @return iterable<string, array{
+     *     focalLength35mm: int,
+     *     focalLengthMm: float,
+     *     fNumber: float,
+     *     expectedCropFactor: float,
+     *     expectedCircleOfConfusion: float,
+     *     expectedHyperfocal: float,
+     *     expectedFovDiagonal: float,
+     *     expectedFovHorizontal: float,
+     *     expectedFovVertical: float,
+     * }>
+     */
+    public static function opticalDatasetProvider(): iterable
+    {
+        yield 'aps-c crop sensor' => [
+            'focalLength35mm' => 75,
+            'focalLengthMm' => 50.0,
+            'fNumber' => 8.0,
+            'expectedCropFactor' => 1.5,
+            'expectedCircleOfConfusion' => 0.019333333333333334,
+            'expectedHyperfocal' => 16.213793103448276,
+            'expectedFovDiagonal' => 32.179788109672,
+            'expectedFovHorizontal' => 26.991466561592,
+            'expectedFovVertical' => 18.180553841645,
+        ];
+
+        yield 'aps-c wide angle' => [
+            'focalLength35mm' => 52,
+            'focalLengthMm' => 35.0,
+            'fNumber' => 5.6,
+            'expectedCropFactor' => 1.4857142857142858,
+            'expectedCircleOfConfusion' => 0.019519230769230768,
+            'expectedHyperfocal' => 11.241896551724139,
+            'expectedFovDiagonal' => 45.17707757599993,
+            'expectedFovHorizontal' => 38.18698400097122,
+            'expectedFovVertical' => 25.989233583833013,
+        ];
+
+        yield 'full frame portrait' => [
+            'focalLength35mm' => 85,
+            'focalLengthMm' => 85.0,
+            'fNumber' => 2.0,
+            'expectedCropFactor' => 1.0,
+            'expectedCircleOfConfusion' => 0.029,
+            'expectedHyperfocal' => 124.65396551724137,
+            'expectedFovDiagonal' => 28.558322254800274,
+            'expectedFovHorizontal' => 23.91316848629826,
+            'expectedFovVertical' => 16.071421421069587,
+        ];
+
+        yield 'micro four thirds normal' => [
+            'focalLength35mm' => 50,
+            'focalLengthMm' => 25.0,
+            'fNumber' => 4.0,
+            'expectedCropFactor' => 2.0,
+            'expectedCircleOfConfusion' => 0.0145,
+            'expectedHyperfocal' => 10.800862068965516,
+            'expectedFovDiagonal' => 46.793003343996574,
+            'expectedFovHorizontal' => 39.59775270904986,
+            'expectedFovVertical' => 26.991466561591626,
+        ];
     }
 }

--- a/tests/Curate/Resolver/GpsResolverTest.php
+++ b/tests/Curate/Resolver/GpsResolverTest.php
@@ -1,0 +1,172 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\ImageMeta\Tests\Curate\Resolver;
+
+use DateTimeImmutable;
+use MagicSunday\ImageMeta\Curate\Resolver\GpsResolver;
+use MagicSunday\ImageMeta\Model\Exif\ExifDocument;
+use MagicSunday\ImageMeta\Model\Exif\ExifRational;
+use MagicSunday\ImageMeta\Model\Exif\ExifRationalList;
+use MagicSunday\ImageMeta\Model\Exif\ExifTag;
+use MagicSunday\ImageMeta\Model\Exif\Ifd;
+use MagicSunday\ImageMeta\Model\Exif\IfdEntry;
+use MagicSunday\ImageMeta\Model\Xmp\XmpDocument;
+use MagicSunday\ImageMeta\Value\Gps;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \MagicSunday\ImageMeta\Curate\Resolver\GpsResolver
+ */
+final class GpsResolverTest extends TestCase
+{
+    #[Test]
+    public function resolvesCompleteGpsDatasetFromExif(): void
+    {
+        $gpsIfd = new Ifd([
+            ExifTag::GPS_VERSION_ID => new IfdEntry(ExifTag::GPS_VERSION_ID, 1, 4, [3, 0, 0, 0]),
+            ExifTag::GPS_LATITUDE_REF => new IfdEntry(ExifTag::GPS_LATITUDE_REF, 2, 2, 'N'),
+            ExifTag::GPS_LATITUDE => new IfdEntry(
+                ExifTag::GPS_LATITUDE,
+                5,
+                3,
+                new ExifRationalList([
+                    new ExifRational(51, 1),
+                    new ExifRational(30, 1),
+                    new ExifRational(0, 1),
+                ]),
+            ),
+            ExifTag::GPS_LONGITUDE_REF => new IfdEntry(ExifTag::GPS_LONGITUDE_REF, 2, 2, 'E'),
+            ExifTag::GPS_LONGITUDE => new IfdEntry(
+                ExifTag::GPS_LONGITUDE,
+                5,
+                3,
+                new ExifRationalList([
+                    new ExifRational(8, 1),
+                    new ExifRational(30, 1),
+                    new ExifRational(0, 1),
+                ]),
+            ),
+            ExifTag::GPS_ALTITUDE_REF => new IfdEntry(ExifTag::GPS_ALTITUDE_REF, 1, 1, 0),
+            ExifTag::GPS_ALTITUDE => new IfdEntry(
+                ExifTag::GPS_ALTITUDE,
+                5,
+                1,
+                new ExifRational(150, 1),
+            ),
+            ExifTag::GPS_TIME_STAMP => new IfdEntry(
+                ExifTag::GPS_TIME_STAMP,
+                5,
+                3,
+                new ExifRationalList([
+                    new ExifRational(12, 1),
+                    new ExifRational(34, 1),
+                    new ExifRational(56789, 1000),
+                ]),
+            ),
+            ExifTag::GPS_DATE_STAMP => new IfdEntry(ExifTag::GPS_DATE_STAMP, 2, 10, '2024:05:06'),
+            ExifTag::GPS_SATELLITES => new IfdEntry(ExifTag::GPS_SATELLITES, 2, 2, '05'),
+            ExifTag::GPS_STATUS => new IfdEntry(ExifTag::GPS_STATUS, 2, 1, 'A'),
+            ExifTag::GPS_MEASURE_MODE => new IfdEntry(ExifTag::GPS_MEASURE_MODE, 2, 1, '3'),
+            ExifTag::GPS_DOP => new IfdEntry(ExifTag::GPS_DOP, 5, 1, new ExifRational(25, 10)),
+            ExifTag::GPS_SPEED_REF => new IfdEntry(ExifTag::GPS_SPEED_REF, 2, 1, 'K'),
+            ExifTag::GPS_SPEED => new IfdEntry(ExifTag::GPS_SPEED, 5, 1, new ExifRational(72000, 1000)),
+            ExifTag::GPS_TRACK_REF => new IfdEntry(ExifTag::GPS_TRACK_REF, 2, 1, 'T'),
+            ExifTag::GPS_TRACK => new IfdEntry(ExifTag::GPS_TRACK, 5, 1, new ExifRational(12345, 100)),
+            ExifTag::GPS_IMG_DIRECTION_REF => new IfdEntry(ExifTag::GPS_IMG_DIRECTION_REF, 2, 1, 'M'),
+            ExifTag::GPS_IMG_DIRECTION => new IfdEntry(ExifTag::GPS_IMG_DIRECTION, 5, 1, new ExifRational(2500, 10)),
+            ExifTag::GPS_MAP_DATUM => new IfdEntry(ExifTag::GPS_MAP_DATUM, 2, 6, 'WGS-84'),
+            ExifTag::GPS_DEST_LATITUDE_REF => new IfdEntry(ExifTag::GPS_DEST_LATITUDE_REF, 2, 1, 'N'),
+            ExifTag::GPS_DEST_LATITUDE => new IfdEntry(
+                ExifTag::GPS_DEST_LATITUDE,
+                5,
+                3,
+                new ExifRationalList([
+                    new ExifRational(41, 1),
+                    new ExifRational(0, 1),
+                    new ExifRational(0, 1),
+                ]),
+            ),
+            ExifTag::GPS_DEST_LONGITUDE_REF => new IfdEntry(ExifTag::GPS_DEST_LONGITUDE_REF, 2, 1, 'E'),
+            ExifTag::GPS_DEST_LONGITUDE => new IfdEntry(
+                ExifTag::GPS_DEST_LONGITUDE,
+                5,
+                3,
+                new ExifRationalList([
+                    new ExifRational(8, 1),
+                    new ExifRational(30, 1),
+                    new ExifRational(0, 1),
+                ]),
+            ),
+            ExifTag::GPS_DEST_BEARING_REF => new IfdEntry(ExifTag::GPS_DEST_BEARING_REF, 2, 1, 'T'),
+            ExifTag::GPS_DEST_BEARING => new IfdEntry(ExifTag::GPS_DEST_BEARING, 5, 1, new ExifRational(123, 1)),
+            ExifTag::GPS_DEST_DISTANCE_REF => new IfdEntry(ExifTag::GPS_DEST_DISTANCE_REF, 2, 1, 'K'),
+            ExifTag::GPS_DEST_DISTANCE => new IfdEntry(ExifTag::GPS_DEST_DISTANCE, 5, 1, new ExifRational(42, 1)),
+            ExifTag::GPS_PROCESSING_METHOD => new IfdEntry(ExifTag::GPS_PROCESSING_METHOD, 7, 11, "ASCII\0\0\0NETWORK"),
+            ExifTag::GPS_AREA_INFORMATION => new IfdEntry(ExifTag::GPS_AREA_INFORMATION, 7, 13, "ASCII\0\0\0AreaName"),
+            ExifTag::GPS_DIFFERENTIAL => new IfdEntry(ExifTag::GPS_DIFFERENTIAL, 3, 1, 2),
+            ExifTag::GPS_H_POSITIONING_ERROR => new IfdEntry(ExifTag::GPS_H_POSITIONING_ERROR, 5, 1, new ExifRational(15, 10)),
+        ]);
+
+        $exifDocument = new ExifDocument(new Ifd([]), null, $gpsIfd, null, null);
+
+        $resolver = new GpsResolver();
+        $gps = $resolver->resolve($exifDocument, null);
+
+        self::assertInstanceOf(Gps::class, $gps);
+        self::assertEqualsWithDelta(51.5, $gps->latitude, 1e-6);
+        self::assertEqualsWithDelta(8.5, $gps->longitude, 1e-6);
+        self::assertSame('N', $gps->latitudeRef);
+        self::assertSame('E', $gps->longitudeRef);
+        self::assertEqualsWithDelta(150.0, $gps->altitude, 1e-6);
+        self::assertSame('05', $gps->satellites);
+        self::assertSame('NETWORK', $gps->processingMethod);
+        self::assertSame('AreaName', $gps->areaInformation);
+        self::assertSame('2024-05-06', $gps->date);
+        self::assertSame('12:34:56.789', $gps->time);
+        self::assertInstanceOf(DateTimeImmutable::class, $gps->timestamp);
+        self::assertSame('2024-05-06T12:34:56+00:00', $gps->timestamp?->format(DATE_ATOM));
+        self::assertEqualsWithDelta(42000.0, $gps->destinationDistanceMetres, 1e-6);
+        self::assertEqualsWithDelta(1.5, $gps->horizontalPositioningError, 1e-6);
+    }
+
+    #[Test]
+    public function fillsMissingFieldsFromXmp(): void
+    {
+        $xmpDocument = new XmpDocument([
+            '{http://ns.adobe.com/exif/1.0/}GPSLatitudeRef' => ['S'],
+            '{http://ns.adobe.com/exif/1.0/}GPSLatitude' => ['51.5'],
+            '{http://ns.adobe.com/exif/1.0/}GPSLongitudeRef' => ['W'],
+            '{http://ns.adobe.com/exif/1.0/}GPSLongitude' => ['8.5'],
+            '{http://ns.adobe.com/exif/1.0/}GPSAltitudeRef' => ['1'],
+            '{http://ns.adobe.com/exif/1.0/}GPSAltitude' => ['120.5'],
+            '{http://ns.adobe.com/exif/1.0/}GPSSpeedRef' => ['K'],
+            '{http://ns.adobe.com/exif/1.0/}GPSSpeed' => ['72'],
+            '{http://ns.adobe.com/exif/1.0/}GPSDateStamp' => ['2024-05-06'],
+            '{http://ns.adobe.com/exif/1.0/}GPSTimeStamp' => ['12:34:56'],
+            '{http://ns.adobe.com/exif/1.0/}GPSDateTime' => ['2024-05-06T12:34:56+02:00'],
+        ]);
+
+        $resolver = new GpsResolver();
+        $gps = $resolver->resolve(null, $xmpDocument);
+
+        self::assertInstanceOf(Gps::class, $gps);
+        self::assertSame('S', $gps->latitudeRef);
+        self::assertEqualsWithDelta(-51.5, $gps->latitude ?? 0.0, 1e-6);
+        self::assertSame('W', $gps->longitudeRef);
+        self::assertEqualsWithDelta(-8.5, $gps->longitude ?? 0.0, 1e-6);
+        self::assertEqualsWithDelta(-120.5, $gps->altitude ?? 0.0, 1e-6);
+        self::assertSame('K', $gps->speedRef);
+        self::assertEqualsWithDelta(20.0, $gps->speedMs ?? 0.0, 1e-6);
+        self::assertSame('2024-05-06T10:34:56+00:00', $gps->timestamp?->format(DATE_ATOM));
+    }
+}

--- a/tests/Curate/Resolver/RegionsResolverTest.php
+++ b/tests/Curate/Resolver/RegionsResolverTest.php
@@ -122,4 +122,62 @@ final class RegionsResolverTest extends TestCase
         self::assertEqualsWithDelta(0.2, $region->w, 0.0001);
         self::assertEqualsWithDelta(0.2, $region->h, 0.0001);
     }
+
+    #[Test]
+    public function mergesSevenFaceRegionsAndFocusAnnotation(): void
+    {
+        $faceCentersX = ['0.10', '0.22', '0.34', '0.46', '0.58', '0.70', '0.82'];
+        $faceCentersY = ['0.15', '0.27', '0.39', '0.51', '0.63', '0.75', '0.87'];
+        $faceWidths   = ['0.12', '0.11', '0.10', '0.09', '0.08', '0.07', '0.06'];
+        $faceHeights  = ['0.14', '0.13', '0.12', '0.11', '0.10', '0.09', '0.08'];
+        $faceNames    = ['Alice', 'Bob', 'Charlie', 'Dora', 'Eve', 'Frank', 'Grace'];
+        $faceIds      = ['1', '2', '3', '4', '5', '6', '7'];
+
+        $mwgTypes = array_fill(0, 7, 'Face');
+        $mwgTypes[] = 'Focus';
+
+        $document = new XmpDocument([
+            '{' . self::NS_ST_AREA . '}x' => [...$faceCentersX, '0.50'],
+            '{' . self::NS_ST_AREA . '}y' => [...$faceCentersY, '0.50'],
+            '{' . self::NS_ST_AREA . '}w' => [...$faceWidths, '0.20'],
+            '{' . self::NS_ST_AREA . '}h' => [...$faceHeights, '0.15'],
+            '{' . self::NS_MWG . '}Type' => $mwgTypes,
+            '{' . self::NS_MWG . '}Name' => [...$faceNames, ''],
+            '{' . self::NS_MWG . '}Confidence' => ['0.95', '0.90', '0.85', '0.80', '0.75', '0.70', '0.65', '0.60'],
+            '{' . self::NS_APPLE . '}CenterX' => $faceCentersX,
+            '{' . self::NS_APPLE . '}CenterY' => $faceCentersY,
+            '{' . self::NS_APPLE . '}Width' => $faceWidths,
+            '{' . self::NS_APPLE . '}Height' => $faceHeights,
+            '{' . self::NS_APPLE . '}Confidence' => ['0.88', '0.86', '0.84', '0.82', '0.80', '0.78', '0.76'],
+            '{' . self::NS_APPLE . '}Roll' => ['1.0', '0.5', '-0.5', '2.0', '-1.5', '0.0', '1.5'],
+            '{' . self::NS_APPLE . '}Name' => $faceNames,
+            '{' . self::NS_APPLE . '}FaceID' => $faceIds,
+        ]);
+
+        $regions = (new RegionsResolver())->resolve($document);
+
+        self::assertCount(8, $regions->items);
+
+        for ($i = 0; $i < 7; ++$i) {
+            $region = $regions->items[$i];
+            self::assertSame(RegionType::FACE, $region->type);
+            self::assertSame($faceNames[$i], $region->personName);
+            self::assertSame($faceIds[$i], $region->faceId);
+            self::assertNotNull($region->confidence);
+            $expectedX = (float) $faceCentersX[$i] - ((float) $faceWidths[$i] / 2.0);
+            $expectedY = (float) $faceCentersY[$i] - ((float) $faceHeights[$i] / 2.0);
+            self::assertEqualsWithDelta($expectedX, $region->x, 0.001);
+            self::assertEqualsWithDelta($expectedY, $region->y, 0.001);
+            self::assertEqualsWithDelta((float) $faceWidths[$i], $region->w, 0.001);
+            self::assertEqualsWithDelta((float) $faceHeights[$i], $region->h, 0.001);
+        }
+
+        $focus = $regions->items[7];
+        self::assertSame(RegionType::FOCUS, $focus->type);
+        self::assertNull($focus->personName);
+        self::assertEqualsWithDelta(0.40, $focus->x, 0.001);
+        self::assertEqualsWithDelta(0.425, $focus->y, 0.001);
+        self::assertEqualsWithDelta(0.20, $focus->w, 0.001);
+        self::assertEqualsWithDelta(0.15, $focus->h, 0.001);
+    }
 }

--- a/tests/Curate/StructuredMetadataBuilderTest.php
+++ b/tests/Curate/StructuredMetadataBuilderTest.php
@@ -672,6 +672,12 @@ final class StructuredMetadataBuilderTest extends TestCase
         self::assertSame(3648, $structured->image->height);
         self::assertNull($structured->video->width);
         self::assertNull($structured->video->height);
+        self::assertNull($structured->video->durationSec);
+        self::assertNull($structured->video->frameRate);
+        self::assertNull($structured->video->codec);
+        self::assertNull($structured->video->hdr);
+        self::assertNull($structured->video->transferFunction);
+        self::assertNull($structured->video->colorPrimaries);
     }
 
     /**
@@ -1068,6 +1074,51 @@ final class StructuredMetadataBuilderTest extends TestCase
         self::assertSame('202', $third->faceId);
         self::assertNotNull($third->rotationDeg);
         self::assertEqualsWithDelta(-5.0, $third->rotationDeg, 0.0001);
+    }
+
+    #[Test]
+    public function usesAppleMakerNotesToPopulateWhiteBalanceDetails(): void
+    {
+        $ifd0 = new Ifd([]);
+        $exifIfd = new Ifd([
+            ExifTag::WHITE_BALANCE => new IfdEntry(ExifTag::WHITE_BALANCE, 3, 1, WhiteBalance::AUTO->value),
+        ]);
+
+        $exifDocument = new ExifDocument($ifd0, $exifIfd, null, null, null);
+
+        $apple = new AppleMakerNotes(
+            'uuid-123',
+            'Tele',
+            2.5,
+            [1.0, 1.1, 1.2],
+            24.0,
+            0.62,
+            3,
+            5200,
+            'Warm',
+            0.15,
+            -0.05,
+            ['hdrEnabled' => true],
+            [0.1, 0.2, 0.3],
+        );
+
+        $makerNotes = new MakerNotesMetadata(
+            'Apple',
+            128,
+            '0123456789abcdef0123456789abcdef01234567',
+            $apple,
+        );
+
+        $metadata = new Metadata(['primary'], null, $exifDocument, [], null, $makerNotes);
+
+        $structured = (new StructuredMetadataBuilder())->build($metadata);
+
+        self::assertSame(WhiteBalance::AUTO, $structured->whiteBalanceDetails->mode);
+        self::assertSame(5200, $structured->whiteBalanceDetails->kelvin);
+        self::assertSame('uuid-123', $structured->apple->contentIdentifier);
+        self::assertSame(5200, $structured->apple->colorTemperature);
+        self::assertArrayHasKey('hdrEnabled', $structured->apple->flags);
+        self::assertTrue($structured->apple->flags['hdrEnabled']);
     }
 
     /**

--- a/tests/MetadataReader/MetadataReaderTest.php
+++ b/tests/MetadataReader/MetadataReaderTest.php
@@ -127,6 +127,28 @@ final class MetadataReaderTest extends TestCase
         self::assertSame([], $metadata->iccSegments);
     }
 
+    #[Test]
+    public function testDeduplicatesXmpPacketsByHash(): void
+    {
+        $xmp = '<x:xmpmeta xmlns:x="adobe:ns:meta/"><rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" /></x:xmpmeta>';
+
+        $jpeg = "\xFF\xD8"
+            . $this->segment(self::MARKER_APP1, self::XMP_SIGNATURE . $xmp)
+            . $this->segment(self::MARKER_APP1, self::XMP_SIGNATURE . $xmp)
+            . "\xFF\xD9";
+
+        $path = $this->writeTempFile($jpeg);
+
+        try {
+            $metadata = (new MetadataReader())->read($path);
+        } finally {
+            @unlink($path);
+        }
+
+        self::assertCount(1, $metadata->xmpBlobs);
+        self::assertSame($xmp, $metadata->xmpBlobs[0]);
+    }
+
     /**
      * Writes the provided binary payload to a temporary file and returns its path.
      *

--- a/tests/Parse/Icc/IccDecoderTest.php
+++ b/tests/Parse/Icc/IccDecoderTest.php
@@ -75,6 +75,41 @@ final class IccDecoderTest extends TestCase
         self::assertNull($decoder->decode(null, [$this->createSegment(1, 2, 'payload')]));
     }
 
+    #[Test]
+    public function testDecodeHandlesOutOfOrderSegments(): void
+    {
+        $profile = IccFixtures::minimalProfile();
+
+        $half = intdiv(strlen($profile) + 1, 2);
+        $segments = [
+            $this->createSegment(2, 2, substr($profile, $half)),
+            $this->createSegment(1, 2, substr($profile, 0, $half)),
+        ];
+
+        $decoder = new IccDecoder();
+        $result  = $decoder->decode(null, $segments);
+
+        self::assertNotNull($result);
+        self::assertSame('Test Profile', $result['description']);
+        self::assertSame('4.2.1', $result['version']);
+    }
+
+    #[Test]
+    public function testDecodeRejectsIncompleteSegmentSequences(): void
+    {
+        $profile = IccFixtures::minimalProfile();
+
+        $third = intdiv(strlen($profile), 3);
+        $segments = [
+            $this->createSegment(1, 3, substr($profile, 0, $third)),
+            $this->createSegment(3, 3, substr($profile, $third * 2)),
+        ];
+
+        $decoder = new IccDecoder();
+
+        self::assertNull($decoder->decode(null, $segments));
+    }
+
     /**
      * @param int    $sequence Sequence index of the ICC fragment.
      * @param int    $count    Total number of ICC fragments.


### PR DESCRIPTION
## Summary
- extend ValueConverters optics tests with multi-format datasets and tolerances
- add GPS resolver coverage for EXIF and XMP sources plus expanded regions merging assertions
- verify Apple maker notes white balance propagation, ICC decoder edge cases, and JPEG XMP hash deduplication

## Testing
- composer ci:test:php:unit

------
https://chatgpt.com/codex/tasks/task_e_68fbd16992e48323a61d866056fadc73