### PR TITLE
fix: normalise apple hdr gain scalar values

### DIFF
--- a/src/MakerNotes/AppleDecoder.php
+++ b/src/MakerNotes/AppleDecoder.php
@@ -225,6 +225,18 @@ final class AppleDecoder implements MakerNotesDecoderInterface
             }
 
             $value = $dictionary[$key];
+            if (is_float($value)) {
+                return [$value];
+            }
+
+            if (is_int($value)) {
+                return [(float) $value];
+            }
+
+            if (is_string($value) && is_numeric($value)) {
+                return [(float) $value];
+            }
+
             if (!is_array($value)) {
                 continue;
             }

--- a/tests/MakerNotes/Apple/AppleDecoderFloatListTest.php
+++ b/tests/MakerNotes/Apple/AppleDecoderFloatListTest.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\ImageMeta\Tests\MakerNotes\Apple;
+
+use MagicSunday\ImageMeta\MakerNotes\AppleDecoder;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
+
+/**
+ * @covers \MagicSunday\ImageMeta\MakerNotes\AppleDecoder
+ */
+final class AppleDecoderFloatListTest extends TestCase
+{
+    /**
+     * Ensures scalar HDR gain values are normalised to single element lists.
+     */
+    #[Test]
+    public function floatListReturnsScalarValuesAsLists(): void
+    {
+        $decoder = new AppleDecoder();
+        $method  = new ReflectionMethod(AppleDecoder::class, 'floatList');
+        $method->setAccessible(true);
+
+        $result = $method->invoke($decoder, ['HdrGain' => 1.25], 'HdrGain');
+
+        self::assertSame([1.25], $result);
+    }
+
+    /**
+     * Ensures list HDR gain payloads keep their existing normalisation.
+     */
+    #[Test]
+    public function floatListNormalisesArrayPayloads(): void
+    {
+        $decoder = new AppleDecoder();
+        $method  = new ReflectionMethod(AppleDecoder::class, 'floatList');
+        $method->setAccessible(true);
+
+        $dictionary = [
+            'HdrGain' => [
+                'values' => [1, '2.5', 3.75],
+            ],
+        ];
+
+        $result = $method->invoke($decoder, $dictionary, 'HdrGain');
+
+        self::assertSame([1.0, 2.5, 3.75], $result);
+    }
+}


### PR DESCRIPTION
## Summary
- normalise scalar HDR gain maker note values to single element lists before processing arrays
- add unit coverage for scalar and array HDR gain payloads via the Apple decoder helper

## Testing
- composer ci:test:php:unit

------
https://chatgpt.com/codex/tasks/task_e_68fbe46e183083238327f340b26708fa