### PR TITLE
docs: translate truth comparison PHPDoc to English

### DIFF
--- a/tests/Truth/Normalizer.php
+++ b/tests/Truth/Normalizer.php
@@ -13,14 +13,14 @@ namespace MagicSunday\ImageMeta\Tests\Truth;
 
 final class Normalizer
 {
-    /** Delta für Floatvergleiche */
+    /** Delta for floating point comparisons. */
     public const DELTA = 1e-6;
 
     /** @var array<string, array<int|string, string>> */
     private array $enumMap;
 
     /**
-     * @param array<string, array<int|string, string>> $enumMap
+     * @param array<string, array<int|string, string>> $enumMap Mapping from numeric codes to enum names.
      */
     public function __construct(array $enumMap)
     {
@@ -28,35 +28,38 @@ final class Normalizer
     }
 
     /**
-     * Enum → vergleichbarer String (Enum-Name) oder passt Wert unverändert durch.
-     * Unterstützt reine PHP-Enums (->name) und Fallbacks.
+     * Converts enums and date/time objects into comparable scalar values.
+     *
+     * @param mixed $value Value returned by the structured metadata API.
+     *
+     * @return mixed Enum name, formatted date/time or the original value when no conversion is needed.
      */
     public static function toComparable(mixed $value): mixed
     {
         if ($value instanceof \BackedEnum) {
-            return $value->name; // Name stabiler als ->value bei BackedEnums
+            return $value->name; // The enum name is more stable than ->value for backed enums.
         }
         if ($value instanceof \UnitEnum) {
             return $value->name;
         }
         if ($value instanceof \DateTimeInterface) {
-            // Sekundenpräzision (SubSec separat, wenn gewünscht)
+            // Keep second precision; SubSec is handled separately when needed.
             return $value->format('Y-m-d\TH:i:sP');
         }
         return $value;
     }
 
     /**
-     * Vergleicht eine Structured-Enum gegen ExifTool(-n) Rohwert über die EnumMap.
+     * Compares a structured enum value against the ExifTool raw value through the configured enum map.
      *
-     * @param non-empty-string $group  z. B. 'Orientation', 'WhiteBalance'
-     * @param int|string $exifNumeric
-     * @param \UnitEnum|\BackedEnum|string|null $structuredEnum
+     * @param non-empty-string                     $group          Enumeration group such as 'Orientation' or 'WhiteBalance'.
+     * @param int|string                           $exifNumeric    Raw ExifTool numeric value.
+     * @param \UnitEnum|\BackedEnum|string|null $structuredEnum Enum value returned by the metadata reader.
      */
     public function compareEnum(string $group, int|string $exifNumeric, mixed $structuredEnum): bool
     {
         if (!isset($this->enumMap[$group])) {
-            return false; // kein Mapping hinterlegt
+            return false; // Missing mapping for this group.
         }
         $expectedName = $this->enumMap[$group][$exifNumeric] ?? null;
         if ($expectedName === null) {
@@ -66,9 +69,16 @@ final class Normalizer
         return $actualName === $expectedName;
     }
 
+    /**
+     * Decodes the EXIF Flash bitmask into its logical components for comparison.
+     *
+     * @param int $val Raw EXIF Flash value from the truth data.
+     *
+     * @return array{fired: bool, returnDetection: string, mode: string, functionPresence: string, redEyeReduction: bool}
+     */
     public static function decodeExifFlash(int $val): array
     {
-        // Spezifikation (EXIF 2.3):
+        // Specification (EXIF 2.3):
         // Bit 0: Fired
         // Bits 1-2: Return status (0,2,3)
         // Bits 3-4: Mode (0..3)
@@ -105,11 +115,11 @@ final class Normalizer
     }
 
     /**
-     * Baut aus EXIF DateTime + SubSec + OffsetTime eine ISO-8601.
-     * Erwartet ExifTool-JSON (mit -n/-struct).
+     * Builds an ISO 8601 timestamp from EXIF DateTime, SubSec and OffsetTime components.
+     * Expects ExifTool JSON output produced with -n/-struct flags.
      *
-     * @param array<string,mixed> $exif
-     * @param 'EXIF:CreateDate'|'EXIF:DateTimeOriginal'|'IFD0:ModifyDate' $baseKey
+     * @param array<string,mixed> $exif Parsed ExifTool data.
+     * @param 'EXIF:CreateDate'|'EXIF:DateTimeOriginal'|'IFD0:ModifyDate' $baseKey Base key that defines the date component.
      */
     public static function buildIso8601FromExif(array $exif, string $baseKey): ?string
     {
@@ -123,16 +133,16 @@ final class Normalizer
             return null;
         }
 
-        // SubSec (passender Schlüssel zu Base)
+        // SubSec key matching the selected base value.
         $subSecKey = match ($baseKey) {
             'EXIF:CreateDate'       => 'EXIF:SubSecTimeDigitized',
             'EXIF:DateTimeOriginal' => 'EXIF:SubSecTimeOriginal',
-            'IFD0:ModifyDate'       => 'EXIF:SubSecTime', // oft nicht vorhanden
+            'IFD0:ModifyDate'       => 'EXIF:SubSecTime', // Often missing in the source data.
         };
         $sub = self::get($exif, $subSecKey);
         $sub = is_string($sub) && $sub !== '' ? $sub : null;
 
-        // Offset (passender Schlüssel zu Base)
+        // Offset key matching the selected base value.
         $offsetKey = match ($baseKey) {
             'EXIF:CreateDate'       => 'EXIF:OffsetTimeDigitized',
             'EXIF:DateTimeOriginal' => 'EXIF:OffsetTimeOriginal',
@@ -141,25 +151,36 @@ final class Normalizer
         $off = self::get($exif, $offsetKey);
         $off = is_string($off) && $off !== '' ? $off : '+00:00';
 
-        // zusammensetzen
+        // Assemble the timestamp components.
         if ($sub !== null) {
-            // normalisiere auf 3 Stellen (Millis)
+            // Normalise to three digits representing milliseconds.
             $sub = str_pad(substr($sub, 0, 3), 3, '0');
             return sprintf('%s.%s%s', $dt, $sub, self::normalizeOffset($off));
         }
         return sprintf('%s%s', $dt, self::normalizeOffset($off));
     }
 
-    /** @param array<string,mixed> $exif */
+    /**
+     * Fetches a value from the ExifTool array using the flat GROUP:Tag key.
+     *
+     * @param array<string,mixed> $exif ExifTool data indexed by GROUP:Tag.
+     */
     private static function get(array $exif, string $key): mixed
     {
-        // ExifTool-JSON gibt flache Keys "GROUP:Tag"
+        // ExifTool JSON exposes flat keys formatted as "GROUP:Tag"
         return $exif[$key] ?? null;
     }
 
+    /**
+     * Normalises various timezone offset formats to the canonical ±HH:MM form.
+     *
+     * @param string $off Offset string from the truth data.
+     *
+     * @return string Normalised offset.
+     */
     private static function normalizeOffset(string $off): string
     {
-        // erlaubt Formate "+01:00" oder "+0100" → immer "+01:00"
+        // Accepts formats like "+01:00" or "+0100" and always returns "+01:00"
         if (preg_match('/^[\+\-]\d{2}:\d{2}$/', $off)) {
             return $off;
         }
@@ -170,9 +191,11 @@ final class Normalizer
     }
 
     /**
-     * Extrahiert MWG Face-Areas aus ExifTool-JSON → [{x,y,w,h}, ...]
-     * @param array<string,mixed> $exif
-     * @return array<int,array{x:float,y:float,w:float,h:float}>
+     * Extracts MWG face regions from ExifTool JSON into [{x,y,w,h}, ...].
+     *
+     * @param array<string,mixed> $exif ExifTool truth data.
+     *
+     * @return array<int,array{x:float,y:float,w:float,h:float}> Normalised face rectangles.
      */
     public static function mwgFaces(array $exif): array
     {
@@ -188,7 +211,7 @@ final class Normalizer
                 $faces[$i][$c] = (float)$v;
             }
         }
-        // nur Gesichter
+        // Only collect entries marked as faces.
         $out = [];
         ksort($faces);
         foreach ($faces as $i => $a) {

--- a/tests/TruthComparisonTest.php
+++ b/tests/TruthComparisonTest.php
@@ -17,24 +17,36 @@ use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\Attributes\DataProvider;
 
-/** @return ?string ISO-8601 (Sekundenauflösung), falls DateTimeInterface oder String übergeben wurde */
+/**
+ * Converts supported date/time values into an ISO 8601 string with second precision.
+ *
+ * @param mixed $value Metadata value that may contain a date/time representation.
+ *
+ * @return string|null Normalized ISO 8601 string or null if the value cannot be converted.
+ */
 function safeIso(mixed $value): ?string
 {
     if ($value instanceof \DateTimeInterface) {
         return $value->format('Y-m-d\TH:i:sP');
     }
     if (is_string($value) && $value !== '') {
-        // Angleichung: schneide Millis ab, stelle Offset sicher
+        // Normalise by trimming milliseconds and ensuring an offset is present.
         if (!str_contains($value, 'T')) {
             return null;
         }
-        // Bei fehlendem Offset annehmen, dass bereits normalisiert ist
+        // Assume the timestamp is already normalised when no offset is provided.
         return preg_replace('/(\.\d+)?([Z\+\-]\d{2}:\d{2})?$/', '$2' === '' ? '' : '$2', $value) ?: $value;
     }
     return null;
 }
 
-/** @return ?string Enum-Name deiner Library */
+/**
+ * Resolves the enum name for comparison or returns the provided string value.
+ *
+ * @param mixed $enum Enum instance or string representation returned by the API under test.
+ *
+ * @return string|null Enum name or null when the value cannot be resolved.
+ */
 function enumName(mixed $enum): ?string
 {
     if ($enum instanceof \BackedEnum || $enum instanceof \UnitEnum) {
@@ -53,6 +65,9 @@ final class TruthComparisonTest extends TestCase
     /** @var array<string, array<int|string, string>> */
     private array $map;
 
+    /**
+     * Boots the enum map and normalizer before each comparison test.
+     */
     protected function setUp(): void
     {
         /** @var array<string, array<int|string, string>> $map */
@@ -61,6 +76,11 @@ final class TruthComparisonTest extends TestCase
         $this->norm = new Normalizer($map);
     }
 
+    /**
+     * Validates that structured metadata matches the ExifTool ground truth for the given file.
+     *
+     * @param string $file Fixture filename relative to the image directory.
+     */
     #[Test]
     #[DataProvider('provideFiles')]
     public function test_core_fields_match_exiftool(string $file): void
@@ -71,12 +91,12 @@ final class TruthComparisonTest extends TestCase
             ->read(self::IMAGES . '/' . $file)
             ->structured();
 
-        // Kamera
+        // Camera
         $this->assertSame($exif['IFD0:Make'] ?? null, $meta->camera->make ?? null, "$file: Make");
         $this->assertSame($exif['IFD0:Model'] ?? null, $meta->camera->model ?? null, "$file: Model");
         $this->assertSame($exif['IFD0:Software'] ?? null, $meta->camera->firmware ?? null, "$file: Firmware");
 
-        // Bildgröße
+        // Image dimensions
         $this->assertSame((int)($exif['File:ImageWidth'] ?? 0), $meta->image->width ?? 0, "$file: width");
         $this->assertSame((int)($exif['File:ImageHeight'] ?? 0), $meta->image->height ?? 0, "$file: height");
 
@@ -92,7 +112,7 @@ final class TruthComparisonTest extends TestCase
             $this->assertTrue($ok, "$file: ColorSpace enum mapping");
         }
 
-        // EXIF Kerndaten
+        // Core EXIF data
         $this->assertEqualsWithDelta((float)($exif['EXIF:FNumber'] ?? 0), (float)($meta->exposure->fNumber ?? 0), Normalizer::DELTA, "$file: FNumber");
         $this->assertEqualsWithDelta((float)($exif['EXIF:ExposureTime'] ?? 0), (float)($meta->exposure->exposureTimeSec ?? 0), Normalizer::DELTA, "$file: ExposureTime");
         $this->assertSame((int)($exif['EXIF:ISOSpeedRatings'] ?? $exif['EXIF:ISO'] ?? 0), (int)($meta->exposure->iso ?? 0), "$file: ISO");
@@ -111,13 +131,13 @@ final class TruthComparisonTest extends TestCase
             $this->assertTrue($ok, "$file: WhiteBalance enum");
         }
 
-        // Belichtungsmodus (neu)
+        // Exposure mode (additional field)
         if (isset($exif['EXIF:ExposureMode'])) {
             $ok = $this->norm->compareEnum('ExposureMode', (int)$exif['EXIF:ExposureMode'], $meta->exposure->exposureMode ?? null);
             $this->assertTrue($ok, "$file: ExposureMode enum");
         }
 
-        // Linseninfos
+        // Lens information
         if (isset($exif['EXIF:FocalLength'])) {
             $this->assertEqualsWithDelta((float)$exif['EXIF:FocalLength'], (float)($meta->lens->focalLengthMm ?? $meta->image->focalLengthMm ?? 0.0), Normalizer::DELTA, "$file: FocalLength");
         }
@@ -128,7 +148,7 @@ final class TruthComparisonTest extends TestCase
             $this->assertSame($exif['EXIF:LensModel'], $meta->lens->lensModel ?? null, "$file: LensModel");
         }
 
-        // Zeiten (ISO-8601)
+        // Timestamp comparisons (ISO-8601)
         $createIso = Normalizer::buildIso8601FromExif($exif, 'EXIF:CreateDate');
         $origIso   = Normalizer::buildIso8601FromExif($exif, 'EXIF:DateTimeOriginal');
         $modifyIso = Normalizer::buildIso8601FromExif($exif, 'IFD0:ModifyDate');
@@ -155,7 +175,7 @@ final class TruthComparisonTest extends TestCase
             $this->assertEqualsWithDelta((float)$exif['GPS:GPSImgDirection'], (float)($meta->gps->imageDirection ?? 0), 1e-6, "$file: GPS direction");
         }
 
