### PR TITLE
fix: handle binary plist signature offsets

### DIFF
--- a/src/MakerNotes/Apple/BinaryPlistDecoder.php
+++ b/src/MakerNotes/Apple/BinaryPlistDecoder.php
@@ -20,7 +20,7 @@ use function is_float;
 use function is_int;
 use function is_string;
 use function ord;
-use function str_starts_with;
+use function strpos;
 use function strlen;
 use function substr;
 
@@ -53,9 +53,12 @@ final class BinaryPlistDecoder
             throw new ParseError('The property list data must not be empty.');
         }
 
-        if (!str_starts_with($data, 'bplist00')) {
+        $signatureOffset = strpos($data, 'bplist00');
+        if ($signatureOffset === false) {
             throw new ParseError('Unsupported property list format.');
         }
+
+        $data = substr($data, $signatureOffset);
 
         if (strlen($data) < 40) {
             throw new ParseError('The property list payload is too small.');


### PR DESCRIPTION
## Summary
- allow the Apple binary plist decoder to locate the plist signature within the payload
- throw a ParseError when the signature is absent and continue decoding from the discovered offset

## Testing
- composer ci:test:php:unit

------
https://chatgpt.com/codex/tasks/task_e_68fbe467442083238294b2608f3802e0