### PR TITLE
docs: add phpdoc coverage for metadata helpers

### DIFF
--- a/src/Curate/Resolver/ExifTagResolver.php
+++ b/src/Curate/Resolver/ExifTagResolver.php
@@ -63,6 +63,11 @@ use function trim;
  */
 final readonly class ExifTagResolver
 {
+    /**
+     * Wraps an optional EXIF document for high level tag lookups.
+     *
+     * @param ExifDocument|null $document Parsed EXIF document instance.
+     */
     public function __construct(private ?ExifDocument $document)
     {
     }

--- a/src/Curate/Resolver/MakerNotesResolver.php
+++ b/src/Curate/Resolver/MakerNotesResolver.php
@@ -19,6 +19,11 @@ use MagicSunday\ImageMeta\MakerNotes\MakerNotesMetadata;
  */
 final readonly class MakerNotesResolver
 {
+    /**
+     * Wraps optional maker note metadata for vendor-specific lookups.
+     *
+     * @param MakerNotesMetadata|null $metadata Parsed maker note metadata aggregate.
+     */
     public function __construct(private ?MakerNotesMetadata $metadata)
     {
     }

--- a/src/Curate/Resolver/QuickTimeResolver.php
+++ b/src/Curate/Resolver/QuickTimeResolver.php
@@ -26,6 +26,11 @@ use function trim;
  */
 final readonly class QuickTimeResolver
 {
+    /**
+     * Wraps an optional QuickTime metadata container for convenient lookups.
+     *
+     * @param QuickTimeMeta|null $meta Parsed QuickTime metadata aggregate.
+     */
     public function __construct(private ?QuickTimeMeta $meta)
     {
     }

--- a/src/Curate/Resolver/RegionsResolver.php
+++ b/src/Curate/Resolver/RegionsResolver.php
@@ -359,6 +359,14 @@ final readonly class RegionsResolver
         return $bestIndex;
     }
 
+    /**
+     * Merges overlapping region metadata, preferring existing geometry while enriching attributes.
+     *
+     * @param Region $base        Primary region resolved from MWG metadata.
+     * @param Region $supplement  Supplementary region derived from Apple metadata.
+     *
+     * @return Region Combined region carrying the most complete metadata set.
+     */
     private function mergeRegion(Region $base, Region $supplement): Region
     {
         $person     = $base->personName ?? $supplement->personName;
@@ -518,6 +526,13 @@ final readonly class RegionsResolver
         ];
     }
 
+    /**
+     * Constrains a normalised coordinate to the unit interval.
+     *
+     * @param float $value Coordinate or dimension value to clamp.
+     *
+     * @return float Value restricted to the range [0.0, 1.0].
+     */
     private function clamp(float $value): float
     {
         if ($value < 0.0) {

--- a/src/Curate/Resolver/XmpResolver.php
+++ b/src/Curate/Resolver/XmpResolver.php
@@ -28,6 +28,11 @@ use function trim;
  */
 final readonly class XmpResolver
 {
+    /**
+     * Wraps an optional XMP document for structured lookups.
+     *
+     * @param XmpDocument|null $document Parsed XMP document instance.
+     */
     public function __construct(private ?XmpDocument $document)
     {
     }

--- a/src/Curate/StructuredMetadata.php
+++ b/src/Curate/StructuredMetadata.php
@@ -51,6 +51,44 @@ use MagicSunday\ImageMeta\Value\Xmp;
  */
 final readonly class StructuredMetadata
 {
+    /**
+     * Creates a structured metadata aggregate populated with curated value objects for each domain.
+     *
+     * @param Interop             $interop Interoperability metadata derived from EXIF tags.
+     * @param TiffData            $tiff TIFF-related imaging parameters.
+     * @param CompositeImageInfo  $composite Composite capture information for multi-image scenes.
+     * @param Standards           $standards Metadata standard identifiers and versions.
+     * @param Camera              $camera Camera manufacturer and model information.
+     * @param Lens                $lens Lens identification and optical properties.
+     * @param Image               $image Image dimensions and orientation details.
+     * @param Exposure            $exposure Exposure settings and capture parameters.
+     * @param Capture             $capture Environmental capture metadata.
+     * @param Gps                 $gps Geographic positioning information.
+     * @param Device              $device Host device information.
+     * @param Apple               $apple Apple-specific metadata aggregate.
+     * @param Xmp                 $xmp Parsed XMP document wrapper.
+     * @param File                $file File level metadata and characteristics.
+     * @param Container           $container Container format metadata.
+     * @param Preview             $preview Embedded preview information.
+     * @param Video               $video Video track metadata when available.
+     * @param Audio               $audio Audio track metadata when available.
+     * @param ColorProfile        $colorProfile Colour profile information.
+     * @param ProcessingSettings  $processing Image processing metadata.
+     * @param WhiteBalanceDetails $whiteBalanceDetails White balance analysis details.
+     * @param Focus               $focus Focus distance and autofocus data.
+     * @param Motion              $motion Motion and acceleration measurements.
+     * @param Scene               $scene Scene classification details.
+     * @param Regions             $regions Region and face annotations.
+     * @param Keywords            $keywords Keyword annotations.
+     * @param Rights              $rights Rights and licensing information.
+     * @param Author              $author Creator metadata values.
+     * @param Temporal            $temporal Temporal metadata beyond capture timestamps.
+     * @param Derived             $derived Derived asset references.
+     * @param RelatedAssets       $related Related asset references from metadata.
+     * @param Sensor              $sensor Sensor and detection metadata.
+     * @param Uav                 $uav Unmanned aerial vehicle metadata.
+     * @param Integrity           $integrity Integrity and validation metadata.
+     */
     public function __construct(
         public Interop $interop,
         public TiffData $tiff,

--- a/src/Curate/StructuredMetadataBuilder.php
+++ b/src/Curate/StructuredMetadataBuilder.php
@@ -645,6 +645,15 @@ final class StructuredMetadataBuilder
         );
     }
 
+    /**
+     * Builds the Apple metadata aggregate by combining maker note values with QuickTime fallbacks.
+     *
+     * @param AppleMakerNotes|null $makerNotes Parsed Apple maker note payload.
+     * @param QuickTimeResolver    $quickTimeResolver Resolver exposing QuickTime metadata entries.
+     * @param QuickTimeMeta|null   $quickTimeMeta QuickTime metadata container used for content identifiers.
+     *
+     * @return Apple Apple metadata value object with normalised fields.
+     */
     private function buildApple(
         ?AppleMakerNotes $makerNotes,
         QuickTimeResolver $quickTimeResolver,
@@ -735,6 +744,13 @@ final class StructuredMetadataBuilder
         );
     }
 
+    /**
+     * Builds the motion metadata aggregate from the Apple acceleration vector.
+     *
+     * @param AppleMakerNotes|null $makerNotes Parsed Apple maker note payload.
+     *
+     * @return Motion Motion metadata aggregate with per-axis acceleration.
+     */
     private function buildMotion(?AppleMakerNotes $makerNotes): Motion
     {
         $vector = $makerNotes?->accelerationVector;
@@ -752,6 +768,14 @@ final class StructuredMetadataBuilder
         return new Motion(null, null, null, $accelX, $accelY, $accelZ, null, null, null);
     }
 
+    /**
+     * Resolves the first non-empty QuickTime string value from the supplied keys.
+     *
+     * @param QuickTimeResolver $resolver Resolver used to read QuickTime metadata keys.
+     * @param string            ...$keys Candidate metadata keys to inspect in order.
+     *
+     * @return string|null First matching string value or null when no value is present.
+     */
     private function quickTimeString(QuickTimeResolver $resolver, string ...$keys): ?string
     {
         foreach ($keys as $key) {
@@ -764,6 +788,14 @@ final class StructuredMetadataBuilder
         return null;
     }
 
+    /**
+     * Resolves the first available QuickTime float value from the provided keys.
+     *
+     * @param QuickTimeResolver $resolver Resolver used to read QuickTime metadata keys.
+     * @param string            ...$keys Candidate metadata keys to inspect in order.
+     *
+     * @return float|null First matching float value or null when no value is present.
+     */
     private function quickTimeFloat(QuickTimeResolver $resolver, string ...$keys): ?float
     {
         foreach ($keys as $key) {
@@ -776,6 +808,14 @@ final class StructuredMetadataBuilder
         return null;
     }
 
+    /**
+     * Resolves the first available QuickTime integer value from the provided keys.
+     *
+     * @param QuickTimeResolver $resolver Resolver used to read QuickTime metadata keys.
+     * @param string            ...$keys Candidate metadata keys to inspect in order.
+     *
+     * @return int|null First matching integer value or null when no value is present.
+     */
     private function quickTimeInt(QuickTimeResolver $resolver, string ...$keys): ?int
     {
         foreach ($keys as $key) {

--- a/src/MakerNotes/Apple/BinaryPlistDecoder.php
+++ b/src/MakerNotes/Apple/BinaryPlistDecoder.php
@@ -86,6 +86,11 @@ final class BinaryPlistDecoder
         return $this->parseObject($topIndex);
     }
 
+    /**
+     * Parses the property list trailer to configure offsets and reference sizing.
+     *
+     * @return void
+     */
     private function decodeTrailer(): void
     {
         $trailer = substr($this->data, -32);
@@ -157,6 +162,13 @@ final class BinaryPlistDecoder
         };
     }
 
+    /**
+     * Decodes simple marker objects such as null and boolean values.
+     *
+     * @param int $info Marker information nibble extracted from the object header.
+     *
+     * @return bool|null Null for the null marker or boolean flag values.
+     */
     private function parseSimple(int $info): ?bool
     {
         return match ($info) {
@@ -167,6 +179,14 @@ final class BinaryPlistDecoder
         };
     }
 
+    /**
+     * Reads an integer object from the payload.
+     *
+     * @param int $offset Byte offset of the object within the payload.
+     * @param int $info   Marker information nibble describing the integer width.
+     *
+     * @return int Decoded integer value.
+     */
     private function parseInteger(int $offset, int $info): int
     {
         $size = 1 << $info;
@@ -179,6 +199,14 @@ final class BinaryPlistDecoder
         return $value;
     }
 
+    /**
+     * Reads a floating point object from the payload.
+     *
+     * @param int $offset Byte offset of the object within the payload.
+     * @param int $info   Marker information nibble describing the float width.
+     *
+     * @return float Decoded floating point value.
+     */
     private function parseReal(int $offset, int $info): float
     {
         $size = 1 << $info;
@@ -223,6 +251,14 @@ final class BinaryPlistDecoder
         throw new ParseError('Unsupported floating point width.');
     }
 
+    /**
+     * Reads a binary data object from the payload.
+     *
+     * @param int $offset Byte offset of the object within the payload.
+     * @param int $info   Marker information nibble describing the payload length encoding.
+     *
+     * @return string Raw binary payload extracted from the property list.
+     */
     private function parseData(int $offset, int $info): string
     {
         [$size, $header] = $this->readLength($offset, $info);
@@ -235,6 +271,14 @@ final class BinaryPlistDecoder
         return $payload;
     }
 
+    /**
+     * Reads an ASCII string object from the payload.
+     *
+     * @param int $offset Byte offset of the object within the payload.
+     * @param int $info   Marker information nibble describing the payload length encoding.
+     *
+     * @return string ASCII string content extracted from the property list.
+     */
     private function parseAscii(int $offset, int $info): string
     {
         [$size, $header] = $this->readLength($offset, $info);
@@ -247,6 +291,14 @@ final class BinaryPlistDecoder
         return $payload;
     }
 
+    /**
+     * Reads a UTF-16 encoded string object from the payload and converts it to UTF-8.
+     *
+     * @param int $offset Byte offset of the object within the payload.
+     * @param int $info   Marker information nibble describing the payload length encoding.
+     *
+     * @return string Unicode string decoded from the property list.
+     */
     private function parseUnicode(int $offset, int $info): string
     {
         [$size, $header] = $this->readLength($offset, $info);
@@ -429,6 +481,14 @@ final class BinaryPlistDecoder
         return [$value, 2 + $sizeBytes];
     }
 
+    /**
+     * Reads an unsigned big-endian integer from the payload.
+     *
+     * @param int $offset Starting byte offset within the property list data.
+     * @param int $length Number of bytes to consume for the integer.
+     *
+     * @return int Parsed unsigned integer value.
+     */
     private function readUint(int $offset, int $length): int
     {
         if ($length < 1) {
@@ -447,6 +507,14 @@ final class BinaryPlistDecoder
         return $value;
     }
 
+    /**
+     * Reads an unsigned 64-bit big-endian integer from the provided string.
+     *
+     * @param string $data   Binary string containing the encoded integer.
+     * @param int    $offset Offset within the string where the integer begins.
+     *
+     * @return int Decoded 64-bit integer value.
+     */
     private function readUint64(string $data, int $offset): int
     {
         $slice = substr($data, $offset, 8);

--- a/src/MakerNotes/AppleDecoder.php
+++ b/src/MakerNotes/AppleDecoder.php
@@ -95,6 +95,13 @@ final class AppleDecoder implements MakerNotesDecoderInterface
         );
     }
 
+    /**
+     * Parses the raw Apple maker note payload into a structured representation.
+     *
+     * @param string $raw Raw maker note data stream.
+     *
+     * @return AppleMakerNotes|null Parsed maker notes instance or null when the payload cannot be decoded.
+     */
     private function parseAppleData(string $raw): ?AppleMakerNotes
     {
         try {

--- a/src/Parse/Icc/IccDecoder.php
+++ b/src/Parse/Icc/IccDecoder.php
@@ -158,6 +158,13 @@ final class IccDecoder
         return $iccData;
     }
 
+    /**
+     * Extracts the ICC specification version string from the profile header.
+     *
+     * @param string $data Raw ICC profile payload.
+     *
+     * @return string|null Human readable version or null when unavailable.
+     */
     private function extractVersion(string $data): ?string
     {
         $majorByte     = ord($data[8]);
@@ -181,6 +188,13 @@ final class IccDecoder
             : sprintf('%d.%d', $major, $minor);
     }
 
+    /**
+     * Normalises a 4-byte signature by uppercasing and validating its contents.
+     *
+     * @param string $signature Raw 4-byte signature string.
+     *
+     * @return string|null Uppercased signature or null when invalid.
+     */
     private function extractSignature(string $signature): ?string
     {
         if ($signature === '' || strlen($signature) < 4) {
@@ -190,6 +204,13 @@ final class IccDecoder
         return strtoupper($signature);
     }
 
+    /**
+     * Maps the rendering intent field from the profile header to a descriptive label.
+     *
+     * @param string $data Raw ICC profile payload.
+     *
+     * @return string|null Rendering intent description or null when unknown.
+     */
     private function extractRenderingIntent(string $data): ?string
     {
         $intent = $this->uInt32Be(substr($data, 64, 4));
@@ -197,6 +218,13 @@ final class IccDecoder
         return self::RENDERING_INTENT_MAP[$intent] ?? null;
     }
 
+    /**
+     * Extracts the profile ID digest when present.
+     *
+     * @param string $data Raw ICC profile payload.
+     *
+     * @return string|null Uppercased hexadecimal profile identifier or null when unset.
+     */
     private function extractProfileId(string $data): ?string
     {
         $profileId = substr($data, 84, 16);
@@ -207,6 +235,14 @@ final class IccDecoder
         return strtoupper(bin2hex($profileId));
     }
 
+    /**
+     * Extracts the profile description from the tag table.
+     *
+     * @param string $data        Raw ICC profile payload.
+     * @param int    $profileSize Declared profile size limiting the accessible range.
+     *
+     * @return string|null Profile description text or null when not available.
+     */
     private function extractDescription(string $data, int $profileSize): ?string
     {
         if ($profileSize < self::HEADER_LENGTH + 4) {
@@ -266,6 +302,13 @@ final class IccDecoder
         return null;
     }
 
+    /**
+     * Parses an ICC 'desc' tag to retrieve its ASCII description.
+     *
+     * @param string $data Raw tag payload beginning with the type signature.
+     *
+     * @return string|null Extracted description or null when invalid.
+     */
     private function parseDescTag(string $data): ?string
     {
         if (strlen($data) < 12) {
@@ -288,6 +331,13 @@ final class IccDecoder
         return rtrim($text, "\0");
     }
 
+    /**
+     * Parses an ICC 'mluc' tag to extract the first non-empty UTF-16 value.
+     *
+     * @param string $data Raw tag payload beginning with the type signature.
+     *
+     * @return string|null Extracted description string or null when no valid record exists.
+     */
     private function parseMlucTag(string $data): ?string
     {
         if (strlen($data) < 16) {
@@ -328,6 +378,13 @@ final class IccDecoder
         return null;
     }
 
+    /**
+     * Converts a UTF-16BE encoded string to UTF-8 when possible.
+     *
+     * @param string $data Raw UTF-16BE encoded bytes.
+     *
+     * @return string|null Converted UTF-8 string or null when conversion fails.
+     */
     private function decodeUtf16Be(string $data): ?string
     {
         if ($data === '') {
@@ -362,6 +419,13 @@ final class IccDecoder
         return null;
     }
 
+    /**
+     * Converts up to four bytes into an unsigned big-endian integer.
+     *
+     * @param string $bytes Raw bytes to interpret as a big-endian integer.
+     *
+     * @return int Parsed unsigned integer value.
+     */
     private function uInt32Be(string $bytes): int
     {
         $bytes = substr($bytes . "\0\0\0\0", 0, 4);

--- a/src/Parse/IsoBmff/BoxDescriptor.php
+++ b/src/Parse/IsoBmff/BoxDescriptor.php
@@ -18,6 +18,17 @@ use MagicSunday\ImageMeta\Core\StreamWindow;
  */
 final readonly class BoxDescriptor
 {
+    /**
+     * Initialises the immutable box descriptor with layout and payload information.
+     *
+     * @param string       $type          Four-character box type.
+     * @param int          $size          Total box size including header.
+     * @param int          $offset        Absolute offset of the box within the stream.
+     * @param int          $contentOffset Offset to the box payload relative to the stream.
+     * @param int          $contentSize   Size of the box payload in bytes.
+     * @param StreamWindow $window        Stream window exposing the box payload.
+     * @param string|null  $userType      UUID for user boxes when applicable.
+     */
     public function __construct(
         public string $type,
         public int $size,


### PR DESCRIPTION
## Summary
- add english phpdoc blocks to maker note, metadata builder, and resolver helpers
- document ICC and ISO BMFF decoding helpers for static analysis context

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68fcb25a0acc832391f893f6264b0656