### PR TITLE
feat: parse Apple maker note runtime metadata

### DIFF
--- a/src/Curate/Resolver/AppleResolver.php
+++ b/src/Curate/Resolver/AppleResolver.php
@@ -88,12 +88,14 @@ final readonly class AppleResolver
             $snr,
             $focusPosition,
             $livePhotoIndex,
+            null,
             $colorTemperature,
             $semanticPreset,
             $semanticWarmth,
             $semanticTone,
             $flags,
             $accelerationVector,
+            null,
         );
     }
 

--- a/src/Curate/StructuredMetadataBuilder.php
+++ b/src/Curate/StructuredMetadataBuilder.php
@@ -23,6 +23,7 @@ use MagicSunday\ImageMeta\Curate\Resolver\QuickTimeResolver;
 use MagicSunday\ImageMeta\Curate\Resolver\RegionsResolver;
 use MagicSunday\ImageMeta\Curate\Resolver\XmpResolver;
 use MagicSunday\ImageMeta\MakerNotes\Apple\AppleMakerNotes;
+use MagicSunday\ImageMeta\MakerNotes\Apple\RunTime as AppleRunTime;
 use MagicSunday\ImageMeta\Model\Metadata;
 use MagicSunday\ImageMeta\Model\QuickTimeMeta;
 use MagicSunday\ImageMeta\Parse\Icc\IccDecoder;
@@ -51,6 +52,7 @@ use MagicSunday\ImageMeta\Value\Preview;
 use MagicSunday\ImageMeta\Value\ProcessingSettings;
 use MagicSunday\ImageMeta\Value\Regions;
 use MagicSunday\ImageMeta\Value\Regions\RegionType;
+use MagicSunday\ImageMeta\Value\RunTime as ValueRunTime;
 use MagicSunday\ImageMeta\Value\RelatedAssets;
 use MagicSunday\ImageMeta\Value\Rights;
 use MagicSunday\ImageMeta\Value\Scene;
@@ -761,6 +763,8 @@ final class StructuredMetadataBuilder
             $livePhotoIndex = $this->quickTimeInt($quickTimeResolver, 'LivePhotoVideoIndex');
         }
 
+        $livePhotoTime = $makerNotes?->livePhotoTime;
+
         $colorTemperature = $makerNotes?->colorTemperature;
         if ($colorTemperature === null) {
             $colorTemperature = $this->quickTimeInt($quickTimeResolver, 'ColorTemperature');
@@ -811,6 +815,8 @@ final class StructuredMetadataBuilder
             }
         }
 
+        $runTime = $this->appleRunTime($makerNotes?->runTime);
+
         return new Apple(
             $contentIdentifier,
             $cameraType,
@@ -819,12 +825,31 @@ final class StructuredMetadataBuilder
             $snr,
             $focusPosition,
             $livePhotoIndex,
+            $livePhotoTime,
             $colorTemperature,
             $semanticPreset,
             $semanticWarmth,
             $semanticTone,
             $flags,
             $accelerationVector,
+            $runTime,
+        );
+    }
+
+    /**
+     * Converts a maker note runtime structure into its curated representation.
+     */
+    private function appleRunTime(?AppleRunTime $runTime): ?ValueRunTime
+    {
+        if (!$runTime instanceof AppleRunTime) {
+            return null;
+        }
+
+        return new ValueRunTime(
+            $runTime->epoch,
+            $runTime->timescale,
+            $runTime->value,
+            $runTime->flags,
         );
     }
 

--- a/src/MakerNotes/Apple/AppleMakerNotes.php
+++ b/src/MakerNotes/Apple/AppleMakerNotes.php
@@ -30,6 +30,8 @@ final readonly class AppleMakerNotes
      * @param float|null          $semanticStyleTone   Semantic style tone adjustment.
      * @param array<string, bool> $flags               Boolean flags derived from maker note keys.
      * @param list<float>|null    $accelerationVector  Acceleration vector recorded during capture.
