### PR TITLE
Refine EXIF GPS type handling

### DIFF
--- a/src/Curate/Resolver/ExifTagResolver.php
+++ b/src/Curate/Resolver/ExifTagResolver.php
@@ -54,7 +54,6 @@ use function is_int;
 use function is_numeric;
 use function is_string;
 use function ord;
-use function round;
 use function strtolower;
 use function trim;
 
@@ -1278,15 +1277,7 @@ final readonly class ExifTagResolver
     {
         $value = $this->gpsField('alt_ref');
 
-        if (is_int($value)) {
-            return $value;
-        }
-
-        if (is_float($value)) {
-            return (int) round($value);
-        }
-
-        return null;
+        return is_int($value) ? $value : null;
     }
 
     /**
@@ -1360,7 +1351,7 @@ final readonly class ExifTagResolver
     {
         $value = $this->gpsField('dop');
 
-        return is_float($value) ? $value : (is_int($value) ? (float) $value : null);
+        return is_float($value) ? $value : null;
     }
 
     /**
@@ -1438,7 +1429,7 @@ final readonly class ExifTagResolver
     {
         $value = $this->gpsField('dest_lat');
 
-        return is_float($value) ? $value : (is_int($value) ? (float) $value : null);
+        return is_float($value) ? $value : null;
     }
 
     /**
@@ -1458,7 +1449,7 @@ final readonly class ExifTagResolver
     {
         $value = $this->gpsField('dest_lon');
 
-        return is_float($value) ? $value : (is_int($value) ? (float) $value : null);
+        return is_float($value) ? $value : null;
     }
 
     /**
@@ -1531,6 +1522,8 @@ final readonly class ExifTagResolver
 
     /**
      * Returns a single field from the cached GPS metadata map.
+     *
+     * @return string|int|float|DateTimeImmutable|null
      */
     private function gpsField(string $key): string|int|float|DateTimeImmutable|null
     {
@@ -2024,7 +2017,9 @@ final readonly class ExifTagResolver
     /**
      * Sanitises associative or nested arrays into rational numerator/denominator pairs.
      *
-     * @param array<int, mixed> $value
+     * @param array<int|string, int|float|string|array<int|string, int|float|string|null>> $value
+     *
+     * @phpstan-param array<int|string, int|float|string|array<int|string, int|float|string|null>> $value
      *
      * @return array<int, int|float|string>|null
      */

--- a/src/Model/Exif/ExifDocument.php
+++ b/src/Model/Exif/ExifDocument.php
@@ -27,7 +27,6 @@ use function is_int;
 use function is_string;
 use function ord;
 use function preg_replace;
-use function round;
 use function rtrim;
 use function str_pad;
 use function str_replace;
@@ -1100,15 +1099,7 @@ final readonly class ExifDocument
     {
         $value = $this->gpsValue('speed_ms');
 
-        if (is_float($value)) {
-            return $value;
-        }
-
-        if (is_int($value)) {
-            return (float) $value;
-        }
-
-        return null;
+        return is_float($value) ? $value : null;
     }
 
     /**
@@ -1128,15 +1119,7 @@ final readonly class ExifDocument
     {
         $value = $this->gpsValue('track');
 
-        if (is_float($value)) {
-            return $value;
-        }
-
-        if (is_int($value)) {
-            return (float) $value;
-        }
-
-        return null;
+        return is_float($value) ? $value : null;
     }
 
     /**
@@ -1156,15 +1139,7 @@ final readonly class ExifDocument
     {
         $value = $this->gpsValue('img_direction');
 
-        if (is_float($value)) {
-            return $value;
-        }
-
-        if (is_int($value)) {
-            return (float) $value;
-        }
-
-        return null;
+        return is_float($value) ? $value : null;
     }
 
     /**
@@ -1184,15 +1159,7 @@ final readonly class ExifDocument
     {
         $value = $this->gpsValue('dest_bearing');
 
-        if (is_float($value)) {
-            return $value;
-        }
-
-        if (is_int($value)) {
-            return (float) $value;
-        }
-
-        return null;
+        return is_float($value) ? $value : null;
     }
 
     /**
@@ -1212,15 +1179,7 @@ final readonly class ExifDocument
     {
         $value = $this->gpsValue('dest_distance_m');
 
-        if (is_float($value)) {
-            return $value;
-        }
-
-        if (is_int($value)) {
-            return (float) $value;
-        }
-
-        return null;
+        return is_float($value) ? $value : null;
     }
 
     /**
@@ -1230,15 +1189,7 @@ final readonly class ExifDocument
     {
         $value = $this->gpsValue('differential');
 
-        if (is_int($value)) {
-            return $value;
-        }
-
-        if (is_float($value)) {
-            return (int) round($value);
-        }
-
-        return null;
+        return is_int($value) ? $value : null;
     }
 
     /**
@@ -1248,15 +1199,7 @@ final readonly class ExifDocument
     {
         $value = $this->gpsValue('h_positioning_error');
 
-        if (is_float($value)) {
-            return $value;
-        }
-
-        if (is_int($value)) {
-            return (float) $value;
-        }
-
-        return null;
+        return is_float($value) ? $value : null;
     }
 
     /**

--- a/src/Model/Exif/IfdEntry.php
+++ b/src/Model/Exif/IfdEntry.php
@@ -19,6 +19,9 @@ use function is_int;
 
 /**
  * Represents a single entry within an image file directory (IFD).
+ *
+ * @phpstan-type ExifScalarValue int|float|string|ExifRational|ExifRationalList|ExifNumericList
+ * @phpstan-type ExifInputValue ExifScalarValue|array<int|string, int|float|array<int|string, int|float>>
  */
 final readonly class IfdEntry
 {
@@ -33,10 +36,10 @@ final readonly class IfdEntry
     /**
      * Normalises raw decoded values so callers may provide convenient array representations.
      *
-     * @param int                                                                                                        $tag   The numeric identifier of the entry.
-     * @param int                                                                                                        $type  The TIFF field type code.
-     * @param int                                                                                                        $count The number of values stored in the entry.
-     * @param int|float|string|ExifRational|ExifRationalList|ExifNumericList|array<int, int|float|array<int, int|float>> $value The raw value or values decoded from the IFD.
+     * @param int            $tag   The numeric identifier of the entry.
+     * @param int            $type  The TIFF field type code.
+     * @param int            $count The number of values stored in the entry.
+     * @param ExifInputValue $value The raw value or values decoded from the IFD.
      */
     public function __construct(
         int $tag,
@@ -53,11 +56,11 @@ final readonly class IfdEntry
     /**
      * Converts shorthand array inputs into strongly typed EXIF value objects.
      *
-     * @param int                                                                                                        $type  TIFF field type code describing the payload.
-     * @param int                                                                                                        $count Number of values stored for the entry.
-     * @param int|float|string|ExifRational|ExifRationalList|ExifNumericList|array<int, int|float|array<int, int|float>> $value Raw value passed to the constructor.
+     * @param int            $type  TIFF field type code describing the payload.
+     * @param int            $count Number of values stored for the entry.
+     * @param ExifInputValue $value Raw value passed to the constructor.
      *
-     * @return int|float|string|ExifRational|ExifRationalList|ExifNumericList
+     * @return ExifScalarValue
      */
     private function normaliseValue(
         int $type,

--- a/src/Model/Exif/ValueConverters.php
+++ b/src/Model/Exif/ValueConverters.php
@@ -45,13 +45,50 @@ use function trim;
 
 /**
  * Helper methods that translate EXIF/TIFF values into PHP friendly scalars.
+ *
+ * @phpstan-type ExifScalar int|float|string|ExifRational|ExifRationalList|ExifNumericList|null
+ * @phpstan-type GpsFieldMap array{
+ *     lat_ref:?string,
+ *     lat:?float,
+ *     lon_ref:?string,
+ *     lon:?float,
+ *     alt_ref:?int,
+ *     alt:?float,
+ *     version:?string,
+ *     satellites:?string,
+ *     status:?string,
+ *     measure_mode:?string,
+ *     dop:?float,
+ *     speed_ref:?string,
+ *     speed_ms:?float,
+ *     track_ref:?string,
+ *     track:?float,
+ *     img_direction_ref:?string,
+ *     img_direction:?float,
+ *     map_datum:?string,
+ *     dest_lat_ref:?string,
+ *     dest_lat:?float,
+ *     dest_lon_ref:?string,
+ *     dest_lon:?float,
+ *     dest_bearing_ref:?string,
+ *     dest_bearing:?float,
+ *     dest_distance_ref:?string,
+ *     dest_distance_m:?float,
+ *     processing_method:?string,
+ *     area_information:?string,
+ *     date:?string,
+ *     time:?string,
+ *     timestamp:?DateTimeImmutable,
+ *     differential:?int,
+ *     h_positioning_error:?float
+ * }
  */
 final readonly class ValueConverters
 {
     /**
      * Converts a TIFF RATIONAL or scalar value into a floating point value.
      *
-     * @param int|float|string|ExifRational|ExifRationalList|ExifNumericList|null $v The value to convert.
+     * @param ExifScalar $v The value to convert.
      *
      * @return float|null
      */
@@ -93,7 +130,7 @@ final readonly class ValueConverters
     /**
      * Converts a stored APEX aperture value into a traditional f-number.
      *
-     * @param int|float|string|ExifRational|ExifRationalList|ExifNumericList|null $value The APEX value to convert.
+     * @param ExifScalar $value The APEX value to convert.
      */
     public static function apexToFNumber(int|float|string|ExifRational|ExifRationalList|ExifNumericList|null $value): ?float
     {
@@ -112,6 +149,8 @@ final readonly class ValueConverters
 
     /**
      * Converts an APEX shutter speed value into seconds.
+     *
+     * @param ExifScalar $value The APEX value to convert.
      */
     public static function apexShutterSpeedToSeconds(
         int|float|string|ExifRational|ExifRationalList|ExifNumericList|null $value,
@@ -210,8 +249,8 @@ final readonly class ValueConverters
     /**
      * Converts a GPS speed measurement into metres per second.
      *
-     * @param string|null                                                         $ref   Speed reference (K, M or N).
-     * @param int|float|string|ExifRational|ExifRationalList|ExifNumericList|null $value The measured value.
+     * @param string|null $ref   Speed reference (K, M or N).
+     * @param ExifScalar  $value The measured value.
      */
     public static function gpsSpeedToMs(
         ?string $ref,
@@ -243,8 +282,8 @@ final readonly class ValueConverters
     /**
      * Converts a GPS destination distance to metres based on the reference unit.
      *
-     * @param string|null                                                         $ref   Distance reference (K, M or N).
-     * @param int|float|string|ExifRational|ExifRationalList|ExifNumericList|null $value The measured value.
+     * @param string|null $ref   Distance reference (K, M or N).
+     * @param ExifScalar  $value The measured value.
      */
     public static function gpsDistanceToMetres(
         ?string $ref,
@@ -302,7 +341,7 @@ final readonly class ValueConverters
     /**
      * Converts the EXIF flash bit field into a typed value object.
      *
-     * @param int|float|string|ExifRational|ExifRationalList|ExifNumericList|null $value Flash tag value representation.
+     * @param ExifScalar $value Flash tag value representation.
      */
     public static function flashFromShort(
         int|float|string|ExifRational|ExifRationalList|ExifNumericList|null $value,
@@ -380,41 +419,7 @@ final readonly class ValueConverters
     /**
      * Returns the default GPS metadata structure with all keys initialised to null.
      *
-     * @return array{
-     *     lat_ref:?string,
-     *     lat:?float,
-     *     lon_ref:?string,
-     *     lon:?float,
-     *     alt_ref:?int,
-     *     alt:?float,
-     *     version:?string,
-     *     satellites:?string,
-     *     status:?string,
-     *     measure_mode:?string,
-     *     dop:?float,
-     *     speed_ref:?string,
-     *     speed_ms:?float,
-     *     track_ref:?string,
-     *     track:?float,
-     *     img_direction_ref:?string,
-     *     img_direction:?float,
-     *     map_datum:?string,
-     *     dest_lat_ref:?string,
-     *     dest_lat:?float,
-     *     dest_lon_ref:?string,
-     *     dest_lon:?float,
-     *     dest_bearing_ref:?string,
-     *     dest_bearing:?float,
-     *     dest_distance_ref:?string,
-     *     dest_distance_m:?float,
-     *     processing_method:?string,
-     *     area_information:?string,
-     *     date:?string,
-     *     time:?string,
-     *     timestamp:?DateTimeImmutable,
-     *     differential:?int,
-     *     h_positioning_error:?float
-     * }
+     * @return GpsFieldMap
      */
     public static function emptyGpsResult(): array
     {
@@ -460,41 +465,7 @@ final readonly class ValueConverters
      *
      * @param Ifd $gps The GPS IFD containing coordinate tags.
      *
-     * @return array{
-     *     lat_ref:?string,
-     *     lat:?float,
-     *     lon_ref:?string,
-     *     lon:?float,
-     *     alt_ref:?int,
-     *     alt:?float,
-     *     version:?string,
-     *     satellites:?string,
-     *     status:?string,
-     *     measure_mode:?string,
-     *     dop:?float,
-     *     speed_ref:?string,
-     *     speed_ms:?float,
-     *     track_ref:?string,
-     *     track:?float,
-     *     img_direction_ref:?string,
-     *     img_direction:?float,
-     *     map_datum:?string,
-     *     dest_lat_ref:?string,
-     *     dest_lat:?float,
-     *     dest_lon_ref:?string,
-     *     dest_lon:?float,
-     *     dest_bearing_ref:?string,
-     *     dest_bearing:?float,
-     *     dest_distance_ref:?string,
-     *     dest_distance_m:?float,
-     *     processing_method:?string,
-     *     area_information:?string,
-     *     date:?string,
-     *     time:?string,
-     *     timestamp:?DateTimeImmutable,
-     *     differential:?int,
-     *     h_positioning_error:?float
-     * }
+     * @return GpsFieldMap
      */
     public static function gpsFromIfd(Ifd $gps): array
     {
@@ -669,7 +640,7 @@ final readonly class ValueConverters
     /**
      * Converts a GPS version payload into a dotted string.
      *
-     * @param string|int|float|ExifRational|ExifRationalList|ExifNumericList|null $value Raw value extracted from the IFD entry.
+     * @param ExifScalar $value Raw value extracted from the IFD entry.
      */
     private static function formatGpsVersion(string|int|float|ExifRational|ExifRationalList|ExifNumericList|null $value): ?string
     {
@@ -702,7 +673,7 @@ final readonly class ValueConverters
     /**
      * Normalises ASCII-like EXIF strings by trimming whitespace and null padding.
      *
-     * @param string|int|float|ExifRational|ExifRationalList|ExifNumericList|null $value Raw value extracted from the IFD entry.
+     * @param ExifScalar $value Raw value extracted from the IFD entry.
      */
     private static function sanitizeString(
         string|int|float|ExifRational|ExifRationalList|ExifNumericList|null $value,
@@ -719,7 +690,7 @@ final readonly class ValueConverters
     /**
      * Decodes undefined GPS ASCII strings with optional encoding prefixes.
      *
-     * @param string|int|float|ExifRational|ExifRationalList|ExifNumericList|null $value Raw value extracted from the IFD entry.
+     * @param ExifScalar $value Raw value extracted from the IFD entry.
      */
     private static function decodeUndefinedString(
         string|int|float|ExifRational|ExifRationalList|ExifNumericList|null $value,
@@ -751,7 +722,7 @@ final readonly class ValueConverters
     /**
      * Normalises a GPS date stamp into an ISO 8601 calendar date.
      *
-     * @param string|int|float|ExifRational|ExifRationalList|ExifNumericList|null $value Raw value extracted from the IFD entry.
+     * @param ExifScalar $value Raw value extracted from the IFD entry.
      */
     private static function normalizeGpsDate(
         string|int|float|ExifRational|ExifRationalList|ExifNumericList|null $value,

--- a/tests/Curate/Resolver/ExifTagResolverTest.php
+++ b/tests/Curate/Resolver/ExifTagResolverTest.php
@@ -135,8 +135,10 @@ final class ExifTagResolverTest extends TestCase
 
         $gps = $resolver->gps();
         self::assertSame('N', $gps['lat_ref']);
+        self::assertIsFloat($gps['lat']);
         self::assertEqualsWithDelta(51.5, $gps['lat'], 0.000001);
         self::assertSame('E', $gps['lon_ref']);
+        self::assertIsFloat($gps['lon']);
         self::assertEqualsWithDelta(8.5, $gps['lon'], 0.000001);
         self::assertSame(0, $gps['alt_ref']);
         self::assertEqualsWithDelta(150.0, $gps['alt'], 0.000001);
@@ -148,22 +150,38 @@ final class ExifTagResolverTest extends TestCase
         self::assertSame('05', $resolver->gpsSatellites());
         self::assertSame('A', $resolver->gpsStatus());
         self::assertSame('3', $resolver->gpsMeasureMode());
-        self::assertEqualsWithDelta(2.5, $resolver->gpsDop(), 0.000001);
+        $dop = $resolver->gpsDop();
+        self::assertIsFloat($dop);
+        self::assertEqualsWithDelta(2.5, $dop, 0.000001);
         self::assertSame('K', $resolver->gpsSpeedRef());
-        self::assertEqualsWithDelta(20.0, $resolver->gpsSpeed(), 0.000001);
+        $speed = $resolver->gpsSpeed();
+        self::assertIsFloat($speed);
+        self::assertEqualsWithDelta(20.0, $speed, 0.000001);
         self::assertSame('T', $resolver->gpsTrackRef());
-        self::assertEqualsWithDelta(123.45, $resolver->gpsTrack(), 0.000001);
+        $track = $resolver->gpsTrack();
+        self::assertIsFloat($track);
+        self::assertEqualsWithDelta(123.45, $track, 0.000001);
         self::assertSame('M', $resolver->gpsImgDirectionRef());
-        self::assertEqualsWithDelta(250.0, $resolver->gpsImgDirection(), 0.000001);
+        $imgDirection = $resolver->gpsImgDirection();
+        self::assertIsFloat($imgDirection);
+        self::assertEqualsWithDelta(250.0, $imgDirection, 0.000001);
         self::assertSame('WGS-84', $resolver->gpsMapDatum());
         self::assertSame('N', $resolver->gpsDestinationLatitudeRef());
-        self::assertEqualsWithDelta(41.0, $resolver->gpsDestinationLatitude(), 0.000001);
+        $destLat = $resolver->gpsDestinationLatitude();
+        self::assertIsFloat($destLat);
+        self::assertEqualsWithDelta(41.0, $destLat, 0.000001);
         self::assertSame('E', $resolver->gpsDestinationLongitudeRef());
-        self::assertEqualsWithDelta(8.5, $resolver->gpsDestinationLongitude(), 0.000001);
+        $destLon = $resolver->gpsDestinationLongitude();
+        self::assertIsFloat($destLon);
+        self::assertEqualsWithDelta(8.5, $destLon, 0.000001);
         self::assertSame('T', $resolver->gpsDestinationBearingRef());
-        self::assertEqualsWithDelta(123.0, $resolver->gpsDestinationBearing(), 0.000001);
+        $destBearing = $resolver->gpsDestinationBearing();
+        self::assertIsFloat($destBearing);
+        self::assertEqualsWithDelta(123.0, $destBearing, 0.000001);
         self::assertSame('K', $resolver->gpsDestinationDistanceRef());
-        self::assertEqualsWithDelta(42000.0, $resolver->gpsDestinationDistance(), 0.000001);
+        $destDistance = $resolver->gpsDestinationDistance();
+        self::assertIsFloat($destDistance);
+        self::assertEqualsWithDelta(42000.0, $destDistance, 0.000001);
         self::assertSame('NETWORK', $resolver->gpsProcessingMethod());
         self::assertSame('AreaName', $resolver->gpsAreaInformation());
         self::assertSame('2024-05-06', $resolver->gpsDate());
@@ -175,7 +193,9 @@ final class ExifTagResolverTest extends TestCase
         self::assertSame('12:34:56.789000', $timestamp->format('H:i:s.u'));
 
         self::assertSame(2, $resolver->gpsDifferential());
-        self::assertEqualsWithDelta(1.5, $resolver->gpsHorizontalPositioningError(), 0.000001);
+        $horizontalError = $resolver->gpsHorizontalPositioningError();
+        self::assertIsFloat($horizontalError);
+        self::assertEqualsWithDelta(1.5, $horizontalError, 0.000001);
     }
 
     /**
@@ -201,15 +221,25 @@ final class ExifTagResolverTest extends TestCase
         self::assertEqualsWithDelta(42000.0, $gps['dest_distance_m'], 0.000001);
 
         self::assertSame('K', $resolver->gpsSpeedRef());
-        self::assertEqualsWithDelta(20.0, $resolver->gpsSpeed(), 0.000001);
+        $speed = $resolver->gpsSpeed();
+        self::assertIsFloat($speed);
+        self::assertEqualsWithDelta(20.0, $speed, 0.000001);
         self::assertSame('T', $resolver->gpsTrackRef());
-        self::assertEqualsWithDelta(90.0, $resolver->gpsTrack(), 0.000001);
+        $track = $resolver->gpsTrack();
+        self::assertIsFloat($track);
+        self::assertEqualsWithDelta(90.0, $track, 0.000001);
         self::assertSame('M', $resolver->gpsImgDirectionRef());
-        self::assertEqualsWithDelta(45.0, $resolver->gpsImgDirection(), 0.000001);
+        $imgDirection = $resolver->gpsImgDirection();
+        self::assertIsFloat($imgDirection);
+        self::assertEqualsWithDelta(45.0, $imgDirection, 0.000001);
         self::assertSame('T', $resolver->gpsDestinationBearingRef());
-        self::assertEqualsWithDelta(45.0, $resolver->gpsDestinationBearing(), 0.000001);
+        $destBearing = $resolver->gpsDestinationBearing();
+        self::assertIsFloat($destBearing);
+        self::assertEqualsWithDelta(45.0, $destBearing, 0.000001);
         self::assertSame('K', $resolver->gpsDestinationDistanceRef());
-        self::assertEqualsWithDelta(42000.0, $resolver->gpsDestinationDistance(), 0.000001);
+        $destDistance = $resolver->gpsDestinationDistance();
+        self::assertIsFloat($destDistance);
+        self::assertEqualsWithDelta(42000.0, $destDistance, 0.000001);
         self::assertSame('2024-05-06', $resolver->gpsDate());
         self::assertSame('12:34:56.789', $resolver->gpsTime());
 
@@ -218,7 +248,9 @@ final class ExifTagResolverTest extends TestCase
         self::assertSame('2024-05-06T12:34:56+00:00', $timestamp->format(DATE_ATOM));
 
         self::assertSame(2, $resolver->gpsDifferential());
-        self::assertEqualsWithDelta(1.5, $resolver->gpsHorizontalPositioningError(), 0.000001);
+        $horizontalError = $resolver->gpsHorizontalPositioningError();
+        self::assertIsFloat($horizontalError);
+        self::assertEqualsWithDelta(1.5, $horizontalError, 0.000001);
     }
 
     /**
@@ -251,6 +283,25 @@ final class ExifTagResolverTest extends TestCase
         self::assertSame([-60, 120], $resolver->timeZoneOffsetMinutes());
         self::assertSame(7, $resolver->selfTimerModeSeconds());
         self::assertSame(1, $resolver->interlace());
+    }
+
+    /**
+     * Ensures GPS conversions return null when unit references are unknown.
+     */
+    #[Test]
+    public function gpsConversionsRequireKnownReferences(): void
+    {
+        $gpsIfd = new Ifd([
+            ExifTag::GPS_SPEED_REF         => new IfdEntry(ExifTag::GPS_SPEED_REF, 2, 1, 'X'),
+            ExifTag::GPS_SPEED             => new IfdEntry(ExifTag::GPS_SPEED, 5, 1, new ExifRational(72000, 1000)),
+            ExifTag::GPS_DEST_DISTANCE_REF => new IfdEntry(ExifTag::GPS_DEST_DISTANCE_REF, 2, 1, 'Q'),
+            ExifTag::GPS_DEST_DISTANCE     => new IfdEntry(ExifTag::GPS_DEST_DISTANCE, 5, 1, new ExifRational(42, 1)),
+        ]);
+
+        $resolver = new ExifTagResolver(new ExifDocument(new Ifd([]), null, $gpsIfd, null, null));
+
+        self::assertNull($resolver->gpsSpeed());
+        self::assertNull($resolver->gpsDestinationDistance());
     }
 
     /**

--- a/tests/Model/Exif/ExifDocumentTest.php
+++ b/tests/Model/Exif/ExifDocumentTest.php
@@ -372,8 +372,10 @@ final class ExifDocumentTest extends TestCase
         $gps = $doc->gps();
 
         self::assertSame('S', $gps['lat_ref']);
+        self::assertIsFloat($gps['lat']);
         self::assertEqualsWithDelta(-33.870094, $gps['lat'], 0.000001);
         self::assertSame('W', $gps['lon_ref']);
+        self::assertIsFloat($gps['lon']);
         self::assertEqualsWithDelta(-18.415772, $gps['lon'], 0.000001);
         self::assertSame(1, $gps['alt_ref']);
         self::assertEqualsWithDelta(-250.0, $gps['alt'], 0.000001);
@@ -382,21 +384,29 @@ final class ExifDocumentTest extends TestCase
         self::assertSame('07', $gps['satellites']);
         self::assertSame('V', $gps['status']);
         self::assertSame('2', $gps['measure_mode']);
+        self::assertIsFloat($gps['dop']);
         self::assertEqualsWithDelta(1.5, $gps['dop'], 0.000001);
         self::assertSame('N', $gps['speed_ref']);
+        self::assertIsFloat($gps['speed_ms']);
         self::assertEqualsWithDelta(6.3508166667, $gps['speed_ms'], 0.000001);
         self::assertSame('M', $gps['track_ref']);
+        self::assertIsFloat($gps['track']);
         self::assertEqualsWithDelta(183.21, $gps['track'], 0.000001);
         self::assertSame('T', $gps['img_direction_ref']);
+        self::assertIsFloat($gps['img_direction']);
         self::assertEqualsWithDelta(90.0, $gps['img_direction'], 0.000001);
         self::assertSame('WGS-84', $gps['map_datum']);
         self::assertSame('N', $gps['dest_lat_ref']);
+        self::assertIsFloat($gps['dest_lat']);
         self::assertEqualsWithDelta(34.0, $gps['dest_lat'], 0.000001);
         self::assertSame('E', $gps['dest_lon_ref']);
+        self::assertIsFloat($gps['dest_lon']);
         self::assertEqualsWithDelta(19.0, $gps['dest_lon'], 0.000001);
         self::assertSame('T', $gps['dest_bearing_ref']);
+        self::assertIsFloat($gps['dest_bearing']);
         self::assertEqualsWithDelta(45.0, $gps['dest_bearing'], 0.000001);
         self::assertSame('M', $gps['dest_distance_ref']);
+        self::assertIsFloat($gps['dest_distance_m']);
         self::assertEqualsWithDelta(160934.4, $gps['dest_distance_m'], 0.000001);
         self::assertSame('SURVEY', $gps['processing_method']);
         self::assertSame('Test Area', $gps['area_information']);
@@ -409,6 +419,46 @@ final class ExifDocumentTest extends TestCase
 
         self::assertSame(1, $gps['differential']);
         self::assertEqualsWithDelta(0.5, $gps['h_positioning_error'], 0.000001);
+
+        self::assertIsFloat($doc->gpsSpeedMetresPerSecond());
+        self::assertIsFloat($doc->gpsTrack());
+        self::assertIsFloat($doc->gpsImgDirection());
+        self::assertIsFloat($doc->gpsDestinationBearing());
+        self::assertIsFloat($doc->gpsDestinationDistanceMetres());
+        self::assertSame(1, $doc->gpsDifferential());
+        self::assertIsFloat($doc->gpsHorizontalPositioningError());
+    }
+
+    /**
+     * Ensures GPS speed conversion returns null when the unit reference is unknown.
+     */
+    #[Test]
+    public function gpsSpeedMetresPerSecondRequiresKnownReference(): void
+    {
+        $gpsIfd = new Ifd([
+            ExifTag::GPS_SPEED_REF => new IfdEntry(ExifTag::GPS_SPEED_REF, 2, 1, 'X'),
+            ExifTag::GPS_SPEED     => new IfdEntry(ExifTag::GPS_SPEED, 5, 1, new ExifRational(5000, 100)),
+        ]);
+
+        $doc = new ExifDocument(new Ifd([]), null, $gpsIfd, null, null);
+
+        self::assertNull($doc->gpsSpeedMetresPerSecond());
+    }
+
+    /**
+     * Ensures destination distance conversion returns null when the unit reference is unknown.
+     */
+    #[Test]
+    public function gpsDestinationDistanceRequiresKnownReference(): void
+    {
+        $gpsIfd = new Ifd([
+            ExifTag::GPS_DEST_DISTANCE_REF => new IfdEntry(ExifTag::GPS_DEST_DISTANCE_REF, 2, 1, 'Q'),
+            ExifTag::GPS_DEST_DISTANCE     => new IfdEntry(ExifTag::GPS_DEST_DISTANCE, 5, 1, new ExifRational(250, 1)),
+        ]);
+
+        $doc = new ExifDocument(new Ifd([]), null, $gpsIfd, null, null);
+
+        self::assertNull($doc->gpsDestinationDistanceMetres());
     }
 
     /**


### PR DESCRIPTION
## Summary
- tighten GPS accessors in `ExifDocument`/`ExifTagResolver` so helpers return only the strongly-typed results produced by the GPS converter
- narrow the ValueConverters and IfdEntry contracts with shared phpstan type definitions for EXIF scalar inputs and the shaped GPS metadata map
- extend EXIF and resolver PHPUnit suites to assert strict float/int behaviour and unknown-reference fallbacks for GPS helpers

## Testing
- `composer ci:test:php:unit:coverage` *(fails: no code coverage driver available)*
- `composer ci:test:php:phpstan` *(fails: existing repository-wide baseline issues reported)*
- `composer ci:cgl` *(applied automatically, reverted unrelated formatting adjustments)*

------
https://chatgpt.com/codex/tasks/task_e_68fcbcfaf5d083238a22d23203c6fa46