### PR TITLE
feat: merge Apple face metadata supplements

### DIFF
--- a/src/Curate/Resolver/RegionsResolver.php
+++ b/src/Curate/Resolver/RegionsResolver.php
@@ -53,11 +53,12 @@ final readonly class RegionsResolver
             return new Regions([]);
         }
 
-        $dimensions   = $this->appliedDimensions($document);
-        $mwgRegions   = $this->extractMwgRegions($document, $dimensions);
-        $appleEntries = $this->appleFaceEntries($document, $dimensions);
-        $appleRegions = $this->regionsFromAppleEntries($appleEntries);
-        $mwgRegions   = $this->applyAppleMetadataWithoutGeometry($mwgRegions, $appleEntries);
+        $dimensions = $this->appliedDimensions($document);
+        $mwgRegions = $this->extractMwgRegions($document, $dimensions);
+        $appleData  = $this->extractAppleFaceRegions($document, $dimensions);
+        $supplement = $appleData['supplemental'];
+        $mwgRegions = $this->applyAppleSupplementalMetadata($mwgRegions, $supplement);
+        $appleRegions = $appleData['regions'];
 
         foreach ($appleRegions as $appleRegion) {
             $matchIndex = $this->findMatchingRegionIndex($mwgRegions, $appleRegion);
@@ -68,6 +69,8 @@ final readonly class RegionsResolver
 
             $mwgRegions[] = $appleRegion;
         }
+
+        $mwgRegions = $this->applyAppleSupplementalMetadata($mwgRegions, $supplement);
 
         return new Regions(array_values($mwgRegions));
     }
@@ -144,17 +147,20 @@ final readonly class RegionsResolver
     }
 
     /**
-     * Extracts Apple FaceInfo face entries.
+     * Extracts Apple FaceInfo face entries along with supplemental metadata.
      *
      * @param array{w: float, h: float}|null $dimensions
      *
-     * @return list<Region>
+     * @return array{regions: list<Region>, supplemental: list<array{geometry: array{x: float, y: float, w: float, h: float}|null, person: string|null, confidence: float|null, rotation: float|null, faceId: string|null}>}
      */
     private function extractAppleFaceRegions(XmpDocument $document, ?array $dimensions): array
     {
         $entries = $this->appleFaceEntries($document, $dimensions);
 
-        return $this->regionsFromAppleEntries($entries);
+        return [
+            'regions' => $this->regionsFromAppleEntries($entries),
+            'supplemental' => $entries,
+        ];
     }
 
     /**
@@ -262,12 +268,12 @@ final readonly class RegionsResolver
     }
 
     /**
-     * @param list<Region>                                                                                                                                                      $regions
+     * @param list<Region> $regions
      * @param list<array{geometry: array{x: float, y: float, w: float, h: float}|null, person: string|null, confidence: float|null, rotation: float|null, faceId: string|null}> $entries
      *
      * @return list<Region>
      */
