### PR TITLE
docs: document structured metadata builder helpers

### DIFF
--- a/src/Curate/Resolver/AppleResolver.php
+++ b/src/Curate/Resolver/AppleResolver.php
@@ -49,18 +49,18 @@ final readonly class AppleResolver
         $identifier = $quickTimeMeta->contentIdentifier();
         $resolver   = new QuickTimeResolver($quickTimeMeta);
 
-        $cameraType       = $resolver->string('CameraType');
-        $hdrHeadroom      = $resolver->float('HdrHeadroom') ?? $resolver->float('HDRHeadroom');
-        $hdrGain          = $this->floatList($resolver, 'HdrGain', 'HDRGain');
-        $snr              = $resolver->float('SNRSetting') ?? $resolver->float('SNR');
-        $focusPosition    = $resolver->float('FocusPosition');
-        $livePhotoIndex   = $resolver->int('LivePhotoVideoIndex');
-        $colorTemperature = $resolver->int('ColorTemperature');
-        $semanticPreset      = $resolver->string('SemanticStylePreset');
-        $semanticWarmth      = $resolver->float('SemanticStyleWarmth');
-        $semanticTone        = $resolver->float('SemanticStyleTone');
+        $cameraType         = $resolver->string('CameraType');
+        $hdrHeadroom        = $resolver->float('HdrHeadroom') ?? $resolver->float('HDRHeadroom');
+        $hdrGain            = $this->floatList($resolver, 'HdrGain', 'HDRGain');
+        $snr                = $resolver->float('SNRSetting') ?? $resolver->float('SNR');
+        $focusPosition      = $resolver->float('FocusPosition');
+        $livePhotoIndex     = $resolver->int('LivePhotoVideoIndex');
+        $colorTemperature   = $resolver->int('ColorTemperature');
+        $semanticPreset     = $resolver->string('SemanticStylePreset');
+        $semanticWarmth     = $resolver->float('SemanticStyleWarmth');
+        $semanticTone       = $resolver->float('SemanticStyleTone');
         $accelerationVector = $this->floatList($resolver, 'AccelerationVector');
-        $flags               = $this->flags($resolver);
+        $flags              = $this->flags($resolver);
 
         if (
             $identifier === null

--- a/src/Curate/Resolver/RegionsResolver.php
+++ b/src/Curate/Resolver/RegionsResolver.php
@@ -262,7 +262,7 @@ final readonly class RegionsResolver
     }
 
     /**
-     * @param list<Region> $regions
+     * @param list<Region>                                                                                                                                                      $regions
      * @param list<array{geometry: array{x: float, y: float, w: float, h: float}|null, person: string|null, confidence: float|null, rotation: float|null, faceId: string|null}> $entries
      *
      * @return list<Region>
@@ -362,8 +362,8 @@ final readonly class RegionsResolver
     /**
      * Merges overlapping region metadata, preferring existing geometry while enriching attributes.
      *
-     * @param Region $base        Primary region resolved from MWG metadata.
-     * @param Region $supplement  Supplementary region derived from Apple metadata.
+     * @param Region $base       Primary region resolved from MWG metadata.
+     * @param Region $supplement Supplementary region derived from Apple metadata.
      *
      * @return Region Combined region carrying the most complete metadata set.
      */

