### PR TITLE
Fix UID handling in binary plist decoder

### DIFF
--- a/src/MakerNotes/Apple/BinaryPlistDecoder.php
+++ b/src/MakerNotes/Apple/BinaryPlistDecoder.php
@@ -14,12 +14,16 @@ namespace MagicSunday\ImageMeta\MakerNotes\Apple;
 use MagicSunday\ImageMeta\Core\ParseError;
 
 use function array_key_exists;
+use function chr;
 use function iconv;
+use function intdiv;
 use function is_array;
 use function is_float;
 use function is_int;
 use function is_string;
+use function ltrim;
 use function ord;
+use function sprintf;
 use function strlen;
 use function strpos;
 use function substr;
@@ -146,6 +150,7 @@ final class BinaryPlistDecoder
             0x4     => $this->parseData($offset, $info),
             0x5     => $this->parseAscii($offset, $info),
             0x6     => $this->parseUnicode($offset, $info),
+            0x8     => $this->parseUid($offset, $info),
             0xA     => $this->parseArray($offset, $info),
             0xD     => $this->parseDictionary($offset, $info),
             default => throw new ParseError('Unsupported property list object type.'),
@@ -258,6 +263,77 @@ final class BinaryPlistDecoder
         }
 
         return $decoded;
+    }
+
+    private function parseUid(int $offset, int $info): int|string
+    {
+        [$lengthValue, $header] = $this->readLength($offset, $info);
+
+        if ($info === 0x0F) {
+            $size = $lengthValue;
+        } else {
+            $size   = $lengthValue + 1;
+            $header = 1;
+        }
+
+        if ($size < 1) {
+            throw new ParseError('UID objects must contain at least one byte.');
+        }
+
+        $payloadOffset = $offset + $header;
+        if ($payloadOffset + $size > $this->length) {
+            throw new ParseError('Incomplete UID payload.');
+        }
+
+        if ($size <= PHP_INT_SIZE) {
+            $value = $this->readUint($payloadOffset, $size);
+
+            if ($size === PHP_INT_SIZE && $value < 0) {
+                return sprintf('%u', $value);
+            }
+
+            return $value;
+        }
+
+        $payload = substr($this->data, $payloadOffset, $size);
+        if (strlen($payload) !== $size) {
+            throw new ParseError('Incomplete UID payload.');
+        }
+
+        return $this->convertUidPayloadToDecimalString($payload);
+    }
+
+    private function convertUidPayloadToDecimalString(string $payload): string
+    {
+        $value = '0';
+        $length = strlen($payload);
+        for ($idx = 0; $idx < $length; ++$idx) {
+            $value = $this->multiplyAndAddDecimalString($value, 256, ord($payload[$idx]));
+        }
+
+        return $value;
+    }
+
+    private function multiplyAndAddDecimalString(string $decimal, int $multiplier, int $addend): string
+    {
+        $carry  = $addend;
+        $result = '';
+
+        for ($idx = strlen($decimal) - 1; $idx >= 0; --$idx) {
+            $digit = ord($decimal[$idx]) - 48;
+            $product = ($digit * $multiplier) + $carry;
+            $result = chr(($product % 10) + 48) . $result;
+            $carry  = intdiv($product, 10);
+        }
+
+        while ($carry > 0) {
+            $result = chr(($carry % 10) + 48) . $result;
+            $carry  = intdiv($carry, 10);
+        }
+
+        $trimmed = ltrim($result, '0');
+
+        return $trimmed === '' ? '0' : $trimmed;
     }
 
     /**

--- a/tests/MakerNotes/Apple/BinaryPlistDecoderTest.php
+++ b/tests/MakerNotes/Apple/BinaryPlistDecoderTest.php
@@ -1,0 +1,95 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\ImageMeta\Tests\MakerNotes\Apple;
+
+use MagicSunday\ImageMeta\MakerNotes\Apple\BinaryPlistDecoder;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+use function chr;
+use function intdiv;
+use function pack;
+use function str_repeat;
+use function strlen;
+
+/**
+ * @covers \MagicSunday\ImageMeta\MakerNotes\Apple\BinaryPlistDecoder
+ */
+final class BinaryPlistDecoderTest extends TestCase
+{
+    #[Test]
+    public function decodeRecognisesUidValues(): void
+    {
+        $decoder = new BinaryPlistDecoder();
+        $plist   = $this->createBinaryPlistWithUid("\x01");
+
+        $result = $decoder->decode($plist);
+
+        self::assertSame(['Uid' => 1], $result);
+    }
+
+    #[Test]
+    public function decodeReturnsStringForLargeUidValues(): void
+    {
+        $decoder = new BinaryPlistDecoder();
+        $plist   = $this->createBinaryPlistWithUid(chr(0x80) . str_repeat("\x00", 7));
+
+        $result = $decoder->decode($plist);
+
+        self::assertSame(['Uid' => '9223372036854775808'], $result);
+    }
+
+    private function createBinaryPlistWithUid(string $uidBytes): string
+    {
+        $header = 'bplist00';
+
+        $key       = 'Uid';
+        $keyMarker = chr(0x50 | strlen($key));
+        $keyObject = $keyMarker . $key;
+
+        $uidLength = strlen($uidBytes);
+        $this->assertGreaterThan(0, $uidLength);
+
+        if ($uidLength > 0x0F) {
+            $this->fail('Test fixture generator does not support UID payloads larger than 15 bytes.');
+        }
+
+        $uidMarker = chr(0x80 | ($uidLength - 1));
+        $uidObject = $uidMarker . $uidBytes;
+
+        $dictionaryObject = "\xD1\x00\x01";
+
+        $offsetKey        = strlen($header);
+        $offsetUid        = $offsetKey + strlen($keyObject);
+        $offsetDictionary = $offsetUid + strlen($uidObject);
+        $offsetTableStart = $offsetDictionary + strlen($dictionaryObject);
+
+        $offsetTable = pack('C*', $offsetKey, $offsetUid, $offsetDictionary);
+
+        $trailer = str_repeat("\x00", 6)
+            . "\x01"
+            . "\x01"
+            . $this->packUint64(3)
+            . $this->packUint64(2)
+            . $this->packUint64($offsetTableStart);
+
+        return $header . $keyObject . $uidObject . $dictionaryObject . $offsetTable . $trailer;
+    }
+
+    private function packUint64(int $value): string
+    {
+        $high = intdiv($value, 0x100000000);
+        $low  = $value % 0x100000000;
+
+        return pack('N2', $high, $low);
+    }
+}


### PR DESCRIPTION
## Summary
- add UID marker support to the binary plist decoder so referenced object numbers are decoded correctly
- coerce wide UID payloads to unsigned strings when they exceed PHP's integer range
- add unit coverage for UID decoding, including large unsigned values

## Testing
- composer ci:test:php:unit

------
https://chatgpt.com/codex/tasks/task_e_68fcb05ffd94832398b4b51a79fa622d