-        // ICC
+        // ICC profile
         if (isset($exif['ICC_Profile:ProfileDescription'])) {
             $this->assertSame($exif['ICC_Profile:ProfileDescription'], $meta->colorProfile->profileName ?? null, "$file: ICC name");
         }
@@ -169,7 +189,7 @@ final class TruthComparisonTest extends TestCase
             $this->assertSame(strtoupper((string)$exif['ICC_Profile:ProfileID']), strtoupper((string)($meta->colorProfile->profileId ?? '')), "$file: ICC id");
         }
 
-        // Flash (Bitmaske → strukturierte Felder)
+        // Flash (bitmask decoded into structured fields)
         if (isset($exif['EXIF:Flash']) && isset($meta->exposure->flash)) {
             $decoded = Normalizer::decodeExifFlash((int)$exif['EXIF:Flash']);
             $this->assertSame($decoded['fired'], (bool)$meta->exposure->flash->fired, "$file: Flash fired");
@@ -211,7 +231,11 @@ final class TruthComparisonTest extends TestCase
         }
     }
 
-    /** @return iterable<string, array{0:string}> */
+    /**
+     * Provides fixture filenames for tests that compare structured metadata against ExifTool output.
+     *
+     * @return iterable<string, array{0:string}> Ordered list of image filenames.
+     */
     public static function provideFiles(): iterable
     {
         $list = glob(self::IMAGES . '/*');
@@ -223,7 +247,13 @@ final class TruthComparisonTest extends TestCase
         }
     }
 
-    /** @return array<string,mixed> */
+    /**
+     * Loads the ExifTool JSON reference data for the provided fixture file.
+     *
+     * @param string $file Fixture filename without the ExifTool suffix.
+     *
+     * @return array<string,mixed> Parsed ExifTool response as an associative array.
+     */
     private function loadExifToolJson(string $file): array
     {
         $json = file_get_contents(self::FIXTURES . '/' . $file . '.exiftool.json');


### PR DESCRIPTION
## Summary
- translate the helper PHPDoc blocks in `TruthComparisonTest` to describe intent and parameters in English
- convert truth normalizer documentation and inline comments to English while adding coverage for helper methods

## Testing
- composer ci:cgl

------
https://chatgpt.com/codex/tasks/task_e_68fccfee67f48323a03a9bf0037d7c00