### PR TITLE
fix(curate): derive scene flags from maker notes

### DIFF
--- a/src/Curate/StructuredMetadataBuilder.php
+++ b/src/Curate/StructuredMetadataBuilder.php
@@ -666,8 +666,8 @@ final class StructuredMetadataBuilder
 
         $hdr   = $quickTime->string('HDRImageType');
         $night = $quickTime->bool('NightMode');
-        if ($night === null && array_key_exists('nightMode', $flags)) {
-            $night = $flags['nightMode'];
+        if ($night === null) {
+            $night = $this->appleFlag($flags, 'nightMode');
         }
 
         $hdrScene = null;
@@ -678,8 +678,8 @@ final class StructuredMetadataBuilder
             if ($hdrHeadroom !== null && $hdrHeadroom > 0.0) {
                 $hdrScene = true;
             } elseif (
-                (array_key_exists('hdrEnabled', $flags) && $flags['hdrEnabled'])
-                || (array_key_exists('hdrAuto', $flags) && $flags['hdrAuto'])
+                $this->appleFlag($flags, 'hdrEnabled') === true
+                || $this->appleFlag($flags, 'hdrAuto') === true
             ) {
                 $hdrScene = true;
             }
@@ -694,6 +694,22 @@ final class StructuredMetadataBuilder
             nightMode: $night,
             subjectDistanceRange: $exif->subjectDistanceRange(),
         );
+    }
+
+    /**
+     * Retrieves a boolean flag from the normalised Apple flag map.
+     *
+     * @param array<string, bool> $flags
+     */
+    private function appleFlag(array $flags, string $key): ?bool
+    {
+        if (!array_key_exists($key, $flags)) {
+            return null;
+        }
+
+        $value = $flags[$key];
+
+        return is_bool($value) ? $value : null;
     }
 
     /**

--- a/tests/Curate/StructuredMetadataBuilderTest.php
+++ b/tests/Curate/StructuredMetadataBuilderTest.php
@@ -636,6 +636,48 @@ final class StructuredMetadataBuilderTest extends TestCase
     }
 
     /**
+     * Ensures maker note flags alone populate scene metadata when QuickTime metadata is absent.
+     */
+    #[Test]
+    public function derivesSceneFlagsFromMakerNotesWithoutQuickTime(): void
+    {
+        $appleMakerNotes = new AppleMakerNotes(
+            contentIdentifier: null,
+            cameraType: null,
+            hdrHeadroom: null,
+            hdrGain: null,
+            snr: null,
+            focusPosition: null,
+            livePhotoIndex: null,
+            colorTemperature: null,
+            semanticStylePreset: null,
+            semanticStyleWarmth: null,
+            semanticStyleTone: null,
+            flags: [
+                'nightMode' => true,
+                'hdrEnabled' => true,
+            ],
+            accelerationVector: null,
+        );
+
+        $makerNotes = new MakerNotesMetadata('Apple', 0, str_repeat('a', 40), $appleMakerNotes);
+
+        $metadata = new Metadata(
+            ['primary'],
+            null,
+            new ExifDocument(new Ifd([]), null, null, null, null, $makerNotes),
+            [],
+            null,
+            $makerNotes,
+        );
+
+        $structured = (new StructuredMetadataBuilder())->build($metadata);
+
+        self::assertTrue($structured->scene->nightMode);
+        self::assertTrue($structured->scene->hdrScene);
+    }
+
+    /**
      * Ensures HDR scene detection falls back to maker note hints when QuickTime metadata is silent.
      */
     #[Test]


### PR DESCRIPTION
## Summary
- ensure `StructuredMetadataBuilder::buildScene()` falls back to Apple maker-note flags when QuickTime scene hints are missing
- cover maker-note-only scene detection with a new test case

## Testing
- .build/bin/phpunit --configuration .build/phpunit.xml tests/Curate/StructuredMetadataBuilderTest.php

------
https://chatgpt.com/codex/tasks/task_e_68fccc5bada08323b77085f776487301