### PR TITLE
Add regression tests for Apple bitmask flag decoding

### DIFF
--- a/tests/MakerNotes/Apple/AppleDecoderFlagMaskTest.php
+++ b/tests/MakerNotes/Apple/AppleDecoderFlagMaskTest.php
@@ -1,0 +1,75 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\ImageMeta\Tests\MakerNotes\Apple;
+
+use MagicSunday\ImageMeta\MakerNotes\AppleDecoder;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
+
+/**
+ * @covers \MagicSunday\ImageMeta\MakerNotes\AppleDecoder
+ */
+final class AppleDecoderFlagMaskTest extends TestCase
+{
+    #[Test]
+    public function extractFlagsDerivesNormalizedFlagsFromBitMasks(): void
+    {
+        $decoder = new AppleDecoder();
+        $method  = new ReflectionMethod(AppleDecoder::class, 'extractFlags');
+
+        $dictionary = [
+            'SceneFlags'            => 0b11,
+            'ImageProcessingFlags'  => '0x3',
+            'PhotosAppFeatureFlags' => [
+                'values' => [0, 1, 2, 3, 4],
+            ],
+        ];
+
+        $result = $method->invoke($decoder, $dictionary);
+        ksort($result);
+
+        $expected = [
+            'hdrAuto'               => true,
+            'hdrEnabled'            => true,
+            'livePhoto'             => true,
+            'livePhotoActive'       => true,
+            'livePhotoAuto'         => true,
+            'livePhotoEnabled'      => true,
+            'livePhotoLongExposure' => true,
+            'longExposure'          => true,
+            'nightMode'             => true,
+        ];
+        ksort($expected);
+
+        self::assertSame($expected, $result);
+    }
+
+    #[Test]
+    public function extractFlagsIgnoresUnmappedBitPositions(): void
+    {
+        $decoder = new AppleDecoder();
+        $method  = new ReflectionMethod(AppleDecoder::class, 'extractFlags');
+
+        $dictionary = [
+            'SceneFlags'            => 0b100000,
+            'PhotosAppFeatureFlags' => [
+                'values' => [9, 15],
+            ],
+            'ImageProcessingFlags'  => 0,
+        ];
+
+        $result = $method->invoke($decoder, $dictionary);
+
+        self::assertSame([], $result);
+    }
+}


### PR DESCRIPTION
## Summary
- add regression coverage for Apple maker note bitmask-derived flags
- ensure unmapped bit positions do not create spurious flags

## Testing
- composer ci:test:php:unit

------
https://chatgpt.com/codex/tasks/task_e_68fccc5935f483238aade0a0787b5faf