+     * @param float|null          $livePhotoTime       Normalised Live Photo timestamp in seconds.
+     * @param RunTime|null        $runTime             Capture runtime metadata describing the CMTime payload.
      */
     public function __construct(
         public ?string $contentIdentifier,
@@ -45,6 +47,8 @@ final readonly class AppleMakerNotes
         public ?float $semanticStyleTone,
         public array $flags,
         public ?array $accelerationVector,
+        public ?float $livePhotoTime = null,
+        public ?RunTime $runTime = null,
     ) {
     }
 }

--- a/src/MakerNotes/Apple/RunTime.php
+++ b/src/MakerNotes/Apple/RunTime.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\ImageMeta\MakerNotes\Apple;
+
+/**
+ * Represents a CoreMedia runtime structure embedded in Apple maker notes.
+ */
+final readonly class RunTime
+{
+    /**
+     * @param int|null $epoch     Timeline epoch of the runtime value.
+     * @param int|null $timescale Timescale used to interpret the runtime value.
+     * @param int|null $value     Raw runtime value expressed in timescale units.
+     * @param int|null $flags     Bit mask describing the runtime value state.
+     */
+    public function __construct(
+        public ?int $epoch,
+        public ?int $timescale,
+        public ?int $value,
+        public ?int $flags,
+    ) {
+    }
+}

--- a/src/MakerNotes/AppleDecoder.php
+++ b/src/MakerNotes/AppleDecoder.php
@@ -15,6 +15,7 @@ use MagicSunday\ImageMeta\Core\ParseError;
 use MagicSunday\ImageMeta\MakerNotes\Apple\AppleMakerNotes;
 use MagicSunday\ImageMeta\MakerNotes\Apple\BinaryPlistDecoder;
 use MagicSunday\ImageMeta\MakerNotes\Apple\KeyedArchiveUnarchiver;
+use MagicSunday\ImageMeta\MakerNotes\Apple\RunTime;
 
 use function array_is_list;
 use function array_key_exists;
@@ -298,7 +299,15 @@ final class AppleDecoder implements MakerNotesDecoderInterface
         $hdrGain              = $this->floatList($dictionary, 'HdrGain', 'HDRGain');
         $snr                  = $this->floatValue($dictionary, 'SNRSetting', 'SNR');
         $focusPosition        = $this->floatValue($dictionary, 'FocusPosition');
+        $runTime              = $this->runTimeValue($dictionary, 'RunTime');
         $livePhotoIndex       = $this->intValue($dictionary, 'LivePhotoVideoIndex');
+        $livePhotoTime        = null;
+        if ($livePhotoIndex !== null && $runTime instanceof RunTime) {
+            $timescale = $runTime->timescale;
+            if ($timescale !== null && $timescale > 0) {
+                $livePhotoTime = $livePhotoIndex / $timescale;
+            }
+        }
         $colorTemperature     = $this->intValue($dictionary, 'ColorTemperature');
         $semanticStylePreset  = $this->stringValue($dictionary, 'SemanticStylePreset');
         $semanticStyleWarmth  = $this->floatValue($dictionary, 'SemanticStyleWarmth');
@@ -330,12 +339,14 @@ final class AppleDecoder implements MakerNotesDecoderInterface
             && $snr === null
             && $focusPosition === null
             && $livePhotoIndex === null
+            && $livePhotoTime === null
             && $colorTemperature === null
             && $semanticStylePreset === null
             && $semanticStyleWarmth === null
             && $semanticStyleTone === null
             && $flags === []
             && $accelerationVector === null
+            && $runTime === null
         ) {
             return null;
         }
@@ -354,7 +365,37 @@ final class AppleDecoder implements MakerNotesDecoderInterface
             $semanticStyleTone,
             $flags,
             $accelerationVector,
+            $livePhotoTime,
+            $runTime,
         );