-    private function applyAppleMetadataWithoutGeometry(array $regions, array $entries): array
+    private function applyAppleSupplementalMetadata(array $regions, array $entries): array
     {
         if ($entries === []) {
             return $regions;
@@ -288,12 +294,20 @@ final readonly class RegionsResolver
             return $regions;
         }
 
-        foreach ($entries as $position => $entry) {
-            if ($entry['geometry'] !== null) {
-                continue;
+        $hasSupplemental = false;
+        foreach ($entries as $entry) {
+            if ($this->hasSupplementalMetadata($entry)) {
+                $hasSupplemental = true;
+                break;
             }
+        }
 
-            if ($entry['person'] === null && $entry['confidence'] === null && $entry['rotation'] === null && $entry['faceId'] === null) {
+        if (!$hasSupplemental) {
+            return $regions;
+        }
+
+        foreach ($entries as $position => $entry) {
+            if (!$this->hasSupplementalMetadata($entry)) {
                 continue;
             }
 
@@ -320,6 +334,17 @@ final readonly class RegionsResolver
         }
 
         return $regions;
+    }
+
+    /**
+     * @param array{geometry: array{x: float, y: float, w: float, h: float}|null, person: string|null, confidence: float|null, rotation: float|null, faceId: string|null} $entry
+     */
+    private function hasSupplementalMetadata(array $entry): bool
+    {
+        return $entry['person'] !== null
+            || $entry['confidence'] !== null
+            || $entry['rotation'] !== null
+            || $entry['faceId'] !== null;
     }
 
     /**

--- a/tests/Curate/Resolver/RegionsResolverTest.php
+++ b/tests/Curate/Resolver/RegionsResolverTest.php
@@ -136,6 +136,41 @@ final class RegionsResolverTest extends TestCase
     }
 
     #[Test]
+    public function mergesSupplementalAppleMetadataByIndex(): void
+    {
+        $document = new XmpDocument([
+            '{' . self::NS_ST_AREA . '}x'             => ['0.3', '0.68'],
+            '{' . self::NS_ST_AREA . '}y'             => ['0.32', '0.66'],
+            '{' . self::NS_ST_AREA . '}w'             => ['0.22', '0.18'],
+            '{' . self::NS_ST_AREA . '}h'             => ['0.28', '0.20'],
+            '{' . self::NS_MWG . '}Type'              => ['Face', 'Face'],
+            '{' . self::NS_APPLE . '}ConfidenceLevel' => ['750', '500'],
+            '{' . self::NS_APPLE . '}Yaw'             => ['11.5', '-6.0'],
+            '{' . self::NS_APPLE . '}FaceID'          => ['face-a', 'face-b'],
+        ]);
+
+        $regions = (new RegionsResolver())->resolve($document);
+
+        self::assertCount(2, $regions->items);
+
+        $first = $regions->items[0];
+        self::assertSame(RegionType::FACE, $first->type);
+        self::assertSame('face-a', $first->faceId);
+        self::assertNotNull($first->confidence);
+        self::assertEqualsWithDelta(0.75, $first->confidence, 0.0001);
+        self::assertNotNull($first->rotationDeg);
+        self::assertEqualsWithDelta(11.5, $first->rotationDeg, 0.0001);
+
+        $second = $regions->items[1];
+        self::assertSame(RegionType::FACE, $second->type);
+        self::assertSame('face-b', $second->faceId);
+        self::assertNotNull($second->confidence);
+        self::assertEqualsWithDelta(0.5, $second->confidence, 0.0001);
+        self::assertNotNull($second->rotationDeg);
+        self::assertEqualsWithDelta(-6.0, $second->rotationDeg, 0.0001);
+    }
+
+    #[Test]
     public function normalisesPixelCoordinatesUsingAppliedDimensions(): void
     {
         $document = new XmpDocument([
@@ -197,10 +232,14 @@ final class RegionsResolverTest extends TestCase
         $method     = $reflection->getMethod('extractAppleFaceRegions');
         $method->setAccessible(true);
 
-        /** @var list<Region> $regions */
-        $regions = $method->invoke($resolver, $document, null);
+        /** @var array{regions: list<Region>, supplemental: list<array{geometry: array{x: float, y: float, w: float, h: float}|null, person: string|null, confidence: float|null, rotation: float|null, faceId: string|null}>} $result */
+        $result = $method->invoke($resolver, $document, null);
+
+        $regions      = $result['regions'];
+        $supplemental = $result['supplemental'];
 
         self::assertCount($count, $regions);
+        self::assertCount($count, $supplemental);
 
         foreach ($regions as $index => $region) {
             self::assertSame(RegionType::FACE, $region->type);


### PR DESCRIPTION
## Summary
- propagate Apple FaceInfo supplemental metadata so MWG regions inherit FaceID, confidence, and rotation data even without geometry
- merge supplemental attributes before and after geometric matching to preserve ordering-based enrichment
- add regression coverage for Apple-only face metadata to verify faceId, confidence, and rotation are exposed

## Testing
- composer ci:test:php:unit *(fails: MemoryBufferTest::testReadThrowsParseErrorOnShortRead)*

------
https://chatgpt.com/codex/tasks/task_e_68fcc488f1548323ba1bddd3b0c99755