--- a/src/Curate/StructuredMetadata.php
+++ b/src/Curate/StructuredMetadata.php
@@ -54,40 +54,40 @@ final readonly class StructuredMetadata
     /**
      * Creates a structured metadata aggregate populated with curated value objects for each domain.
      *
-     * @param Interop             $interop Interoperability metadata derived from EXIF tags.
-     * @param TiffData            $tiff TIFF-related imaging parameters.
-     * @param CompositeImageInfo  $composite Composite capture information for multi-image scenes.
-     * @param Standards           $standards Metadata standard identifiers and versions.
-     * @param Camera              $camera Camera manufacturer and model information.
-     * @param Lens                $lens Lens identification and optical properties.
-     * @param Image               $image Image dimensions and orientation details.
-     * @param Exposure            $exposure Exposure settings and capture parameters.
-     * @param Capture             $capture Environmental capture metadata.
-     * @param Gps                 $gps Geographic positioning information.
-     * @param Device              $device Host device information.
-     * @param Apple               $apple Apple-specific metadata aggregate.
-     * @param Xmp                 $xmp Parsed XMP document wrapper.
-     * @param File                $file File level metadata and characteristics.
-     * @param Container           $container Container format metadata.
-     * @param Preview             $preview Embedded preview information.
-     * @param Video               $video Video track metadata when available.
-     * @param Audio               $audio Audio track metadata when available.
-     * @param ColorProfile        $colorProfile Colour profile information.
-     * @param ProcessingSettings  $processing Image processing metadata.
+     * @param Interop             $interop             Interoperability metadata derived from EXIF tags.
+     * @param TiffData            $tiff                TIFF-related imaging parameters.
+     * @param CompositeImageInfo  $composite           Composite capture information for multi-image scenes.
+     * @param Standards           $standards           Metadata standard identifiers and versions.
+     * @param Camera              $camera              Camera manufacturer and model information.
+     * @param Lens                $lens                Lens identification and optical properties.
+     * @param Image               $image               Image dimensions and orientation details.
+     * @param Exposure            $exposure            Exposure settings and capture parameters.
+     * @param Capture             $capture             Environmental capture metadata.
+     * @param Gps                 $gps                 Geographic positioning information.
+     * @param Device              $device              Host device information.
+     * @param Apple               $apple               Apple-specific metadata aggregate.
+     * @param Xmp                 $xmp                 Parsed XMP document wrapper.
+     * @param File                $file                File level metadata and characteristics.
+     * @param Container           $container           Container format metadata.
+     * @param Preview             $preview             Embedded preview information.
+     * @param Video               $video               Video track metadata when available.
+     * @param Audio               $audio               Audio track metadata when available.
+     * @param ColorProfile        $colorProfile        Colour profile information.
+     * @param ProcessingSettings  $processing          Image processing metadata.
      * @param WhiteBalanceDetails $whiteBalanceDetails White balance analysis details.
-     * @param Focus               $focus Focus distance and autofocus data.
-     * @param Motion              $motion Motion and acceleration measurements.
-     * @param Scene               $scene Scene classification details.
-     * @param Regions             $regions Region and face annotations.
-     * @param Keywords            $keywords Keyword annotations.
-     * @param Rights              $rights Rights and licensing information.
-     * @param Author              $author Creator metadata values.
-     * @param Temporal            $temporal Temporal metadata beyond capture timestamps.
-     * @param Derived             $derived Derived asset references.
-     * @param RelatedAssets       $related Related asset references from metadata.
-     * @param Sensor              $sensor Sensor and detection metadata.
-     * @param Uav                 $uav Unmanned aerial vehicle metadata.
-     * @param Integrity           $integrity Integrity and validation metadata.
+     * @param Focus               $focus               Focus distance and autofocus data.
+     * @param Motion              $motion              Motion and acceleration measurements.
+     * @param Scene               $scene               Scene classification details.
+     * @param Regions             $regions             Region and face annotations.
+     * @param Keywords            $keywords            Keyword annotations.
+     * @param Rights              $rights              Rights and licensing information.
+     * @param Author              $author              Creator metadata values.
+     * @param Temporal            $temporal            Temporal metadata beyond capture timestamps.
+     * @param Derived             $derived             Derived asset references.
+     * @param RelatedAssets       $related             Related asset references from metadata.
+     * @param Sensor              $sensor              Sensor and detection metadata.
+     * @param Uav                 $uav                 Unmanned aerial vehicle metadata.
+     * @param Integrity           $integrity           Integrity and validation metadata.
      */
     public function __construct(
         public Interop $interop,

--- a/src/Curate/StructuredMetadataBuilder.php
+++ b/src/Curate/StructuredMetadataBuilder.php
@@ -91,6 +91,10 @@ final class StructuredMetadataBuilder
 
     /**
      * Builds the structured metadata aggregate from the supplied metadata container.
+     *
+     * @param Metadata $metadata Metadata container with decoded EXIF, XMP and QuickTime data.
+     *
+     * @return StructuredMetadata Structured aggregate composed from specialised resolvers.
      */
     public function build(Metadata $metadata): StructuredMetadata
     {
@@ -443,7 +447,12 @@ final class StructuredMetadataBuilder
     }
 
     /**
-     * Builds a device value object using container level metadata.
+     * Builds the device metadata aggregate by combining EXIF and QuickTime sources.
+     *
+     * @param ExifTagResolver   $exif              Resolver exposing EXIF tag helpers.
+     * @param QuickTimeResolver $quickTimeResolver Resolver exposing QuickTime metadata fields.
+     *
+     * @return Device Device value object describing capture hardware and software.
      */
     private function buildDevice(ExifTagResolver $exif, QuickTimeResolver $quickTimeResolver): Device
     {
@@ -465,6 +474,12 @@ final class StructuredMetadataBuilder
      *
      * Fractional seconds are mirrored into the generic field to keep display values consistent
      * whenever only the original or digitized timestamp carries sub-second precision.
+     *
+     * @param ExifTagResolver   $resolver  Resolver exposing EXIF timestamps and offsets.
+     * @param QuickTimeResolver $quickTime QuickTime metadata resolver used for time fallbacks.
+     * @param XmpResolver       $xmp       Resolver providing XMP timestamp fields.
+     *
+     * @return Temporal Normalised temporal metadata aggregate.
      */
     private function buildTemporal(ExifTagResolver $resolver, QuickTimeResolver $quickTime, XmpResolver $xmp): Temporal
     {
@@ -528,6 +543,10 @@ final class StructuredMetadataBuilder
 
     /**
      * Builds a camera value object using EXIF metadata.
+     *
+     * @param ExifTagResolver $exif Resolver exposing camera related EXIF tags.
+     *
+     * @return Camera Normalised camera metadata aggregate.
      */
     private function buildCamera(ExifTagResolver $exif): Camera
     {
@@ -548,6 +567,10 @@ final class StructuredMetadataBuilder
 
     /**
      * Builds a lens value object using EXIF metadata.
+     *
+     * @param ExifTagResolver $exif Resolver exposing lens specific EXIF tags.
+     *
+     * @return Lens Normalised lens metadata aggregate.
      */
     private function buildLens(ExifTagResolver $exif): Lens
     {
@@ -567,6 +590,10 @@ final class StructuredMetadataBuilder
 
     /**
      * Builds the image value object using EXIF metadata.
+     *
+     * @param ExifTagResolver $exif Resolver exposing image related EXIF tags.
+     *
+     * @return Image Normalised image metadata aggregate.
      */
     private function buildImage(ExifTagResolver $exif): Image
     {
@@ -591,7 +618,11 @@ final class StructuredMetadataBuilder
     }
 
     /**
-     * Counts detected face regions for the scene aggregate.
+     * Counts the number of face regions detected in the supplied region aggregate.
+     *
+     * @param Regions $regions Region aggregate containing detected regions.
+     *
+     * @return int|null Number of face regions or null when no face region exists.
      */
     private function countFaceRegions(Regions $regions): ?int
     {
@@ -607,7 +638,14 @@ final class StructuredMetadataBuilder
     }
 
     /**
-     * Builds the scene value object incorporating EXIF and container hints.
+     * Builds the scene metadata aggregate using EXIF, QuickTime and Apple sources.
+     *
+     * @param ExifTagResolver   $exif      Resolver exposing EXIF scene metadata.
+     * @param QuickTimeResolver $quickTime Resolver providing QuickTime scene hints.
+     * @param Apple             $apple     Aggregated Apple maker note metadata.
+     * @param int|null          $faceCount Number of detected face regions.
+     *
+     * @return Scene Scene metadata value object.
      */
     private function buildScene(
         ExifTagResolver $exif,
@@ -650,9 +688,9 @@ final class StructuredMetadataBuilder
     /**
      * Builds the Apple metadata aggregate by combining maker note values with QuickTime fallbacks.
      *
-     * @param AppleMakerNotes|null $makerNotes Parsed Apple maker note payload.
+     * @param AppleMakerNotes|null $makerNotes        Parsed Apple maker note payload.
      * @param QuickTimeResolver    $quickTimeResolver Resolver exposing QuickTime metadata entries.
-     * @param QuickTimeMeta|null   $quickTimeMeta QuickTime metadata container used for content identifiers.
+     * @param QuickTimeMeta|null   $quickTimeMeta     QuickTime metadata container used for content identifiers.
      *
      * @return Apple Apple metadata value object with normalised fields.
      */
@@ -774,7 +812,7 @@ final class StructuredMetadataBuilder
      * Resolves the first non-empty QuickTime string value from the supplied keys.
      *
      * @param QuickTimeResolver $resolver Resolver used to read QuickTime metadata keys.
-     * @param string            ...$keys Candidate metadata keys to inspect in order.
+     * @param string            ...$keys  Candidate metadata keys to inspect in order.
      *
      * @return string|null First matching string value or null when no value is present.
      */
@@ -794,7 +832,7 @@ final class StructuredMetadataBuilder
      * Resolves the first available QuickTime float value from the provided keys.
      *
      * @param QuickTimeResolver $resolver Resolver used to read QuickTime metadata keys.
-     * @param string            ...$keys Candidate metadata keys to inspect in order.
+     * @param string            ...$keys  Candidate metadata keys to inspect in order.
      *
      * @return float|null First matching float value or null when no value is present.
      */
@@ -814,7 +852,7 @@ final class StructuredMetadataBuilder
      * Resolves the first available QuickTime integer value from the provided keys.
      *
      * @param QuickTimeResolver $resolver Resolver used to read QuickTime metadata keys.
-     * @param string            ...$keys Candidate metadata keys to inspect in order.
+     * @param string            ...$keys  Candidate metadata keys to inspect in order.
      *
      * @return int|null First matching integer value or null when no value is present.
      */
@@ -831,7 +869,12 @@ final class StructuredMetadataBuilder
     }
 
     /**
-     * @return list<float>|null
+     * Resolves a list of floating point values from a space or comma separated QuickTime field.
+     *
+     * @param QuickTimeResolver $resolver Resolver used to read QuickTime metadata keys.
+     * @param string            ...$keys  Candidate metadata keys to inspect in order.
+     *
+     * @return list<float>|null Normalised list of float values or null when unavailable.
      */
     private function quickTimeFloatList(QuickTimeResolver $resolver, string ...$keys): ?array
     {
@@ -860,7 +903,11 @@ final class StructuredMetadataBuilder
     }
 
     /**
-     * @return array<string, bool>
+     * Builds a normalised map of QuickTime boolean flags relevant to Apple metadata.
+     *
+     * @param QuickTimeResolver $resolver Resolver used to read QuickTime metadata keys.
+     *
+     * @return array<string, bool> Normalised flag map keyed by camelCase identifiers.
      */
     private function quickTimeFlags(QuickTimeResolver $resolver): array
     {
@@ -877,6 +924,10 @@ final class StructuredMetadataBuilder
 
     /**
      * Normalises the colour space based on interoperability metadata hints.
+     *
+     * @param ExifTagResolver $resolver Resolver exposing colour space and interoperability tags.
+     *
+     * @return ColorSpace|null Normalised colour space enumeration or null when undefined.
      */
     private function normalizedColorSpace(ExifTagResolver $resolver): ?ColorSpace
     {
@@ -895,7 +946,9 @@ final class StructuredMetadataBuilder
     /**
      * Returns the first string from the list or null.
      *
-     * @param list<string> $values
+     * @param list<string> $values List of candidate string values in priority order.
+     *
+     * @return string|null First entry in the list or null when the list is empty.
      */
     private function firstListValue(array $values): ?string
     {
@@ -904,6 +957,10 @@ final class StructuredMetadataBuilder
 
     /**
      * Normalises EXIF fractional second strings.
+     *
+     * @param string|null $value Raw fractional second string as stored in EXIF tags.
+     *
+     * @return string|null Cleaned fractional second string or null when empty.
      */
     private function sanitizeSubSeconds(?string $value): ?string
     {
@@ -912,6 +969,10 @@ final class StructuredMetadataBuilder
 
     /**
      * Attempts to parse various ISO 8601 date representations.
+     *
+     * @param string|null $value Timestamp string in ISO 8601 format.
+     *
+     * @return DateTimeImmutable|null Parsed timestamp or null when parsing fails.
      */
     private function parseFlexibleDate(?string $value): ?DateTimeImmutable
     {

--- a/src/MakerNotes/Apple/BinaryPlistDecoder.php
+++ b/src/MakerNotes/Apple/BinaryPlistDecoder.php
@@ -357,7 +357,7 @@ final class BinaryPlistDecoder
 
     private function convertUidPayloadToDecimalString(string $payload): string
     {
-        $value = '0';
+        $value  = '0';
         $length = strlen($payload);
         for ($idx = 0; $idx < $length; ++$idx) {
             $value = $this->multiplyAndAddDecimalString($value, 256, ord($payload[$idx]));
@@ -372,10 +372,10 @@ final class BinaryPlistDecoder
         $result = '';
 
         for ($idx = strlen($decimal) - 1; $idx >= 0; --$idx) {
-            $digit = ord($decimal[$idx]) - 48;
+            $digit   = ord($decimal[$idx]) - 48;
             $product = ($digit * $multiplier) + $carry;
-            $result = chr(($product % 10) + 48) . $result;
-            $carry  = intdiv($product, 10);
+            $result  = chr(($product % 10) + 48) . $result;
+            $carry   = intdiv($product, 10);
         }
 
         while ($carry > 0) {

--- a/src/MakerNotes/AppleDecoder.php
+++ b/src/MakerNotes/AppleDecoder.php
@@ -26,8 +26,8 @@ use function is_int;
 use function is_numeric;
 use function is_string;
 use function sha1;
-use function strlen;
 use function str_starts_with;
+use function strlen;
 use function substr;
 use function trim;
 
@@ -124,17 +124,17 @@ final class AppleDecoder implements MakerNotesDecoderInterface
      */
     private function buildAppleMakerNotes(array $dictionary): ?AppleMakerNotes
     {
-        $contentIdentifier   = $this->stringValue($dictionary, 'ContentIdentifier');
-        $cameraType          = $this->stringValue($dictionary, 'CameraType');
-        $hdrHeadroom         = $this->floatValue($dictionary, 'HdrHeadroom', 'HDRHeadroom');
-        $hdrGain             = $this->floatList($dictionary, 'HdrGain', 'HDRGain');
-        $snr                 = $this->floatValue($dictionary, 'SNRSetting', 'SNR');
-        $focusPosition       = $this->floatValue($dictionary, 'FocusPosition');
-        $livePhotoIndex      = $this->intValue($dictionary, 'LivePhotoVideoIndex');
-        $colorTemperature    = $this->intValue($dictionary, 'ColorTemperature');
-        $semanticStylePreset = $this->stringValue($dictionary, 'SemanticStylePreset');
-        $semanticStyleWarmth = $this->floatValue($dictionary, 'SemanticStyleWarmth');
-        $semanticStyleTone   = $this->floatValue($dictionary, 'SemanticStyleTone');
+        $contentIdentifier    = $this->stringValue($dictionary, 'ContentIdentifier');
+        $cameraType           = $this->stringValue($dictionary, 'CameraType');
+        $hdrHeadroom          = $this->floatValue($dictionary, 'HdrHeadroom', 'HDRHeadroom');
+        $hdrGain              = $this->floatList($dictionary, 'HdrGain', 'HDRGain');
+        $snr                  = $this->floatValue($dictionary, 'SNRSetting', 'SNR');
+        $focusPosition        = $this->floatValue($dictionary, 'FocusPosition');
+        $livePhotoIndex       = $this->intValue($dictionary, 'LivePhotoVideoIndex');
+        $colorTemperature     = $this->intValue($dictionary, 'ColorTemperature');
+        $semanticStylePreset  = $this->stringValue($dictionary, 'SemanticStylePreset');
+        $semanticStyleWarmth  = $this->floatValue($dictionary, 'SemanticStyleWarmth');
+        $semanticStyleTone    = $this->floatValue($dictionary, 'SemanticStyleTone');
         $semanticStyleCompact = $this->semanticStyleFromCollection($dictionary);
         if ($semanticStyleCompact !== null) {
             [$compactPreset, $compactWarmth, $compactTone] = $semanticStyleCompact;
@@ -151,8 +151,8 @@ final class AppleDecoder implements MakerNotesDecoderInterface
                 $semanticStyleTone = $compactTone;
             }
         }
-        $accelerationVector  = $this->floatList($dictionary, 'AccelerationVector');
-        $flags               = $this->extractFlags($dictionary);
+        $accelerationVector = $this->floatList($dictionary, 'AccelerationVector');
+        $flags              = $this->extractFlags($dictionary);
 
         if (
             $contentIdentifier === null

--- a/tests/Curate/Resolver/RegionsResolverTest.php
+++ b/tests/Curate/Resolver/RegionsResolverTest.php
@@ -100,7 +100,6 @@ final class RegionsResolverTest extends TestCase
         self::assertSame('202', $appleOnlyRegion->faceId);
     }
 
-
     #[Test]
     public function enrichesMwgFacesWithAppleMetadataWithoutGeometry(): void
     {
@@ -135,7 +134,6 @@ final class RegionsResolverTest extends TestCase
         self::assertNotNull($second->rotationDeg);
         self::assertEqualsWithDelta(-2.0, $second->rotationDeg, 0.0001);
     }
-
 
     #[Test]
     public function normalisesPixelCoordinatesUsingAppliedDimensions(): void
@@ -176,8 +174,8 @@ final class RegionsResolverTest extends TestCase
     #[DataProvider('provideAppleConfidenceProperty')]
     public function normalisesAppleConfidenceValues(string $confidenceProperty): void
     {
-        $count          = 1001;
-        $maxConfidence  = $count - 1;
+        $count            = 1001;
+        $maxConfidence    = $count - 1;
         $confidenceValues = array_map(static fn (int $value): string => (string) $value, range(0, $maxConfidence));
 
         $values = [
@@ -193,8 +191,8 @@ final class RegionsResolverTest extends TestCase
             $values['{' . self::NS_APPLE . '}Confidence'] = $confidenceValues;
         }
 
-        $resolver  = new RegionsResolver();
-        $document  = new XmpDocument($values);
+        $resolver   = new RegionsResolver();
+        $document   = new XmpDocument($values);
         $reflection = new ReflectionClass($resolver);
         $method     = $reflection->getMethod('extractAppleFaceRegions');
         $method->setAccessible(true);
@@ -208,7 +206,7 @@ final class RegionsResolverTest extends TestCase
             self::assertSame(RegionType::FACE, $region->type);
             self::assertNotNull($region->confidence);
 
-            $rawConfidence = (float) $confidenceValues[$index];
+            $rawConfidence      = (float) $confidenceValues[$index];
             $expectedConfidence = $rawConfidence > 1.0
                 ? $rawConfidence / $maxConfidence
                 : $rawConfidence;

--- a/tests/MakerNotes/AppleDecoder/AppleDecoderTest.php
+++ b/tests/MakerNotes/AppleDecoder/AppleDecoderTest.php
@@ -69,8 +69,8 @@ final class AppleDecoderTest extends TestCase
     #[Test]
     public function decodeMapsSemanticStyleFromCompactArray(): void
     {
-        $raw      = (string) hex2bin('62706c6973743030d2010203045f1011436f6e74656e744964656e7469666965725d53656d616e7469635374796c655d636f6d706163742d7374796c65d405060708090a0b0c525f30525f31525f32525f33555669766964233fd000000000000023bfb999999999999a1001080d212f3d46494c4f5258616a0000000000000101000000000000000d0000000000000000000000000000006c');
-        $decoder  = new AppleDecoder();
+        $raw     = (string) hex2bin('62706c6973743030d2010203045f1011436f6e74656e744964656e7469666965725d53656d616e7469635374796c655d636f6d706163742d7374796c65d405060708090a0b0c525f30525f31525f32525f33555669766964233fd000000000000023bfb999999999999a1001080d212f3d46494c4f5258616a0000000000000101000000000000000d0000000000000000000000000000006c');
+        $decoder = new AppleDecoder();
 
         $metadata = $decoder->decode($raw, 'Apple', 'iPhone');
 
@@ -110,16 +110,16 @@ final class AppleDecoderTest extends TestCase
         $method->setAccessible(true);
 
         $scalarNotes = $method->invoke($decoder, [
-            'ContentIdentifier'    => 'scalar',
-            'LivePhotoAuto'        => true,
-            'LivePhotoEnabled'     => true,
-            'LivePhotoActive'      => true,
-            'LivePhotoLongExposure'=> true,
-            'LivePhoto'            => 1,
-            'HdrAuto'              => 1,
-            'HdrEnabled'           => '1',
-            'NightMode'            => true,
-            'LongExposure'         => true,
+            'ContentIdentifier'     => 'scalar',
+            'LivePhotoAuto'         => true,
+            'LivePhotoEnabled'      => true,
+            'LivePhotoActive'       => true,
+            'LivePhotoLongExposure' => true,
+            'LivePhoto'             => 1,
+            'HdrAuto'               => 1,
+            'HdrEnabled'            => '1',
+            'NightMode'             => true,
+            'LongExposure'          => true,
         ]);
 
         $maskNotes = $method->invoke($decoder, [


### PR DESCRIPTION
## Summary
- add detailed PHPDoc blocks to StructuredMetadataBuilder helper methods covering inputs and return values
- accept php-cs-fixer alignment updates for structured metadata, Apple metadata resolvers, and associated tests

## Testing
- composer ci:cgl
- composer ci:test:php:phpstan *(fails: existing project-wide errors outside the modified files)*
- php .build/vendor/phpstan/phpstan/phpstan analyze src/Curate/StructuredMetadataBuilder.php --configuration .build/phpstan.neon --memory-limit=-1
- composer ci:test:php:unit *(fails: existing MemoryBufferTest expectation)
- composer ci:test:php:unit:coverage *(fails: Xdebug/PCOV coverage driver unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68fcc1b24c7c832391562ed0c4ec6117