### PR TITLE
Fix motion acceleration vector propagation from QuickTime metadata

### DIFF
--- a/src/Curate/StructuredMetadataBuilder.php
+++ b/src/Curate/StructuredMetadataBuilder.php
@@ -315,7 +315,7 @@ final class StructuredMetadataBuilder
             afMode: null,
         );
 
-        $motion = $this->buildMotion($appleMakerNotes);
+        $motion = $this->buildMotion($apple);
 
         $regions = $regionsResolver->resolve($xmpDocument);
 
@@ -856,13 +856,13 @@ final class StructuredMetadataBuilder
     /**
      * Builds the motion metadata aggregate from the Apple acceleration vector.
      *
-     * @param AppleMakerNotes|null $makerNotes Parsed Apple maker note payload.
+     * @param Apple $apple Aggregated Apple metadata composed from maker notes and QuickTime sources.
      *
      * @return Motion Motion metadata aggregate with per-axis acceleration.
      */
-    private function buildMotion(?AppleMakerNotes $makerNotes): Motion
+    private function buildMotion(Apple $apple): Motion
     {
-        $vector = $makerNotes?->accelerationVector;
+        $vector = $apple->accelerationVector;
 
         $accelX = null;
         $accelY = null;

--- a/tests/Curate/StructuredMetadataBuilderTest.php
+++ b/tests/Curate/StructuredMetadataBuilderTest.php
@@ -571,6 +571,9 @@ final class StructuredMetadataBuilderTest extends TestCase
 
         self::assertSame('qt-content', $structured->apple->contentIdentifier);
         self::assertSame([0.12, -0.34, 0.56], $structured->apple->accelerationVector);
+        self::assertEqualsWithDelta(0.12, $structured->motion->accelX, 1e-12);
+        self::assertEqualsWithDelta(-0.34, $structured->motion->accelY, 1e-12);
+        self::assertEqualsWithDelta(0.56, $structured->motion->accelZ, 1e-12);
     }
 
     #[Test]


### PR DESCRIPTION
## Summary
- update the structured metadata builder to populate motion data from the aggregated Apple acceleration vector
- ensure QuickTime-only acceleration vectors propagate into the motion aggregate via unit coverage

## Testing
- composer ci:test:php:unit *(fails: fixture-based comparison suite expects assets unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68fcd7b3aad88323a6a53c569861b3d9