### PR TITLE
Fix ICC decoder version parsing for legacy headers

### DIFF
--- a/src/Parse/Icc/IccDecoder.php
+++ b/src/Parse/Icc/IccDecoder.php
@@ -160,19 +160,24 @@ final class IccDecoder
 
     private function extractVersion(string $data): ?string
     {
-        $majorMinor = ord($data[8]);
-        $bugfix     = ord($data[9]);
+        $majorByte     = ord($data[8]);
+        $minorBugfix   = ord($data[9]);
+        $major         = $majorByte;
+        $minor         = $minorBugfix >> 4;
+        $bugfixVersion = $minorBugfix & 0x0F;
 
-        $major = $majorMinor >> 4;
-        $minor = $majorMinor & 0x0F;
-        $bug   = $bugfix >> 4;
+        if ($majorByte >= 0x10) {
+            $major         = $majorByte >> 4;
+            $minor         = $majorByte & 0x0F;
+            $bugfixVersion = $minorBugfix >> 4;
+        }
 
-        if ($major === 0 && $minor === 0 && $bug === 0) {
+        if ($major === 0 && $minor === 0 && $bugfixVersion === 0) {
             return null;
         }
 
-        return $bug > 0
-            ? sprintf('%d.%d.%d', $major, $minor, $bug)
+        return $bugfixVersion > 0
+            ? sprintf('%d.%d.%d', $major, $minor, $bugfixVersion)
             : sprintf('%d.%d', $major, $minor);
     }
 

--- a/tests/Parse/Icc/IccDecoderTest.php
+++ b/tests/Parse/Icc/IccDecoderTest.php
@@ -21,6 +21,7 @@ use function chr;
 use function intdiv;
 use function strlen;
 use function substr;
+use function substr_replace;
 
 /**
  * @covers \MagicSunday\ImageMeta\Parse\Icc\IccDecoder
@@ -108,6 +109,20 @@ final class IccDecoderTest extends TestCase
         $decoder = new IccDecoder();
 
         self::assertNull($decoder->decode(null, $segments));
+    }
+
+    #[Test]
+    public function testDecodeExtractsLegacyVersionEncoding(): void
+    {
+        $profile = IccFixtures::minimalProfile();
+        $profile = substr_replace($profile, chr(0x02), 8, 1);
+        $profile = substr_replace($profile, chr(0x13), 9, 1);
+
+        $decoder = new IccDecoder();
+        $result  = $decoder->decode($profile);
+
+        self::assertNotNull($result);
+        self::assertSame('2.1.3', $result['version']);
     }
 
     /**


### PR DESCRIPTION
## Summary
- adjust ICC version extraction to support both nibble-based and legacy byte major values
- ensure zeroed version components still return null
- cover ICC version parsing for legacy v2 encoding in unit tests

## Testing
- composer ci:test:php:unit

------
https://chatgpt.com/codex/tasks/task_e_68fbe4a098fc8323884c5edb402923ae