### PR TITLE
Fix Apple semantic style fallback handling

### DIFF
--- a/src/Core/MemoryBuffer.php
+++ b/src/Core/MemoryBuffer.php
@@ -15,7 +15,6 @@ use MagicSunday\ImageMeta\Core\Util\Unpack;
 
 use function ord;
 use function strlen;
-use function substr;
 
 /**
  * Provides a simple, bounds-checked in-memory buffer abstraction.

--- a/src/Curate/StructuredMetadataBuilder.php
+++ b/src/Curate/StructuredMetadataBuilder.php
@@ -62,11 +62,17 @@ use MagicSunday\ImageMeta\Value\Uav;
 use MagicSunday\ImageMeta\Value\Video;
 use MagicSunday\ImageMeta\Value\WhiteBalanceDetails;
 
+use function array_is_list;
 use function array_key_exists;
 use function count;
 use function is_array;
+use function is_bool;
+use function is_float;
+use function is_int;
 use function is_numeric;
+use function is_string;
 use function preg_split;
+use function trim;
 use function strtoupper;
 
 /**
@@ -754,6 +760,23 @@ final class StructuredMetadataBuilder
             $semanticTone = $this->quickTimeFloat($quickTimeResolver, 'SemanticStyleTone');
         }
 
+        $semanticStyleComposite = $this->quickTimeSemanticStyle($quickTimeMeta);
+        if ($semanticStyleComposite !== null) {
+            [$compositePreset, $compositeWarmth, $compositeTone] = $semanticStyleComposite;
+
+            if ($semanticPreset === null && $compositePreset !== null) {
+                $semanticPreset = $compositePreset;
+            }
+
+            if ($semanticWarmth === null && $compositeWarmth !== null) {
+                $semanticWarmth = $compositeWarmth;
+            }
+
+            if ($semanticTone === null && $compositeTone !== null) {
+                $semanticTone = $compositeTone;
+            }
+        }
+
         $accelerationVector = $makerNotes?->accelerationVector;
         if ($accelerationVector === null) {
             $accelerationVector = $this->quickTimeFloatList($quickTimeResolver, 'AccelerationVector');
@@ -900,6 +923,134 @@ final class StructuredMetadataBuilder
         }
 
         return $values !== [] ? $values : null;
+    }
+
+    /**
+     * Extracts semantic style values from QuickTime composite metadata entries.
+     *
+     * @return array{0:?string,1:?float,2:?float}|null
+     */
+    private function quickTimeSemanticStyle(?QuickTimeMeta $meta): ?array
+    {
+        if ($meta === null) {
+            return null;
+        }
+
+        $value = $meta->keys['SemanticStyle'] ?? null;
+        if (!is_array($value)) {
+            return null;
+        }
+
+        /** @var array<int|string, mixed> $semantic */
+        $semantic = $value;
+
+        $entries = $this->normaliseSemanticStyleEntries($semantic);
+        if ($entries === null) {
+            return null;
+        }
+
+        $presetRaw      = $this->semanticStyleEntry($entries, 0);
+        $legacyWarmth   = $this->semanticStyleEntry($entries, 1);
+        $modernWarmth   = $legacyWarmth === null ? $this->semanticStyleEntry($entries, 2) : null;
+        $warmthRaw      = $legacyWarmth ?? $modernWarmth;
+        $toneRawLegacy  = $legacyWarmth !== null ? $this->semanticStyleEntry($entries, 2) : null;
+        $toneRawModern  = $legacyWarmth === null ? $this->semanticStyleEntry($entries, 3, 2) : null;
+        $toneRaw        = $toneRawLegacy ?? $toneRawModern;
+
+        $preset = $this->semanticStylePreset($presetRaw);
+        $warmth = $this->semanticStyleFloat($warmthRaw);
+        $tone   = $this->semanticStyleFloat($toneRaw);
+
+        if ($preset === null && $warmth === null && $tone === null) {
+            return null;
+        }
+
+        return [$preset, $warmth, $tone];
+    }
+
+    /**
+     * @param array<int|string, mixed> $semantic
+     *
+     * @return array<int|string, string|int|float|bool|null>|null
+     */
+    private function normaliseSemanticStyleEntries(array $semantic): ?array
+    {
+        if (!array_is_list($semantic)) {
+            foreach (['values', 'Values'] as $key) {
+                if (array_key_exists($key, $semantic) && is_array($semantic[$key])) {
+                    /** @var array<int|string, mixed> $values */
+                    $values = $semantic[$key];
+
+                    return $this->normaliseSemanticStyleEntries($values);
+                }
+            }
+        }
+
+        return $semantic;
+    }
+
+    /**
+     * @param array<int|string, string|int|float|bool|null> $entries
+     */
+    private function semanticStyleEntry(array $entries, int ...$indexes): string|int|float|bool|null
+    {
+        foreach ($indexes as $index) {
+            $candidates = [$index, (string) $index, '_' . $index];
+            foreach ($candidates as $key) {
+                if (!array_key_exists($key, $entries)) {
+                    continue;
+                }
+
+                $value = $entries[$key];
+                if (is_array($value)) {
+                    foreach (['value', 'Value'] as $innerKey) {
+                        if (array_key_exists($innerKey, $value)) {
+                            $inner = $value[$innerKey];
+                            if (!is_array($inner)) {
+                                $value = $inner;
+                            }
+
+                            break;
+                        }
+                    }
+
+                    if (is_array($value)) {
+                        continue;
+                    }
+                }
+
+                if (is_string($value) || is_int($value) || is_float($value) || is_bool($value)) {
+                    return $value;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private function semanticStylePreset(string|int|float|bool|null $value): ?string
+    {
+        if (is_string($value)) {
+            $trimmed = trim($value);
+            if ($trimmed !== '') {
+                return $trimmed;
+            }
+        }
+
+        return null;
+    }
+
+    private function semanticStyleFloat(string|int|float|bool|null $value): ?float
+    {
+        if (is_float($value)) {
+            return $value;
+        }
+
+        if (is_int($value) || is_numeric($value)) {
+            return (float) $value;
+        }
+
+        return null;
     }
 
     /**

--- a/src/MakerNotes/AppleDecoder.php
+++ b/src/MakerNotes/AppleDecoder.php
@@ -343,57 +343,113 @@ final class AppleDecoder implements MakerNotesDecoderInterface
         /** @var array<int|string, mixed> $semantic */
         $semantic = $value;
 
-        $resolve = static function (array $entries, int $index): string|int|float|bool|array|null {
-            $intKey      = $index;
-            $stringKey   = (string) $index;
-            $underscored = '_' . $index;
-
-            if (array_key_exists($intKey, $entries)) {
-                return $entries[$intKey];
-            }
-
-            if (array_key_exists($stringKey, $entries)) {
-                return $entries[$stringKey];
-            }
-
-            if (array_key_exists($underscored, $entries)) {
-                return $entries[$underscored];
-            }
-
+        $entries = $this->semanticStyleEntries($semantic);
+        if ($entries === null) {
             return null;
-        };
-
-        $presetRaw = $resolve($semantic, 0);
-        $warmthRaw = $resolve($semantic, 1);
-        $toneRaw   = $resolve($semantic, 2);
-
-        $preset = null;
-        if (is_string($presetRaw)) {
-            $trimmed = trim($presetRaw);
-            if ($trimmed !== '') {
-                $preset = $trimmed;
-            }
         }
 
-        $warmth = null;
-        if (is_float($warmthRaw)) {
-            $warmth = $warmthRaw;
-        } elseif (is_int($warmthRaw) || is_numeric($warmthRaw)) {
-            $warmth = (float) $warmthRaw;
-        }
+        $presetRaw      = $this->semanticStyleEntry($entries, 0);
+        $legacyWarmth   = $this->semanticStyleEntry($entries, 1);
+        $modernWarmth   = $legacyWarmth === null ? $this->semanticStyleEntry($entries, 2) : null;
+        $warmthRaw      = $legacyWarmth ?? $modernWarmth;
+        $toneRawLegacy  = $legacyWarmth !== null ? $this->semanticStyleEntry($entries, 2) : null;
+        $toneRawModern  = $legacyWarmth === null ? $this->semanticStyleEntry($entries, 3, 2) : null;
+        $toneRaw        = $toneRawLegacy ?? $toneRawModern;
 
-        $tone = null;
-        if (is_float($toneRaw)) {
-            $tone = $toneRaw;
-        } elseif (is_int($toneRaw) || is_numeric($toneRaw)) {
-            $tone = (float) $toneRaw;
-        }
+        $preset = $this->semanticStylePreset($presetRaw);
+        $warmth = $this->semanticStyleFloat($warmthRaw);
+        $tone   = $this->semanticStyleFloat($toneRaw);
 
         if ($preset === null && $warmth === null && $tone === null) {
             return null;
         }
 
         return [$preset, $warmth, $tone];
+    }
+
+    /**
+     * @param array<int|string, mixed> $semantic
+     *
+     * @return array<int|string, string|int|float|bool|null>|null
+     */
+    private function semanticStyleEntries(array $semantic): ?array
+    {
+        if (!array_is_list($semantic)) {
+            foreach (['values', 'Values'] as $key) {
+                if (array_key_exists($key, $semantic) && is_array($semantic[$key])) {
+                    /** @var array<int|string, mixed> $values */
+                    $values = $semantic[$key];
+
+                    return $this->semanticStyleEntries($values);
+                }
+            }
+        }
+
+        return $semantic;
+    }
+
+    /**
+     * @param array<int|string, string|int|float|bool|null> $entries
+     */
+    private function semanticStyleEntry(array $entries, int ...$indexes): string|int|float|bool|null
+    {
+        foreach ($indexes as $index) {
+            $candidates = [$index, (string) $index, '_' . $index];
+            foreach ($candidates as $key) {
+                if (!array_key_exists($key, $entries)) {
+                    continue;
+                }
+
+                $value = $entries[$key];
+                if (is_array($value)) {
+                    foreach (['value', 'Value'] as $innerKey) {
+                        if (array_key_exists($innerKey, $value)) {
+                            $inner = $value[$innerKey];
+                            if (!is_array($inner)) {
+                                $value = $inner;
+                            }
+
+                            break;
+                        }
+                    }
+
+                    if (is_array($value)) {
+                        continue;
+                    }
+                }
+
+                if (is_string($value) || is_int($value) || is_float($value) || is_bool($value)) {
+                    return $value;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private function semanticStylePreset(string|int|float|bool|null $value): ?string
+    {
+        if (is_string($value)) {
+            $trimmed = trim($value);
+            if ($trimmed !== '') {
+                return $trimmed;
+            }
+        }
+
+        return null;
+    }
+
+    private function semanticStyleFloat(string|int|float|bool|null $value): ?float
+    {
+        if (is_float($value)) {
+            return $value;
+        }
+
+        if (is_int($value) || is_numeric($value)) {
+            return (float) $value;
+        }
+
+        return null;
     }
 
     /**

--- a/tests/Curate/StructuredMetadataBuilderTest.php
+++ b/tests/Curate/StructuredMetadataBuilderTest.php
@@ -523,6 +523,26 @@ final class StructuredMetadataBuilderTest extends TestCase
         self::assertSame([0.12, -0.34, 0.56], $structured->apple->accelerationVector);
     }
 
+    #[Test]
+    public function usesQuickTimeSemanticStyleDictionaryWhenMakerNotesMissing(): void
+    {
+        $quickTime = new QuickTimeMeta([
+            QuickTimeMeta::CONTENT_IDENTIFIER_KEY => 'qt-content',
+            'SemanticStyle'                       => [
+                '_0' => 'CompositePreset',
+                '_2' => 0.4,
+                '_3' => -0.15,
+            ],
+        ]);
+
+        $metadata   = new Metadata(['primary'], $quickTime, null, []);
+        $structured = (new StructuredMetadataBuilder())->build($metadata);
+
+        self::assertSame('CompositePreset', $structured->apple->semanticStylePreset);
+        self::assertEqualsWithDelta(0.4, $structured->apple->semanticStyleWarmth, 1e-12);
+        self::assertEqualsWithDelta(-0.15, $structured->apple->semanticStyleTone, 1e-12);
+    }
+
     /**
      * Ensures JPEG-only metadata uses the maker note night mode flag when QuickTime metadata is absent.
      */

--- a/tests/MakerNotes/AppleDecoder/AppleDecoderTest.php
+++ b/tests/MakerNotes/AppleDecoder/AppleDecoderTest.php
@@ -84,6 +84,30 @@ final class AppleDecoderTest extends TestCase
         self::assertEqualsWithDelta(-0.1, $apple->semanticStyleTone, 1e-12);
     }
 
+    #[Test]
+    public function buildAppleMakerNotesFallsBackToSemanticStyleDictionary(): void
+    {
+        $decoder = new AppleDecoder();
+        $method  = new ReflectionMethod(AppleDecoder::class, 'buildAppleMakerNotes');
+        $method->setAccessible(true);
+
+        $notes = $method->invoke($decoder, [
+            'ContentIdentifier' => 'dictionary-style',
+            'SemanticStyle'     => [
+                'values' => [
+                    '_0' => 'DictionaryPreset',
+                    '_2' => ['value' => 0.45],
+                    '_3' => -0.25,
+                ],
+            ],
+        ]);
+
+        self::assertInstanceOf(AppleMakerNotes::class, $notes);
+        self::assertSame('DictionaryPreset', $notes->semanticStylePreset);
+        self::assertEqualsWithDelta(0.45, $notes->semanticStyleWarmth, 1e-12);
+        self::assertEqualsWithDelta(-0.25, $notes->semanticStyleTone, 1e-12);
+    }
+
     private function buildMakerNotesBlob(): string
     {
         $hex = '62706c6973743030de0102030405060708090a0b0c0d0e0f13141516171b1c1d1e1f2021225f1012416363656c65726174696f6e566563746f725a43616d657261547970655f1010436f6c6f7254656d70657261747572655f1011436f6e74656e744964656e7469666965725d466f637573506f736974696f6e574864724761696e5b48647248656164726f6f6d5d4c69766550686f746f4175746f5f10134c69766550686f746f566964656f496e646578594e696768744d6f64655a534e5253657474696e675f101353656d616e7469635374796c655072657365745f101153656d616e7469635374796c65546f6e655f101353656d616e7469635374796c655761726d7468a3101112233fb999999999999a23bfc999999999999a233fd33333333333335454656c651113885a70686f746f2d75756964233fe3d70a3d70a3d7a318191a233ff0000000000000233ff3333333333333233ff4cccccccccccd23400400000000000009100208234038800000000000545761726d23bfa999999999999a233fc333333333333300080025003a00450058006c007a0082008e009c00b200bc00c700dd00f10107010b0114011d0126012b012e013901420146014f01580161016a016b016d016e0177017c0185000000000000020100000000000000230000000000000000000000000000018e';


### PR DESCRIPTION
## Summary
- add a semantic-style dictionary fallback to the Apple maker-note decoder when discrete keys are absent
- mirror the fallback for QuickTime metadata so structured output receives preset, warmth, and tone values
- extend maker-note and curator tests for both layouts and keep the MemoryBuffer short-read hook active for PHPUnit

## Testing
- composer ci:test:php:unit

------
https://chatgpt.com/codex/tasks/task_e_68fcc48729c48323b7f6a1eae12de1e3