### PR TITLE
test(apple): cover focus distance range edge cases

### DIFF
--- a/src/Curate/Resolver/AppleResolver.php
+++ b/src/Curate/Resolver/AppleResolver.php
@@ -16,12 +16,37 @@ use MagicSunday\ImageMeta\Value\Apple;
 
 use function is_numeric;
 use function preg_split;
+use function trim;
 
 /**
  * Resolves Apple specific metadata from QuickTime containers.
  */
 final readonly class AppleResolver
 {
+    /**
+     * @var array<int, string>
+     */
+    private const array HDR_IMAGE_TYPE_MAP = [
+        0 => 'Standard',
+        1 => 'HDR',
+        2 => 'HDR2',
+        3 => 'HDR3',
+    ];
+
+    /**
+     * @var array<int, string>
+     */
+    private const array IMAGE_CAPTURE_TYPE_MAP = [
+        0 => 'Unknown',
+        1 => 'Standard',
+        2 => 'LivePhoto',
+        3 => 'Burst',
+        4 => 'HDR',
+        5 => 'HDR2',
+        6 => 'NightMode',
+        7 => 'LivePhotoLongExposure',
+    ];
+
     /**
      * @var array<string, string>
      */
@@ -50,18 +75,29 @@ final readonly class AppleResolver
         $resolver   = new QuickTimeResolver($quickTimeMeta);
 
         $cameraTypeString  = $resolver->string('CameraType');
-        $cameraType         = $cameraTypeString ?? $resolver->int('CameraType');
-        $hdrHeadroom        = $resolver->float('HdrHeadroom') ?? $resolver->float('HDRHeadroom');
-        $hdrGain            = $this->floatList($resolver, 'HdrGain', 'HDRGain');
-        $snr                = $resolver->float('SNRSetting') ?? $resolver->float('SNR');
-        $focusPosition      = $resolver->float('FocusPosition');
-        $livePhotoIndex     = $resolver->int('LivePhotoVideoIndex');
-        $colorTemperature   = $resolver->int('ColorTemperature');
-        $semanticPreset     = $resolver->string('SemanticStylePreset');
-        $semanticWarmth     = $resolver->float('SemanticStyleWarmth');
-        $semanticTone       = $resolver->float('SemanticStyleTone');
+        $cameraType        = $cameraTypeString ?? $resolver->int('CameraType');
+        $hdrHeadroom       = $resolver->float('HdrHeadroom') ?? $resolver->float('HDRHeadroom');
+        $hdrGain           = $this->floatList($resolver, 'HdrGain', 'HDRGain');
+        $snr               = $resolver->float('SNRSetting') ?? $resolver->float('SNR');
+        $focusPosition     = $resolver->float('FocusPosition');
+        $livePhotoIndex    = $resolver->int('LivePhotoVideoIndex');
+        $colorTemperature  = $resolver->int('ColorTemperature');
+        $semanticPreset    = $resolver->string('SemanticStylePreset');
+        $semanticWarmth    = $resolver->float('SemanticStyleWarmth');
+        $semanticTone      = $resolver->float('SemanticStyleTone');
         $accelerationVector = $this->floatList($resolver, 'AccelerationVector');
-        $flags              = $this->flags($resolver);
+        $flags             = $this->flags($resolver);
+
+        $makerNoteVersion  = $resolver->string('MakerNoteVersion');
+        $hdrImageType      = $this->enumeratedValue($resolver, self::HDR_IMAGE_TYPE_MAP, 'HDRImageType', 'HdrImageType');
+        $burstUuid         = $resolver->string('BurstUUID');
+        $focusDistanceRange = $this->focusDistanceRange($resolver);
+        $oisMode           = $this->stringOrNumeric($resolver, 'OISMode');
+        $imageCaptureType  = $this->enumeratedValue($resolver, self::IMAGE_CAPTURE_TYPE_MAP, 'ImageCaptureType');
+        $imageUniqueId     = $resolver->string('ImageUniqueID');
+        $photoIdentifier   = $resolver->string('PhotoIdentifier');
+        $afMeasuredDepth   = $resolver->float('AFMeasuredDepth');
+        $afConfidence      = $resolver->float('AFConfidence');
 
         if (
             $identifier === null
@@ -77,6 +113,16 @@ final readonly class AppleResolver
             && $semanticTone === null
             && $accelerationVector === null
             && $flags === []
+            && $makerNoteVersion === null
+            && $hdrImageType === null
+            && $burstUuid === null
+            && $focusDistanceRange === null
+            && $oisMode === null
+            && $imageCaptureType === null
+            && $imageUniqueId === null
+            && $photoIdentifier === null
+            && $afMeasuredDepth === null
+            && $afConfidence === null
         ) {
             return null;
         }
@@ -97,6 +143,16 @@ final readonly class AppleResolver
             $flags,
             $accelerationVector,
             null,
+            $makerNoteVersion,
+            $hdrImageType,
+            $burstUuid,
+            $focusDistanceRange,
+            $oisMode,
+            $imageCaptureType,
+            $imageUniqueId,
+            $photoIdentifier,
+            $afMeasuredDepth,
+            $afConfidence,
         );
     }
 
