### PR TITLE
Fix HDR scene inference for Standard HDRImageType

### DIFF
--- a/src/Curate/StructuredMetadataBuilder.php
+++ b/src/Curate/StructuredMetadataBuilder.php
@@ -76,6 +76,7 @@ use function is_string;
 use function preg_split;
 use function trim;
 use function strtoupper;
+use function in_array;
 
 /**
  * Builds the structured metadata aggregate by orchestrating specialised resolvers.
@@ -91,6 +92,11 @@ final class StructuredMetadataBuilder
         2 => 'HDR2',
         3 => 'HDR3',
     ];
+
+    /**
+     * @var list<string>
+     */
+    private const array APPLE_HDR_SCENE_LABELS = ['HDR', 'HDR2', 'HDR3'];
 
     /**
      * @var array<int, string>
@@ -702,9 +708,12 @@ final class StructuredMetadataBuilder
         }
 
         $hdrScene = null;
-        if ($hdr !== null) {
+
+        if ($hdr !== null && $this->isHdrSceneLabel($hdr)) {
             $hdrScene = true;
-        } else {
+        }
+
+        if ($hdrScene === null) {
             $hdrHeadroom = $apple->hdrHeadroom;
             if ($hdrHeadroom !== null && $hdrHeadroom > 0.0) {
                 $hdrScene = true;
@@ -732,6 +741,13 @@ final class StructuredMetadataBuilder
      *
      * @param array<string, bool> $flags
      */
+    private function isHdrSceneLabel(string $label): bool
+    {
+        $normalized = strtoupper(trim($label));
+
+        return in_array($normalized, self::APPLE_HDR_SCENE_LABELS, true);
+    }
+
     private function appleFlag(array $flags, string $key): ?bool
     {
         if (!array_key_exists($key, $flags)) {

--- a/tests/Curate/StructuredMetadataBuilderTest.php
+++ b/tests/Curate/StructuredMetadataBuilderTest.php
@@ -714,6 +714,97 @@ final class StructuredMetadataBuilderTest extends TestCase
     }
 
     /**
+     * Ensures "Standard" HDR image types do not force HDR scenes without supporting hints.
+     */
+    #[Test]
+    public function treatsStandardHdrImageTypeAsNonHdrHint(): void
+    {
+        $standardMakerNotes = new AppleMakerNotes(
+            contentIdentifier: null,
+            cameraType: null,
+            hdrHeadroom: null,
+            hdrGain: null,
+            snr: null,
+            focusPosition: null,
+            livePhotoIndex: null,
+            colorTemperature: null,
+            semanticStylePreset: null,
+            semanticStyleWarmth: null,
+            semanticStyleTone: null,
+            flags: [],
+            accelerationVector: null,
+            livePhotoTime: null,
+            runTime: null,
+            makerNoteVersion: null,
+            hdrImageType: 'Standard',
+        );
+
+        $makerNotes = new MakerNotesMetadata('Apple', 8, str_repeat('c', 40), $standardMakerNotes);
+        $exifDocument = new ExifDocument(new Ifd([]), null, null, null, null, $makerNotes);
+        $metadata = new Metadata(['primary'], new QuickTimeMeta([]), $exifDocument, [], null, $makerNotes);
+
+        $structured = (new StructuredMetadataBuilder())->build($metadata);
+
+        self::assertNull($structured->scene->hdrScene);
+
+        $headroomMakerNotes = new AppleMakerNotes(
+            contentIdentifier: null,
+            cameraType: null,
+            hdrHeadroom: 1.2,
+            hdrGain: null,
+            snr: null,
+            focusPosition: null,
+            livePhotoIndex: null,
+            colorTemperature: null,
+            semanticStylePreset: null,
+            semanticStyleWarmth: null,
+            semanticStyleTone: null,
+            flags: [],
+            accelerationVector: null,
+            livePhotoTime: null,
+            runTime: null,
+            makerNoteVersion: null,
+            hdrImageType: 'Standard',
+        );
+
+        $headroomMakerNotesMeta = new MakerNotesMetadata('Apple', 9, str_repeat('d', 40), $headroomMakerNotes);
+        $headroomExif = new ExifDocument(new Ifd([]), null, null, null, null, $headroomMakerNotesMeta);
+        $headroomMetadata = new Metadata(['primary'], new QuickTimeMeta([]), $headroomExif, [], null, $headroomMakerNotesMeta);
+
+        $structuredHeadroom = (new StructuredMetadataBuilder())->build($headroomMetadata);
+
+        self::assertTrue($structuredHeadroom->scene->hdrScene);
+
+        $flagMakerNotes = new AppleMakerNotes(
+            contentIdentifier: null,
+            cameraType: null,
+            hdrHeadroom: null,
+            hdrGain: null,
+            snr: null,
+            focusPosition: null,
+            livePhotoIndex: null,
+            colorTemperature: null,
+            semanticStylePreset: null,
+            semanticStyleWarmth: null,
+            semanticStyleTone: null,
+            flags: ['hdrEnabled' => true],
+            accelerationVector: null,
+            livePhotoTime: null,
+            runTime: null,
+            makerNoteVersion: null,
+            hdrImageType: 'Standard',
+        );
+
+        $flagMakerNotesMeta = new MakerNotesMetadata('Apple', 10, str_repeat('e', 40), $flagMakerNotes);
+        $flagExif = new ExifDocument(new Ifd([]), null, null, null, null, $flagMakerNotesMeta);
+        $flagMetadata = new Metadata(['primary'], new QuickTimeMeta([]), $flagExif, [], null, $flagMakerNotesMeta);
+
+        $structuredFlags = (new StructuredMetadataBuilder())->build($flagMetadata);
+
+        self::assertTrue($structuredFlags->scene->hdrScene);
+    }
+
+    /**
      * Ensures maker note flags alone populate scene metadata when QuickTime metadata is absent.
      */
     #[Test]


### PR DESCRIPTION
## Summary
- gate hdrScene inference to actual HDR labels instead of any enumerated value
- ensure Standard HDRImageType keeps heuristics available via new regression test

## Testing
- composer ci:test:php:unit *(fails: repository lacks large fixture set required by TruthComparisonTest)*

------
https://chatgpt.com/codex/tasks/task_e_68fcebbbaee883238708f3c40bdee3b1