### PR TITLE
Normalise Apple semantic style dictionaries

### DIFF
--- a/src/MakerNotes/AppleDecoder.php
+++ b/src/MakerNotes/AppleDecoder.php
@@ -268,6 +268,30 @@ final class AppleDecoder implements MakerNotesDecoderInterface
      */
     private function buildAppleMakerNotes(array $dictionary): ?AppleMakerNotes
     {
+        $semanticStyleCompact = null;
+        if (
+            !array_key_exists('SemanticStylePreset', $dictionary)
+            && !array_key_exists('SemanticStyleWarmth', $dictionary)
+            && !array_key_exists('SemanticStyleTone', $dictionary)
+        ) {
+            $semanticStyleCompact = $this->semanticStyleFromCollection($dictionary);
+            if ($semanticStyleCompact !== null) {
+                [$compactPreset, $compactWarmth, $compactTone] = $semanticStyleCompact;
+
+                if ($compactPreset !== null) {
+                    $dictionary['SemanticStylePreset'] = $compactPreset;
+                }
+
+                if ($compactWarmth !== null) {
+                    $dictionary['SemanticStyleWarmth'] = $compactWarmth;
+                }
+
+                if ($compactTone !== null) {
+                    $dictionary['SemanticStyleTone'] = $compactTone;
+                }
+            }
+        }
+
         $contentIdentifier    = $this->stringValue($dictionary, 'ContentIdentifier');
         $cameraType           = $this->stringValue($dictionary, 'CameraType');
         $hdrHeadroom          = $this->floatValue($dictionary, 'HdrHeadroom', 'HDRHeadroom');
@@ -279,7 +303,7 @@ final class AppleDecoder implements MakerNotesDecoderInterface
         $semanticStylePreset  = $this->stringValue($dictionary, 'SemanticStylePreset');
         $semanticStyleWarmth  = $this->floatValue($dictionary, 'SemanticStyleWarmth');
         $semanticStyleTone    = $this->floatValue($dictionary, 'SemanticStyleTone');
-        $semanticStyleCompact = $this->semanticStyleFromCollection($dictionary);
+        $semanticStyleCompact ??= $this->semanticStyleFromCollection($dictionary);
         if ($semanticStyleCompact !== null) {
             [$compactPreset, $compactWarmth, $compactTone] = $semanticStyleCompact;
 
@@ -464,8 +488,9 @@ final class AppleDecoder implements MakerNotesDecoderInterface
      * Extracts semantic style values from Apple's compact semantic style array.
      *
      * Apple stores semantic style metadata as an ordered collection where index 0 / `_0`
-     * contains the preset name, index 1 / `_1` the warmth adjustment, and index 2 / `_2` the
-     * tone adjustment. Index `_3` is currently unused by the curated metadata object.
+     * contains the preset name. Legacy payloads store the warmth adjustment at index 1 / `_1`
+     * and tone at index 2 / `_2`. Modern payloads use index 2 / `_2` for warmth and index 3 / `_3`
+     * for tone.
      *
      * @param array<int|string, array<int|string, mixed>|bool|float|int|string|null> $dictionary
      *

--- a/tests/MakerNotes/Apple/AppleDecoderSemanticStyleTest.php
+++ b/tests/MakerNotes/Apple/AppleDecoderSemanticStyleTest.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\ImageMeta\Tests\MakerNotes\Apple;
+
+use MagicSunday\ImageMeta\MakerNotes\Apple\AppleMakerNotes;
+use MagicSunday\ImageMeta\MakerNotes\AppleDecoder;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
+
+/**
+ * @covers \MagicSunday\ImageMeta\MakerNotes\AppleDecoder
+ */
+final class AppleDecoderSemanticStyleTest extends TestCase
+{
+    #[Test]
+    public function buildAppleMakerNotesExtractsSemanticStyleDictionary(): void
+    {
+        $decoder = new AppleDecoder();
+        $method  = new ReflectionMethod(AppleDecoder::class, 'buildAppleMakerNotes');
+        $method->setAccessible(true);
+
+        $dictionary = [
+            'SemanticStyle' => [
+                '_0' => 'RichWarm',
+                '_2' => 0.25,
+                '_3' => -0.4,
+            ],
+        ];
+
+        /** @var AppleMakerNotes|null $makerNotes */
+        $makerNotes = $method->invoke($decoder, $dictionary);
+
+        self::assertInstanceOf(AppleMakerNotes::class, $makerNotes);
+        self::assertSame('RichWarm', $makerNotes->semanticStylePreset);
+        self::assertSame(0.25, $makerNotes->semanticStyleWarmth);
+        self::assertSame(-0.4, $makerNotes->semanticStyleTone);
+    }
+}


### PR DESCRIPTION
## Summary
- normalise semantic style collections into dedicated semantic style fields when preset/warmth/tone keys are missing
- clarify the modern index mapping used by Apple semantic style payloads
- add a unit test covering semantic-style-only maker note payloads

## Testing
- composer ci:test:php:unit

------
https://chatgpt.com/codex/tasks/task_e_68fccc5722e08323b80ce53ca49666c0