### PR TITLE
feat: decode Apple maker note flag masks

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,3 +86,11 @@ The diagonal field of view exposed via `fovDiagonalDeg` corresponds to the value
 The expanded temporal aggregate surfaces raw EXIF offset tags alongside a resolved `DateTimeZone` instance. This makes it possible to reconstruct original capture times even when the offset varies between creation, digitisation and modification steps. File level metadata now reports size, extension and cryptographic digests to help consumers correlate assets or detect tampering.
 
 Apple maker note data now includes semantic style parameters, colour temperature and Live Photo flags from both maker notes and QuickTime metadata. GPS coverage has been widened with horizontal positioning error and full destination navigation metrics from EXIF 2.32 table 66.
+
+Bit-mask sources such as `SceneFlags`, `ImageProcessingFlags` and `PhotosAppFeatureFlags` are decoded so their individual bits populate the normalised `apple.flags` array:
+
+* `SceneFlags`: bit 0 → `nightMode`, bit 1 → `longExposure`
+* `ImageProcessingFlags`: bit 0 → `hdrEnabled`, bit 1 → `hdrAuto`
+* `PhotosAppFeatureFlags`: bit 0 → `livePhoto`, bit 1 → `livePhotoAuto`, bit 2 → `livePhotoEnabled`, bit 3 → `livePhotoActive`, bit 4 → `livePhotoLongExposure`
+
+Explicit boolean keys continue to override the derived values when both representations are present.

--- a/src/MakerNotes/AppleDecoder.php
+++ b/src/MakerNotes/AppleDecoder.php
@@ -17,6 +17,8 @@ use MagicSunday\ImageMeta\MakerNotes\Apple\BinaryPlistDecoder;
 
 use function array_is_list;
 use function array_key_exists;
+use function ctype_xdigit;
+use function hexdec;
 use function is_array;
 use function is_bool;
 use function is_float;
@@ -25,6 +27,8 @@ use function is_numeric;
 use function is_string;
 use function sha1;
 use function strlen;
+use function str_starts_with;
+use function substr;
 use function trim;
 
 /**
@@ -47,6 +51,29 @@ final class AppleDecoder implements MakerNotesDecoderInterface
         'HdrEnabled'            => 'hdrEnabled',
         'NightMode'             => 'nightMode',
         'LongExposure'          => 'longExposure',
+    ];
+
+    /**
+     * Maps bit masks provided by Apple maker note dictionaries to normalised flags.
+     *
+     * @var array<string, array<int, string>>
+     */
+    private const array FLAG_MASK_MAP = [
+        'SceneFlags' => [
+            1 << 0 => 'nightMode',
+            1 << 1 => 'longExposure',
+        ],
+        'ImageProcessingFlags' => [
+            1 << 0 => 'hdrEnabled',
+            1 << 1 => 'hdrAuto',
+        ],
+        'PhotosAppFeatureFlags' => [
+            1 << 0 => 'livePhoto',
+            1 << 1 => 'livePhotoAuto',
+            1 << 2 => 'livePhotoEnabled',
+            1 << 3 => 'livePhotoActive',
+            1 << 4 => 'livePhotoLongExposure',
+        ],
     ];
 
     /**
@@ -290,6 +317,23 @@ final class AppleDecoder implements MakerNotesDecoderInterface
             $flags[$normalized] = $bool;
         }
 
+        foreach (self::FLAG_MASK_MAP as $makerKey => $bitMap) {
+            if (!array_key_exists($makerKey, $dictionary)) {
+                continue;
+            }
+
+            $mask = $this->maskValue($dictionary[$makerKey]);
+            if ($mask === null) {
+                continue;
+            }
+
+            foreach ($bitMap as $bit => $normalized) {
+                if (($mask & $bit) === $bit && !array_key_exists($normalized, $flags)) {
+                    $flags[$normalized] = true;
+                }
+            }
+        }
+
         return $flags;
     }
 
@@ -328,5 +372,87 @@ final class AppleDecoder implements MakerNotesDecoderInterface
         }
 
         return null;
+    }
+
+    /**
+     * @param string|int|float|bool|array<int|string, mixed>|null $value
+     *
+     * @phpstan-param string|int|float|bool|null|array<int|string, mixed> $value
+     */
+    private function maskValue(string|int|float|bool|array|null $value): ?int
+    {
+        if (is_int($value)) {
+            return $value;
+        }
+
+        if (is_float($value)) {
+            return (int) $value;
+        }
+
+        if (is_string($value)) {
+            $normalized = trim($value);
+            if ($normalized === '') {
+                return null;
+            }
+
+            if (str_starts_with($normalized, '0x') || str_starts_with($normalized, '0X')) {
+                $hex = substr($normalized, 2);
+                if ($hex !== '' && ctype_xdigit($hex)) {
+                    return (int) hexdec($hex);
+                }
+
+                return null;
+            }
+
+            if (is_numeric($normalized)) {
+                return (int) $normalized;
+            }
+
+            return null;
+        }
+
+        if (is_bool($value) || $value === null) {
+            return null;
+        }
+
+        if (!is_array($value)) {
+            return null;
+        }
+
+        if ($value === []) {
+            return null;
+        }
+
+        if (!array_is_list($value)) {
+            foreach (['flags', 'Flags', 'value', 'Value', 'mask', 'Mask'] as $key) {
+                if (array_key_exists($key, $value)) {
+                    $mask = $this->maskValue($value[$key]);
+                    if ($mask !== null) {
+                        return $mask;
+                    }
+                }
+            }
+
+            if (!array_key_exists('values', $value)) {
+                return null;
+            }
+
+            $values = $value['values'];
+            if (!is_array($values)) {
+                return $this->maskValue($values);
+            }
+
+            $value = $values;
+        }
+
+        $mask = 0;
+        foreach ($value as $entry) {
+            $part = $this->maskValue($entry);
+            if ($part !== null) {
+                $mask |= $part;
+            }
+        }
+
+        return $mask !== 0 ? $mask : null;
     }
 }

