### PR TITLE
Add camera type mapping for Apple maker notes

### DIFF
--- a/src/Curate/Resolver/AppleResolver.php
+++ b/src/Curate/Resolver/AppleResolver.php
@@ -49,7 +49,8 @@ final readonly class AppleResolver
         $identifier = $quickTimeMeta->contentIdentifier();
         $resolver   = new QuickTimeResolver($quickTimeMeta);
 
-        $cameraType         = $resolver->string('CameraType');
+        $cameraTypeString  = $resolver->string('CameraType');
+        $cameraType         = $cameraTypeString ?? $resolver->int('CameraType');
         $hdrHeadroom        = $resolver->float('HdrHeadroom') ?? $resolver->float('HDRHeadroom');
         $hdrGain            = $this->floatList($resolver, 'HdrGain', 'HDRGain');
         $snr                = $resolver->float('SNRSetting') ?? $resolver->float('SNR');

--- a/src/MakerNotes/Apple/AppleMakerNotes.php
+++ b/src/MakerNotes/Apple/AppleMakerNotes.php
@@ -18,7 +18,7 @@ final readonly class AppleMakerNotes
 {
     /**
      * @param string|null         $contentIdentifier   Unique content identifier assigned by Apple platforms.
-     * @param string|null         $cameraType          Describes the hardware camera (e.g. "Wide", "Tele").
+     * @param string|int|null     $cameraType          Describes the hardware camera (e.g. "Wide", "Tele").
      * @param float|null          $hdrHeadroom         HDR headroom value reported by the device.
      * @param list<float>|null    $hdrGain             HDR gain values per colour channel.
      * @param float|null          $snr                 Signal-to-noise ratio setting.
@@ -33,7 +33,7 @@ final readonly class AppleMakerNotes
      */
     public function __construct(
         public ?string $contentIdentifier,
-        public ?string $cameraType,
+        public string|int|null $cameraType,
         public ?float $hdrHeadroom,
         public ?array $hdrGain,
         public ?float $snr,

--- a/src/MakerNotes/AppleDecoder.php
+++ b/src/MakerNotes/AppleDecoder.php
@@ -59,6 +59,17 @@ final class AppleDecoder implements MakerNotesDecoderInterface
     ];
 
     /**
+     * Maps known camera type codes to descriptive labels.
+     *
+     * @var array<int, string>
+     */
+    private const array CAMERA_TYPE_MAP = [
+        0 => 'Back Wide Angle',
+        1 => 'Back Normal',
+        6 => 'Front',
+    ];
+
+    /**
      * Maps Apple bitfield sources (indexed by zero-based bit position) to normalised flags.
      *
      * @var array<string, array<int, string>>
@@ -293,7 +304,12 @@ final class AppleDecoder implements MakerNotesDecoderInterface
         }
 
         $contentIdentifier    = $this->stringValue($dictionary, 'ContentIdentifier');
-        $cameraType           = $this->stringValue($dictionary, 'CameraType');
+        $cameraTypeCode       = $this->intValue($dictionary, 'CameraType');
+        if ($cameraTypeCode !== null) {
+            $cameraType = self::CAMERA_TYPE_MAP[$cameraTypeCode] ?? $cameraTypeCode;
+        } else {
+            $cameraType = $this->stringValue($dictionary, 'CameraType');
+        }
         $hdrHeadroom          = $this->floatValue($dictionary, 'HdrHeadroom', 'HDRHeadroom');
         $hdrGain              = $this->floatList($dictionary, 'HdrGain', 'HDRGain');
         $snr                  = $this->floatValue($dictionary, 'SNRSetting', 'SNR');

--- a/src/Value/Apple.php
+++ b/src/Value/Apple.php
@@ -18,7 +18,7 @@ final readonly class Apple
 {
     /**
      * @param string|null         $contentIdentifier   Unique content identifier assigned by Apple platforms.
-     * @param string|null         $cameraType          Reported hardware camera type (e.g. "Wide", "Tele").
+     * @param string|int|null     $cameraType          Reported hardware camera type (e.g. "Wide", "Tele").
      * @param float|null          $hdrHeadroom         HDR headroom value reported by the capture pipeline.
      * @param list<float>|null    $hdrGain             HDR gain values per colour channel.
      * @param float|null          $snr                 Signal-to-noise ratio setting applied during capture.
@@ -33,7 +33,7 @@ final readonly class Apple
      */
     public function __construct(
         public ?string $contentIdentifier,
-        public ?string $cameraType,
+        public string|int|null $cameraType,
         public ?float $hdrHeadroom,
         public ?array $hdrGain,
         public ?float $snr,

--- a/tests/MakerNotes/AppleDecoder/AppleDecoderTest.php
+++ b/tests/MakerNotes/AppleDecoder/AppleDecoderTest.php
@@ -31,6 +31,38 @@ use function strlen;
 final class AppleDecoderTest extends TestCase
 {
     /**
+     * Ensures keyed archive payloads map integer camera type codes to descriptive labels.
+     */
+    #[Test]
+    public function decodeMapsCameraTypeCodeFromKeyedArchive(): void
+    {
+        $hex = ''
+            . '62706c6973743030d401020304050622265924617263686976657258246f626a'
+            . '656374735424746f70582476657273696f6e5f100f4e534b6579656441726368'
+            . '69766572a70708191f20211855246e756c6cd3090a0b0c0f145624636c617373'
+            . '574e532e6b6579735a4e532e6f626a65637473d10d0e564346245549441002a2'
+            . '1012d10d111003d10d131004a21517d10d161005d10d181006d21a1b1c1d5824'
+            . '636c61737365735a24636c6173736e616d65a21d1e5c4e5344696374696f6e61'
+            . '7279584e534f626a6563745f1011436f6e74656e744964656e7469666965725a'
+            . '43616d657261547970655f101361726368697665642d70686f746f2d75756964'
+            . 'd1232454726f6f74d10d25100112000186a000080011001b0024002900320044'
+            . '004c005200590060006800730076007d007f008200850087008a008c008f0092'
+            . '009400970099009e00a700b200b500c200cb00df00ea010001030108010b010d'
+            . '0000000000000201000000000000002700000000000000000000000000000112';
+        $raw = (string) hex2bin($hex);
+        $decoder = new AppleDecoder();
+
+        $metadata = $decoder->decode($raw, 'Apple', 'iPhone');
+
+        self::assertInstanceOf(MakerNotesMetadata::class, $metadata);
+
+        $apple = $metadata->apple();
+        self::assertInstanceOf(AppleMakerNotes::class, $apple);
+        self::assertSame('archived-photo-uuid', $apple->contentIdentifier);
+        self::assertSame('Front', $apple->cameraType);
+    }
+
+    /**
      * Ensures the decoder resolves keyed archive maker note data into structured metadata.
      */
     #[Test]
@@ -142,6 +174,29 @@ final class AppleDecoderTest extends TestCase
         self::assertSame('Vivid', $apple->semanticStylePreset);
         self::assertEqualsWithDelta(0.25, $apple->semanticStyleWarmth, 1e-12);
         self::assertEqualsWithDelta(-0.1, $apple->semanticStyleTone, 1e-12);
+    }
+
+    #[Test]
+    public function buildAppleMakerNotesHandlesCameraTypeCodes(): void
+    {
+        $decoder = new AppleDecoder();
+        $method  = new ReflectionMethod(AppleDecoder::class, 'buildAppleMakerNotes');
+        $method->setAccessible(true);
+
+        $mapped = $method->invoke($decoder, [
+            'ContentIdentifier' => 'mapped-camera',
+            'CameraType'        => 0,
+        ]);
+
+        $unknown = $method->invoke($decoder, [
+            'ContentIdentifier' => 'unknown-camera',
+            'CameraType'        => 42,
+        ]);
+
+        self::assertInstanceOf(AppleMakerNotes::class, $mapped);
+        self::assertInstanceOf(AppleMakerNotes::class, $unknown);
+        self::assertSame('Back Wide Angle', $mapped->cameraType);
+        self::assertSame(42, $unknown->cameraType);
     }
 
     #[Test]


### PR DESCRIPTION
## Summary
- map documented Apple camera type codes to descriptive labels while keeping string fallbacks for non-standard payloads
- allow Apple maker notes, resolver, and value objects to expose either the mapped label or raw integer codes
- extend the Apple maker note tests with keyed-archive and direct builder coverage for integer camera types

## Testing
- composer ci:test:php:unit *(fails: truth comparison fixtures require proprietary sample assets in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68fcd2320a108323ac68a4eeec9b156f