### PR TITLE
Normalize EXIF fractional second handling

### DIFF
--- a/src/Curate/StructuredMetadataBuilder.php
+++ b/src/Curate/StructuredMetadataBuilder.php
@@ -73,7 +73,10 @@ use function is_float;
 use function is_int;
 use function is_numeric;
 use function is_string;
+use function preg_replace;
 use function preg_split;
+use function str_pad;
+use function substr;
 use function trim;
 use function strtoupper;
 use function in_array;
@@ -550,11 +553,11 @@ final class StructuredMetadataBuilder
         $offsetTimeDigitized = $resolver->string('OffsetTimeDigitized');
 
         $subSecTime         = $this->sanitizeSubSeconds($resolver->string('SubSecTime'));
-        $subSecDigitizedRaw = $this->sanitizeSubSeconds($resolver->string('SubSecTimeDigitized'));
+        $subSecTimeDigitized = $this->sanitizeSubSeconds($resolver->string('SubSecTimeDigitized'));
         $subSecOriginal     = $this->sanitizeSubSeconds($subOriginalRaw);
 
         if ($subSecTime === null) {
-            $subSecTime = $subSecOriginal ?? $subSecDigitizedRaw;
+            $subSecTime = $subSecOriginal ?? $subSecTimeDigitized;
         }
 
         $timeZoneOffsets = $resolver->ints('TimeZoneOffset');
@@ -579,7 +582,7 @@ final class StructuredMetadataBuilder
             offsetTimeDigitized: $offsetTimeDigitized,
             subSecTime: $subSecTime,
             subSecTimeOriginal: $subSecOriginal,
-            subSecTimeDigitized: $subSecDigitizedRaw,
+            subSecTimeDigitized: $subSecTimeDigitized,
             timeZoneOffsetMinutes: $timeZoneOffsets,
         );
     }
@@ -1365,7 +1368,18 @@ final class StructuredMetadataBuilder
      */
     private function sanitizeSubSeconds(?string $value): ?string
     {
-        return $value === null || $value === '' ? null : $value;
+        if ($value === null || $value === '') {
+            return null;
+        }
+
+        $digits = preg_replace('/\\D+/', '', $value);
+        if ($digits === '') {
+            return null;
+        }
+
+        $digits = substr($digits, 0, 3);
+
+        return str_pad($digits, 3, '0');
     }
 
     /**

--- a/tests/Curate/StructuredMetadataBuilderTest.php
+++ b/tests/Curate/StructuredMetadataBuilderTest.php
@@ -1218,6 +1218,28 @@ final class StructuredMetadataBuilderTest extends TestCase
     }
 
     /**
+     * Ensures EXIF fractional seconds are normalised to millisecond precision.
+     */
+    #[Test]
+    public function normalizesFractionalSecondsToMillisecondsPrecision(): void
+    {
+        $exifIfd = new Ifd([
+            ExifTag::SUB_SEC_TIME           => new IfdEntry(ExifTag::SUB_SEC_TIME, 2, 6, '654321'),
+            ExifTag::SUB_SEC_TIME_ORIGINAL  => new IfdEntry(ExifTag::SUB_SEC_TIME_ORIGINAL, 2, 9, '123456789'),
+            ExifTag::SUB_SEC_TIME_DIGITIZED => new IfdEntry(ExifTag::SUB_SEC_TIME_DIGITIZED, 2, 7, '98a7654'),
+        ]);
+
+        $exifDocument = new ExifDocument(new Ifd([]), $exifIfd, null, null, null);
+        $metadata     = new Metadata(['primary'], null, $exifDocument);
+
+        $structured = (new StructuredMetadataBuilder())->build($metadata);
+
+        self::assertSame('654', $structured->temporal->subSecTime);
+        self::assertSame('123', $structured->temporal->subSecTimeOriginal);
+        self::assertSame('987', $structured->temporal->subSecTimeDigitized);
+    }
+
+    /**
      * Ensures fractional seconds mirror into the generic field when the original precision is available.
      */
     #[Test]


### PR DESCRIPTION
## Summary
- normalise EXIF fractional seconds to millisecond precision and strip non-digit characters
- keep the temporal aggregate in sync with the normalised EXIF subseconds
- cover millisecond normalisation with a StructuredMetadataBuilder test case

## Testing
- composer ci:test:php:unit *(fails: relies on unavailable sample assets in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68fcfa23830c83238d70c03718ca09cb