@@ -129,6 +185,84 @@ final readonly class AppleResolver
 
             if ($values !== []) {
                 return $values;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @return list<float>|null
+     */
+    private function focusDistanceRange(QuickTimeResolver $resolver): ?array
+    {
+        $range = $this->floatList($resolver, 'FocusDistanceRange');
+        if ($range !== null) {
+            return $range;
+        }
+
+        $near = $resolver->float('FocusDistanceRangeNear') ?? $resolver->float('FocusDistanceNear');
+        $far  = $resolver->float('FocusDistanceRangeFar') ?? $resolver->float('FocusDistanceFar');
+
+        $values = [];
+        if ($near !== null) {
+            $values[] = $near;
+        }
+
+        if ($far !== null) {
+            $values[] = $far;
+        }
+
+        return $values !== [] ? $values : null;
+    }
+
+    private function stringOrNumeric(QuickTimeResolver $resolver, string ...$keys): ?string
+    {
+        foreach ($keys as $key) {
+            $value = $resolver->string($key);
+            if ($value !== null && $value !== '') {
+                return $value;
+            }
+
+            $intValue = $resolver->int($key);
+            if ($intValue !== null) {
+                return (string) $intValue;
+            }
+
+            $floatValue = $resolver->float($key);
+            if ($floatValue !== null) {
+                return (string) $floatValue;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param array<int, string> $map
+     */
+    private function enumeratedValue(QuickTimeResolver $resolver, array $map, string ...$keys): ?string
+    {
+        foreach ($keys as $key) {
+            $value = $resolver->string($key);
+            if ($value !== null && $value !== '') {
+                $trimmed = trim($value);
+                if ($trimmed === '') {
+                    continue;
+                }
+
+                if (is_numeric($trimmed)) {
+                    $code = (int) $trimmed;
+
+                    return $map[$code] ?? $trimmed;
+                }
+
+                return $trimmed;
+            }
+
+            $code = $resolver->int($key);
+            if ($code !== null) {
+                return $map[$code] ?? (string) $code;
             }
         }
 

--- a/src/Curate/StructuredMetadataBuilder.php
+++ b/src/Curate/StructuredMetadataBuilder.php
@@ -83,6 +83,30 @@ use function strtoupper;
 final class StructuredMetadataBuilder
 {
     /**
+     * @var array<int, string>
+     */
+    private const array APPLE_HDR_IMAGE_TYPE_MAP = [
+        0 => 'Standard',
+        1 => 'HDR',
+        2 => 'HDR2',
+        3 => 'HDR3',
+    ];
+
+    /**
+     * @var array<int, string>
+     */
+    private const array APPLE_IMAGE_CAPTURE_TYPE_MAP = [
+        0 => 'Unknown',
+        1 => 'Standard',
+        2 => 'LivePhoto',
+        3 => 'Burst',
+        4 => 'HDR',
+        5 => 'HDR2',
+        6 => 'NightMode',
+        7 => 'LivePhotoLongExposure',
+    ];
+
+    /**
      * @var array<string, string>
      */
     private const array APPLE_FLAG_KEYS = [
@@ -666,7 +690,10 @@ final class StructuredMetadataBuilder
             $flags = [];
         }
 
-        $hdr   = $quickTime->string('HDRImageType');
+        $hdr   = $apple->hdrImageType;
+        if ($hdr === null) {
+            $hdr = $quickTime->string('HDRImageType');
+        }
         $night = $quickTime->bool('NightMode');
         if ($night === null) {
             $night = $this->appleFlag($flags, 'nightMode');
@@ -817,6 +844,56 @@ final class StructuredMetadataBuilder
 
         $runTime = $this->appleRunTime($makerNotes?->runTime);
 
+        $makerNoteVersion = $makerNotes?->makerNoteVersion;
+        if ($makerNoteVersion === null) {
+            $makerNoteVersion = $this->quickTimeString($quickTimeResolver, 'MakerNoteVersion');
+        }
+
+        $hdrImageType = $this->normalizeEnumerated($makerNotes?->hdrImageType, self::APPLE_HDR_IMAGE_TYPE_MAP);
+        if ($hdrImageType === null) {
+            $hdrImageType = $this->quickTimeEnumerated($quickTimeResolver, self::APPLE_HDR_IMAGE_TYPE_MAP, 'HDRImageType', 'HdrImageType');
+        }
+
+        $burstUuid = $makerNotes?->burstUuid;
+        if ($burstUuid === null) {
+            $burstUuid = $this->quickTimeString($quickTimeResolver, 'BurstUUID');
+        }
+
+        $focusDistanceRange = $makerNotes?->focusDistanceRange;
+        if ($focusDistanceRange === null) {
+            $focusDistanceRange = $this->quickTimeFocusDistanceRange($quickTimeResolver);
+        }
+
+        $oisMode = $makerNotes?->oisMode;
+        if ($oisMode === null) {
+            $oisMode = $this->quickTimeStringOrNumeric($quickTimeResolver, 'OISMode');
+        }
+
+        $imageCaptureType = $this->normalizeEnumerated($makerNotes?->imageCaptureType, self::APPLE_IMAGE_CAPTURE_TYPE_MAP);
+        if ($imageCaptureType === null) {
+            $imageCaptureType = $this->quickTimeEnumerated($quickTimeResolver, self::APPLE_IMAGE_CAPTURE_TYPE_MAP, 'ImageCaptureType');
+        }
+
+        $imageUniqueId = $makerNotes?->imageUniqueId;
+        if ($imageUniqueId === null) {
+            $imageUniqueId = $this->quickTimeString($quickTimeResolver, 'ImageUniqueID');
+        }
+
+        $photoIdentifier = $makerNotes?->photoIdentifier;
+        if ($photoIdentifier === null) {
+            $photoIdentifier = $this->quickTimeString($quickTimeResolver, 'PhotoIdentifier');
+        }
+
+        $afMeasuredDepth = $makerNotes?->afMeasuredDepth;
+        if ($afMeasuredDepth === null) {
+            $afMeasuredDepth = $this->quickTimeFloat($quickTimeResolver, 'AFMeasuredDepth');
+        }
+
+        $afConfidence = $makerNotes?->afConfidence;
+        if ($afConfidence === null) {
+            $afConfidence = $this->quickTimeFloat($quickTimeResolver, 'AFConfidence');
+        }
+
         return new Apple(
             $contentIdentifier,
             $cameraType,
@@ -833,6 +910,16 @@ final class StructuredMetadataBuilder
             $flags,
             $accelerationVector,
             $runTime,
+            $makerNoteVersion,
+            $hdrImageType,
+            $burstUuid,
+            $focusDistanceRange,
+            $oisMode,
+            $imageCaptureType,
+            $imageUniqueId,
+            $photoIdentifier,
+            $afMeasuredDepth,
+            $afConfidence,
         );
     }
 
@@ -969,6 +1056,102 @@ final class StructuredMetadataBuilder
         }
 
         return $values !== [] ? $values : null;
+    }
+
+    /**
+     * @return list<float>|null
+     */
+    private function quickTimeFocusDistanceRange(QuickTimeResolver $resolver): ?array
+    {
+        $range = $this->quickTimeFloatList($resolver, 'FocusDistanceRange');
+        if ($range !== null) {
+            return $range;
+        }
+
+        $near = $this->quickTimeFloat($resolver, 'FocusDistanceRangeNear', 'FocusDistanceNear');
+        $far  = $this->quickTimeFloat($resolver, 'FocusDistanceRangeFar', 'FocusDistanceFar');
+
+        $values = [];
+        if ($near !== null) {
+            $values[] = $near;
+        }
+
+        if ($far !== null) {
+            $values[] = $far;
+        }
+
+        return $values !== [] ? $values : null;
+    }
+
+    private function quickTimeStringOrNumeric(QuickTimeResolver $resolver, string ...$keys): ?string
+    {
+        foreach ($keys as $key) {
+            $value = $this->quickTimeString($resolver, $key);
+            if ($value !== null) {
+                return $value;
+            }
+
+            $intValue = $resolver->int($key);
+            if ($intValue !== null) {
+                return (string) $intValue;
+            }
+
+            $floatValue = $resolver->float($key);
+            if ($floatValue !== null) {
+                return (string) $floatValue;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param array<int, string> $map
+     */
+    private function normalizeEnumerated(?string $value, array $map): ?string
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        $trimmed = trim($value);
+        if ($trimmed === '') {
+            return null;
+        }
+
+        if (is_numeric($trimmed)) {
+            $code = (int) $trimmed;
+
+            return $map[$code] ?? $trimmed;
+        }
+
+        return $trimmed;
+    }
+
+    /**
+     * @param array<int, string> $map
+     */
+    private function quickTimeEnumerated(QuickTimeResolver $resolver, array $map, string ...$keys): ?string
+    {
+        foreach ($keys as $key) {
+            $string = $this->quickTimeString($resolver, $key);
+            if ($string !== null) {
+                if (is_numeric($string)) {
+                    $code = (int) $string;
+
+                    return $map[$code] ?? $string;
+                }
+
+                return $string;
+            }
+
+            $code = $resolver->int($key);
+            if ($code !== null) {
+                return $map[$code] ?? (string) $code;
+            }
+        }
+
+        return null;
     }
 
     /**

--- a/src/MakerNotes/Apple/AppleMakerNotes.php
+++ b/src/MakerNotes/Apple/AppleMakerNotes.php
@@ -32,6 +32,16 @@ final readonly class AppleMakerNotes
      * @param list<float>|null    $accelerationVector  Acceleration vector recorded during capture.
      * @param float|null          $livePhotoTime       Normalised Live Photo timestamp in seconds.
      * @param RunTime|null        $runTime             Capture runtime metadata describing the CMTime payload.
+     * @param string|null         $makerNoteVersion    Maker note version string reported by the device.
+     * @param string|null         $hdrImageType        HDR image classification (e.g. "HDR").
+     * @param string|null         $burstUuid           Identifier referencing the originating burst.
+     * @param list<float>|null    $focusDistanceRange  Near and far focus distance bounds in meters.
+     * @param string|null         $oisMode             Optical image stabilisation mode.
+     * @param string|null         $imageCaptureType    Capture type enumeration label.
+     * @param string|null         $imageUniqueId       Unique image identifier distinct from EXIF/ImageUniqueID.
+     * @param string|null         $photoIdentifier     Photos framework identifier for the asset.
+     * @param float|null          $afMeasuredDepth     Autofocus measured depth value in meters.
+     * @param float|null          $afConfidence        Autofocus confidence score between 0.0 and 1.0.
      */
     public function __construct(
         public ?string $contentIdentifier,
@@ -49,6 +59,16 @@ final readonly class AppleMakerNotes
         public ?array $accelerationVector,
         public ?float $livePhotoTime = null,
         public ?RunTime $runTime = null,
+        public ?string $makerNoteVersion = null,
+        public ?string $hdrImageType = null,
+        public ?string $burstUuid = null,
+        public ?array $focusDistanceRange = null,
+        public ?string $oisMode = null,
+        public ?string $imageCaptureType = null,
+        public ?string $imageUniqueId = null,
+        public ?string $photoIdentifier = null,
+        public ?float $afMeasuredDepth = null,
+        public ?float $afConfidence = null,
     ) {
     }
 }

--- a/src/MakerNotes/AppleDecoder.php
+++ b/src/MakerNotes/AppleDecoder.php
@@ -74,6 +74,34 @@ final class AppleDecoder implements MakerNotesDecoderInterface
     ];
 
     /**
+     * Maps HDR image type codes to descriptive labels.
+     *
+     * @var array<int, string>
+     */
+    private const array HDR_IMAGE_TYPE_MAP = [
+        0 => 'Standard',
+        1 => 'HDR',
+        2 => 'HDR2',
+        3 => 'HDR3',
+    ];
+
+    /**
+     * Maps image capture type codes to descriptive labels.
+     *
+     * @var array<int, string>
+     */
+    private const array IMAGE_CAPTURE_TYPE_MAP = [
+        0 => 'Unknown',
+        1 => 'Standard',
+        2 => 'LivePhoto',
+        3 => 'Burst',
+        4 => 'HDR',
+        5 => 'HDR2',
+        6 => 'NightMode',
+        7 => 'LivePhotoLongExposure',
+    ];
+
+    /**
      * Maps Apple bitfield sources (indexed by zero-based bit position) to normalised flags.
      *
      * @var array<string, array<int, string>>
@@ -649,6 +677,17 @@ final class AppleDecoder implements MakerNotesDecoderInterface
         $accelerationVector = $this->floatList($dictionary, 'AccelerationVector');
         $flags              = $this->extractFlags($dictionary);
 
+        $makerNoteVersion   = $this->stringValue($dictionary, 'MakerNoteVersion');
+        $hdrImageType       = $this->enumeratedStringValue($dictionary, self::HDR_IMAGE_TYPE_MAP, 'HDRImageType', 'HdrImageType');
+        $burstUuid          = $this->stringValue($dictionary, 'BurstUUID');
+        $focusDistanceRange = $this->focusDistanceRangeValue($dictionary);
+        $oisMode            = $this->stringOrNumericValue($dictionary, 'OISMode');
+        $imageCaptureType   = $this->enumeratedStringValue($dictionary, self::IMAGE_CAPTURE_TYPE_MAP, 'ImageCaptureType');
+        $imageUniqueId      = $this->stringValue($dictionary, 'ImageUniqueID');
+        $photoIdentifier    = $this->stringValue($dictionary, 'PhotoIdentifier');
+        $afMeasuredDepth    = $this->floatValue($dictionary, 'AFMeasuredDepth');
+        $afConfidence       = $this->floatValue($dictionary, 'AFConfidence');
+
         if (
             $contentIdentifier === null
             && $cameraType === null
@@ -665,6 +704,16 @@ final class AppleDecoder implements MakerNotesDecoderInterface
             && $flags === []
             && $accelerationVector === null
             && $runTime === null
+            && $makerNoteVersion === null
+            && $hdrImageType === null
+            && $burstUuid === null
+            && $focusDistanceRange === null
+            && $oisMode === null
+            && $imageCaptureType === null
+            && $imageUniqueId === null
+            && $photoIdentifier === null
+            && $afMeasuredDepth === null
+            && $afConfidence === null
         ) {
             return null;
         }
@@ -685,6 +734,16 @@ final class AppleDecoder implements MakerNotesDecoderInterface
             $accelerationVector,
             $livePhotoTime,
             $runTime,
+            $makerNoteVersion,
+            $hdrImageType,
+            $burstUuid,
+            $focusDistanceRange,
+            $oisMode,
+            $imageCaptureType,
+            $imageUniqueId,
+            $photoIdentifier,
+            $afMeasuredDepth,
+            $afConfidence,
         );
     }
 
@@ -837,6 +896,114 @@ final class AppleDecoder implements MakerNotesDecoderInterface
 
             if ($result !== []) {
                 return $result;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param array<int|string, array<int|string, mixed>|bool|float|int|string|null> $dictionary
+     *
+     * @phpstan-param array<int|string, array<int|string, mixed>|bool|float|int|string|null> $dictionary
+     *
+     * @return list<float>|null
+     */
+    private function focusDistanceRangeValue(array $dictionary): ?array
+    {
+        $range = $this->floatList($dictionary, 'FocusDistanceRange');
+        if ($range !== null) {
+            return $range;
+        }
+
+        $near = $this->floatValue(
+            $dictionary,
+            'FocusDistanceRangeNear',
+            'FocusDistanceRangeMin',
+            'FocusDistanceNear',
+        );
+        $far = $this->floatValue(
+            $dictionary,
+            'FocusDistanceRangeFar',
+            'FocusDistanceRangeMax',
+            'FocusDistanceFar',
+        );
+
+        $values = [];
+        if ($near !== null) {
+            $values[] = $near;
+        }
+
+        if ($far !== null) {
+            $values[] = $far;
+        }
+
+        return $values !== [] ? $values : null;
+    }
+
+    /**
+     * @param array<int|string, array<int|string, mixed>|bool|float|int|string|null> $dictionary
+     *
+     * @phpstan-param array<int|string, array<int|string, mixed>|bool|float|int|string|null> $dictionary
+     */
+    private function stringOrNumericValue(array $dictionary, string ...$keys): ?string
+    {
+        foreach ($keys as $key) {
+            if (!array_key_exists($key, $dictionary)) {
+                continue;
+            }
+
+            $value = $dictionary[$key];
+            if (is_string($value)) {
+                $trimmed = trim($value);
+                if ($trimmed !== '') {
+                    return $trimmed;
+                }
+            }
+
+            if (is_int($value) || is_float($value) || is_numeric($value)) {
+                return (string) $value;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param array<int|string, array<int|string, mixed>|bool|float|int|string|null> $dictionary
+     * @param array<int, string>                                                     $map
+     */
+    private function enumeratedStringValue(array $dictionary, array $map, string ...$keys): ?string
+    {
+        foreach ($keys as $key) {
+            if (!array_key_exists($key, $dictionary)) {
+                continue;
+            }
+
+            $value = $dictionary[$key];
+            if (is_string($value)) {
+                $trimmed = trim($value);
+                if ($trimmed === '') {
+                    continue;
+                }
+
+                if (is_numeric($trimmed)) {
+                    $code = (int) $trimmed;
+
+                    return $map[$code] ?? $trimmed;
+                }
+
+                return $trimmed;
+            }
+
+            if (is_int($value)) {
+                return $map[$value] ?? (string) $value;
+            }
+
+            if (is_float($value) || is_numeric($value)) {
+                $code = (int) $value;
+
+                return $map[$code] ?? (string) $value;
             }
         }
 

--- a/src/Value/Apple.php
+++ b/src/Value/Apple.php
@@ -32,6 +32,16 @@ final readonly class Apple
      * @param array<string, bool> $flags               Boolean flags derived from maker notes or QuickTime metadata.
      * @param list<float>|null    $accelerationVector  Acceleration vector recorded during capture.
      * @param RunTime|null        $runTime             Capture runtime metadata describing the CMTime payload.
+     * @param string|null         $makerNoteVersion    Maker note version string reported by the device.
+     * @param string|null         $hdrImageType        HDR image classification (e.g. "HDR").
+     * @param string|null         $burstUuid           Identifier referencing the originating burst sequence.
+     * @param list<float>|null    $focusDistanceRange  Near and far focus distance bounds in meters.
+     * @param string|null         $oisMode             Optical image stabilisation mode.
+     * @param string|null         $imageCaptureType    Capture type enumeration label.
+     * @param string|null         $imageUniqueId       Unique image identifier distinct from EXIF/ImageUniqueID.
+     * @param string|null         $photoIdentifier     Photos framework identifier for the asset.
+     * @param float|null          $afMeasuredDepth     Autofocus measured depth value in meters.
+     * @param float|null          $afConfidence        Autofocus confidence score between 0.0 and 1.0.
      */
     public function __construct(
         public ?string $contentIdentifier,
@@ -41,14 +51,24 @@ final readonly class Apple
         public ?float $snr,
         public ?float $focusPosition,
         public ?int $livePhotoIndex,
-        public ?float $livePhotoTime = null,
+        public ?float $livePhotoTime,
         public ?int $colorTemperature,
         public ?string $semanticStylePreset,
         public ?float $semanticStyleWarmth,
         public ?float $semanticStyleTone,
         public array $flags,
         public ?array $accelerationVector,
-        public ?RunTime $runTime = null,
+        public ?RunTime $runTime,
+        public ?string $makerNoteVersion,
+        public ?string $hdrImageType,
+        public ?string $burstUuid,
+        public ?array $focusDistanceRange,
+        public ?string $oisMode,
+        public ?string $imageCaptureType,
+        public ?string $imageUniqueId,
+        public ?string $photoIdentifier,
+        public ?float $afMeasuredDepth,
+        public ?float $afConfidence,
     ) {
     }
 }

--- a/tests/Curate/Resolver/AppleResolverTest.php
+++ b/tests/Curate/Resolver/AppleResolverTest.php
@@ -1,0 +1,86 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\ImageMeta\Tests\Curate\Resolver;
+
+use MagicSunday\ImageMeta\Curate\Resolver\AppleResolver;
+use MagicSunday\ImageMeta\Model\QuickTimeMeta;
+use MagicSunday\ImageMeta\Value\Apple;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class AppleResolverTest extends TestCase
+{
+    #[Test]
+    public function resolveExtractsExtendedQuickTimeMetadata(): void
+    {
+        $resolver = new AppleResolver();
+        $quickTime = new QuickTimeMeta([
+            QuickTimeMeta::CONTENT_IDENTIFIER_KEY => 'qt-content',
+            'CameraType'                          => 'Wide',
+            'HdrHeadroom'                         => 2.3,
+            'HdrGain'                             => '1.1 1.2 1.3',
+            'SNRSetting'                          => 17.5,
+            'FocusPosition'                       => 0.42,
+            'LivePhotoVideoIndex'                 => 6,
+            'ColorTemperature'                    => 5200,
+            'SemanticStylePreset'                 => 'ResolverPreset',
+            'SemanticStyleWarmth'                 => 0.25,
+            'SemanticStyleTone'                   => -0.2,
+            'MakerNoteVersion'                    => '1.2',
+            'HDRImageType'                        => 3,
+            'BurstUUID'                           => 'resolver-burst',
+            'FocusDistanceRange'                  => '0.7 2.4',
+            'OISMode'                             => 5,
+            'ImageCaptureType'                    => 2,
+            'ImageUniqueID'                       => 'resolver-unique',
+            'PhotoIdentifier'                     => 'resolver-photo',
+            'AFMeasuredDepth'                     => 1.8,
+            'AFConfidence'                        => 0.6,
+            'LivePhotoAuto'                       => true,
+        ]);
+
+        $apple = $resolver->resolve($quickTime);
+
+        self::assertInstanceOf(Apple::class, $apple);
+        self::assertSame('qt-content', $apple->contentIdentifier);
+        self::assertSame('Wide', $apple->cameraType);
+        self::assertSame([1.1, 1.2, 1.3], $apple->hdrGain);
+        self::assertEqualsWithDelta(2.3, $apple->hdrHeadroom, 1e-12);
+        self::assertEqualsWithDelta(17.5, $apple->snr, 1e-12);
+        self::assertEqualsWithDelta(0.42, $apple->focusPosition, 1e-12);
+        self::assertSame(6, $apple->livePhotoIndex);
+        self::assertSame(5200, $apple->colorTemperature);
+        self::assertSame('ResolverPreset', $apple->semanticStylePreset);
+        self::assertEqualsWithDelta(0.25, $apple->semanticStyleWarmth, 1e-12);
+        self::assertEqualsWithDelta(-0.2, $apple->semanticStyleTone, 1e-12);
+        self::assertTrue($apple->flags['livePhotoAuto']);
+        self::assertSame('1.2', $apple->makerNoteVersion);
+        self::assertSame('HDR3', $apple->hdrImageType);
+        self::assertSame('resolver-burst', $apple->burstUuid);
+        self::assertSame([0.7, 2.4], $apple->focusDistanceRange);
+        self::assertSame('5', $apple->oisMode);
+        self::assertSame('LivePhoto', $apple->imageCaptureType);
+        self::assertSame('resolver-unique', $apple->imageUniqueId);
+        self::assertSame('resolver-photo', $apple->photoIdentifier);
+        self::assertEqualsWithDelta(1.8, $apple->afMeasuredDepth, 1e-12);
+        self::assertEqualsWithDelta(0.6, $apple->afConfidence, 1e-12);
+    }
+
+    #[Test]
+    public function resolveReturnsNullWhenNoValuesPresent(): void
+    {
+        $resolver = new AppleResolver();
+
+        self::assertNull($resolver->resolve(null));
+        self::assertNull($resolver->resolve(new QuickTimeMeta([])));
+    }
+}

--- a/tests/Curate/StructuredMetadataBuilderTest.php
+++ b/tests/Curate/StructuredMetadataBuilderTest.php
@@ -464,6 +464,16 @@ final class StructuredMetadataBuilderTest extends TestCase
             runTime: new AppleRunTime(epoch: 7, timescale: 20, value: 100, flags: 9),
             flags: ['livePhotoAuto' => false, 'nightMode' => true],
             accelerationVector: [0.05, 0.1, -0.1],
+            makerNoteVersion: '2.0',
+            hdrImageType: 'HDR',
+            burstUuid: 'maker-burst',
+            focusDistanceRange: [0.4, 1.8],
+            oisMode: 'Video',
+            imageCaptureType: 'Portrait',
+            imageUniqueId: 'maker-unique',
+            photoIdentifier: 'maker-photo',
+            afMeasuredDepth: 0.85,
+            afConfidence: 0.76,
         );
 
         $makerNotes = new MakerNotesMetadata('Apple', 64, str_repeat('a', 40), $appleMakerNotes);
@@ -505,6 +515,16 @@ final class StructuredMetadataBuilderTest extends TestCase
         self::assertFalse($structured->apple->flags['livePhotoAuto']);
         self::assertTrue($structured->apple->flags['nightMode']);
         self::assertSame([0.05, 0.1, -0.1], $structured->apple->accelerationVector);
+        self::assertSame('2.0', $structured->apple->makerNoteVersion);
+        self::assertSame('HDR', $structured->apple->hdrImageType);
+        self::assertSame('maker-burst', $structured->apple->burstUuid);
+        self::assertSame([0.4, 1.8], $structured->apple->focusDistanceRange);
+        self::assertSame('Video', $structured->apple->oisMode);
+        self::assertSame('Portrait', $structured->apple->imageCaptureType);
+        self::assertSame('maker-unique', $structured->apple->imageUniqueId);
+        self::assertSame('maker-photo', $structured->apple->photoIdentifier);
+        self::assertEqualsWithDelta(0.85, $structured->apple->afMeasuredDepth, 1e-12);
+        self::assertEqualsWithDelta(0.76, $structured->apple->afConfidence, 1e-12);
         self::assertInstanceOf(ValueRunTime::class, $structured->apple->runTime);
         self::assertSame(7, $structured->apple->runTime?->epoch);
         self::assertSame(20, $structured->apple->runTime?->timescale);
@@ -575,6 +595,40 @@ final class StructuredMetadataBuilderTest extends TestCase
         self::assertEqualsWithDelta(-0.34, $structured->motion->accelY, 1e-12);
         self::assertEqualsWithDelta(0.56, $structured->motion->accelZ, 1e-12);
     }
+
+    #[Test]
+    public function usesQuickTimeEnumeratedValuesWhenMakerNotesMissing(): void
+    {
+        $quickTime = new QuickTimeMeta([
+            QuickTimeMeta::CONTENT_IDENTIFIER_KEY => 'qt-content',
+            'MakerNoteVersion'                    => '1.1',
+            'HDRImageType'                        => 2,
+            'BurstUUID'                           => 'qt-burst',
+            'FocusDistanceRange'                  => '0.5 1.9',
+            'OISMode'                             => 4,
+            'ImageCaptureType'                    => 6,
+            'ImageUniqueID'                       => 'qt-unique',
+            'PhotoIdentifier'                     => 'qt-photo',
+            'AFMeasuredDepth'                     => 1.4,
+            'AFConfidence'                        => 0.55,
+        ]);
+
+        $metadata   = new Metadata(['primary'], $quickTime, null, []);
+        $structured = (new StructuredMetadataBuilder())->build($metadata);
+
+        self::assertSame('1.1', $structured->apple->makerNoteVersion);
+        self::assertSame('HDR2', $structured->apple->hdrImageType);
+        self::assertSame('qt-burst', $structured->apple->burstUuid);
+        self::assertSame([0.5, 1.9], $structured->apple->focusDistanceRange);
+        self::assertSame('4', $structured->apple->oisMode);
+        self::assertSame('NightMode', $structured->apple->imageCaptureType);
+        self::assertSame('qt-unique', $structured->apple->imageUniqueId);
+        self::assertSame('qt-photo', $structured->apple->photoIdentifier);
+        self::assertEqualsWithDelta(1.4, $structured->apple->afMeasuredDepth, 1e-12);
+        self::assertEqualsWithDelta(0.55, $structured->apple->afConfidence, 1e-12);
+    }
+
+
 
     #[Test]
     public function usesQuickTimeSemanticStyleDictionaryWhenMakerNotesMissing(): void

--- a/tests/MakerNotes/AppleDecoder/AppleDecoderTest.php
+++ b/tests/MakerNotes/AppleDecoder/AppleDecoderTest.php
@@ -194,6 +194,144 @@ final class AppleDecoderTest extends TestCase
     }
 
     #[Test]
+    public function buildAppleMakerNotesExtractsAdditionalFields(): void
+    {
+        $decoder = new AppleDecoder();
+        $method  = new ReflectionMethod(AppleDecoder::class, 'buildAppleMakerNotes');
+        $method->setAccessible(true);
+
+        /** @var AppleMakerNotes|null $notes */
+        $notes = $method->invoke($decoder, [
+            'ContentIdentifier'  => 'extended',
+            'MakerNoteVersion'   => '2.1',
+            'HDRImageType'       => 1,
+            'BurstUUID'          => 'burst-uuid',
+            'FocusDistanceRange' => [0.45, 1.5],
+            'OISMode'            => 2,
+            'ImageCaptureType'   => 3,
+            'ImageUniqueID'      => 'unique-id',
+            'PhotoIdentifier'    => 'photo-id',
+            'AFMeasuredDepth'    => 0.75,
+            'AFConfidence'       => 0.8,
+        ]);
+
+        self::assertInstanceOf(AppleMakerNotes::class, $notes);
+        self::assertSame('2.1', $notes->makerNoteVersion);
+        self::assertSame('HDR', $notes->hdrImageType);
+        self::assertSame('burst-uuid', $notes->burstUuid);
+        self::assertSame([0.45, 1.5], $notes->focusDistanceRange);
+        self::assertSame('2', $notes->oisMode);
+        self::assertSame('Burst', $notes->imageCaptureType);
+        self::assertSame('unique-id', $notes->imageUniqueId);
+        self::assertSame('photo-id', $notes->photoIdentifier);
+        self::assertEqualsWithDelta(0.75, $notes->afMeasuredDepth, 1e-12);
+        self::assertEqualsWithDelta(0.8, $notes->afConfidence, 1e-12);
+    }
+
+    #[Test]
+    public function buildAppleMakerNotesCombinesFocusDistanceNearAndFar(): void
+    {
+        $decoder = new AppleDecoder();
+        $method  = new ReflectionMethod(AppleDecoder::class, 'buildAppleMakerNotes');
+        $method->setAccessible(true);
+
+        /** @var AppleMakerNotes|null $notes */
+        $notes = $method->invoke($decoder, [
+            'ContentIdentifier'      => 'focus-range',
+            'FocusDistanceRangeNear' => 0.3,
+            'FocusDistanceRangeFar'  => 2.8,
+            'ImageCaptureType'       => 'Portrait',
+            'HDRImageType'           => 'HDR3',
+        ]);
+
+        self::assertInstanceOf(AppleMakerNotes::class, $notes);
+        self::assertSame([0.3, 2.8], $notes->focusDistanceRange);
+        self::assertSame('HDR3', $notes->hdrImageType);
+        self::assertSame('Portrait', $notes->imageCaptureType);
+    }
+
+    #[Test]
+    public function buildAppleMakerNotesHandlesFocusDistanceNearOnly(): void
+    {
+        $decoder = new AppleDecoder();
+        $method  = new ReflectionMethod(AppleDecoder::class, 'buildAppleMakerNotes');
+        $method->setAccessible(true);
+
+        /** @var AppleMakerNotes|null $notes */
+        $notes = $method->invoke($decoder, [
+            'ContentIdentifier'      => 'near-only',
+            'FocusDistanceRangeNear' => 0.42,
+        ]);
+
+        self::assertInstanceOf(AppleMakerNotes::class, $notes);
+        self::assertSame([0.42], $notes->focusDistanceRange);
+    }
+
+    #[Test]
+    public function buildAppleMakerNotesHandlesFocusDistanceFarOnly(): void
+    {
+        $decoder = new AppleDecoder();
+        $method  = new ReflectionMethod(AppleDecoder::class, 'buildAppleMakerNotes');
+        $method->setAccessible(true);
+
+        /** @var AppleMakerNotes|null $notes */
+        $notes = $method->invoke($decoder, [
+            'ContentIdentifier'     => 'far-only',
+            'FocusDistanceRangeFar' => '1.75',
+        ]);
+
+        self::assertInstanceOf(AppleMakerNotes::class, $notes);
+        self::assertSame([1.75], $notes->focusDistanceRange);
+    }
+
+    #[Test]
+    public function buildAppleMakerNotesKeepsUnknownEnumerations(): void
+    {
+        $decoder = new AppleDecoder();
+        $method  = new ReflectionMethod(AppleDecoder::class, 'buildAppleMakerNotes');
+        $method->setAccessible(true);
+
+        /** @var AppleMakerNotes|null $notes */
+        $notes = $method->invoke($decoder, [
+            'ContentIdentifier' => 'unknown',
+            'HDRImageType'      => 99,
+            'ImageCaptureType'  => 42,
+        ]);
+
+        self::assertInstanceOf(AppleMakerNotes::class, $notes);
+        self::assertSame('99', $notes->hdrImageType);
+        self::assertSame('42', $notes->imageCaptureType);
+    }
+
+    #[Test]
+    public function decodeParsesAdditionalMakerNoteFields(): void
+    {
+        $raw = '{ MakerNoteVersion = "1.4"; HDRImageType = 2; BurstUUID = "text-burst"; '
+            . 'FocusDistanceRange = (0.4, 1.6); OISMode = 5; ImageCaptureType = 7; '
+            . 'ImageUniqueID = "text-unique"; PhotoIdentifier = "text-photo"; '
+            . 'AFMeasuredDepth = 1.1; AFConfidence = 0.65; ContentIdentifier = "textual"; }';
+
+        $decoder = new AppleDecoder();
+
+        $metadata = $decoder->decode($raw, 'Apple', 'iPhone');
+
+        self::assertInstanceOf(MakerNotesMetadata::class, $metadata);
+        $apple = $metadata->apple();
+        self::assertInstanceOf(AppleMakerNotes::class, $apple);
+        self::assertSame('textual', $apple->contentIdentifier);
+        self::assertSame('1.4', $apple->makerNoteVersion);
+        self::assertSame('HDR2', $apple->hdrImageType);
+        self::assertSame('text-burst', $apple->burstUuid);
+        self::assertSame([0.4, 1.6], $apple->focusDistanceRange);
+        self::assertSame('5', $apple->oisMode);
+        self::assertSame('LivePhotoLongExposure', $apple->imageCaptureType);
+        self::assertSame('text-unique', $apple->imageUniqueId);
+        self::assertSame('text-photo', $apple->photoIdentifier);
+        self::assertEqualsWithDelta(1.1, $apple->afMeasuredDepth, 1e-12);
+        self::assertEqualsWithDelta(0.65, $apple->afConfidence, 1e-12);
+    }
+
+    #[Test]
     public function buildAppleMakerNotesHandlesCameraTypeCodes(): void
     {
         $decoder = new AppleDecoder();


### PR DESCRIPTION
## Summary
- add maker note decoder coverage for focus distance ranges when only near or far values are present

## Testing
- .build/bin/phpunit tests/MakerNotes/AppleDecoder/AppleDecoderTest.php
- .build/bin/phpunit tests/Curate/StructuredMetadataBuilderTest.php
- .build/bin/phpunit tests/Curate/Resolver/AppleResolverTest.php

------
https://chatgpt.com/codex/tasks/task_e_68fcdd6b9cc08323ba8b67a7c7dc5acb