### PR TITLE
Add keyed archive support to Apple maker note decoder

### DIFF
--- a/src/MakerNotes/Apple/KeyedArchiveUnarchiver.php
+++ b/src/MakerNotes/Apple/KeyedArchiveUnarchiver.php
@@ -1,0 +1,228 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\ImageMeta\MakerNotes\Apple;
+
+use MagicSunday\ImageMeta\Core\ParseError;
+
+use function array_is_list;
+use function array_key_exists;
+use function count;
+use function is_array;
+use function is_int;
+use function is_string;
+
+/**
+ * Minimal keyed archive unarchiver converting `CF$UID` based dictionaries into associative arrays.
+ */
+final class KeyedArchiveUnarchiver
+{
+    /**
+     * @var list<array<int|string, mixed>|bool|float|int|string|null>
+     */
+    private array $objects = [];
+
+    /**
+     * @var array<int, array<int|string, mixed>|bool|float|int|string|null>
+     */
+    private array $resolved = [];
+
+    /**
+     * @var array<int, bool>
+     */
+    private array $inProgress = [];
+
+    /**
+     * @param array<int|string, array<int|string, mixed>|bool|float|int|string|null> $archive
+     *
+     * @return array<int|string, array<int|string, mixed>|bool|float|int|string|null>
+     */
+    public function unarchive(array $archive): array
+    {
+        if (!array_key_exists('$objects', $archive)) {
+            throw new ParseError('The keyed archive does not define any objects.');
+        }
+
+        $objects = $archive['$objects'];
+        if (!is_array($objects) || !array_is_list($objects) || $objects === []) {
+            throw new ParseError('The keyed archive object table is malformed.');
+        }
+
+        if (!array_key_exists('$top', $archive) || !is_array($archive['$top'])) {
+            throw new ParseError('The keyed archive is missing the top object reference.');
+        }
+
+        $top = $archive['$top'];
+        if (!array_key_exists('root', $top) || !is_array($top['root'])) {
+            throw new ParseError('The keyed archive does not define a root object.');
+        }
+
+        $this->objects    = $objects;
+        $this->resolved   = [];
+        $this->inProgress = [];
+
+        $root = $this->resolveValue($top['root']);
+        if (!is_array($root) || array_is_list($root)) {
+            throw new ParseError('The keyed archive root object must be a dictionary.');
+        }
+
+        return $root;
+    }
+
+    /**
+     * @param array<int|string, mixed>|bool|float|int|string|null $value
+     *
+     * @return array<int|string, mixed>|bool|float|int|string|null
+     */
+    private function resolveValue(array|bool|float|int|string|null $value): array|bool|float|int|string|null
+    {
+        if (!is_array($value)) {
+            return $value;
+        }
+
+        if ($this->isUidReference($value)) {
+            $uid = $value['CF$UID'];
+            if (!is_int($uid)) {
+                throw new ParseError('The keyed archive UID reference is invalid.');
+            }
+
+            return $this->resolveUid($uid);
+        }
+
+        if (array_key_exists('NS.keys', $value) && array_key_exists('NS.objects', $value)) {
+            return $this->resolveDictionary($value);
+        }
+
+        if (array_key_exists('NS.objects', $value) && !array_key_exists('NS.keys', $value)) {
+            return $this->resolveArray($value);
+        }
+
+        if (array_is_list($value)) {
+            $result = [];
+            foreach ($value as $entry) {
+                $result[] = $this->resolveValue($entry);
+            }
+
+            return $result;
+        }
+
+        $result = [];
+        foreach ($value as $key => $entry) {
+            if ($key === '$class') {
+                continue;
+            }
+
+            $result[$key] = $this->resolveValue($entry);
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param array<int|string, mixed> $reference
+     */
+    private function isUidReference(array $reference): bool
+    {
+        return count($reference) === 1 && array_key_exists('CF$UID', $reference);
+    }
+
+    /**
+     * @return array<int|string, mixed>|list<mixed>|bool|float|int|string|null
+     */
+    private function resolveUid(int $uid): array|bool|float|int|string|null
+    {
+        if (array_key_exists($uid, $this->resolved)) {
+            return $this->resolved[$uid];
+        }
+
+        if (array_key_exists($uid, $this->inProgress)) {
+            throw new ParseError('Recursive keyed archive reference detected.');
+        }
+
+        if (!array_key_exists($uid, $this->objects)) {
+            throw new ParseError('The keyed archive object reference is invalid.');
+        }
+
+        $this->inProgress[$uid] = true;
+
+        $object = $this->objects[$uid];
+        $value  = $this->resolveValue($object);
+
+        unset($this->inProgress[$uid]);
+
+        $this->resolved[$uid] = $value;
+
+        return $value;
+    }
+
+    /**
+     * @param array<int|string, mixed> $dictionary
+     *
+     * @return array<int|string, array<int|string, mixed>|bool|float|int|string|null>
+     */
+    private function resolveDictionary(array $dictionary): array
+    {
+        if (!array_key_exists('NS.keys', $dictionary) || !array_key_exists('NS.objects', $dictionary)) {
+            throw new ParseError('The keyed archive dictionary is incomplete.');
+        }
+
+        $keys   = $dictionary['NS.keys'];
+        $values = $dictionary['NS.objects'];
+
+        if (!is_array($keys) || !array_is_list($keys)) {
+            throw new ParseError('The keyed archive dictionary keys are invalid.');
+        }
+
+        if (!is_array($values) || !array_is_list($values)) {
+            throw new ParseError('The keyed archive dictionary values are invalid.');
+        }
+
+        if (count($keys) !== count($values)) {
+            throw new ParseError('The keyed archive dictionary contains mismatched entries.');
+        }
+
+        $result = [];
+        foreach ($keys as $index => $keyReference) {
+            $key = $this->resolveValue($keyReference);
+            if (!is_string($key) && !is_int($key)) {
+                continue;
+            }
+
+            $result[(string) $key] = $this->resolveValue($values[$index]);
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param array<int|string, mixed> $array
+     *
+     * @return list<array<int|string, mixed>|bool|float|int|string|null>
+     */
+    private function resolveArray(array $array): array
+    {
+        if (!array_key_exists('NS.objects', $array)) {
+            throw new ParseError('The keyed archive array payload is missing its objects.');
+        }
+
+        $objects = $array['NS.objects'];
+        if (!is_array($objects) || !array_is_list($objects)) {
+            throw new ParseError('The keyed archive array contents are invalid.');
+        }
+
+        $result = [];
+        foreach ($objects as $entry) {
+            $result[] = $this->resolveValue($entry);
+        }
+
+        return $result;
+    }
+}

--- a/src/MakerNotes/AppleDecoder.php
+++ b/src/MakerNotes/AppleDecoder.php
@@ -14,6 +14,7 @@ namespace MagicSunday\ImageMeta\MakerNotes;
 use MagicSunday\ImageMeta\Core\ParseError;
 use MagicSunday\ImageMeta\MakerNotes\Apple\AppleMakerNotes;
 use MagicSunday\ImageMeta\MakerNotes\Apple\BinaryPlistDecoder;
+use MagicSunday\ImageMeta\MakerNotes\Apple\KeyedArchiveUnarchiver;
 
 use function array_is_list;
 use function array_key_exists;
@@ -114,7 +115,63 @@ final class AppleDecoder implements MakerNotesDecoderInterface
             return null;
         }
 
+        if ($this->isKeyedArchive($decoded)) {
+            try {
+                $decoded = (new KeyedArchiveUnarchiver())->unarchive($decoded);
+            } catch (ParseError) {
+                return null;
+            }
+        }
+
+        if (!is_array($decoded) || array_is_list($decoded)) {
+            return null;
+        }
+
         return $this->buildAppleMakerNotes($decoded);
+    }
+
+    /**
+     * @param array<int|string, array<int|string, mixed>|bool|float|int|string|null> $dictionary
+     */
+    private function isKeyedArchive(array $dictionary): bool
+    {
+        if (!array_key_exists('$archiver', $dictionary)) {
+            return false;
+        }
+
+        if (!array_key_exists('$top', $dictionary) || !is_array($dictionary['$top'])) {
+            return false;
+        }
+
+        if (!array_key_exists('$objects', $dictionary) || !is_array($dictionary['$objects'])) {
+            return false;
+        }
+
+        $top = $dictionary['$top'];
+
+        if (!is_array($top)) {
+            return false;
+        }
+
+        return $this->containsUidReference($top);
+    }
+
+    /**
+     * @param array<int|string, array<int|string, mixed>|bool|float|int|string|null> $value
+     */
+    private function containsUidReference(array $value): bool
+    {
+        if (array_key_exists('CF$UID', $value)) {
+            return true;
+        }
+
+        foreach ($value as $entry) {
+            if (is_array($entry) && $this->containsUidReference($entry)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/tests/MakerNotes/AppleDecoder/AppleDecoderTest.php
+++ b/tests/MakerNotes/AppleDecoder/AppleDecoderTest.php
@@ -31,8 +31,68 @@ use function strlen;
 final class AppleDecoderTest extends TestCase
 {
     /**
-     * Ensures the decoder extracts structured Apple maker note data from a representative payload.
+     * Ensures the decoder resolves keyed archive maker note data into structured metadata.
      */
+    #[Test]
+    public function decodeUnarchivesKeyedArchivePayload(): void
+    {
+        $hex = ''
+            . '62706c6973743030d40102030405066e725924617263686976657258246f626a656374735424746f70582476657273696f6e5f100f4e534b65796564'
+            . '4172636869766572af101f07080f101112131415161718191a1b1c1d1e1f232425262728292d2e2f303155246e756c6cd2090a0b0c5824636c617373'
+            . '65735a24636c6173736e616d65a30c0d0e5f10134e534d757461626c6544696374696f6e6172795c4e5344696374696f6e617279584e534f626a6563'
+            . '745f1011436f6e74656e744964656e7469666965725b48647248656164726f6f6d574864724761696e5a534e5253657474696e675d466f637573506f'
+            . '736974696f6e5f10134c69766550686f746f566964656f496e6465785f101353656d616e7469635374796c655072657365745f101353656d616e7469'
+            . '635374796c655761726d74685f101153656d616e7469635374796c65546f6e655f1012416363656c65726174696f6e566563746f725f101550686f74'
+            . '6f7341707046656174757265466c6167735a5363656e65466c6167735f1014496d61676550726f63657373696e67466c6167735d4c69766550686f74'
+            . '6f4175746f5f101361726368697665642d70686f746f2d7575696423400a000000000000a3202122233ff0000000000000233ff8000000000000233f'
+            . 'fc000000000000234037800000000000233fe28f5c28f5c28f10055c4472616d617469635761726d233fd333333333333323bfc3333333333333a32a'
+            . '2b2c233fbeb851eb851eb823bfd5c28f5c28f5c3233fe1eb851eb851ec10151002100309d33233343538525624636c617373574e532e6b6579735a4e'
+            . '532e6f626a65637473d13637564346245549441001ae393a3b3d3e40424446484a4c4e50d1362ed1362fd1363c1004d13625d1363f1006d136411007'
+            . 'd136431008d136451009d13647100ad13649100bd1364b100cd1364d100dd1364f100ed13651100fae535557595b5d5e60626466686a6cd136541010'
+            . 'd136561011d136581012d1365a1013d1365c1014d1362dd1365f1016d136611017d136631018d136651019d13667101ad13669101bd1366b101cd136'
+            . '6d101dd16f7054726f6f74d13671101e12000186a000080011001b00240029003200440066006c0071007a00850089009f00ac00b500c900d500dd00'
+            . 'e800f6010c01220138014c016101790184019b01a901bf01c801cc01d501de01e701f001f901fb02080211021a021e022702300239023b023d023f02'
+            . '400247024e025602610264026b026d027c027f028202850287028a028d028f0292029402970299029c029e02a102a302a602a802ab02ad02b002b202'
+            . 'b502b702ba02bc02cb02ce02d002d302d502d802da02dd02df02e202e402e702ea02ec02ef02f102f402f602f902fb02fe0300030303050308030a03'
+            . '0d030f03120317031a031c0000000000000201000000000000007300000000000000000000000000000321'
+        ;
+        $raw = (string) hex2bin($hex);
+        $decoder = new AppleDecoder();
+
+        $metadata = $decoder->decode($raw, 'Apple', 'iPhone');
+
+        self::assertInstanceOf(MakerNotesMetadata::class, $metadata);
+
+        $apple = $metadata->apple();
+        self::assertInstanceOf(AppleMakerNotes::class, $apple);
+        self::assertSame('archived-photo-uuid', $apple->contentIdentifier);
+        self::assertEqualsWithDelta(3.25, $apple->hdrHeadroom, 1e-12);
+        self::assertSame([1.0, 1.5, 1.75], $apple->hdrGain);
+        self::assertEqualsWithDelta(23.5, $apple->snr, 1e-12);
+        self::assertEqualsWithDelta(0.58, $apple->focusPosition, 1e-12);
+        self::assertSame(5, $apple->livePhotoIndex);
+        self::assertSame('DramaticWarm', $apple->semanticStylePreset);
+        self::assertEqualsWithDelta(0.3, $apple->semanticStyleWarmth, 1e-12);
+        self::assertEqualsWithDelta(-0.15, $apple->semanticStyleTone, 1e-12);
+        self::assertSame([0.12, -0.34, 0.56], $apple->accelerationVector);
+
+        self::assertArrayHasKey('livePhoto', $apple->flags);
+        self::assertArrayHasKey('livePhotoAuto', $apple->flags);
+        self::assertArrayHasKey('livePhotoEnabled', $apple->flags);
+        self::assertArrayHasKey('livePhotoLongExposure', $apple->flags);
+        self::assertArrayHasKey('hdrAuto', $apple->flags);
+        self::assertArrayHasKey('hdrEnabled', $apple->flags);
+        self::assertArrayHasKey('longExposure', $apple->flags);
+
+        self::assertTrue($apple->flags['livePhoto']);
+        self::assertTrue($apple->flags['livePhotoAuto']);
+        self::assertTrue($apple->flags['livePhotoEnabled']);
+        self::assertTrue($apple->flags['livePhotoLongExposure']);
+        self::assertTrue($apple->flags['hdrAuto']);
+        self::assertTrue($apple->flags['hdrEnabled']);
+        self::assertTrue($apple->flags['longExposure']);
+    }
+
     #[Test]
     public function decodeParsesAppleMakerNotes(): void
     {


### PR DESCRIPTION
## Summary
- add a dedicated keyed-archive unarchiver that resolves CF$UID references into plain PHP arrays
- detect keyed archive payloads in the Apple decoder and flatten them before building maker notes
- cover the regression with a keyed-archive maker note fixture exercising HDR, focus, semantic style, acceleration vector, and flag decoding

## Testing
- composer ci:test:php:unit *(fails: existing `MemoryBufferTest::testReadThrowsParseErrorOnShortRead` expectation not met)*
- .build/bin/phpunit --configuration .build/phpunit.xml tests/MakerNotes/AppleDecoder/AppleDecoderTest.php

------
https://chatgpt.com/codex/tasks/task_e_68fcc486b450832398d78e9d6638e689