+    }
+
+    /**
+     * @param array<int|string, array<int|string, mixed>|bool|float|int|string|null> $dictionary
+     *
+     * @phpstan-param array<int|string, array<int|string, mixed>|bool|float|int|string|null> $dictionary
+     */
+    private function runTimeValue(array $dictionary, string $key): ?RunTime
+    {
+        if (!array_key_exists($key, $dictionary)) {
+            return null;
+        }
+
+        $value = $dictionary[$key];
+        if (!is_array($value)) {
+            return null;
+        }
+
+        $epoch     = $this->intValue($value, 'epoch', 'Epoch');
+        $timescale = $this->intValue($value, 'timescale', 'Timescale');
+        $rawValue  = $this->intValue($value, 'value', 'Value');
+        $flags     = $this->intValue($value, 'flags', 'Flags');
+
+        if ($epoch === null && $timescale === null && $rawValue === null && $flags === null) {
+            return null;
+        }
+
+        return new RunTime($epoch, $timescale, $rawValue, $flags);
     }
 
     /**

--- a/src/Value/Apple.php
+++ b/src/Value/Apple.php
@@ -24,12 +24,14 @@ final readonly class Apple
      * @param float|null          $snr                 Signal-to-noise ratio setting applied during capture.
      * @param float|null          $focusPosition       Focus position within the device specific range.
      * @param int|null            $livePhotoIndex      Index of the still frame for Live Photo sequences.
+     * @param float|null          $livePhotoTime       Normalised Live Photo timestamp in seconds.
      * @param int|null            $colorTemperature    White balance colour temperature in Kelvin.
      * @param string|null         $semanticStylePreset Semantic style preset name.
      * @param float|null          $semanticStyleWarmth Semantic style warmth value.
      * @param float|null          $semanticStyleTone   Semantic style tone value.
      * @param array<string, bool> $flags               Boolean flags derived from maker notes or QuickTime metadata.
      * @param list<float>|null    $accelerationVector  Acceleration vector recorded during capture.
+     * @param RunTime|null        $runTime             Capture runtime metadata describing the CMTime payload.
      */
     public function __construct(
         public ?string $contentIdentifier,
@@ -39,12 +41,14 @@ final readonly class Apple
         public ?float $snr,
         public ?float $focusPosition,
         public ?int $livePhotoIndex,
+        public ?float $livePhotoTime = null,
         public ?int $colorTemperature,
         public ?string $semanticStylePreset,
         public ?float $semanticStyleWarmth,
         public ?float $semanticStyleTone,
         public array $flags,
         public ?array $accelerationVector,
+        public ?RunTime $runTime = null,
     ) {
     }
 }

--- a/src/Value/RunTime.php
+++ b/src/Value/RunTime.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\ImageMeta\Value;
+
+/**
+ * Represents a CoreMedia runtime structure exposed via curated metadata.
+ */
+final readonly class RunTime
+{
+    /**
+     * @param int|null $epoch     Timeline epoch of the runtime value.
+     * @param int|null $timescale Timescale used to interpret the runtime value.
+     * @param int|null $value     Raw runtime value expressed in timescale units.
+     * @param int|null $flags     Bit mask describing the runtime value state.
+     */
+    public function __construct(
+        public ?int $epoch,
+        public ?int $timescale,
+        public ?int $value,
+        public ?int $flags,
+    ) {
+    }
+}

--- a/tests/Curate/StructuredMetadataBuilderTest.php
+++ b/tests/Curate/StructuredMetadataBuilderTest.php
@@ -14,6 +14,7 @@ namespace MagicSunday\ImageMeta\Tests\Curate;
 use DateTimeImmutable;
 use MagicSunday\ImageMeta\Curate\StructuredMetadataBuilder;
 use MagicSunday\ImageMeta\MakerNotes\Apple\AppleMakerNotes;
+use MagicSunday\ImageMeta\MakerNotes\Apple\RunTime as AppleRunTime;
 use MagicSunday\ImageMeta\MakerNotes\AppleDecoder;
 use MagicSunday\ImageMeta\MakerNotes\MakerNotesMetadata;
 use MagicSunday\ImageMeta\Model\Exif\ExifDocument;
@@ -48,6 +49,7 @@ use MagicSunday\ImageMeta\Value\Enum\SubjectDistanceRange;
 use MagicSunday\ImageMeta\Value\Enum\WhiteBalance;
 use MagicSunday\ImageMeta\Value\Enum\YCbCrPositioning;
 use MagicSunday\ImageMeta\Value\Regions\RegionType;
