### PR TITLE
feat: expose Apple acceleration vector in structured metadata

### DIFF
--- a/src/Curate/Resolver/AppleResolver.php
+++ b/src/Curate/Resolver/AppleResolver.php
@@ -56,10 +56,11 @@ final readonly class AppleResolver
         $focusPosition    = $resolver->float('FocusPosition');
         $livePhotoIndex   = $resolver->int('LivePhotoVideoIndex');
         $colorTemperature = $resolver->int('ColorTemperature');
-        $semanticPreset   = $resolver->string('SemanticStylePreset');
-        $semanticWarmth   = $resolver->float('SemanticStyleWarmth');
-        $semanticTone     = $resolver->float('SemanticStyleTone');
-        $flags            = $this->flags($resolver);
+        $semanticPreset      = $resolver->string('SemanticStylePreset');
+        $semanticWarmth      = $resolver->float('SemanticStyleWarmth');
+        $semanticTone        = $resolver->float('SemanticStyleTone');
+        $accelerationVector = $this->floatList($resolver, 'AccelerationVector');
+        $flags               = $this->flags($resolver);
 
         if (
             $identifier === null
@@ -73,6 +74,7 @@ final readonly class AppleResolver
             && $semanticPreset === null
             && $semanticWarmth === null
             && $semanticTone === null
+            && $accelerationVector === null
             && $flags === []
         ) {
             return null;
@@ -91,6 +93,7 @@ final readonly class AppleResolver
             $semanticWarmth,
             $semanticTone,
             $flags,
+            $accelerationVector,
         );
     }
 

--- a/src/Curate/StructuredMetadataBuilder.php
+++ b/src/Curate/StructuredMetadataBuilder.php
@@ -703,6 +703,11 @@ final class StructuredMetadataBuilder
             $semanticTone = $this->quickTimeFloat($quickTimeResolver, 'SemanticStyleTone');
         }
 
+        $accelerationVector = $makerNotes?->accelerationVector;
+        if ($accelerationVector === null) {
+            $accelerationVector = $this->quickTimeFloatList($quickTimeResolver, 'AccelerationVector');
+        }
+
         $flags          = $makerNotes instanceof AppleMakerNotes ? $makerNotes->flags : [];
         $quickTimeFlags = $this->quickTimeFlags($quickTimeResolver);
         foreach ($quickTimeFlags as $key => $value) {
@@ -724,6 +729,7 @@ final class StructuredMetadataBuilder
             $semanticWarmth,
             $semanticTone,
             $flags,
+            $accelerationVector,
         );
     }
 

--- a/src/Value/Apple.php
+++ b/src/Value/Apple.php
@@ -29,6 +29,7 @@ final readonly class Apple
      * @param float|null          $semanticStyleWarmth Semantic style warmth value.
      * @param float|null          $semanticStyleTone   Semantic style tone value.
      * @param array<string, bool> $flags               Boolean flags derived from maker notes or QuickTime metadata.
+     * @param list<float>|null    $accelerationVector  Acceleration vector recorded during capture.
      */
     public function __construct(
         public ?string $contentIdentifier,
@@ -43,6 +44,7 @@ final readonly class Apple
         public ?float $semanticStyleWarmth,
         public ?float $semanticStyleTone,
         public array $flags,
+        public ?array $accelerationVector,
     ) {
     }
 }

--- a/tests/Curate/StructuredMetadataBuilderTest.php
+++ b/tests/Curate/StructuredMetadataBuilderTest.php
@@ -496,11 +496,30 @@ final class StructuredMetadataBuilderTest extends TestCase
         self::assertEqualsWithDelta(-0.2, $structured->apple->semanticStyleTone, 1e-12);
         self::assertFalse($structured->apple->flags['livePhotoAuto']);
         self::assertTrue($structured->apple->flags['nightMode']);
+        self::assertSame([0.05, 0.1, -0.1], $structured->apple->accelerationVector);
 
         self::assertSame(4300, $structured->whiteBalanceDetails->kelvin);
         self::assertEqualsWithDelta(0.05, $structured->motion->accelX, 1e-12);
         self::assertEqualsWithDelta(0.1, $structured->motion->accelY, 1e-12);
         self::assertEqualsWithDelta(-0.1, $structured->motion->accelZ, 1e-12);
+    }
+
+    /**
+     * Ensures QuickTime metadata provides an acceleration vector when maker notes are absent.
+     */
+    #[Test]
+    public function usesQuickTimeAccelerationVectorWhenMakerNotesMissing(): void
+    {
+        $quickTime = new QuickTimeMeta([
+            QuickTimeMeta::CONTENT_IDENTIFIER_KEY => 'qt-content',
+            'AccelerationVector'                  => '0.12 -0.34 0.56',
+        ]);
+
+        $metadata   = new Metadata(['primary'], $quickTime, null, []);
+        $structured = (new StructuredMetadataBuilder())->build($metadata);
+
+        self::assertSame('qt-content', $structured->apple->contentIdentifier);
+        self::assertSame([0.12, -0.34, 0.56], $structured->apple->accelerationVector);
     }
 
     /**
@@ -1250,6 +1269,7 @@ final class StructuredMetadataBuilderTest extends TestCase
         self::assertSame(5200, $structured->apple->colorTemperature);
         self::assertArrayHasKey('hdrEnabled', $structured->apple->flags);
         self::assertTrue($structured->apple->flags['hdrEnabled']);
+        self::assertSame([0.1, 0.2, 0.3], $structured->apple->accelerationVector);
     }
 
     /**


### PR DESCRIPTION
## Summary
- add an acceleration vector property to the Apple value object
- propagate maker note or QuickTime acceleration vectors into structured metadata
- extend structured metadata tests to cover acceleration vector preservation

## Testing
- composer ci:test:php:unit

------
https://chatgpt.com/codex/tasks/task_e_68fbe60b3e148323b76134284e13d95d