### PR TITLE
fix: handle padding in Apple maker-note dictionaries

### DIFF
--- a/src/MakerNotes/AppleDecoder.php
+++ b/src/MakerNotes/AppleDecoder.php
@@ -470,7 +470,15 @@ final class AppleDecoder implements MakerNotesDecoderInterface
     private function skipWhitespace(string $raw, int &$offset, int $length): void
     {
         while ($offset < $length) {
-            if (!ctype_space($raw[$offset])) {
+            $char = $raw[$offset];
+
+            if ($char === "\0") {
+                ++$offset;
+
+                continue;
+            }
+
+            if (!ctype_space($char)) {
                 break;
             }
 

--- a/tests/MakerNotes/AppleDecoder/AppleDecoderTest.php
+++ b/tests/MakerNotes/AppleDecoder/AppleDecoderTest.php
@@ -158,6 +158,23 @@ final class AppleDecoderTest extends TestCase
     }
 
     #[Test]
+    public function decodeAcceptsPaddedDictionaryPayload(): void
+    {
+        $raw = '{ ContentIdentifier = "padded"; LivePhotoAuto = 1; }' . str_repeat("\0", 8);
+
+        $decoder = new AppleDecoder();
+
+        $metadata = $decoder->decode($raw, 'Apple', 'iPhone');
+
+        self::assertInstanceOf(MakerNotesMetadata::class, $metadata);
+
+        $apple = $metadata->apple();
+        self::assertInstanceOf(AppleMakerNotes::class, $apple);
+        self::assertSame('padded', $apple->contentIdentifier);
+        self::assertTrue($apple->flags['livePhotoAuto']);
+    }
+
+    #[Test]
     public function decodeResolvesLivePhotoMovieIndex(): void
     {
         $raw     = $this->buildMakerNotesBlobWithMovieIndex();


### PR DESCRIPTION
## Summary
- skip NUL padding when advancing over whitespace in the Apple maker-note dictionary parser
- add a regression test to ensure padded dictionary payloads still decode correctly

## Testing
- `composer ci:test:php:unit` *(fails: existing truth comparison fixtures require unsupported formats in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68fcebe640e483239ebf106593ae4a93