### PR TITLE
refactor: replace mixed helper signatures in EXIF flow

### DIFF
--- a/src/Curate/Resolver/DeviceResolver.php
+++ b/src/Curate/Resolver/DeviceResolver.php
@@ -71,7 +71,7 @@ final readonly class DeviceResolver
     /**
      * Normalises arbitrary QuickTime metadata values to strings.
      */
-    private function stringFromMixed(mixed $value): ?string
+    private function stringFromMixed(string|int|float|bool|null $value): ?string
     {
         if (is_string($value)) {
             return $value;

--- a/src/Curate/Resolver/ExifTagResolver.php
+++ b/src/Curate/Resolver/ExifTagResolver.php
@@ -817,14 +817,7 @@ final readonly class ExifTagResolver
             return CoreValueConverters::toWhitePoint($value);
         }
 
-        if (!is_array($value)) {
-            return null;
-        }
-
-        /** @var array<int, array<int, int|float|string>|int|float|string> $arrayValue */
-        $arrayValue = array_values($value);
-
-        return CoreValueConverters::toWhitePoint($arrayValue);
+        return null;
     }
 
     /**
@@ -840,14 +833,7 @@ final readonly class ExifTagResolver
             return CoreValueConverters::toPrimaryChromaticities($value);
         }
 
-        if (!is_array($value)) {
-            return null;
-        }
-
-        /** @var array<int, array<int, int|float|string>|int|float|string> $arrayValue */
-        $arrayValue = array_values($value);
-
-        return CoreValueConverters::toPrimaryChromaticities($arrayValue);
+        return null;
     }
 
     /**
@@ -1545,10 +1531,8 @@ final readonly class ExifTagResolver
 
     /**
      * Returns a single field from the cached GPS metadata map.
-     *
-     * @return mixed
      */
