### PR TITLE
fix: resolve phpstan warnings across metadata pipeline

### DIFF
--- a/docs/phpstan-follow-up.md
+++ b/docs/phpstan-follow-up.md
@@ -10,3 +10,47 @@ PHPUNIT
 3. For each failure, implement the necessary fixes in the relevant source or test files while adhering to the repository’s PHP 8.4+ conventions.
 4. Rerun the PHPUnit command until it exits successfully, and document the resolved failures.
 
+
+---
+
+## PHPStan run 2024-07-05
+
+### Core/ValueConverters.php
+- [x] `function.alreadyNarrowedType`: Call to function `is_numeric()` with `float|int` will always evaluate to true at lines 196, 209, and 228.
+- [x] `booleanOr.alwaysFalse`: Result of `||` is always false at lines 196, 209, and 228.
+
+### Curate/Resolver/CompositeResolver.php
+- [x] `argument.type`: Parameter `$candidates` of `CompositeResolver::firstInt()` expects `list<(Closure(): int)|float|int|string|null>`; lists of nullable closures reported at lines 77, 92, and 97.
+
+### Curate/Resolver/ExifTagResolver.php
+- [x] `argument.type`: Parameter `$enumClass` of `ValueConverters::toEnumOrNull()` expects `class-string<BackedEnum>`, string given at line 182.
+- [x] `argument.templateType`: Unable to resolve template type `T` in call to `ValueConverters::toEnumOrNull()` at line 182.
+- [x] `arrayValues.list`: `array_values()` called on an array that is already a list at lines 639, 651, 663, and 861.
+- [x] `nullsafe.neverNull`: Nullsafe property access before `??` operator is unnecessary at lines 631-643.
+
+### Curate/Resolver/RegionsResolver.php
+- [x] `arrayValues.list`: `array_values()` called on an array that is already a list at lines 127 and 188.
+
+### Curate/StructuredMetadataBuilder.php
+- [x] `nullsafe.neverNull`: Nullsafe property access before `??` operator is unnecessary at lines 631-643.
+- [x] `function.alreadyNarrowedType`: `array_is_list()` with `list<float>` always true at line 675.
+
+### MakerNotes/Apple/BinaryPlistDecoder.php
+- [x] `missingType.iterableValue`: Return type lacks iterable value type in `decode()` (line 48), `parseObject()` (line 119), `parseArray()` (line 242), and `parseDictionary()` (line 267).
+- [x] `return.type`: `BinaryPlistDecoder::decode()` should return `array<int|string, array|bool|float|int|string|null>|bool|float|int|string|null` but returns `array|bool|float|int|string|null` at line 77.
+- [x] `identical.alwaysFalse`: Strict comparison `=== false` always false at lines 83, 174, 185, 202, 214, 227, and 353.
+- [x] `cast.useless`: Casting to int something already int at line 116.
+- [x] `offsetAccess.nonOffsetAccessible`: Cannot access offset `1` on `array|false` at lines 180 and 191.
+- [x] `cast.double`: Cannot cast `mixed` to float at lines 180 and 191.
+- [x] `cast.int`: Cannot cast `mixed` to int at line 362 (reported twice).
+
+### MakerNotes/AppleDecoder.php
+- [x] `argument.type`: Parameter `$dictionary` of `AppleDecoder::buildAppleMakerNotes()` expects `array<string, array|bool|float|int|string|null>`, `array<int|string, array|bool|float|int|string|null>` given at line 77.
+- [x] `missingType.iterableValue`: Parameter `$dictionary` lacks iterable value type annotations in `buildAppleMakerNotes()` (line 83), `stringValue()` (line 137), `floatValue()` (line 156), `intValue()` (line 179), `floatList()` (line 204), `extractFlags()` (line 246), and parameter `$value` in `boolValue()` (line 266).
+
+### Parse/Icc/IccDecoder.php
+- [x] `cast.int`: Cannot cast mixed to int at line 355.
+
+### Parse/Xmp/XmpParser.php
+- [x] `arrayValues.list`: `array_values()` called on a list at lines 176 and 186.
+

