### PR TITLE
refactor(value): rename flash return enum cases

### DIFF
--- a/src/Value/Enum/FlashReturn.php
+++ b/src/Value/Enum/FlashReturn.php
@@ -17,9 +17,8 @@ namespace MagicSunday\ImageMeta\Value\Enum;
 enum FlashReturn: int
 {
     case NO_STROBE_DETECTION = 0;
-    case RESERVED            = 1;
-    case NOT_DETECTED        = 2;
-    case DETECTED            = 3;
+    case RETURN_NOT_DETECTED = 2;
+    case RETURN_DETECTED     = 3;
 
     /**
      * Creates an enum instance from the flash bit field.

--- a/tests/Curate/Value/FlashInfoTest.php
+++ b/tests/Curate/Value/FlashInfoTest.php
@@ -34,7 +34,7 @@ final class FlashInfoTest extends TestCase
         self::assertNotNull($info);
         self::assertTrue($info->fired);
         self::assertSame(FlashMode::AUTO, $info->mode);
-        self::assertSame(FlashReturn::DETECTED, $info->returnDetection);
+        self::assertSame(FlashReturn::RETURN_DETECTED, $info->returnDetection);
         self::assertSame(FlashFunction::ABSENT, $info->functionPresence);
         self::assertTrue($info->redEyeReduction);
     }

--- a/tests/Model/Exif/ValueConvertersTest.php
+++ b/tests/Model/Exif/ValueConvertersTest.php
@@ -215,7 +215,7 @@ final class ValueConvertersTest extends TestCase
         self::assertInstanceOf(FlashInfo::class, $info);
         self::assertTrue($info->fired);
         self::assertSame(FlashMode::AUTO, $info->mode);
-        self::assertSame(FlashReturn::DETECTED, $info->returnDetection);
+        self::assertSame(FlashReturn::RETURN_DETECTED, $info->returnDetection);
         self::assertSame(FlashFunction::ABSENT, $info->functionPresence);
         self::assertFalse($info->redEyeReduction);
     }


### PR DESCRIPTION
## Summary
- rename the FlashReturn enum detection cases to RETURN_NOT_DETECTED and RETURN_DETECTED
- drop the unused reserved flag and update flash conversion helpers/tests to the new names

## Testing
- .build/bin/phpunit --configuration .build/phpunit.xml tests/Curate/Value/FlashInfoTest.php tests/Model/Exif/ValueConvertersTest.php tests/Core/ValueConvertersTest.php

------
https://chatgpt.com/codex/tasks/task_e_68fcd1a354d08323a50afb845a73ce72