-    private function gpsField(string $key): mixed
+    private function gpsField(string $key): string|int|float|DateTimeImmutable|null
     {
         $gps = $this->gps();
 
@@ -1799,7 +1783,7 @@ final readonly class ExifTagResolver
     /**
      * Returns the raw entry value for a tag.
      */
-    private function getValue(?Ifd $ifd, int $tag): mixed
+    private function getValue(?Ifd $ifd, int $tag): int|float|string|ExifRational|ExifRationalList|ExifNumericList|null
     {
         return $this->getEntry($ifd, $tag)?->value;
     }
@@ -1874,10 +1858,15 @@ final readonly class ExifTagResolver
     /**
      * Returns an array of floats converted from rational values.
      *
+     * @param array|int|float|string|ExifRational|ExifRationalList|ExifNumericList|null $value
+     *
+     * @phpstan-param array<int|string, int|float|string|array<int|string, int|float|string|null>>|int|float|string|ExifRational|ExifRationalList|ExifNumericList|null $value
+     *
      * @return list<float>
      */
-    private function normalizeRationalList(mixed $value): array
-    {
+    private function normalizeRationalList(
+        array|int|float|string|ExifRational|ExifRationalList|ExifNumericList|null $value,
+    ): array {
         if ($value instanceof ExifRationalList) {
             $floats = [];
             foreach ($value->values as $rational) {
@@ -1900,7 +1889,10 @@ final readonly class ExifTagResolver
 
         if (is_array($value)) {
             $values = [];
-            foreach (array_values($value) as $component) {
+            /** @var list<array<int|string, int|float|string|null>|int|float|string> $components */
+            $components = array_values($value);
+
+            foreach ($components as $component) {
                 $sanitised = $this->sanitizeRationalArrayComponent($component);
                 if ($sanitised === null) {
                     return [];
@@ -1930,17 +1922,24 @@ final readonly class ExifTagResolver
     /**
      * Normalises numeric lists from EXIF entries.
      *
+     * @param array|int|float|string|ExifRational|ExifRationalList|ExifNumericList|null $value
+     *
+     * @phpstan-param array<int|string, int|float|string|array<int|string, int|float|string|null>>|int|float|string|ExifRational|ExifRationalList|ExifNumericList|null $value
+     *
      * @return list<int|float>
      */
-    private function normalizeNumericList(mixed $value): array
+    private function normalizeNumericList(array|int|float|string|ExifRational|ExifRationalList|ExifNumericList|null $value): array
     {
         if ($value instanceof ExifNumericList) {
             return $value->values;
         }
 
         if (is_array($value)) {
+            /** @var array<int|string, int|float|string|array<int|string, int|float|string|null>> $numericComponents */
+            $numericComponents = $value;
+
             $result = [];
-            foreach ($value as $component) {
+            foreach ($numericComponents as $component) {
                 if (is_int($component) || is_float($component)) {
                     $result[] = $component;
                 }
@@ -1959,10 +1958,15 @@ final readonly class ExifTagResolver
     /**
      * Normalises raw rational values into formats accepted by the shared converter.
      *
+     * @param array|int|float|string|ExifRational|ExifRationalList|ExifNumericList|null $value
+     *
+     * @phpstan-param array<int|string, int|float|string|array<int|string, int|float|string|null>>|int|float|string|ExifRational|ExifRationalList|ExifNumericList|null $value
+     *
      * @return array<int, int|float|string>|int|float|ExifRational|ExifRationalList|ExifNumericList|null
      */
-    private function sanitizeRationalInput(mixed $value): array|int|float|ExifRational|ExifRationalList|ExifNumericList|null
-    {
+    private function sanitizeRationalInput(
+        array|int|float|string|ExifRational|ExifRationalList|ExifNumericList|null $value,
+    ): array|int|float|ExifRational|ExifRationalList|ExifNumericList|null {
         if ($value instanceof ExifRationalList || $value instanceof ExifRational || $value instanceof ExifNumericList) {
             return $value;
         }
@@ -1989,10 +1993,15 @@ final readonly class ExifTagResolver
     /**
      * Normalises list elements into rational-compatible representations.
      *
+     * @param array|int|float|string|null $component
+     *
+     * @phpstan-param array<int|string, array<int|string, int|float|string|null>|int|float|string|null>|int|float|string|null $component
+     *
      * @return array<int, int|float|string>|int|float|null
      */
-    private function sanitizeRationalArrayComponent(mixed $component): array|int|float|null
-    {
+    private function sanitizeRationalArrayComponent(
+        array|int|float|string|null $component,
+    ): array|int|float|null {
         if (is_int($component) || is_float($component)) {
             return $component;
         }

--- a/src/Curate/Resolver/GpsResolver.php
+++ b/src/Curate/Resolver/GpsResolver.php
@@ -22,7 +22,6 @@ use function array_map;
 use function count;
 use function is_float;
 use function is_int;
-use function is_string;
 use function preg_match;
 use function preg_split;
 use function sprintf;
@@ -322,9 +321,9 @@ final readonly class GpsResolver
     /**
      * Returns the value as string when not empty.
      */
-    private function stringValue(mixed $value): ?string
+    private function stringValue(?string $value): ?string
     {
-        if (!is_string($value)) {
+        if ($value === null) {
             return null;
         }
 
@@ -336,7 +335,7 @@ final readonly class GpsResolver
     /**
      * Returns the value as float when numeric.
      */
-    private function floatValue(mixed $value): ?float
+    private function floatValue(int|float|null $value): ?float
     {
         if (is_float($value)) {
             return $value;
@@ -352,7 +351,7 @@ final readonly class GpsResolver
     /**
      * Returns the value as integer when numeric.
      */
-    private function intValue(mixed $value): ?int
+    private function intValue(int|float|null $value): ?int
     {
         if (is_int($value)) {
             return $value;

--- a/src/Model/Exif/ExifDocument.php
+++ b/src/Model/Exif/ExifDocument.php
@@ -31,8 +31,8 @@ use function round;
 use function rtrim;
 use function str_pad;
 use function str_replace;
-use function strtoupper;
 use function strlen;
+use function strtoupper;
 use function substr;
 use function trim;
 
@@ -494,17 +494,7 @@ final readonly class ExifDocument
     {
         $raw = $this->value($this->exifIfd, ExifTag::SHUTTER_SPEED_VALUE);
 
-        if (
-            $raw === null
-            || (
-                !is_int($raw)
-                && !is_float($raw)
-                && !is_string($raw)
-                && !$raw instanceof ExifRational
-                && !$raw instanceof ExifRationalList
-                && !$raw instanceof ExifNumericList
-            )
-        ) {
+        if ($raw === null) {
             return null;
         }
 
@@ -1271,8 +1261,10 @@ final readonly class ExifDocument
 
     /**
      * Returns a single value from the cached GPS metadata map.
+     *
+     * @return string|int|float|DateTimeImmutable|null
      */
-    private function gpsValue(string $key): mixed
+    private function gpsValue(string $key): string|int|float|DateTimeImmutable|null
     {
         $gps = $this->gps();
 
@@ -1407,15 +1399,7 @@ final readonly class ExifDocument
     {
         $value = $this->value($ifd, $tag);
 
-        if (
-            $value !== null
-            && !is_int($value)
-            && !is_float($value)
-            && !is_string($value)
-            && !$value instanceof ExifRational
-            && !$value instanceof ExifRationalList
-            && !$value instanceof ExifNumericList
-        ) {
+        if ($value === null) {
             return null;
         }
 
@@ -1424,8 +1408,10 @@ final readonly class ExifDocument
 
     /**
      * Retrieves the raw entry value for the provided tag.
+     *
+     * @return int|float|string|ExifRational|ExifRationalList|ExifNumericList|null
      */
-    private function value(?Ifd $ifd, int $tag): mixed
+    private function value(?Ifd $ifd, int $tag): int|float|string|ExifRational|ExifRationalList|ExifNumericList|null
     {
         if (!$ifd instanceof Ifd) {
             return null;

--- a/src/Model/Exif/IfdEntry.php
+++ b/src/Model/Exif/IfdEntry.php
@@ -95,7 +95,7 @@ final readonly class IfdEntry
     /**
      * Builds a list of {@see ExifRational} objects from array inputs.
      *
-     * @param array<int, mixed> $value The raw array representation.
+     * @param array<int, int|float|array<int, int|float>> $value The raw array representation.
      *
      * @return list<ExifRational>
      */
@@ -124,7 +124,7 @@ final readonly class IfdEntry
     /**
      * Extracts numeric list components from an array representation.
      *
-     * @param array<int, mixed> $value Raw numeric components.
+     * @param array<int, int|float|array<int, int|float>> $value Raw numeric components.
      *
      * @return list<int|float>
      */
@@ -143,11 +143,13 @@ final readonly class IfdEntry
     /**
      * Extracts a rational numerator/denominator pair from the provided value.
      *
-     * @param mixed $value Potential rational pair to inspect.
+     * @param array<int|string, int|float|array<int|string, int|float>>|int|float|null $value Potential rational pair to inspect.
+     *
+     * @phpstan-param array<int|string, int|float|array<int|string, int|float>>|int|float|null $value Potential rational pair to inspect.
      *
      * @return array{0: int|float, 1: int|float}|null
      */
-    private function extractRationalPair(mixed $value): ?array
+    private function extractRationalPair(array|int|float|null $value): ?array
     {
         if (!is_array($value)) {
             return null;

--- a/src/Model/Exif/ValueConverters.php
+++ b/src/Model/Exif/ValueConverters.php
@@ -669,9 +669,9 @@ final readonly class ValueConverters
     /**
      * Converts a GPS version payload into a dotted string.
      *
-     * @param mixed $value Raw value extracted from the IFD entry.
+     * @param string|int|float|ExifRational|ExifRationalList|ExifNumericList|null $value Raw value extracted from the IFD entry.
      */
-    private static function formatGpsVersion(mixed $value): ?string
+    private static function formatGpsVersion(string|int|float|ExifRational|ExifRationalList|ExifNumericList|null $value): ?string
     {
         if ($value instanceof ExifNumericList) {
             $components = array_map(static fn (int|float $component): int => (int) $component, $value->values);
@@ -702,10 +702,11 @@ final readonly class ValueConverters
     /**
      * Normalises ASCII-like EXIF strings by trimming whitespace and null padding.
      *
-     * @param mixed $value Raw value extracted from the IFD entry.
+     * @param string|int|float|ExifRational|ExifRationalList|ExifNumericList|null $value Raw value extracted from the IFD entry.
      */
-    private static function sanitizeString(mixed $value): ?string
-    {
+    private static function sanitizeString(
+        string|int|float|ExifRational|ExifRationalList|ExifNumericList|null $value,
+    ): ?string {
         if (!is_string($value)) {
             return null;
         }
@@ -718,10 +719,11 @@ final readonly class ValueConverters
     /**
      * Decodes undefined GPS ASCII strings with optional encoding prefixes.
      *
-     * @param mixed $value Raw value extracted from the IFD entry.
+     * @param string|int|float|ExifRational|ExifRationalList|ExifNumericList|null $value Raw value extracted from the IFD entry.
      */
-    private static function decodeUndefinedString(mixed $value): ?string
-    {
+    private static function decodeUndefinedString(
+        string|int|float|ExifRational|ExifRationalList|ExifNumericList|null $value,
+    ): ?string {
         if (!is_string($value)) {
             return null;
         }
@@ -749,10 +751,11 @@ final readonly class ValueConverters
     /**
      * Normalises a GPS date stamp into an ISO 8601 calendar date.
      *
-     * @param mixed $value Raw value extracted from the IFD entry.
+     * @param string|int|float|ExifRational|ExifRationalList|ExifNumericList|null $value Raw value extracted from the IFD entry.
      */
-    private static function normalizeGpsDate(mixed $value): ?string
-    {
+    private static function normalizeGpsDate(
+        string|int|float|ExifRational|ExifRationalList|ExifNumericList|null $value,
+    ): ?string {
         if (!is_string($value)) {
             return null;
         }


### PR DESCRIPTION
## Summary
- update GPS resolver helpers to accept explicit scalar unions instead of mixed
- narrow device and EXIF resolvers to use concrete value unions with matching PHPDoc metadata
- adjust EXIF document and value converters to align helper signatures for GPS metadata handling

## Testing
- composer ci:cgl
- composer ci:test:php:phpstan *(fails: existing repository issues unrelated to this change)*
- composer ci:test:php:unit:coverage *(fails: no coverage driver available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68fcb513e6b08323a558d6b7a74e7c6a