### PR TITLE
Fix Apple Live Photo index fallbacks

### DIFF
--- a/src/Curate/StructuredMetadataBuilder.php
+++ b/src/Curate/StructuredMetadataBuilder.php
@@ -760,7 +760,7 @@ final class StructuredMetadataBuilder
 
         $livePhotoIndex = $makerNotes?->livePhotoIndex;
         if ($livePhotoIndex === null) {
-            $livePhotoIndex = $this->quickTimeInt($quickTimeResolver, 'LivePhotoVideoIndex');
+            $livePhotoIndex = $this->quickTimeInt($quickTimeResolver, 'LivePhotoVideoIndex', 'LivePhotoMovieIndex');
         }
 
         $livePhotoTime = $makerNotes?->livePhotoTime;

--- a/src/MakerNotes/AppleDecoder.php
+++ b/src/MakerNotes/AppleDecoder.php
@@ -97,6 +97,16 @@ final class AppleDecoder implements MakerNotesDecoderInterface
     ];
 
     /**
+     * Maker note keys that encode the Live Photo still frame index.
+     *
+     * @var array<int, string>
+     */
+    private const array LIVE_PHOTO_INDEX_KEYS = [
+        'LivePhotoVideoIndex',
+        'LivePhotoMovieIndex',
+    ];
+
+    /**
      * Creates a metadata value object describing the Apple maker note payload.
      *
      * @param string      $raw   Raw maker note data stream.
@@ -618,7 +628,7 @@ final class AppleDecoder implements MakerNotesDecoderInterface
         $snr                  = $this->floatValue($dictionary, 'SNRSetting', 'SNR');
         $focusPosition        = $this->floatValue($dictionary, 'FocusPosition');
         $runTime              = $this->runTimeValue($dictionary, 'RunTime');
-        $livePhotoIndex       = $this->intValue($dictionary, 'LivePhotoVideoIndex', 'LivePhotoMovieIndex');
+        $livePhotoIndex       = $this->intValue($dictionary, ...self::LIVE_PHOTO_INDEX_KEYS);
         $livePhotoTime        = null;
         if ($livePhotoIndex !== null && $runTime instanceof RunTime) {
             $timescale = $runTime->timescale;

--- a/tests/Curate/StructuredMetadataBuilderTest.php
+++ b/tests/Curate/StructuredMetadataBuilderTest.php
@@ -519,6 +519,20 @@ final class StructuredMetadataBuilderTest extends TestCase
     }
 
     #[Test]
+    public function usesQuickTimeMovieIndexWhenMakerNotesMissing(): void
+    {
+        $quickTime = new QuickTimeMeta([
+            'LivePhotoMovieIndex' => 6,
+        ]);
+
+        $metadata   = new Metadata([], $quickTime);
+        $structured = (new StructuredMetadataBuilder())->build($metadata);
+
+        self::assertSame(6, $structured->apple->livePhotoIndex);
+        self::assertNull($structured->apple->livePhotoTime);
+    }
+
+    #[Test]
     public function propagatesBitmaskFlagsFromAppleMakerNotes(): void
     {
         $decoder = new AppleDecoder();


### PR DESCRIPTION
## Summary
- add a shared Live Photo index key list so the maker note decoder accepts both LivePhotoVideoIndex and LivePhotoMovieIndex
- extend the structured metadata builder to pull the Live Photo index from either key in QuickTime metadata
- cover the QuickTime-only LivePhotoMovieIndex case with a dedicated PHPUnit regression test

## Testing
- composer ci:test:php:unit *(fails: fixture-based truth tests require media samples that are unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68fcddb18ee4832388fbd712c094913e