### PR TITLE
Fix Photos app detection flag interpretation

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,6 @@ Bit-mask sources such as `SceneFlags`, `ImageProcessingFlags` and `PhotosAppFeat
 
 * `SceneFlags`: bit 0 → `nightMode`, bit 1 → `longExposure`
 * `ImageProcessingFlags`: bit 0 → `hdrEnabled`, bit 1 → `hdrAuto`
-* `PhotosAppFeatureFlags`: bit 0 → `livePhoto`, bit 1 → `livePhotoAuto`, bit 2 → `livePhotoEnabled`, bit 3 → `livePhotoActive`, bit 4 → `livePhotoLongExposure`
+* `PhotosAppFeatureFlags`: any non-zero value indicates `personOrPetDetected`
 
 Explicit boolean keys continue to override the derived values when both representations are present.

--- a/src/MakerNotes/AppleDecoder.php
+++ b/src/MakerNotes/AppleDecoder.php
@@ -72,14 +72,9 @@ final class AppleDecoder implements MakerNotesDecoderInterface
             0 => 'hdrEnabled',         // Bit 0 – HDR rendering enabled.
             1 => 'hdrAuto',            // Bit 1 – HDR auto detection engaged.
         ],
-        'PhotosAppFeatureFlags' => [
-            0 => 'livePhoto',          // Bit 0 – Live Photo asset present.
-            1 => 'livePhotoAuto',      // Bit 1 – Live Photo auto capture.
-            2 => 'livePhotoEnabled',   // Bit 2 – Live Photo enabled by the user.
-            3 => 'livePhotoActive',    // Bit 3 – Live Photo active during capture.
-            4 => 'livePhotoLongExposure', // Bit 4 – Live Photo long exposure fused asset.
-        ],
     ];
+
+    private const string PHOTOS_APP_DETECTION_FLAG = 'personOrPetDetected';
 
     /**
      * Creates a metadata value object describing the Apple maker note payload.
@@ -662,7 +657,76 @@ final class AppleDecoder implements MakerNotesDecoderInterface
             }
         }
 
+        if (
+            array_key_exists('PhotosAppFeatureFlags', $dictionary)
+            && !array_key_exists(self::PHOTOS_APP_DETECTION_FLAG, $flags)
+        ) {
+            $detected = $this->photosAppDetectionFlag($dictionary['PhotosAppFeatureFlags']);
+            if ($detected !== null) {
+                $flags[self::PHOTOS_APP_DETECTION_FLAG] = $detected;
+            }
+        }
+
         return $flags;
+    }
+
+    /**
+     * Normalises the Photos app detection mask into a boolean flag.
+     *
+     * @param string|int|float|bool|array<int|string, mixed>|null $value Raw Photos app feature flag value.
+     *
+     * @return bool|null Normalised detection flag or null when it cannot be derived.
+     */
+    private function photosAppDetectionFlag(string|int|float|bool|array|null $value): ?bool
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        if (is_bool($value)) {
+            return $value;
+        }
+
+        if (is_int($value)) {
+            return $value !== 0;
+        }
+
+        if (is_float($value)) {
+            return $value !== 0.0;
+        }
+
+        if (is_string($value)) {
+            $normalized = trim($value);
+            if ($normalized === '') {
+                return null;
+            }
+
+            if (str_starts_with($normalized, '0x') || str_starts_with($normalized, '0X')) {
+                $hex = substr($normalized, 2);
+                if ($hex === '' || !ctype_xdigit($hex)) {
+                    return null;
+                }
+
+                return hexdec($hex) !== 0;
+            }
+
+            if (is_numeric($normalized)) {
+                return (int) $normalized !== 0;
+            }
+
+            return null;
+        }
+
+        if (!is_array($value) || $value === []) {
+            return null;
+        }
+
+        $positions = $this->bitPositions($value);
+        if ($positions === []) {
+            return false;
+        }
+
+        return true;
     }
 
     /**

--- a/tests/Curate/StructuredMetadataBuilderTest.php
+++ b/tests/Curate/StructuredMetadataBuilderTest.php
@@ -538,11 +538,7 @@ final class StructuredMetadataBuilderTest extends TestCase
         self::assertTrue($structured->apple->flags['longExposure']);
         self::assertTrue($structured->apple->flags['hdrEnabled']);
         self::assertTrue($structured->apple->flags['hdrAuto']);
-        self::assertTrue($structured->apple->flags['livePhoto']);
-        self::assertTrue($structured->apple->flags['livePhotoAuto']);
-        self::assertTrue($structured->apple->flags['livePhotoEnabled']);
-        self::assertTrue($structured->apple->flags['livePhotoActive']);
-        self::assertTrue($structured->apple->flags['livePhotoLongExposure']);
+        self::assertTrue($structured->apple->flags['personOrPetDetected']);
     }
 
     /**

--- a/tests/MakerNotes/Apple/AppleDecoderFlagMaskTest.php
+++ b/tests/MakerNotes/Apple/AppleDecoderFlagMaskTest.php
@@ -39,15 +39,11 @@ final class AppleDecoderFlagMaskTest extends TestCase
         ksort($result);
 
         $expected = [
-            'hdrAuto'               => true,
-            'hdrEnabled'            => true,
-            'livePhoto'             => true,
-            'livePhotoActive'       => true,
-            'livePhotoAuto'         => true,
-            'livePhotoEnabled'      => true,
-            'livePhotoLongExposure' => true,
-            'longExposure'          => true,
-            'nightMode'             => true,
+            'hdrAuto'              => true,
+            'hdrEnabled'           => true,
+            'longExposure'         => true,
+            'nightMode'            => true,
+            'personOrPetDetected'  => true,
         ];
         ksort($expected);
 
@@ -70,6 +66,23 @@ final class AppleDecoderFlagMaskTest extends TestCase
 
         $result = $method->invoke($decoder, $dictionary);
 
-        self::assertSame([], $result);
+        self::assertSame([
+            'personOrPetDetected' => true,
+        ], $result);
+    }
+
+    #[Test]
+    public function extractFlagsDetectsPhotosAppMaskWhenZero(): void
+    {
+        $decoder = new AppleDecoder();
+        $method  = new ReflectionMethod(AppleDecoder::class, 'extractFlags');
+
+        $result = $method->invoke($decoder, [
+            'PhotosAppFeatureFlags' => 0,
+        ]);
+
+        self::assertSame([
+            'personOrPetDetected' => false,
+        ], $result);
     }
 }

--- a/tests/MakerNotes/AppleDecoder/AppleDecoderTest.php
+++ b/tests/MakerNotes/AppleDecoder/AppleDecoderTest.php
@@ -18,6 +18,7 @@ use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use ReflectionMethod;
 
+use function base64_decode;
 use function hex2bin;
 use function sha1;
 use function str_repeat;
@@ -30,6 +31,8 @@ use function strlen;
  */
 final class AppleDecoderTest extends TestCase
 {
+    private const string PHOTOS_APP_DETECTION_BPLIST = 'YnBsaXN0MDDSAQIDBF8QEUNvbnRlbnRJZGVudGlmaWVyXxAVUGhvdG9zQXBwRmVhdHVyZUZsYWdzXxAUcGhvdG9zLWFwcC1kZXRlY3Rpb24QAQgNITlQAAAAAAAAAQEAAAAAAAAABQAAAAAAAAAAAAAAAAAAAFI=';
+
     /**
      * Ensures the decoder resolves keyed archive maker note data into structured metadata.
      */
@@ -76,21 +79,19 @@ final class AppleDecoderTest extends TestCase
         self::assertEqualsWithDelta(-0.15, $apple->semanticStyleTone, 1e-12);
         self::assertSame([0.12, -0.34, 0.56], $apple->accelerationVector);
 
-        self::assertArrayHasKey('livePhoto', $apple->flags);
-        self::assertArrayHasKey('livePhotoAuto', $apple->flags);
-        self::assertArrayHasKey('livePhotoEnabled', $apple->flags);
-        self::assertArrayHasKey('livePhotoLongExposure', $apple->flags);
-        self::assertArrayHasKey('hdrAuto', $apple->flags);
-        self::assertArrayHasKey('hdrEnabled', $apple->flags);
-        self::assertArrayHasKey('longExposure', $apple->flags);
+        $flags = $apple->flags;
+        ksort($flags);
 
-        self::assertTrue($apple->flags['livePhoto']);
-        self::assertTrue($apple->flags['livePhotoAuto']);
-        self::assertTrue($apple->flags['livePhotoEnabled']);
-        self::assertTrue($apple->flags['livePhotoLongExposure']);
-        self::assertTrue($apple->flags['hdrAuto']);
-        self::assertTrue($apple->flags['hdrEnabled']);
-        self::assertTrue($apple->flags['longExposure']);
+        self::assertSame(
+            [
+                'hdrAuto'             => true,
+                'hdrEnabled'          => true,
+                'livePhotoAuto'       => true,
+                'longExposure'        => true,
+                'personOrPetDetected' => true,
+            ],
+            $flags,
+        );
     }
 
     #[Test]
@@ -217,12 +218,36 @@ final class AppleDecoderTest extends TestCase
         self::assertInstanceOf(AppleMakerNotes::class, $maskNotes);
 
         $scalarFlags = $scalarNotes->flags;
-        $maskFlags   = $maskNotes->flags;
-
         ksort($scalarFlags);
+
+        self::assertSame(
+            [
+                'hdrAuto'               => true,
+                'hdrEnabled'            => true,
+                'livePhoto'             => true,
+                'livePhotoActive'       => true,
+                'livePhotoAuto'         => true,
+                'livePhotoEnabled'      => true,
+                'livePhotoLongExposure' => true,
+                'longExposure'          => true,
+                'nightMode'             => true,
+            ],
+            $scalarFlags,
+        );
+
+        $maskFlags = $maskNotes->flags;
         ksort($maskFlags);
 
-        self::assertSame($scalarFlags, $maskFlags);
+        self::assertSame(
+            [
+                'hdrAuto'             => true,
+                'hdrEnabled'          => true,
+                'longExposure'        => true,
+                'nightMode'           => true,
+                'personOrPetDetected' => true,
+            ],
+            $maskFlags,
+        );
     }
 
     #[Test]
@@ -245,6 +270,7 @@ final class AppleDecoderTest extends TestCase
             [
                 'livePhotoLongExposure' => false,
                 'nightMode'             => false,
+                'personOrPetDetected'   => true,
             ],
             $notes->flags,
         );
@@ -271,17 +297,31 @@ final class AppleDecoderTest extends TestCase
 
         self::assertSame(
             [
-                'hdrAuto'               => true,
-                'hdrEnabled'            => true,
-                'livePhoto'             => true,
-                'livePhotoActive'       => true,
-                'livePhotoAuto'         => true,
-                'livePhotoEnabled'      => true,
-                'livePhotoLongExposure' => true,
-                'longExposure'          => true,
-                'nightMode'             => true,
+                'hdrAuto'             => true,
+                'hdrEnabled'          => true,
+                'longExposure'        => true,
+                'nightMode'           => true,
+                'personOrPetDetected' => true,
             ],
             $flags,
         );
+    }
+
+    #[Test]
+    public function decodeInterpretsPhotosAppDetectionFlag(): void
+    {
+        $raw = base64_decode(self::PHOTOS_APP_DETECTION_BPLIST, true);
+        self::assertIsString($raw);
+
+        $decoder = new AppleDecoder();
+        $metadata = $decoder->decode($raw, 'Apple', 'iPhone');
+
+        self::assertInstanceOf(MakerNotesMetadata::class, $metadata);
+
+        $apple = $metadata->apple();
+        self::assertInstanceOf(AppleMakerNotes::class, $apple);
+        self::assertSame('photos-app-detection', $apple->contentIdentifier);
+        self::assertArrayHasKey('personOrPetDetected', $apple->flags);
+        self::assertTrue($apple->flags['personOrPetDetected']);
     }
 }


### PR DESCRIPTION
## Summary
- treat Photos app feature flags as person/pet detection instead of live photo bitfield and expose a dedicated flag
- update documentation, maker note expectations, and add a fixture-backed test for the detection flag
- inline the Photos app detection sample as base64 to avoid binary fixtures

## Testing
- .build/bin/phpunit tests/MakerNotes/AppleDecoder


------
https://chatgpt.com/codex/tasks/task_e_68fcd24ca8fc8323b4a9870633096a3a