### PR TITLE
feat(curate): infer HDR scene from Apple maker notes

### DIFF
--- a/src/Curate/StructuredMetadataBuilder.php
+++ b/src/Curate/StructuredMetadataBuilder.php
@@ -308,6 +308,7 @@ final class StructuredMetadataBuilder
         $scene = $this->buildScene(
             $exifResolver,
             $quickTimeResolver,
+            $apple,
             $this->countFaceRegions($regions),
         );
 
@@ -606,17 +607,37 @@ final class StructuredMetadataBuilder
     /**
      * Builds the scene value object incorporating EXIF and container hints.
      */
-    private function buildScene(ExifTagResolver $exif, QuickTimeResolver $quickTime, ?int $faceCount): Scene
+    private function buildScene(
+        ExifTagResolver $exif,
+        QuickTimeResolver $quickTime,
+        Apple $apple,
+        ?int $faceCount,
+    ): Scene
     {
         $hdr   = $quickTime->string('HDRImageType');
         $night = $quickTime->bool('NightMode');
+
+        $hdrScene = null;
+        if ($hdr !== null) {
+            $hdrScene = true;
+        } else {
+            $hdrHeadroom = $apple->hdrHeadroom;
+            if ($hdrHeadroom !== null && $hdrHeadroom > 0.0) {
+                $hdrScene = true;
+            } else {
+                $flags = $apple->flags;
+                if (($flags['hdrEnabled'] ?? false) || ($flags['hdrAuto'] ?? false)) {
+                    $hdrScene = true;
+                }
+            }
+        }
 
         return new Scene(
             type: $exif->sceneCaptureType(),
             sceneType: $exif->sceneType()?->value,
             light: $exif->lightSource(),
             faceCount: $faceCount,
-            hdrScene: $hdr !== null ? true : null,
+            hdrScene: $hdrScene,
             nightMode: $night,
             subjectDistanceRange: $exif->subjectDistanceRange(),
         );

--- a/tests/Curate/StructuredMetadataBuilderTest.php
+++ b/tests/Curate/StructuredMetadataBuilderTest.php
@@ -503,6 +503,63 @@ final class StructuredMetadataBuilderTest extends TestCase
     }
 
     /**
+     * Ensures HDR scene detection falls back to maker note hints when QuickTime metadata is silent.
+     */
+    #[Test]
+    public function infersHdrSceneFromAppleMakerNotes(): void
+    {
+        $makerNotesWithHeadroom = new AppleMakerNotes(
+            contentIdentifier: null,
+            cameraType: null,
+            hdrHeadroom: 1.5,
+            hdrGain: null,
+            snr: null,
+            focusPosition: null,
+            livePhotoIndex: null,
+            colorTemperature: null,
+            semanticStylePreset: null,
+            semanticStyleWarmth: null,
+            semanticStyleTone: null,
+            flags: [],
+            accelerationVector: null,
+        );
+
+        $makerNotes = new MakerNotesMetadata('Apple', 32, str_repeat('a', 40), $makerNotesWithHeadroom);
+
+        $exifDocument = new ExifDocument(new Ifd([]), null, null, null, null, $makerNotes);
+        $metadata     = new Metadata(['primary'], new QuickTimeMeta([]), $exifDocument, [], null, $makerNotes);
+
+        $structured = (new StructuredMetadataBuilder())->build($metadata);
+
+        self::assertTrue($structured->scene->hdrScene);
+
+        $makerNotesWithFlags = new AppleMakerNotes(
+            contentIdentifier: null,
+            cameraType: null,
+            hdrHeadroom: null,
+            hdrGain: null,
+            snr: null,
+            focusPosition: null,
+            livePhotoIndex: null,
+            colorTemperature: null,
+            semanticStylePreset: null,
+            semanticStyleWarmth: null,
+            semanticStyleTone: null,
+            flags: ['hdrEnabled' => true],
+            accelerationVector: null,
+        );
+
+        $makerNotesFlags = new MakerNotesMetadata('Apple', 16, str_repeat('b', 40), $makerNotesWithFlags);
+
+        $exifDocumentFlags = new ExifDocument(new Ifd([]), null, null, null, null, $makerNotesFlags);
+        $metadataFlags     = new Metadata(['primary'], new QuickTimeMeta([]), $exifDocumentFlags, [], null, $makerNotesFlags);
+
+        $structuredFlags = (new StructuredMetadataBuilder())->build($metadataFlags);
+
+        self::assertTrue($structuredFlags->scene->hdrScene);
+    }
+
+    /**
      * Ensures EXIF 2.2 markers derive the legacy profile identifier.
      */
     #[Test]


### PR DESCRIPTION
## Summary
- derive the scene HDR flag from Apple maker notes when QuickTime metadata does not expose HDRImageType
- use maker note headroom and HDR flag hints to mark HDR scenes in StructuredMetadataBuilder
- cover the Apple-driven HDR detection path with new unit tests

## Testing
- composer ci:test:php:unit

------
https://chatgpt.com/codex/tasks/task_e_68fbe485a01c8323a105bb71b24f1931