--- a/src/Core/ValueConverters.php
+++ b/src/Core/ValueConverters.php
@@ -24,7 +24,6 @@ use MagicSunday\ImageMeta\Value\Enum\FlashMode;
 use MagicSunday\ImageMeta\Value\Enum\FlashReturn;
 use MagicSunday\ImageMeta\Value\FlashInfo;
 use Throwable;
-use UnitEnum;
 
 use function array_filter;
 use function array_slice;
@@ -183,7 +182,7 @@ final readonly class ValueConverters
     /**
      * Normalises EXIF subject area representations into a rectangle map.
      *
-     * @param array<int, int|float> $values Subject area values as extracted from metadata.
+     * @param array<int, int|float|string> $values Subject area values as extracted from metadata.
      *
      * @return array{x:?int,y:?int,w:?int,h:?int}|null
      */
@@ -448,7 +447,7 @@ final readonly class ValueConverters
      *
      * @return T|null
      */
-    public static function toEnumOrNull(string $enumClass, int|string|null $raw): ?UnitEnum
+    public static function toEnumOrNull(string $enumClass, int|string|null $raw): ?BackedEnum
     {
         if ($raw === null) {
             return null;
@@ -465,7 +464,10 @@ final readonly class ValueConverters
 
         /** @var class-string<T> $enumClass */
         try {
-            return $enumClass::from($value);
+            /** @var T $resolved */
+            $resolved = $enumClass::from($value);
+
+            return $resolved;
         } catch (Throwable) {
             return null;
         }

--- a/src/Curate/Resolver/CompositeResolver.php
+++ b/src/Curate/Resolver/CompositeResolver.php
@@ -53,7 +53,7 @@ final readonly class CompositeResolver
     /**
      * Selects the first integer value from the candidate list applying numeric normalisation.
      *
-     * @param list<Closure():int|float|string|int|float|string|null|null> $candidates
+     * @param array<int, (Closure(): (int|null))|float|int|string|null> $candidates
      */
     public static function firstInt(array $candidates): ?int
     {

--- a/src/Curate/Resolver/ExifTagResolver.php
+++ b/src/Curate/Resolver/ExifTagResolver.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace MagicSunday\ImageMeta\Curate\Resolver;
 
+use BackedEnum;
 use DateTimeImmutable;
 use MagicSunday\ImageMeta\Core\ValueConverters as CoreValueConverters;
 use MagicSunday\ImageMeta\Model\Exif\ExifDocument;
@@ -43,7 +44,6 @@ use MagicSunday\ImageMeta\Value\Enum\SubjectDistanceRange;
 use MagicSunday\ImageMeta\Value\Enum\WhiteBalance;
 use MagicSunday\ImageMeta\Value\Enum\YCbCrPositioning;
 use MagicSunday\ImageMeta\Value\FlashInfo;
-use UnitEnum;
 
 use function array_map;
 use function array_values;
@@ -175,13 +175,18 @@ final readonly class ExifTagResolver
     /**
      * Returns a backed enum mapped from the requested EXIF tag value.
      */
-    public function enum(string $tag, string $enumClass): ?UnitEnum
+    /**
+     * @template T of BackedEnum
+     *
+     * @param class-string<T> $enumClass
+     *
+     * @return T|null
+     */
+    public function enum(string $tag, string $enumClass): ?BackedEnum
     {
         $value = $this->int($tag);
 
-        $enum = CoreValueConverters::toEnumOrNull($enumClass, $value);
-
-        return $enum instanceof UnitEnum ? $enum : null;
+        return CoreValueConverters::toEnumOrNull($enumClass, $value);
     }
 
     /**
@@ -634,9 +639,7 @@ final readonly class ExifTagResolver
      */
     public function stripOffsets(): ?array
     {
-        $offsets = $this->document?->stripOffsets();
-
-        return $offsets !== null ? array_values($offsets) : null;
+        return $this->document?->stripOffsets();
     }
 
     /**
@@ -646,9 +649,7 @@ final readonly class ExifTagResolver
      */
     public function stripByteCounts(): ?array
     {
-        $counts = $this->document?->stripByteCounts();
-
-        return $counts !== null ? array_values($counts) : null;
+        return $this->document?->stripByteCounts();
     }
 
     /**
@@ -658,9 +659,7 @@ final readonly class ExifTagResolver
      */
     public function transferFunction(): ?array
     {
-        $values = $this->document?->transferFunction();
-
-        return $values !== null ? array_values($values) : null;
+        return $this->document?->transferFunction();
     }
 
     /**
@@ -858,7 +857,7 @@ final readonly class ExifTagResolver
             return null;
         }
 
-        return array_values($values);
+        return $values;
     }
 
     /**

--- a/src/Curate/Resolver/RegionsResolver.php
+++ b/src/Curate/Resolver/RegionsResolver.php
@@ -124,7 +124,7 @@ final readonly class RegionsResolver
             );
         }
 
-        return array_values($resolved);
+        return $resolved;
     }
 
     /**
@@ -185,7 +185,7 @@ final readonly class RegionsResolver
             );
         }
 
-        return array_values($resolved);
+        return $resolved;
     }
 
     /**

--- a/src/Curate/StructuredMetadataBuilder.php
+++ b/src/Curate/StructuredMetadataBuilder.php
@@ -64,7 +64,6 @@ use MagicSunday\ImageMeta\Value\WhiteBalanceDetails;
 use MagicSunday\ImageMeta\Value\Xmp;
 
 use function array_key_exists;
-use function array_is_list;
 use function is_numeric;
 use function preg_split;
 use function strtoupper;
@@ -628,19 +627,62 @@ final class StructuredMetadataBuilder
         QuickTimeResolver $quickTimeResolver,
         ?QuickTimeMeta $quickTimeMeta,
     ): Apple {
-        $contentIdentifier = $makerNotes?->contentIdentifier ?? $quickTimeMeta?->contentIdentifier();
-        $cameraType        = $makerNotes?->cameraType ?? $this->quickTimeString($quickTimeResolver, 'CameraType');
-        $hdrHeadroom       = $makerNotes?->hdrHeadroom ?? $this->quickTimeFloat($quickTimeResolver, 'HdrHeadroom', 'HDRHeadroom');
-        $hdrGain           = $makerNotes?->hdrGain ?? $this->quickTimeFloatList($quickTimeResolver, 'HdrGain', 'HDRGain');
-        $snr               = $makerNotes?->snr ?? $this->quickTimeFloat($quickTimeResolver, 'SNRSetting', 'SNR');
-        $focusPosition     = $makerNotes?->focusPosition ?? $this->quickTimeFloat($quickTimeResolver, 'FocusPosition');
-        $livePhotoIndex    = $makerNotes?->livePhotoIndex ?? $this->quickTimeInt($quickTimeResolver, 'LivePhotoVideoIndex');
-        $colorTemperature  = $makerNotes?->colorTemperature ?? $this->quickTimeInt($quickTimeResolver, 'ColorTemperature');
-        $semanticPreset    = $makerNotes?->semanticStylePreset ?? $this->quickTimeString($quickTimeResolver, 'SemanticStylePreset');
-        $semanticWarmth    = $makerNotes?->semanticStyleWarmth ?? $this->quickTimeFloat($quickTimeResolver, 'SemanticStyleWarmth');
-        $semanticTone      = $makerNotes?->semanticStyleTone ?? $this->quickTimeFloat($quickTimeResolver, 'SemanticStyleTone');
+        $contentIdentifier = $makerNotes?->contentIdentifier;
+        if ($contentIdentifier === null) {
+            $contentIdentifier = $quickTimeMeta?->contentIdentifier();
+        }
 
-        $flags         = $makerNotes?->flags ?? [];
+        $cameraType = $makerNotes?->cameraType;
+        if ($cameraType === null) {
+            $cameraType = $this->quickTimeString($quickTimeResolver, 'CameraType');
+        }
+
+        $hdrHeadroom = $makerNotes?->hdrHeadroom;
+        if ($hdrHeadroom === null) {
+            $hdrHeadroom = $this->quickTimeFloat($quickTimeResolver, 'HdrHeadroom', 'HDRHeadroom');
+        }
+
+        $hdrGain = $makerNotes?->hdrGain;
+        if ($hdrGain === null) {
+            $hdrGain = $this->quickTimeFloatList($quickTimeResolver, 'HdrGain', 'HDRGain');
+        }
+
+        $snr = $makerNotes?->snr;
+        if ($snr === null) {
+            $snr = $this->quickTimeFloat($quickTimeResolver, 'SNRSetting', 'SNR');
+        }
+
+        $focusPosition = $makerNotes?->focusPosition;
+        if ($focusPosition === null) {
+            $focusPosition = $this->quickTimeFloat($quickTimeResolver, 'FocusPosition');
+        }
+
+        $livePhotoIndex = $makerNotes?->livePhotoIndex;
+        if ($livePhotoIndex === null) {
+            $livePhotoIndex = $this->quickTimeInt($quickTimeResolver, 'LivePhotoVideoIndex');
+        }
+
+        $colorTemperature = $makerNotes?->colorTemperature;
+        if ($colorTemperature === null) {
+            $colorTemperature = $this->quickTimeInt($quickTimeResolver, 'ColorTemperature');
+        }
+
+        $semanticPreset = $makerNotes?->semanticStylePreset;
+        if ($semanticPreset === null) {
+            $semanticPreset = $this->quickTimeString($quickTimeResolver, 'SemanticStylePreset');
+        }
+
+        $semanticWarmth = $makerNotes?->semanticStyleWarmth;
+        if ($semanticWarmth === null) {
+            $semanticWarmth = $this->quickTimeFloat($quickTimeResolver, 'SemanticStyleWarmth');
+        }
+
+        $semanticTone = $makerNotes?->semanticStyleTone;
+        if ($semanticTone === null) {
+            $semanticTone = $this->quickTimeFloat($quickTimeResolver, 'SemanticStyleTone');
+        }
+
+        $flags = $makerNotes !== null ? $makerNotes->flags : [];
         $quickTimeFlags = $this->quickTimeFlags($quickTimeResolver);
         foreach ($quickTimeFlags as $key => $value) {
             if (!array_key_exists($key, $flags)) {
@@ -672,7 +714,7 @@ final class StructuredMetadataBuilder
         $accelY = null;
         $accelZ = null;
 
-        if ($vector !== null && array_is_list($vector)) {
+        if (is_array($vector)) {
             $accelX = $vector[0] ?? null;
             $accelY = $vector[1] ?? null;
             $accelZ = $vector[2] ?? null;

--- a/src/MakerNotes/Apple/BinaryPlistDecoder.php
+++ b/src/MakerNotes/Apple/BinaryPlistDecoder.php
@@ -15,6 +15,8 @@ use MagicSunday\ImageMeta\Core\ParseError;
 
 use function array_key_exists;
 use function iconv;
+use function is_array;
+use function is_float;
 use function is_int;
 use function is_string;
 use function ord;
@@ -43,7 +45,7 @@ final class BinaryPlistDecoder
     /**
      * Decodes the supplied binary property list and returns the top level value.
      *
-     * @return array<int, string|int|float|bool|array|null>|array<string, string|int|float|bool|array|null>|string|int|float|bool|null
+     * @return array<int|string, array<int|string, mixed>|bool|float|int|string|null>|bool|float|int|string|null
      */
     public function decode(string $data): array|string|int|float|bool|null
     {
@@ -80,7 +82,7 @@ final class BinaryPlistDecoder
     private function decodeTrailer(): void
     {
         $trailer = substr($this->data, -32);
-        if ($trailer === false || strlen($trailer) !== 32) {
+        if (strlen($trailer) !== 32) {
             throw new ParseError('Invalid property list trailer.');
         }
 
@@ -113,9 +115,12 @@ final class BinaryPlistDecoder
         }
 
         $this->offsetTable   = $entries;
-        $this->topObjectIndex = (int) $topObject;
+        $this->topObjectIndex = $topObject;
     }
 
+    /**
+     * @return array<int|string, array<int|string, mixed>|bool|float|int|string|null>|bool|float|int|string|null
+     */
     private function parseObject(int $index): array|string|int|float|bool|null
     {
         if (!array_key_exists($index, $this->offsetTable)) {
@@ -171,24 +176,40 @@ final class BinaryPlistDecoder
         $size = 1 << $info;
         if ($size === 4) {
             $bytes = substr($this->data, $offset + 1, 4);
-            if ($bytes === false || strlen($bytes) !== 4) {
+            if (strlen($bytes) !== 4) {
                 throw new ParseError('Incomplete real payload.');
             }
 
-            $value = unpack('G', $bytes);
+            $value = unpack('Gfloat', $bytes);
+            if (!is_array($value) || !array_key_exists('float', $value)) {
+                throw new ParseError('Failed to decode floating point value.');
+            }
 
-            return (float) $value[1];
+            $float = $value['float'];
+            if (!is_float($float) && !is_int($float)) {
+                throw new ParseError('Failed to decode floating point value.');
+            }
+
+            return (float) $float;
         }
 
         if ($size === 8) {
             $bytes = substr($this->data, $offset + 1, 8);
-            if ($bytes === false || strlen($bytes) !== 8) {
+            if (strlen($bytes) !== 8) {
                 throw new ParseError('Incomplete double payload.');
             }
 
-            $value = unpack('E', $bytes);
+            $value = unpack('Efloat', $bytes);
+            if (!is_array($value) || !array_key_exists('float', $value)) {
+                throw new ParseError('Failed to decode floating point value.');
+            }
 
-            return (float) $value[1];
+            $float = $value['float'];
+            if (!is_float($float) && !is_int($float)) {
+                throw new ParseError('Failed to decode floating point value.');
+            }
+
+            return (float) $float;
         }
 
         throw new ParseError('Unsupported floating point width.');
@@ -199,7 +220,7 @@ final class BinaryPlistDecoder
         [$size, $header] = $this->readLength($offset, $info);
 
         $payload = substr($this->data, $offset + $header, $size);
-        if ($payload === false || strlen($payload) !== $size) {
+        if (strlen($payload) !== $size) {
             throw new ParseError('Incomplete data payload.');
         }
 
@@ -211,7 +232,7 @@ final class BinaryPlistDecoder
         [$size, $header] = $this->readLength($offset, $info);
 
         $payload = substr($this->data, $offset + $header, $size);
-        if ($payload === false || strlen($payload) !== $size) {
+        if (strlen($payload) !== $size) {
             throw new ParseError('Incomplete ASCII string payload.');
         }
 
@@ -224,7 +245,7 @@ final class BinaryPlistDecoder
 
         $byteLength = $size * 2;
         $payload    = substr($this->data, $offset + $header, $byteLength);
-        if ($payload === false || strlen($payload) !== $byteLength) {
+        if (strlen($payload) !== $byteLength) {
             throw new ParseError('Incomplete Unicode string payload.');
         }
 
@@ -237,7 +258,7 @@ final class BinaryPlistDecoder
     }
 
     /**
-     * @return array<int, string|int|float|bool|array|null>
+     * @return list<array<int|string, mixed>|bool|float|int|string|null>
      */
     private function parseArray(int $offset, int $info): array
     {
@@ -262,7 +283,7 @@ final class BinaryPlistDecoder
     }
 
     /**
-     * @return array<string, string|int|float|bool|array|null>
+     * @return array<string, array<int|string, mixed>|bool|float|int|string|null>
      */
     private function parseDictionary(int $offset, int $info): array
     {
@@ -350,15 +371,22 @@ final class BinaryPlistDecoder
     private function readUint64(string $data, int $offset): int
     {
         $slice = substr($data, $offset, 8);
-        if ($slice === false || strlen($slice) !== 8) {
+        if (strlen($slice) !== 8) {
             throw new ParseError('Failed to read 64-bit integer.');
         }
 
         $parts = unpack('Nhigh/Nlow', $slice);
-        if ($parts === false) {
+        if (!is_array($parts) || !array_key_exists('high', $parts) || !array_key_exists('low', $parts)) {
             throw new ParseError('Failed to unpack 64-bit integer.');
         }
 
-        return ((int) $parts['high'] << 32) | (int) $parts['low'];
+        $rawHigh = $parts['high'];
+        $rawLow  = $parts['low'];
+
+        if (!is_int($rawHigh) || !is_int($rawLow)) {
+            throw new ParseError('Unexpected 64-bit integer components.');
+        }
+
+        return ($rawHigh << 32) | $rawLow;
     }
 }

--- a/src/MakerNotes/AppleDecoder.php
+++ b/src/MakerNotes/AppleDecoder.php
@@ -78,7 +78,8 @@ final class AppleDecoder implements MakerNotesDecoderInterface
     }
 
     /**
-     * @param array<string, string|int|float|bool|array|null> $dictionary
+     * @param array<int|string, array<int|string, mixed>|bool|float|int|string|null> $dictionary
+     * @phpstan-param array<int|string, array<int|string, mixed>|bool|float|int|string|null> $dictionary
      */
     private function buildAppleMakerNotes(array $dictionary): ?AppleMakerNotes
     {
@@ -132,7 +133,8 @@ final class AppleDecoder implements MakerNotesDecoderInterface
     }
 
     /**
-     * @param array<string, string|int|float|bool|array|null> $dictionary
+     * @param array<int|string, array<int|string, mixed>|bool|float|int|string|null> $dictionary
+     * @phpstan-param array<int|string, array<int|string, mixed>|bool|float|int|string|null> $dictionary
      */
     private function stringValue(array $dictionary, string $key): ?string
     {
@@ -151,7 +153,8 @@ final class AppleDecoder implements MakerNotesDecoderInterface
     }
 
     /**
-     * @param array<string, string|int|float|bool|array|null> $dictionary
+     * @param array<int|string, array<int|string, mixed>|bool|float|int|string|null> $dictionary
+     * @phpstan-param array<int|string, array<int|string, mixed>|bool|float|int|string|null> $dictionary
      */
     private function floatValue(array $dictionary, string ...$keys): ?float
     {
@@ -174,7 +177,8 @@ final class AppleDecoder implements MakerNotesDecoderInterface
     }
 
     /**
-     * @param array<string, string|int|float|bool|array|null> $dictionary
+     * @param array<int|string, array<int|string, mixed>|bool|float|int|string|null> $dictionary
+     * @phpstan-param array<int|string, array<int|string, mixed>|bool|float|int|string|null> $dictionary
      */
     private function intValue(array $dictionary, string ...$keys): ?int
     {
@@ -197,7 +201,8 @@ final class AppleDecoder implements MakerNotesDecoderInterface
     }
 
     /**
-     * @param array<string, string|int|float|bool|array|null> $dictionary
+     * @param array<int|string, array<int|string, mixed>|bool|float|int|string|null> $dictionary
+     * @phpstan-param array<int|string, array<int|string, mixed>|bool|float|int|string|null> $dictionary
      *
      * @return list<float>|null
      */
@@ -239,7 +244,8 @@ final class AppleDecoder implements MakerNotesDecoderInterface
     }
 
     /**
-     * @param array<string, string|int|float|bool|array|null> $dictionary
+     * @param array<int|string, array<int|string, mixed>|bool|float|int|string|null> $dictionary
+     * @phpstan-param array<int|string, array<int|string, mixed>|bool|float|int|string|null> $dictionary
      *
      * @return array<string, bool>
      */
@@ -263,6 +269,10 @@ final class AppleDecoder implements MakerNotesDecoderInterface
         return $flags;
     }
 
+    /**
+     * @param string|int|float|bool|null|array<int|string, mixed> $value
+     * @phpstan-param string|int|float|bool|null|array<int|string, mixed> $value
+     */
     private function boolValue(string|int|float|bool|null|array $value): ?bool
     {
         if (is_bool($value)) {

--- a/src/Parse/Icc/IccDecoder.php
+++ b/src/Parse/Icc/IccDecoder.php
@@ -11,11 +11,14 @@ declare(strict_types=1);
 
 namespace MagicSunday\ImageMeta\Parse\Icc;
 
+use MagicSunday\ImageMeta\Core\ParseError;
 use function array_key_exists;
 use function bin2hex;
 use function class_exists;
 use function function_exists;
 use function iconv;
+use function is_array;
+use function is_int;
 use function mb_convert_encoding;
 use function min;
 use function ord;
@@ -351,7 +354,15 @@ final class IccDecoder
         $bytes = substr($bytes . "\0\0\0\0", 0, 4);
 
         $unpacked = unpack('Nvalue', $bytes);
+        if (!is_array($unpacked) || !array_key_exists('value', $unpacked)) {
+            return 0;
+        }
 
-        return isset($unpacked['value']) ? (int) $unpacked['value'] : 0;
+        $value = $unpacked['value'];
+        if (!is_int($value)) {
+            throw new ParseError('Unexpected integer value while decoding ICC profile.');
+        }
+
+        return $value;
     }
 }

--- a/src/Parse/Xmp/XmpParser.php
+++ b/src/Parse/Xmp/XmpParser.php
@@ -14,10 +14,8 @@ namespace MagicSunday\ImageMeta\Parse\Xmp;
 use MagicSunday\ImageMeta\Model\Xmp\XmpDocument;
 use XMLReader;
 
-use function array_filter;
 use function array_key_exists;
 use function array_merge;
-use function array_values;
 use function is_array;
 use function sprintf;
 use function trim;
@@ -145,9 +143,15 @@ final class XmpParser
      */
     private function finalizeValue(array $items, string $text): array|string|null
     {
-        $items = array_values(array_filter($items, static fn (string $value): bool => $value !== ''));
-        if ($items !== []) {
-            return $items;
+        $filtered = [];
+        foreach ($items as $value) {
+            if ($value !== '') {
+                $filtered[] = $value;
+            }
+        }
+
+        if ($filtered !== []) {
+            return $filtered;
         }
 
         $text = trim($text);
@@ -173,17 +177,17 @@ final class XmpParser
 
         if (is_array($existing)) {
             if (is_array($value)) {
-                $data[$key] = array_values([...$existing, ...$value]);
+                $data[$key] = [...$existing, ...$value];
             } else {
                 $existing[] = $value;
-                $data[$key] = array_values($existing);
+                $data[$key] = $existing;
             }
 
             return;
         }
 
         if (is_array($value)) {
-            $data[$key] = array_values(array_merge([$existing], $value));
+            $data[$key] = [$existing, ...$value];
 
             return;
         }


### PR DESCRIPTION
## Summary
- document the resolved PHPStan findings from the latest analysis run
- relax subject area handling and enum conversion to remove redundant guards
- align Apple metadata decoders and XMP helpers with precise typing

## Testing
- composer ci:test:php:phpstan

------
https://chatgpt.com/codex/tasks/task_e_68fbd6602dd88323aecd70ab9316d404