### PR TITLE
fix: propagate SceneType enum through structured metadata

### DIFF
--- a/src/Curate/StructuredMetadataBuilder.php
+++ b/src/Curate/StructuredMetadataBuilder.php
@@ -613,7 +613,7 @@ final class StructuredMetadataBuilder
 
         return new Scene(
             type: $exif->sceneCaptureType(),
-            sceneType: $exif->sceneType()?->value,
+            sceneType: $exif->sceneType(),
             light: $exif->lightSource(),
             faceCount: $faceCount,
             hdrScene: $hdr !== null ? true : null,

--- a/src/Value/Scene.php
+++ b/src/Value/Scene.php
@@ -13,6 +13,7 @@ namespace MagicSunday\ImageMeta\Value;
 
 use MagicSunday\ImageMeta\Value\Enum\LightSource;
 use MagicSunday\ImageMeta\Value\Enum\SceneCaptureType;
+use MagicSunday\ImageMeta\Value\Enum\SceneType;
 use MagicSunday\ImageMeta\Value\Enum\SubjectDistanceRange;
 
 /**
@@ -22,7 +23,7 @@ final readonly class Scene
 {
     /**
      * @param SceneCaptureType|null     $type                 Scene capture type classification.
-     * @param int|null                  $sceneType            Scene type classification (e.g. direct capture).
+     * @param SceneType|null            $sceneType            Scene type classification (e.g. direct capture).
      * @param LightSource|null          $light                Dominant light source as reported by the camera.
      * @param int|null                  $faceCount            Number of detected faces.
      * @param bool|null                 $hdrScene             Indicates whether HDR scene processing was applied.
@@ -31,7 +32,7 @@ final readonly class Scene
      */
     public function __construct(
         public ?SceneCaptureType $type,
-        public ?int $sceneType,
+        public ?SceneType $sceneType,
         public ?LightSource $light,
         public ?int $faceCount,
         public ?bool $hdrScene,

--- a/tests/Curate/StructuredMetadataBuilderTest.php
+++ b/tests/Curate/StructuredMetadataBuilderTest.php
@@ -41,6 +41,7 @@ use MagicSunday\ImageMeta\Value\Enum\Photometric;
 use MagicSunday\ImageMeta\Value\Enum\PlanarConfiguration;
 use MagicSunday\ImageMeta\Value\Enum\ResolutionUnit;
 use MagicSunday\ImageMeta\Value\Enum\SceneCaptureType;
+use MagicSunday\ImageMeta\Value\Enum\SceneType;
 use MagicSunday\ImageMeta\Value\Enum\SensingMethod;
 use MagicSunday\ImageMeta\Value\Enum\SubjectDistanceRange;
 use MagicSunday\ImageMeta\Value\Enum\WhiteBalance;
@@ -273,7 +274,7 @@ final class StructuredMetadataBuilderTest extends TestCase
         self::assertTrue($flash->fired);
 
         self::assertSame(SceneCaptureType::STANDARD, $structured->scene->type);
-        self::assertSame(1, $structured->scene->sceneType);
+        self::assertSame(SceneType::DIRECTLY_PHOTOGRAPHED_IMAGE, $structured->scene->sceneType);
         self::assertSame(SubjectDistanceRange::DISTANT, $structured->scene->subjectDistanceRange);
 
         self::assertSame('3.00', $structured->standards->exifVersion);


### PR DESCRIPTION
## Summary
- type-hint the `Scene` value object with the `SceneType` enum
- pass the enum from the EXIF resolver into the structured metadata builder
- adjust the structured metadata test expectations for the enum instance

## Testing
- composer ci:test:php:unit

------
https://chatgpt.com/codex/tasks/task_e_68fbe4a85f9c8323ab0f1ea268324d7e