+use MagicSunday\ImageMeta\Value\RunTime as ValueRunTime;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -454,10 +456,12 @@ final class StructuredMetadataBuilderTest extends TestCase
             snr: 18.5,
             focusPosition: 0.5,
             livePhotoIndex: 4,
+            livePhotoTime: 0.2,
             colorTemperature: 4300,
             semanticStylePreset: 'MakerPreset',
             semanticStyleWarmth: 0.3,
             semanticStyleTone: -0.2,
+            runTime: new AppleRunTime(epoch: 7, timescale: 20, value: 100, flags: 9),
             flags: ['livePhotoAuto' => false, 'nightMode' => true],
             accelerationVector: [0.05, 0.1, -0.1],
         );
@@ -493,6 +497,7 @@ final class StructuredMetadataBuilderTest extends TestCase
         self::assertEqualsWithDelta(18.5, $structured->apple->snr, 1e-12);
         self::assertEqualsWithDelta(0.5, $structured->apple->focusPosition, 1e-12);
         self::assertSame(4, $structured->apple->livePhotoIndex);
+        self::assertEqualsWithDelta(0.2, $structured->apple->livePhotoTime, 1e-12);
         self::assertSame(4300, $structured->apple->colorTemperature);
         self::assertSame('MakerPreset', $structured->apple->semanticStylePreset);
         self::assertEqualsWithDelta(0.3, $structured->apple->semanticStyleWarmth, 1e-12);
@@ -500,6 +505,11 @@ final class StructuredMetadataBuilderTest extends TestCase
         self::assertFalse($structured->apple->flags['livePhotoAuto']);
         self::assertTrue($structured->apple->flags['nightMode']);
         self::assertSame([0.05, 0.1, -0.1], $structured->apple->accelerationVector);
+        self::assertInstanceOf(ValueRunTime::class, $structured->apple->runTime);
+        self::assertSame(7, $structured->apple->runTime?->epoch);
+        self::assertSame(20, $structured->apple->runTime?->timescale);
+        self::assertSame(100, $structured->apple->runTime?->value);
+        self::assertSame(9, $structured->apple->runTime?->flags);
 
         self::assertSame(4300, $structured->whiteBalanceDetails->kelvin);
         self::assertEqualsWithDelta(0.05, $structured->motion->accelX, 1e-12);
@@ -1405,6 +1415,8 @@ final class StructuredMetadataBuilderTest extends TestCase
             -0.05,
             ['hdrEnabled' => true],
             [0.1, 0.2, 0.3],
+            null,
+            null,
         );
 
         $makerNotes = new MakerNotesMetadata(

--- a/tests/MakerNotes/Apple/AppleDecoderKeyedArchiveTest.php
+++ b/tests/MakerNotes/Apple/AppleDecoderKeyedArchiveTest.php
@@ -13,6 +13,7 @@ namespace MagicSunday\ImageMeta\Tests\MakerNotes\Apple;
 
 use MagicSunday\ImageMeta\MakerNotes\Apple\AppleMakerNotes;
 use MagicSunday\ImageMeta\MakerNotes\AppleDecoder;
+use MagicSunday\ImageMeta\MakerNotes\Apple\RunTime;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
@@ -50,8 +51,14 @@ final class AppleDecoderKeyedArchiveTest extends TestCase
         self::assertSame(10.5, $apple->snr);
         self::assertSame(0.75, $apple->focusPosition);
         self::assertSame(5, $apple->livePhotoIndex);
+        self::assertEqualsWithDelta(0.5, $apple->livePhotoTime, 1e-12);
         self::assertSame(6500, $apple->colorTemperature);
         self::assertSame([0.1, 0.2, 0.3], $apple->accelerationVector);
+        self::assertInstanceOf(RunTime::class, $apple->runTime);
+        self::assertSame(1, $apple->runTime?->epoch);
+        self::assertSame(10, $apple->runTime?->timescale);
+        self::assertSame(50, $apple->runTime?->value);
+        self::assertSame(3, $apple->runTime?->flags);
     }
 
     private function createKeyedArchiveBlob(): string
