### PR TITLE
feat: extend Apple FaceInfo roll parsing

### DIFF
--- a/src/Curate/Resolver/RegionsResolver.php
+++ b/src/Curate/Resolver/RegionsResolver.php
@@ -151,11 +151,11 @@ final readonly class RegionsResolver
         $centersY    = $this->floatValues($document, self::NS_APPLE_FACEINFO, 'CenterY');
         $widths      = $this->floatValues($document, self::NS_APPLE_FACEINFO, 'Width');
         $heights     = $this->floatValues($document, self::NS_APPLE_FACEINFO, 'Height');
-        $confidences = $this->floatValues($document, self::NS_APPLE_FACEINFO, 'Confidence');
-        $rolls       = $this->floatValues($document, self::NS_APPLE_FACEINFO, 'Roll');
-        if ($rolls === []) {
-            $rolls = $this->floatValues($document, self::NS_APPLE_FACEINFO, 'Yaw');
-        }
+        $confidenceLevels = $this->floatValues($document, self::NS_APPLE_FACEINFO, 'ConfidenceLevel');
+        $confidences       = $this->floatValues($document, self::NS_APPLE_FACEINFO, 'Confidence');
+        $angleInfoRolls    = $this->floatValues($document, self::NS_APPLE_FACEINFO, 'AngleInfoRoll');
+        $rolls             = $this->floatValues($document, self::NS_APPLE_FACEINFO, 'Roll');
+        $yaws              = $this->floatValues($document, self::NS_APPLE_FACEINFO, 'Yaw');
 
         $names = $this->stringValues($document, self::NS_APPLE_FACEINFO, 'Name');
         if ($names === []) {
@@ -196,6 +196,9 @@ final readonly class RegionsResolver
                 continue;
             }
 
+            $confidence = $confidenceLevels[$index] ?? $confidences[$index] ?? null;
+            $rotation   = $angleInfoRolls[$index] ?? $rolls[$index] ?? $yaws[$index] ?? null;
+
             $resolved[] = new Region(
                 RegionType::FACE,
                 $normalised['x'],
@@ -203,8 +206,8 @@ final readonly class RegionsResolver
                 $normalised['w'],
                 $normalised['h'],
                 $this->stringAt($names, $index),
-                $confidences[$index] ?? null,
-                $rolls[$index] ?? null,
+                $confidence,
+                $rotation,
                 $this->stringAt($faceIds, $index),
             );
         }

--- a/tests/Curate/Resolver/RegionsResolverTest.php
+++ b/tests/Curate/Resolver/RegionsResolverTest.php
@@ -46,10 +46,10 @@ final class RegionsResolverTest extends TestCase
             '{' . self::NS_APPLE . '}CenterY'    => ['0.45', '0.61'],
             '{' . self::NS_APPLE . '}Width'      => ['0.2', '0.12'],
             '{' . self::NS_APPLE . '}Height'     => ['0.25', '0.09'],
-            '{' . self::NS_APPLE . '}Confidence' => ['0.88', '0.42'],
-            '{' . self::NS_APPLE . '}Roll'       => ['2.0', '-5.0'],
-            '{' . self::NS_APPLE . '}Name'       => ['Alice', 'Bob'],
-            '{' . self::NS_APPLE . '}FaceID'     => ['101', '202'],
+            '{' . self::NS_APPLE . '}ConfidenceLevel' => ['0.88', '0.42'],
+            '{' . self::NS_APPLE . '}AngleInfoRoll'  => ['2.0', '-5.0'],
+            '{' . self::NS_APPLE . '}Name'            => ['Alice', 'Bob'],
+            '{' . self::NS_APPLE . '}FaceID'          => ['101', '202'],
         ]);
 
         $resolver = new RegionsResolver();
@@ -180,4 +180,37 @@ final class RegionsResolverTest extends TestCase
         self::assertEqualsWithDelta(0.20, $focus->w, 0.001);
         self::assertEqualsWithDelta(0.15, $focus->h, 0.001);
     }
+
+    #[Test]
+    public function fallsBackToYawWhenNoAngleInfoRollOrRoll(): void
+    {
+        $document = new XmpDocument([
+            '{' . self::NS_APPLE . '}CenterX'    => ['0.5'],
+            '{' . self::NS_APPLE . '}CenterY'    => ['0.55'],
+            '{' . self::NS_APPLE . '}Width'      => ['0.2'],
+            '{' . self::NS_APPLE . '}Height'     => ['0.3'],
+            '{' . self::NS_APPLE . '}Confidence' => ['0.77'],
+            '{' . self::NS_APPLE . '}Yaw'        => ['-3.5'],
+            '{' . self::NS_APPLE . '}Name'       => ['Yawy'],
+            '{' . self::NS_APPLE . '}FaceUUID'   => ['abc-123'],
+        ]);
+
+        $regions = (new RegionsResolver())->resolve($document);
+
+        self::assertCount(1, $regions->items);
+        $region = $regions->items[0];
+
+        self::assertSame(RegionType::FACE, $region->type);
+        self::assertEqualsWithDelta(0.4, $region->x, 0.0001);
+        self::assertEqualsWithDelta(0.4, $region->y, 0.0001);
+        self::assertEqualsWithDelta(0.2, $region->w, 0.0001);
+        self::assertEqualsWithDelta(0.3, $region->h, 0.0001);
+        self::assertSame('Yawy', $region->personName);
+        self::assertNotNull($region->confidence);
+        self::assertEqualsWithDelta(0.77, $region->confidence, 0.0001);
+        self::assertNotNull($region->rotationDeg);
+        self::assertEqualsWithDelta(-3.5, $region->rotationDeg, 0.0001);
+        self::assertSame('abc-123', $region->faceId);
+    }
+
 }


### PR DESCRIPTION
## Summary
- prefer Apple FaceInfo AngleInfoRoll and ConfidenceLevel entries when building face regions
- maintain roll and yaw fallbacks while covering the new key variants with resolver tests

## Testing
- composer ci:test:php:unit

------
https://chatgpt.com/codex/tasks/task_e_68fbe473e0708323b7188619e7060cc6