### PR TITLE
fix: guard MIME detection when fileinfo extension missing

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
         "php": "^8.4",
         "ext-ctype": "*",
         "ext-date": "*",
+        "ext-fileinfo": "*",
         "ext-hash": "*",
         "ext-iconv": "*",
         "ext-json": "*",

--- a/src/MetadataReader.php
+++ b/src/MetadataReader.php
@@ -23,6 +23,7 @@ use MagicSunday\ImageMeta\Parse\Jpeg\JpegExtractor;
 use MagicSunday\ImageMeta\Parse\Tiff\TiffExifReader;
 use MagicSunday\ImageMeta\Parse\Xmp\XmpParser;
 
+use function class_exists;
 use function filesize;
 use function hash_file;
 use function is_string;
@@ -175,6 +176,10 @@ final class MetadataReader
      */
     private function detectMimeType(string $path): ?string
     {
+        if (!class_exists(finfo::class)) {
+            return null;
+        }
+
         $finfo = new finfo(FILEINFO_MIME_TYPE);
         $mime  = $finfo->file($path);
 


### PR DESCRIPTION
## Summary
- guard `MetadataReader::detectMimeType()` when the `fileinfo` extension is unavailable
- declare the `ext-fileinfo` requirement in `composer.json`

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68fca6d8e8dc832398e379fe7a09378c