### PR TITLE
Normalize Apple face confidence scaling

### DIFF
--- a/src/Curate/Resolver/RegionsResolver.php
+++ b/src/Curate/Resolver/RegionsResolver.php
@@ -18,10 +18,13 @@ use MagicSunday\ImageMeta\Value\Regions\RegionType;
 
 use function abs;
 use function array_values;
+use function ceil;
 use function count;
 use function is_array;
 use function is_string;
+use function log10;
 use function max;
+use function pow;
 use function trim;
 
 /**
@@ -157,6 +160,8 @@ final readonly class RegionsResolver
         $rolls            = $this->floatValues($document, self::NS_APPLE_FACEINFO, 'Roll');
         $yaws             = $this->floatValues($document, self::NS_APPLE_FACEINFO, 'Yaw');
 
+        $confidenceScale = $this->confidenceScale($confidenceLevels, $confidences);
+
         $names = $this->stringValues($document, self::NS_APPLE_FACEINFO, 'Name');
         if ($names === []) {
             $names = $this->stringValues($document, self::NS_APPLE_FACEINFO, 'FullName');
@@ -196,8 +201,12 @@ final readonly class RegionsResolver
                 continue;
             }
 
-            $confidence = $confidenceLevels[$index] ?? $confidences[$index] ?? null;
-            $rotation   = $angleInfoRolls[$index] ?? $rolls[$index] ?? $yaws[$index] ?? null;
+            $confidence = $this->normalisedConfidence($confidenceLevels[$index] ?? null, $confidenceScale);
+            if ($confidence === null) {
+                $confidence = $this->normalisedConfidence($confidences[$index] ?? null, $confidenceScale);
+            }
+
+            $rotation = $angleInfoRolls[$index] ?? $rolls[$index] ?? $yaws[$index] ?? null;
 
             $resolved[] = new Region(
                 RegionType::FACE,
@@ -303,6 +312,66 @@ final readonly class RegionsResolver
         $trimmed = trim($value);
 
         return $trimmed === '' ? null : $trimmed;
+    }
+
+    /**
+     * Normalises Apple-specific confidence values to the unit interval.
+     */
+    private function normalisedConfidence(?float $confidence, float $scale): ?float
+    {
+        if ($confidence === null) {
+            return null;
+        }
+
+        if ($scale <= 1.0 || abs($confidence) <= 1.0) {
+            return $confidence;
+        }
+
+        $normalised = $confidence / $scale;
+
+        if ($normalised > 1.0) {
+            return 1.0;
+        }
+
+        if ($normalised < -1.0) {
+            return -1.0;
+        }
+
+        return $normalised;
+    }
+
+    /**
+     * @param list<float|null> $confidenceLevels
+     * @param list<float|null> $confidences
+     */
+    private function confidenceScale(array $confidenceLevels, array $confidences): float
+    {
+        $maxConfidence = 0.0;
+
+        foreach ([$confidenceLevels, $confidences] as $values) {
+            foreach ($values as $value) {
+                if ($value === null) {
+                    continue;
+                }
+
+                $absolute = abs($value);
+                if ($absolute > $maxConfidence) {
+                    $maxConfidence = $absolute;
+                }
+            }
+        }
+
+        if ($maxConfidence <= 1.0) {
+            return 1.0;
+        }
+
+        $scale = pow(10.0, ceil(log10($maxConfidence)));
+
+        if ($scale <= 0.0) {
+            return 1.0;
+        }
+
+        return $scale;
     }
 
     /**

--- a/tests/Curate/Resolver/RegionsResolverTest.php
+++ b/tests/Curate/Resolver/RegionsResolverTest.php
@@ -13,9 +13,12 @@ namespace MagicSunday\ImageMeta\Tests\Curate\Resolver;
 
 use MagicSunday\ImageMeta\Curate\Resolver\RegionsResolver;
 use MagicSunday\ImageMeta\Model\Xmp\XmpDocument;
+use MagicSunday\ImageMeta\Value\Regions\Region;
 use MagicSunday\ImageMeta\Value\Regions\RegionType;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
+use ReflectionClass;
 
 /**
  * @covers \MagicSunday\ImageMeta\Curate\Resolver\RegionsResolver
@@ -121,6 +124,60 @@ final class RegionsResolverTest extends TestCase
         self::assertEqualsWithDelta(0.4, $region->y, 0.0001);
         self::assertEqualsWithDelta(0.2, $region->w, 0.0001);
         self::assertEqualsWithDelta(0.2, $region->h, 0.0001);
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function provideAppleConfidenceProperty(): iterable
+    {
+        yield 'confidence-level' => ['ConfidenceLevel'];
+        yield 'confidence' => ['Confidence'];
+    }
+
+    #[Test]
+    #[DataProvider('provideAppleConfidenceProperty')]
+    public function normalisesAppleConfidenceValues(string $confidenceProperty): void
+    {
+        $count          = 1001;
+        $maxConfidence  = $count - 1;
+        $confidenceValues = array_map(static fn (int $value): string => (string) $value, range(0, $maxConfidence));
+
+        $values = [
+            '{' . self::NS_APPLE . '}CenterX' => array_fill(0, $count, '0.5'),
+            '{' . self::NS_APPLE . '}CenterY' => array_fill(0, $count, '0.5'),
+            '{' . self::NS_APPLE . '}Width'   => array_fill(0, $count, '0.1'),
+            '{' . self::NS_APPLE . '}Height'  => array_fill(0, $count, '0.1'),
+        ];
+
+        $values['{' . self::NS_APPLE . '}' . $confidenceProperty] = $confidenceValues;
+
+        if ($confidenceProperty === 'ConfidenceLevel') {
+            $values['{' . self::NS_APPLE . '}Confidence'] = $confidenceValues;
+        }
+
+        $resolver  = new RegionsResolver();
+        $document  = new XmpDocument($values);
+        $reflection = new ReflectionClass($resolver);
+        $method     = $reflection->getMethod('extractAppleFaceRegions');
+        $method->setAccessible(true);
+
+        /** @var list<Region> $regions */
+        $regions = $method->invoke($resolver, $document, null);
+
+        self::assertCount($count, $regions);
+
+        foreach ($regions as $index => $region) {
+            self::assertSame(RegionType::FACE, $region->type);
+            self::assertNotNull($region->confidence);
+
+            $rawConfidence = (float) $confidenceValues[$index];
+            $expectedConfidence = $rawConfidence > 1.0
+                ? $rawConfidence / $maxConfidence
+                : $rawConfidence;
+
+            self::assertEqualsWithDelta($expectedConfidence, $region->confidence, 0.0001);
+        }
     }
 
     #[Test]


### PR DESCRIPTION
## Summary
- normalise Apple FaceInfo confidence readings above the unit interval by applying a scale factor
- add helpers to compute the scale from the raw data and clamp the resulting values
- cover the normalisation with a 0–1000 confidence fixture in the resolver tests

## Testing
- composer ci:test:php:unit

------
https://chatgpt.com/codex/tasks/task_e_68fca6d49184832386d5c7a0a89c4f4e