### PR TITLE
Fix PhotosAppFeatureFlags decoding to report subject detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@
   capture time reconstruction.
 - Enriched `Value\File` with mime type, file size, extension and SHA-1/MD5 digests so that consumers can correlate assets without
   re-reading the original payload.
-- Broadened the Apple aggregate with semantic style parameters, colour temperature in Kelvin and Live Photo flags sourced from
-  maker notes and QuickTime metadata.
+- Broadened the Apple aggregate with semantic style parameters, colour temperature in Kelvin and person/pet detection flags
+  sourced from maker notes and QuickTime metadata.
 - Expanded GPS coverage to include horizontal positioning error and the full destination navigation set from EXIF 2.32 table 66.
 - Introduced dedicated maker note decoders for Apple (`MakerNotes\AppleDecoder`), Canon, Nikon and Sony plus the
   `Curate\Resolver\AppleResolver` and `Curate\Resolver\MakerNotesResolver` convenience helpers.

--- a/README.md
+++ b/README.md
@@ -91,6 +91,6 @@ Bit-mask sources such as `SceneFlags`, `ImageProcessingFlags` and `PhotosAppFeat
 
 * `SceneFlags`: bit 0 → `nightMode`, bit 1 → `longExposure`
 * `ImageProcessingFlags`: bit 0 → `hdrEnabled`, bit 1 → `hdrAuto`
-* `PhotosAppFeatureFlags`: bit 0 → `livePhoto`, bit 1 → `livePhotoAuto`, bit 2 → `livePhotoEnabled`, bit 3 → `livePhotoActive`, bit 4 → `livePhotoLongExposure`
+* `PhotosAppFeatureFlags`: bit 0 → `personInPhoto`, bit 1 → `petInPhoto`
 
 Explicit boolean keys continue to override the derived values when both representations are present.

--- a/src/Curate/Resolver/AppleResolver.php
+++ b/src/Curate/Resolver/AppleResolver.php
@@ -35,6 +35,8 @@ final readonly class AppleResolver
         'HdrEnabled'            => 'hdrEnabled',
         'NightMode'             => 'nightMode',
         'LongExposure'          => 'longExposure',
+        'PersonInPhoto'         => 'personInPhoto',
+        'PetInPhoto'            => 'petInPhoto',
     ];
 
     /**

--- a/src/Curate/StructuredMetadataBuilder.php
+++ b/src/Curate/StructuredMetadataBuilder.php
@@ -95,6 +95,8 @@ final class StructuredMetadataBuilder
         'HdrEnabled'            => 'hdrEnabled',
         'NightMode'             => 'nightMode',
         'LongExposure'          => 'longExposure',
+        'PersonInPhoto'         => 'personInPhoto',
+        'PetInPhoto'            => 'petInPhoto',
     ];
 
     /**

--- a/src/MakerNotes/AppleDecoder.php
+++ b/src/MakerNotes/AppleDecoder.php
@@ -56,6 +56,8 @@ final class AppleDecoder implements MakerNotesDecoderInterface
         'LivePhotoActive'       => 'livePhotoActive',
         'LivePhotoLongExposure' => 'livePhotoLongExposure',
         'LivePhoto'             => 'livePhoto',
+        'PersonInPhoto'         => 'personInPhoto',
+        'PetInPhoto'            => 'petInPhoto',
         'HdrAuto'               => 'hdrAuto',
         'HdrEnabled'            => 'hdrEnabled',
         'NightMode'             => 'nightMode',
@@ -88,11 +90,8 @@ final class AppleDecoder implements MakerNotesDecoderInterface
             1 => 'hdrAuto',            // Bit 1 – HDR auto detection engaged.
         ],
         'PhotosAppFeatureFlags' => [
-            0 => 'livePhoto',          // Bit 0 – Live Photo asset present.
-            1 => 'livePhotoAuto',      // Bit 1 – Live Photo auto capture.
-            2 => 'livePhotoEnabled',   // Bit 2 – Live Photo enabled by the user.
-            3 => 'livePhotoActive',    // Bit 3 – Live Photo active during capture.
-            4 => 'livePhotoLongExposure', // Bit 4 – Live Photo long exposure fused asset.
+            0 => 'personInPhoto',      // Bit 0 – Person detected in the asset.
+            1 => 'petInPhoto',         // Bit 1 – Pet detected in the asset.
         ],
     ];
 
@@ -1010,13 +1009,20 @@ final class AppleDecoder implements MakerNotesDecoderInterface
             }
 
             $enabledBits = $this->bitPositions($dictionary[$makerKey]);
-            if ($enabledBits === []) {
+            if ($enabledBits === null) {
                 continue;
             }
 
+            $assignFalse = $makerKey === 'PhotosAppFeatureFlags';
+
             foreach ($bitMap as $bitPosition => $normalized) {
-                if (in_array($bitPosition, $enabledBits, true) && !array_key_exists($normalized, $flags)) {
-                    $flags[$normalized] = true;
+                if (array_key_exists($normalized, $flags)) {
+                    continue;
+                }
+
+                $isEnabled = in_array($bitPosition, $enabledBits, true);
+                if ($isEnabled || $assignFalse) {
+                    $flags[$normalized] = $isEnabled;
                 }
             }
         }
@@ -1033,9 +1039,9 @@ final class AppleDecoder implements MakerNotesDecoderInterface
      *
      * @param string|int|float|bool|array<int|string, mixed>|null $value
      *
-     * @return list<int> Zero-based bit positions detected in the value.
+     * @return list<int>|null Zero-based bit positions detected in the value or null when the value does not encode a bit mask.
      */
-    private function bitPositions(string|int|float|bool|array|null $value): array
+    private function bitPositions(string|int|float|bool|array|null $value): ?array
     {
         if (is_int($value)) {
             return $this->bitPositionsFromMask($value);
@@ -1048,30 +1054,34 @@ final class AppleDecoder implements MakerNotesDecoderInterface
         if (is_string($value)) {
             $normalized = trim($value);
             if ($normalized === '') {
-                return [];
+                return null;
             }
 
             if (str_starts_with($normalized, '0x') || str_starts_with($normalized, '0X')) {
                 $hex = substr($normalized, 2);
                 if ($hex === '' || !ctype_xdigit($hex)) {
-                    return [];
+                    return null;
                 }
 
                 return $this->bitPositionsFromMask((int) hexdec($hex));
             }
 
             if (!is_numeric($normalized)) {
-                return [];
+                return null;
             }
 
             return $this->bitPositionsFromMask((int) $normalized);
         }
 
         if (is_bool($value) || $value === null) {
-            return [];
+            return null;
         }
 
-        if (!is_array($value) || $value === []) {
+        if (!is_array($value)) {
+            return null;
+        }
+
+        if ($value === []) {
             return [];
         }
 
@@ -1083,13 +1093,14 @@ final class AppleDecoder implements MakerNotesDecoderInterface
             }
 
             if (!array_key_exists('values', $value)) {
-                return [];
+                return null;
             }
 
             return $this->bitPositions($value['values']);
         }
 
         $positions = [];
+        $hasEntry  = false;
         foreach ($value as $entry) {
             if (is_int($entry) || is_float($entry) || (is_string($entry) && is_numeric($entry))) {
                 $position = (int) $entry;
@@ -1097,15 +1108,24 @@ final class AppleDecoder implements MakerNotesDecoderInterface
                     $positions[] = $position;
                 }
 
+                $hasEntry = true;
                 continue;
             }
 
             $nested = $this->bitPositions($entry);
-            if ($nested !== []) {
-                foreach ($nested as $bit) {
-                    $positions[] = $bit;
-                }
+            if ($nested === null) {
+                continue;
             }
+
+            $hasEntry = true;
+
+            foreach ($nested as $bit) {
+                $positions[] = $bit;
+            }
+        }
+
+        if (!$hasEntry) {
+            return null;
         }
 
         if ($positions === []) {

--- a/tests/Curate/StructuredMetadataBuilderTest.php
+++ b/tests/Curate/StructuredMetadataBuilderTest.php
@@ -529,7 +529,7 @@ final class StructuredMetadataBuilderTest extends TestCase
             'ContentIdentifier'     => 'bitfield',
             'SceneFlags'            => [0, 1],
             'ImageProcessingFlags'  => ['values' => [0, 1]],
-            'PhotosAppFeatureFlags' => [0, 1, ['values' => [2, 3]], 4],
+            'PhotosAppFeatureFlags' => [0],
         ]);
 
         self::assertInstanceOf(AppleMakerNotes::class, $appleMakerNotes);
@@ -548,11 +548,8 @@ final class StructuredMetadataBuilderTest extends TestCase
         self::assertTrue($structured->apple->flags['longExposure']);
         self::assertTrue($structured->apple->flags['hdrEnabled']);
         self::assertTrue($structured->apple->flags['hdrAuto']);
-        self::assertTrue($structured->apple->flags['livePhoto']);
-        self::assertTrue($structured->apple->flags['livePhotoAuto']);
-        self::assertTrue($structured->apple->flags['livePhotoEnabled']);
-        self::assertTrue($structured->apple->flags['livePhotoActive']);
-        self::assertTrue($structured->apple->flags['livePhotoLongExposure']);
+        self::assertTrue($structured->apple->flags['personInPhoto']);
+        self::assertFalse($structured->apple->flags['petInPhoto']);
     }
 
     /**

--- a/tests/MakerNotes/Apple/AppleDecoderFlagMaskTest.php
+++ b/tests/MakerNotes/Apple/AppleDecoderFlagMaskTest.php
@@ -31,7 +31,7 @@ final class AppleDecoderFlagMaskTest extends TestCase
             'SceneFlags'            => 0b11,
             'ImageProcessingFlags'  => '0x3',
             'PhotosAppFeatureFlags' => [
-                'values' => [0, 1, 2, 3, 4],
+                'values' => [0, 1],
             ],
         ];
 
@@ -41,13 +41,10 @@ final class AppleDecoderFlagMaskTest extends TestCase
         $expected = [
             'hdrAuto'               => true,
             'hdrEnabled'            => true,
-            'livePhoto'             => true,
-            'livePhotoActive'       => true,
-            'livePhotoAuto'         => true,
-            'livePhotoEnabled'      => true,
-            'livePhotoLongExposure' => true,
             'longExposure'          => true,
             'nightMode'             => true,
+            'personInPhoto'         => true,
+            'petInPhoto'            => true,
         ];
         ksort($expected);
 
@@ -55,7 +52,7 @@ final class AppleDecoderFlagMaskTest extends TestCase
     }
 
     #[Test]
-    public function extractFlagsIgnoresUnmappedBitPositions(): void
+    public function extractFlagsDefaultsPhotosAppFeatureBitsToFalse(): void
     {
         $decoder = new AppleDecoder();
         $method  = new ReflectionMethod(AppleDecoder::class, 'extractFlags');
@@ -70,6 +67,9 @@ final class AppleDecoderFlagMaskTest extends TestCase
 
         $result = $method->invoke($decoder, $dictionary);
 
-        self::assertSame([], $result);
+        self::assertSame([
+            'personInPhoto' => false,
+            'petInPhoto'    => false,
+        ], $result);
     }
 }

--- a/tests/MakerNotes/AppleDecoder/AppleDecoderTest.php
+++ b/tests/MakerNotes/AppleDecoder/AppleDecoderTest.php
@@ -110,21 +110,18 @@ final class AppleDecoderTest extends TestCase
         self::assertEqualsWithDelta(-0.15, $apple->semanticStyleTone, 1e-12);
         self::assertSame([0.12, -0.34, 0.56], $apple->accelerationVector);
 
-        self::assertArrayHasKey('livePhoto', $apple->flags);
-        self::assertArrayHasKey('livePhotoAuto', $apple->flags);
-        self::assertArrayHasKey('livePhotoEnabled', $apple->flags);
-        self::assertArrayHasKey('livePhotoLongExposure', $apple->flags);
         self::assertArrayHasKey('hdrAuto', $apple->flags);
         self::assertArrayHasKey('hdrEnabled', $apple->flags);
         self::assertArrayHasKey('longExposure', $apple->flags);
+        self::assertArrayHasKey('personInPhoto', $apple->flags);
+        self::assertArrayHasKey('petInPhoto', $apple->flags);
 
-        self::assertTrue($apple->flags['livePhoto']);
-        self::assertTrue($apple->flags['livePhotoAuto']);
-        self::assertTrue($apple->flags['livePhotoEnabled']);
-        self::assertTrue($apple->flags['livePhotoLongExposure']);
         self::assertTrue($apple->flags['hdrAuto']);
         self::assertTrue($apple->flags['hdrEnabled']);
         self::assertTrue($apple->flags['longExposure']);
+        self::assertTrue($apple->flags['personInPhoto']);
+        self::assertFalse($apple->flags['petInPhoto']);
+
     }
 
     #[Test]
@@ -311,13 +308,15 @@ final class AppleDecoderTest extends TestCase
             'HdrEnabled'            => '1',
             'NightMode'             => true,
             'LongExposure'          => true,
+            'PersonInPhoto'         => true,
+            'PetInPhoto'            => false,
         ]);
 
         $maskNotes = $method->invoke($decoder, [
             'ContentIdentifier'     => 'mask',
             'SceneFlags'            => (1 << 0) | (1 << 1),
             'ImageProcessingFlags'  => (1 << 0) | (1 << 1),
-            'PhotosAppFeatureFlags' => (1 << 0) | (1 << 1) | (1 << 2) | (1 << 3) | (1 << 4),
+            'PhotosAppFeatureFlags' => 1 << 0,
         ]);
 
         self::assertInstanceOf(AppleMakerNotes::class, $scalarNotes);
@@ -326,10 +325,30 @@ final class AppleDecoderTest extends TestCase
         $scalarFlags = $scalarNotes->flags;
         $maskFlags   = $maskNotes->flags;
 
-        ksort($scalarFlags);
         ksort($maskFlags);
 
-        self::assertSame($scalarFlags, $maskFlags);
+        self::assertSame(
+            [
+                'hdrAuto'       => true,
+                'hdrEnabled'    => true,
+                'longExposure'  => true,
+                'nightMode'     => true,
+                'personInPhoto' => true,
+                'petInPhoto'    => false,
+            ],
+            $maskFlags,
+        );
+
+        foreach ($maskFlags as $flag => $value) {
+            self::assertArrayHasKey($flag, $scalarFlags);
+            self::assertSame($value, $scalarFlags[$flag]);
+        }
+
+        self::assertTrue($scalarFlags['livePhoto']);
+        self::assertTrue($scalarFlags['livePhotoAuto']);
+        self::assertTrue($scalarFlags['livePhotoEnabled']);
+        self::assertTrue($scalarFlags['livePhotoActive']);
+        self::assertTrue($scalarFlags['livePhotoLongExposure']);
     }
 
     #[Test]
@@ -344,16 +363,22 @@ final class AppleDecoderTest extends TestCase
             'LivePhotoLongExposure' => false,
             'NightMode'             => false,
             'SceneFlags'            => 1 << 0,
-            'PhotosAppFeatureFlags' => 1 << 4,
+            'PetInPhoto'            => false,
+            'PhotosAppFeatureFlags' => 1 << 1,
         ]);
 
         self::assertInstanceOf(AppleMakerNotes::class, $notes);
+        $flags = $notes->flags;
+        ksort($flags);
+
         self::assertSame(
             [
                 'livePhotoLongExposure' => false,
                 'nightMode'             => false,
+                'personInPhoto'         => false,
+                'petInPhoto'            => false,
             ],
-            $notes->flags,
+            $flags,
         );
     }
 
@@ -368,7 +393,7 @@ final class AppleDecoderTest extends TestCase
             'ContentIdentifier'     => 'positions',
             'SceneFlags'            => [0, 1],
             'ImageProcessingFlags'  => ['values' => [0, 1]],
-            'PhotosAppFeatureFlags' => [0, 1, ['values' => [2, 3]], 4],
+            'PhotosAppFeatureFlags' => [0],
         ]);
 
         self::assertInstanceOf(AppleMakerNotes::class, $notes);
@@ -380,13 +405,10 @@ final class AppleDecoderTest extends TestCase
             [
                 'hdrAuto'               => true,
                 'hdrEnabled'            => true,
-                'livePhoto'             => true,
-                'livePhotoActive'       => true,
-                'livePhotoAuto'         => true,
-                'livePhotoEnabled'      => true,
-                'livePhotoLongExposure' => true,
                 'longExposure'          => true,
                 'nightMode'             => true,
+                'personInPhoto'         => true,
+                'petInPhoto'            => false,
             ],
             $flags,
         );


### PR DESCRIPTION
## Summary
- map PhotosAppFeatureFlags bits to person/pet detection flags and adjust mask handling to emit false when unset
- propagate the new detection flags through AppleResolver, StructuredMetadataBuilder, documentation, and tests

## Testing
- composer ci:test:php:unit (fails: missing reference media fixtures in TruthComparisonTest)
- .build/bin/phpunit tests/MakerNotes/AppleDecoder
- .build/bin/phpunit tests/Curate/StructuredMetadataBuilderTest.php
- .build/bin/phpunit tests/MakerNotes/Apple


------
https://chatgpt.com/codex/tasks/task_e_68fcdd6bed4c83238b0571830328adbd