### PR TITLE
fix: honor Apple maker-note night mode flags without QuickTime metadata

### DIFF
--- a/src/Curate/StructuredMetadataBuilder.php
+++ b/src/Curate/StructuredMetadataBuilder.php
@@ -653,10 +653,15 @@ final class StructuredMetadataBuilder
         Apple $apple,
         ?int $faceCount,
     ): Scene {
+        $flags = $apple->flags;
+        if (!is_array($flags)) {
+            $flags = [];
+        }
+
         $hdr   = $quickTime->string('HDRImageType');
         $night = $quickTime->bool('NightMode');
-        if ($night === null) {
-            $night = $apple->flags['nightMode'] ?? null;
+        if ($night === null && array_key_exists('nightMode', $flags)) {
+            $night = $flags['nightMode'];
         }
 
         $hdrScene = null;
@@ -666,11 +671,11 @@ final class StructuredMetadataBuilder
             $hdrHeadroom = $apple->hdrHeadroom;
             if ($hdrHeadroom !== null && $hdrHeadroom > 0.0) {
                 $hdrScene = true;
-            } else {
-                $flags = $apple->flags;
-                if (($flags['hdrEnabled'] ?? false) || ($flags['hdrAuto'] ?? false)) {
-                    $hdrScene = true;
-                }
+            } elseif (
+                (array_key_exists('hdrEnabled', $flags) && $flags['hdrEnabled'])
+                || (array_key_exists('hdrAuto', $flags) && $flags['hdrAuto'])
+            ) {
+                $hdrScene = true;
             }
         }
 

--- a/tests/Curate/StructuredMetadataBuilderTest.php
+++ b/tests/Curate/StructuredMetadataBuilderTest.php
@@ -47,6 +47,7 @@ use MagicSunday\ImageMeta\Value\Enum\SubjectDistanceRange;
 use MagicSunday\ImageMeta\Value\Enum\WhiteBalance;
 use MagicSunday\ImageMeta\Value\Enum\YCbCrPositioning;
 use MagicSunday\ImageMeta\Value\Regions\RegionType;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
@@ -525,9 +526,12 @@ final class StructuredMetadataBuilderTest extends TestCase
 
     /**
      * Ensures JPEG-only metadata uses the maker note night mode flag when QuickTime metadata is absent.
+     *
+     * @param bool $nightModeFlag Maker note flag value to assert.
      */
     #[Test]
-    public function usesMakerNoteNightModeWhenQuickTimeMissing(): void
+    #[DataProvider('makerNoteNightModeFlagsProvider')]
+    public function usesMakerNoteNightModeWhenQuickTimeMissing(bool $nightModeFlag): void
     {
         $appleMakerNotes = new AppleMakerNotes(
             contentIdentifier: null,
@@ -541,7 +545,7 @@ final class StructuredMetadataBuilderTest extends TestCase
             semanticStylePreset: null,
             semanticStyleWarmth: null,
             semanticStyleTone: null,
-            flags: ['nightMode' => true],
+            flags: ['nightMode' => $nightModeFlag],
             accelerationVector: null,
         );
 
@@ -558,7 +562,18 @@ final class StructuredMetadataBuilderTest extends TestCase
 
         $structured = (new StructuredMetadataBuilder())->build($metadata);
 
-        self::assertTrue($structured->scene->nightMode);
+        self::assertSame($nightModeFlag, $structured->scene->nightMode);
+    }
+
+    /**
+     * Provides maker note night mode flag variations for JPEG-only captures.
+     *
+     * @return iterable<string, array{0: bool}>
+     */
+    public static function makerNoteNightModeFlagsProvider(): iterable
+    {
+        yield 'night-mode-enabled' => [true];
+        yield 'night-mode-disabled' => [false];
     }
 
     /**


### PR DESCRIPTION
## Summary
- guard scene builder against missing Apple flag arrays and reuse maker-note flags when QuickTime night mode is absent
- keep HDR detection fallbacks intact while covering the maker-note boolean flags path
- exercise JPEG-only night mode handling for both enabled and disabled maker-note flags

## Testing
- composer ci:test:php:unit
- .build/bin/phpunit --configuration .build/phpunit.xml tests/Curate/StructuredMetadataBuilderTest.php

------
https://chatgpt.com/codex/tasks/task_e_68fcc48a1a448323af06e2b2d828969e