### PR TITLE
fix: align Apple image capture type enumerations

### DIFF
--- a/src/Curate/Resolver/AppleResolver.php
+++ b/src/Curate/Resolver/AppleResolver.php
@@ -37,14 +37,17 @@ final readonly class AppleResolver
      * @var array<int, string>
      */
     private const array IMAGE_CAPTURE_TYPE_MAP = [
-        0 => 'Unknown',
-        1 => 'Standard',
-        2 => 'LivePhoto',
-        3 => 'Burst',
-        4 => 'HDR',
-        5 => 'HDR2',
-        6 => 'NightMode',
-        7 => 'LivePhotoLongExposure',
+        0  => 'Unknown',
+        1  => 'ProRAW',
+        2  => 'Portrait',
+        3  => 'Live Photo',
+        4  => 'Live Photo Long Exposure',
+        5  => 'Burst',
+        6  => 'Night Mode',
+        7  => 'Night Mode Portrait',
+        10 => 'Photo',
+        11 => 'Manual Focus',
+        12 => 'Scene',
     ];
 
     /**

--- a/src/Curate/StructuredMetadataBuilder.php
+++ b/src/Curate/StructuredMetadataBuilder.php
@@ -96,14 +96,17 @@ final class StructuredMetadataBuilder
      * @var array<int, string>
      */
     private const array APPLE_IMAGE_CAPTURE_TYPE_MAP = [
-        0 => 'Unknown',
-        1 => 'Standard',
-        2 => 'LivePhoto',
-        3 => 'Burst',
-        4 => 'HDR',
-        5 => 'HDR2',
-        6 => 'NightMode',
-        7 => 'LivePhotoLongExposure',
+        0  => 'Unknown',
+        1  => 'ProRAW',
+        2  => 'Portrait',
+        3  => 'Live Photo',
+        4  => 'Live Photo Long Exposure',
+        5  => 'Burst',
+        6  => 'Night Mode',
+        7  => 'Night Mode Portrait',
+        10 => 'Photo',
+        11 => 'Manual Focus',
+        12 => 'Scene',
     ];
 
     /**

--- a/src/MakerNotes/AppleDecoder.php
+++ b/src/MakerNotes/AppleDecoder.php
@@ -93,14 +93,17 @@ final class AppleDecoder implements MakerNotesDecoderInterface
      * @var array<int, string>
      */
     private const array IMAGE_CAPTURE_TYPE_MAP = [
-        0 => 'Unknown',
-        1 => 'Standard',
-        2 => 'LivePhoto',
-        3 => 'Burst',
-        4 => 'HDR',
-        5 => 'HDR2',
-        6 => 'NightMode',
-        7 => 'LivePhotoLongExposure',
+        0  => 'Unknown',
+        1  => 'ProRAW',
+        2  => 'Portrait',
+        3  => 'Live Photo',
+        4  => 'Live Photo Long Exposure',
+        5  => 'Burst',
+        6  => 'Night Mode',
+        7  => 'Night Mode Portrait',
+        10 => 'Photo',
+        11 => 'Manual Focus',
+        12 => 'Scene',
     ];
 
     /**

--- a/tests/Curate/Resolver/AppleResolverTest.php
+++ b/tests/Curate/Resolver/AppleResolverTest.php
@@ -68,7 +68,7 @@ final class AppleResolverTest extends TestCase
         self::assertSame('resolver-burst', $apple->burstUuid);
         self::assertSame([0.7, 2.4], $apple->focusDistanceRange);
         self::assertSame('5', $apple->oisMode);
-        self::assertSame('LivePhoto', $apple->imageCaptureType);
+        self::assertSame('Portrait', $apple->imageCaptureType);
         self::assertSame('resolver-unique', $apple->imageUniqueId);
         self::assertSame('resolver-photo', $apple->photoIdentifier);
         self::assertEqualsWithDelta(1.8, $apple->afMeasuredDepth, 1e-12);

--- a/tests/Curate/StructuredMetadataBuilderTest.php
+++ b/tests/Curate/StructuredMetadataBuilderTest.php
@@ -632,7 +632,7 @@ final class StructuredMetadataBuilderTest extends TestCase
         self::assertSame('qt-burst', $structured->apple->burstUuid);
         self::assertSame([0.5, 1.9], $structured->apple->focusDistanceRange);
         self::assertSame('4', $structured->apple->oisMode);
-        self::assertSame('NightMode', $structured->apple->imageCaptureType);
+        self::assertSame('Night Mode', $structured->apple->imageCaptureType);
         self::assertSame('qt-unique', $structured->apple->imageUniqueId);
         self::assertSame('qt-photo', $structured->apple->photoIdentifier);
         self::assertEqualsWithDelta(1.4, $structured->apple->afMeasuredDepth, 1e-12);

--- a/tests/MakerNotes/AppleDecoder/AppleDecoderTest.php
+++ b/tests/MakerNotes/AppleDecoder/AppleDecoderTest.php
@@ -15,6 +15,7 @@ use MagicSunday\ImageMeta\MakerNotes\Apple\AppleMakerNotes;
 use MagicSunday\ImageMeta\MakerNotes\Apple\RunTime;
 use MagicSunday\ImageMeta\MakerNotes\AppleDecoder;
 use MagicSunday\ImageMeta\MakerNotes\MakerNotesMetadata;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use ReflectionMethod;
@@ -205,7 +206,7 @@ final class AppleDecoderTest extends TestCase
             'BurstUUID'          => 'burst-uuid',
             'FocusDistanceRange' => [0.45, 1.5],
             'OISMode'            => 2,
-            'ImageCaptureType'   => 3,
+            'ImageCaptureType'   => 5,
             'ImageUniqueID'      => 'unique-id',
             'PhotoIdentifier'    => 'photo-id',
             'AFMeasuredDepth'    => 0.75,
@@ -301,10 +302,45 @@ final class AppleDecoderTest extends TestCase
     }
 
     #[Test]
+    #[DataProvider('imageCaptureTypeProvider')]
+    public function buildAppleMakerNotesMapsImageCaptureTypeCodes(int $code, string $label): void
+    {
+        $decoder = new AppleDecoder();
+        $method  = new ReflectionMethod(AppleDecoder::class, 'buildAppleMakerNotes');
+        $method->setAccessible(true);
+
+        /** @var AppleMakerNotes|null $notes */
+        $notes = $method->invoke($decoder, [
+            'ContentIdentifier' => 'mapped-' . $code,
+            'ImageCaptureType'  => $code,
+        ]);
+
+        self::assertInstanceOf(AppleMakerNotes::class, $notes);
+        self::assertSame($label, $notes->imageCaptureType);
+    }
+
+    /**
+     * @return iterable<int, array{int, string}>
+     */
+    public static function imageCaptureTypeProvider(): iterable
+    {
+        yield 'ProRAW' => [1, 'ProRAW'];
+        yield 'Portrait' => [2, 'Portrait'];
+        yield 'Live Photo' => [3, 'Live Photo'];
+        yield 'Live Photo Long Exposure' => [4, 'Live Photo Long Exposure'];
+        yield 'Burst' => [5, 'Burst'];
+        yield 'Night Mode' => [6, 'Night Mode'];
+        yield 'Night Mode Portrait' => [7, 'Night Mode Portrait'];
+        yield 'Photo' => [10, 'Photo'];
+        yield 'Manual Focus' => [11, 'Manual Focus'];
+        yield 'Scene' => [12, 'Scene'];
+    }
+
+    #[Test]
     public function decodeParsesAdditionalMakerNoteFields(): void
     {
         $raw = '{ MakerNoteVersion = "1.4"; HDRImageType = 2; BurstUUID = "text-burst"; '
-            . 'FocusDistanceRange = (0.4, 1.6); OISMode = 5; ImageCaptureType = 7; '
+            . 'FocusDistanceRange = (0.4, 1.6); OISMode = 5; ImageCaptureType = 4; '
             . 'ImageUniqueID = "text-unique"; PhotoIdentifier = "text-photo"; '
             . 'AFMeasuredDepth = 1.1; AFConfidence = 0.65; ContentIdentifier = "textual"; }';
 
@@ -321,7 +357,7 @@ final class AppleDecoderTest extends TestCase
         self::assertSame('text-burst', $apple->burstUuid);
         self::assertSame([0.4, 1.6], $apple->focusDistanceRange);
         self::assertSame('5', $apple->oisMode);
-        self::assertSame('LivePhotoLongExposure', $apple->imageCaptureType);
+        self::assertSame('Live Photo Long Exposure', $apple->imageCaptureType);
         self::assertSame('text-unique', $apple->imageUniqueId);
         self::assertSame('text-photo', $apple->photoIdentifier);
         self::assertEqualsWithDelta(1.1, $apple->afMeasuredDepth, 1e-12);


### PR DESCRIPTION
## Summary
- update Apple image capture type mappings to use the maker note specification labels across the decoder and structured resolvers
- extend Apple decoder and curation tests to cover every documented capture type code and refresh expectations for the new labels

## Testing
- composer ci:test:php:unit *(fails: fixture-based TruthComparison tests require proprietary media that is unavailable in the sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68fcebfe4a2c8323b1502c1145d2f03c