### PR TITLE
fix: fall back to Apple night mode flag for JPEG scenes

### DIFF
--- a/src/Curate/StructuredMetadataBuilder.php
+++ b/src/Curate/StructuredMetadataBuilder.php
@@ -615,6 +615,9 @@ final class StructuredMetadataBuilder
     ): Scene {
         $hdr   = $quickTime->string('HDRImageType');
         $night = $quickTime->bool('NightMode');
+        if ($night === null) {
+            $night = $apple->flags['nightMode'] ?? null;
+        }
 
         $hdrScene = null;
         if ($hdr !== null) {

--- a/tests/Curate/StructuredMetadataBuilderTest.php
+++ b/tests/Curate/StructuredMetadataBuilderTest.php
@@ -502,6 +502,7 @@ final class StructuredMetadataBuilderTest extends TestCase
         self::assertEqualsWithDelta(0.05, $structured->motion->accelX, 1e-12);
         self::assertEqualsWithDelta(0.1, $structured->motion->accelY, 1e-12);
         self::assertEqualsWithDelta(-0.1, $structured->motion->accelZ, 1e-12);
+        self::assertFalse($structured->scene->nightMode);
     }
 
     /**
@@ -520,6 +521,44 @@ final class StructuredMetadataBuilderTest extends TestCase
 
         self::assertSame('qt-content', $structured->apple->contentIdentifier);
         self::assertSame([0.12, -0.34, 0.56], $structured->apple->accelerationVector);
+    }
+
+    /**
+     * Ensures JPEG-only metadata uses the maker note night mode flag when QuickTime metadata is absent.
+     */
+    #[Test]
+    public function usesMakerNoteNightModeWhenQuickTimeMissing(): void
+    {
+        $appleMakerNotes = new AppleMakerNotes(
+            contentIdentifier: null,
+            cameraType: null,
+            hdrHeadroom: null,
+            hdrGain: null,
+            snr: null,
+            focusPosition: null,
+            livePhotoIndex: null,
+            colorTemperature: null,
+            semanticStylePreset: null,
+            semanticStyleWarmth: null,
+            semanticStyleTone: null,
+            flags: ['nightMode' => true],
+            accelerationVector: null,
+        );
+
+        $makerNotes = new MakerNotesMetadata('Apple', 0, str_repeat('a', 40), $appleMakerNotes);
+
+        $metadata = new Metadata(
+            ['primary'],
+            null,
+            new ExifDocument(new Ifd([]), null, null, null, null, $makerNotes),
+            [],
+            null,
+            $makerNotes,
+        );
+
+        $structured = (new StructuredMetadataBuilder())->build($metadata);
+
+        self::assertTrue($structured->scene->nightMode);
     }
 
     /**


### PR DESCRIPTION
## Summary
- ensure the scene builder falls back to the Apple maker-note night mode flag when QuickTime metadata is missing
- extend the builder tests to cover QuickTime precedence and JPEG-only fallback for the night mode flag

## Testing
- composer ci:test:php:unit -- --filter StructuredMetadataBuilderTest

------
https://chatgpt.com/codex/tasks/task_e_68fcb08a2de48323814e6fac06087848