### PR TITLE
Fix Apple flag mask defaults

### DIFF
--- a/src/MakerNotes/AppleDecoder.php
+++ b/src/MakerNotes/AppleDecoder.php
@@ -19,6 +19,7 @@ use MagicSunday\ImageMeta\MakerNotes\Apple\RunTime;
 
 use function array_is_list;
 use function array_key_exists;
+use function array_flip;
 use function array_unique;
 use function array_values;
 use function ctype_space;
@@ -1197,20 +1198,20 @@ final class AppleDecoder implements MakerNotesDecoderInterface
             }
 
             $enabledBits = $this->bitPositions($dictionary[$makerKey]);
-            if ($enabledBits === null) {
-                continue;
-            }
-
-            $assignFalse = $makerKey === 'PhotosAppFeatureFlags';
+            $enabledLookup = $enabledBits !== null ? array_flip($enabledBits) : null;
 
             foreach ($bitMap as $bitPosition => $normalized) {
-                if (array_key_exists($normalized, $flags)) {
+                $hasExisting = array_key_exists($normalized, $flags);
+                if (!$hasExisting) {
+                    $flags[$normalized] = false;
+                }
+
+                if ($enabledLookup === null || !array_key_exists($bitPosition, $enabledLookup)) {
                     continue;
                 }
 
-                $isEnabled = in_array($bitPosition, $enabledBits, true);
-                if ($isEnabled || $assignFalse) {
-                    $flags[$normalized] = $isEnabled;
+                if (!$hasExisting || $flags[$normalized] === false) {
+                    $flags[$normalized] = true;
                 }
             }
         }

--- a/tests/MakerNotes/Apple/AppleDecoderFlagMaskTest.php
+++ b/tests/MakerNotes/Apple/AppleDecoderFlagMaskTest.php
@@ -52,7 +52,7 @@ final class AppleDecoderFlagMaskTest extends TestCase
     }
 
     #[Test]
-    public function extractFlagsDefaultsPhotosAppFeatureBitsToFalse(): void
+    public function extractFlagsAssignsFalseDefaultsWhenNoMappedBitsEnabled(): void
     {
         $decoder = new AppleDecoder();
         $method  = new ReflectionMethod(AppleDecoder::class, 'extractFlags');
@@ -66,10 +66,18 @@ final class AppleDecoderFlagMaskTest extends TestCase
         ];
 
         $result = $method->invoke($decoder, $dictionary);
+        ksort($result);
 
-        self::assertSame([
+        $expected = [
+            'hdrAuto'       => false,
+            'hdrEnabled'    => false,
+            'longExposure'  => false,
+            'nightMode'     => false,
             'personInPhoto' => false,
             'petInPhoto'    => false,
-        ], $result);
+        ];
+        ksort($expected);
+
+        self::assertSame($expected, $result);
     }
 }


### PR DESCRIPTION
## Summary
- ensure Apple flag mask decoding records false defaults whenever a recognised mask is present
- extend the AppleDecoder flag mask tests to cover zero-mask scenarios

## Testing
- .build/bin/phpunit tests/MakerNotes/Apple/AppleDecoderFlagMaskTest.php

------
https://chatgpt.com/codex/tasks/task_e_68fcfa1f0a608323ab1774fbd10c88a0