### PR TITLE
fix: update Apple HDR image type mapping

### DIFF
--- a/src/MakerNotes/AppleDecoder.php
+++ b/src/MakerNotes/AppleDecoder.php
@@ -84,7 +84,8 @@ final class AppleDecoder implements MakerNotesDecoderInterface
         0 => 'Standard',
         1 => 'HDR',
         2 => 'HDR2',
-        3 => 'HDR3',
+        3 => 'HDR Image',
+        4 => 'Original Image',
     ];
 
     /**

--- a/tests/MakerNotes/AppleDecoder/AppleDecoderTest.php
+++ b/tests/MakerNotes/AppleDecoder/AppleDecoderTest.php
@@ -319,6 +319,36 @@ final class AppleDecoderTest extends TestCase
     }
 
     #[Test]
+    #[DataProvider('hdrImageTypeProvider')]
+    public function buildAppleMakerNotesMapsHdrImageTypeCodes(int $code, string $label): void
+    {
+        $decoder = new AppleDecoder();
+        $method  = new ReflectionMethod(AppleDecoder::class, 'buildAppleMakerNotes');
+        $method->setAccessible(true);
+
+        /** @var AppleMakerNotes|null $notes */
+        $notes = $method->invoke($decoder, [
+            'ContentIdentifier' => 'hdr-' . $code,
+            'HDRImageType'      => $code,
+        ]);
+
+        self::assertInstanceOf(AppleMakerNotes::class, $notes);
+        self::assertSame($label, $notes->hdrImageType);
+    }
+
+    /**
+     * @return iterable<int, array{int, string}>
+     */
+    public static function hdrImageTypeProvider(): iterable
+    {
+        yield 'Standard' => [0, 'Standard'];
+        yield 'HDR' => [1, 'HDR'];
+        yield 'HDR2' => [2, 'HDR2'];
+        yield 'HDR Image' => [3, 'HDR Image'];
+        yield 'Original Image' => [4, 'Original Image'];
+    }
+
+    #[Test]
     #[DataProvider('imageCaptureTypeProvider')]
     public function buildAppleMakerNotesMapsImageCaptureTypeCodes(int $code, string $label): void
     {


### PR DESCRIPTION
## Summary
- align the Apple HDR image type map with the documented labels, including the new Original Image code
- extend the Apple decoder tests to cover the revised HDR mappings

## Testing
- composer ci:test:php:unit -- --filter AppleDecoderTest

------
https://chatgpt.com/codex/tasks/task_e_68fcfa32924483239dae2da5bc5d540a