--- a/tests/MakerNotes/AppleDecoder/AppleDecoderTest.php
+++ b/tests/MakerNotes/AppleDecoder/AppleDecoderTest.php
@@ -16,6 +16,7 @@ use MagicSunday\ImageMeta\MakerNotes\AppleDecoder;
 use MagicSunday\ImageMeta\MakerNotes\MakerNotesMetadata;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
 
 use function hex2bin;
 use function sha1;
@@ -81,5 +82,69 @@ final class AppleDecoderTest extends TestCase
 
         self::assertInstanceOf(MakerNotesMetadata::class, $metadata);
         self::assertNull($metadata->apple());
+    }
+
+    #[Test]
+    public function flagMasksMirrorScalarInputs(): void
+    {
+        $decoder = new AppleDecoder();
+        $method  = new ReflectionMethod(AppleDecoder::class, 'buildAppleMakerNotes');
+        $method->setAccessible(true);
+
+        $scalarNotes = $method->invoke($decoder, [
+            'ContentIdentifier'    => 'scalar',
+            'LivePhotoAuto'        => true,
+            'LivePhotoEnabled'     => true,
+            'LivePhotoActive'      => true,
+            'LivePhotoLongExposure'=> true,
+            'LivePhoto'            => 1,
+            'HdrAuto'              => 1,
+            'HdrEnabled'           => '1',
+            'NightMode'            => true,
+            'LongExposure'         => true,
+        ]);
+
+        $maskNotes = $method->invoke($decoder, [
+            'ContentIdentifier'     => 'mask',
+            'SceneFlags'            => (1 << 0) | (1 << 1),
+            'ImageProcessingFlags'  => (1 << 0) | (1 << 1),
+            'PhotosAppFeatureFlags' => (1 << 0) | (1 << 1) | (1 << 2) | (1 << 3) | (1 << 4),
+        ]);
+
+        self::assertInstanceOf(AppleMakerNotes::class, $scalarNotes);
+        self::assertInstanceOf(AppleMakerNotes::class, $maskNotes);
+
+        $scalarFlags = $scalarNotes->flags;
+        $maskFlags   = $maskNotes->flags;
+
+        ksort($scalarFlags);
+        ksort($maskFlags);
+
+        self::assertSame($scalarFlags, $maskFlags);
+    }
+
+    #[Test]
+    public function explicitFlagValuesOverrideMasks(): void
+    {
+        $decoder = new AppleDecoder();
+        $method  = new ReflectionMethod(AppleDecoder::class, 'buildAppleMakerNotes');
+        $method->setAccessible(true);
+
+        $notes = $method->invoke($decoder, [
+            'ContentIdentifier'     => 'override',
+            'LivePhotoLongExposure' => false,
+            'NightMode'             => false,
+            'SceneFlags'            => 1 << 0,
+            'PhotosAppFeatureFlags' => 1 << 4,
+        ]);
+
+        self::assertInstanceOf(AppleMakerNotes::class, $notes);
+        self::assertSame(
+            [
+                'livePhotoLongExposure' => false,
+                'nightMode'             => false,
+            ],
+            $notes->flags,
+        );
     }
 }


### PR DESCRIPTION
## Summary
- decode Apple maker note flag masks and merge them with explicit boolean keys
- document the mapping between SceneFlags/ImageProcessingFlags/PhotosAppFeatureFlags bits and normalised apple.flags entries
- add PHPUnit coverage that checks mask-derived flags match scalar inputs and that booleans override masks

## Testing
- composer ci:test:php:unit

------
https://chatgpt.com/codex/tasks/task_e_68fcb099ea2c8323a5afc33ca05a2331