@@ -68,6 +75,7 @@ final class AppleDecoderKeyedArchiveTest extends TestCase
                 'HdrHeadroom'         => ['CF$UID' => 4],
                 'LivePhotoVideoIndex' => ['CF$UID' => 8],
                 'SNRSetting'          => ['CF$UID' => 6],
+                'RunTime'             => ['CF$UID' => 17],
             ],
             [
                 '$classes'   => ['AppleMakerNotesRoot', 'NSObject'],
@@ -95,6 +103,12 @@ final class AppleDecoderKeyedArchiveTest extends TestCase
             0.1,
             0.2,
             0.3,
+            [
+                'epoch'     => 1,
+                'timescale' => 10,
+                'value'     => 50,
+                'flags'     => 3,
+            ],
         ];
 
         $archive = [

--- a/tests/MakerNotes/AppleDecoder/AppleDecoderTest.php
+++ b/tests/MakerNotes/AppleDecoder/AppleDecoderTest.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 namespace MagicSunday\ImageMeta\Tests\MakerNotes\AppleDecoder;
 
 use MagicSunday\ImageMeta\MakerNotes\Apple\AppleMakerNotes;
+use MagicSunday\ImageMeta\MakerNotes\Apple\RunTime;
 use MagicSunday\ImageMeta\MakerNotes\AppleDecoder;
 use MagicSunday\ImageMeta\MakerNotes\MakerNotesMetadata;
 use PHPUnit\Framework\Attributes\Test;
@@ -166,6 +167,36 @@ final class AppleDecoderTest extends TestCase
         self::assertSame('DictionaryPreset', $notes->semanticStylePreset);
         self::assertEqualsWithDelta(0.45, $notes->semanticStyleWarmth, 1e-12);
         self::assertEqualsWithDelta(-0.25, $notes->semanticStyleTone, 1e-12);
+    }
+
+    #[Test]
+    public function buildAppleMakerNotesParsesRunTime(): void
+    {
+        $decoder = new AppleDecoder();
+        $method  = new ReflectionMethod(AppleDecoder::class, 'buildAppleMakerNotes');
+        $method->setAccessible(true);
+
+        $dictionary = [
+            'RunTime'             => [
+                'epoch'     => '2',
+                'timescale' => 600,
+                'value'     => 1500,
+                'flags'     => 5,
+            ],
+            'LivePhotoVideoIndex' => 1200,
+        ];
+
+        /** @var AppleMakerNotes|null $notes */
+        $notes = $method->invoke($decoder, $dictionary);
+
+        self::assertInstanceOf(AppleMakerNotes::class, $notes);
+        self::assertSame(1200, $notes->livePhotoIndex);
+        self::assertEqualsWithDelta(2.0, $notes->livePhotoTime, 1e-12);
+        self::assertInstanceOf(RunTime::class, $notes->runTime);
+        self::assertSame(2, $notes->runTime?->epoch);
+        self::assertSame(600, $notes->runTime?->timescale);
+        self::assertSame(1500, $notes->runTime?->value);
+        self::assertSame(5, $notes->runTime?->flags);
     }
 
     private function buildMakerNotesBlob(): string


### PR DESCRIPTION
## Summary
- parse the RunTime dictionary from Apple maker note payloads and normalise the Live Photo index to seconds
- expose the runtime structure and derived timestamp via Apple maker note and curated Apple value objects
- extend keyed-archive fixtures and unit coverage to validate runtime extraction and propagation

## Testing
- .build/bin/phpunit tests/MakerNotes/AppleDecoder/AppleDecoderTest.php
- .build/bin/phpunit tests/MakerNotes/Apple/AppleDecoderKeyedArchiveTest.php
- .build/bin/phpunit tests/Curate/StructuredMetadataBuilderTest.php

------
https://chatgpt.com/codex/tasks/task_e_68fcd2562ec88323877584b7fa5caa78