### PR TITLE
Fix EXIF textual tag detection in IFD0

### DIFF
--- a/src/Model/Exif/ExifDocument.php
+++ b/src/Model/Exif/ExifDocument.php
@@ -195,6 +195,12 @@ final readonly class ExifDocument
      */
     public function imageTitle(): ?string
     {
+        $value = $this->str($this->ifd0, ExifTag::IMAGE_TITLE);
+
+        if ($value !== null) {
+            return $value;
+        }
+
         $value = $this->str($this->exifIfd, ExifTag::IMAGE_TITLE);
 
         if ($value !== null) {
@@ -215,6 +221,12 @@ final readonly class ExifDocument
      */
     public function photographer(): ?string
     {
+        $value = $this->str($this->ifd0, ExifTag::PHOTOGRAPHER);
+
+        if ($value !== null) {
+            return $value;
+        }
+
         $value = $this->str($this->exifIfd, ExifTag::PHOTOGRAPHER);
 
         if ($value !== null) {
@@ -235,6 +247,12 @@ final readonly class ExifDocument
      */
     public function imageEditor(): ?string
     {
+        $value = $this->str($this->ifd0, ExifTag::IMAGE_EDITOR);
+
+        if ($value !== null) {
+            return $value;
+        }
+
         $value = $this->str($this->exifIfd, ExifTag::IMAGE_EDITOR);
 
         return $value ?? $this->str($this->ifd0, ExifTag::IMAGE_EDITOR_LEGACY);

--- a/tests/Curate/Resolver/ExifTagResolverTest.php
+++ b/tests/Curate/Resolver/ExifTagResolverTest.php
@@ -312,6 +312,9 @@ final class ExifTagResolverTest extends TestCase
     {
         $ifd0 = new Ifd([
             ExifTag::IMAGE_DESCRIPTION => new IfdEntry(ExifTag::IMAGE_DESCRIPTION, 2, 1, 'Evening scene'),
+            ExifTag::IMAGE_TITLE       => new IfdEntry(ExifTag::IMAGE_TITLE, 2, 1, 'Evening Glow'),
+            ExifTag::PHOTOGRAPHER      => new IfdEntry(ExifTag::PHOTOGRAPHER, 2, 1, 'Jamie Doe'),
+            ExifTag::IMAGE_EDITOR      => new IfdEntry(ExifTag::IMAGE_EDITOR, 2, 1, 'Casey Edit'),
         ]);
 
         $exifIfd = new Ifd([
@@ -319,9 +322,6 @@ final class ExifTagResolverTest extends TestCase
             ExifTag::SCENE_TYPE                => new IfdEntry(ExifTag::SCENE_TYPE, 7, 1, chr(1)),
             ExifTag::CFA_PATTERN               => new IfdEntry(ExifTag::CFA_PATTERN, 7, 4, "\x00\x01\x02\x03"),
             ExifTag::CUSTOM_RENDERED           => new IfdEntry(ExifTag::CUSTOM_RENDERED, 3, 1, 1),
-            ExifTag::IMAGE_TITLE               => new IfdEntry(ExifTag::IMAGE_TITLE, 2, 1, 'Evening Glow'),
-            ExifTag::PHOTOGRAPHER              => new IfdEntry(ExifTag::PHOTOGRAPHER, 2, 1, 'Jamie Doe'),
-            ExifTag::IMAGE_EDITOR              => new IfdEntry(ExifTag::IMAGE_EDITOR, 2, 1, 'Casey Edit'),
             ExifTag::CAMERA_FIRMWARE           => new IfdEntry(ExifTag::CAMERA_FIRMWARE, 2, 1, 'FW Main'),
             ExifTag::RAW_DEVELOPING_SOFTWARE   => new IfdEntry(ExifTag::RAW_DEVELOPING_SOFTWARE, 2, 1, 'Raw Studio'),
             ExifTag::IMAGE_EDITING_SOFTWARE    => new IfdEntry(ExifTag::IMAGE_EDITING_SOFTWARE, 2, 1, 'Pixel Edit'),

--- a/tests/Model/Exif/ExifDocumentTest.php
+++ b/tests/Model/Exif/ExifDocumentTest.php
@@ -561,6 +561,9 @@ final class ExifDocumentTest extends TestCase
     {
         $ifd0 = new Ifd([
             ExifTag::IMAGE_DESCRIPTION => new IfdEntry(ExifTag::IMAGE_DESCRIPTION, 2, 1, 'Coastal cliffs'),
+            ExifTag::IMAGE_TITLE       => new IfdEntry(ExifTag::IMAGE_TITLE, 2, 1, 'Cliffside Dusk'),
+            ExifTag::PHOTOGRAPHER      => new IfdEntry(ExifTag::PHOTOGRAPHER, 2, 1, 'Alex Light'),
+            ExifTag::IMAGE_EDITOR      => new IfdEntry(ExifTag::IMAGE_EDITOR, 2, 1, 'Chris Edit'),
         ]);
 
         $exifIfd = new Ifd([
@@ -593,9 +596,6 @@ final class ExifDocumentTest extends TestCase
             ExifTag::CFA_PATTERN                 => new IfdEntry(ExifTag::CFA_PATTERN, 7, 4, "\x02\x01\x01\x02"),
             ExifTag::CUSTOM_RENDERED             => new IfdEntry(ExifTag::CUSTOM_RENDERED, 3, 1, 1),
             ExifTag::DEVICE_SETTING_DESCRIPTION  => new IfdEntry(ExifTag::DEVICE_SETTING_DESCRIPTION, 7, 1, 'Neutral profile'),
-            ExifTag::IMAGE_TITLE                 => new IfdEntry(ExifTag::IMAGE_TITLE, 2, 1, 'Cliffside Dusk'),
-            ExifTag::PHOTOGRAPHER                => new IfdEntry(ExifTag::PHOTOGRAPHER, 2, 1, 'Alex Light'),
-            ExifTag::IMAGE_EDITOR                => new IfdEntry(ExifTag::IMAGE_EDITOR, 2, 1, 'Chris Edit'),
             ExifTag::CAMERA_FIRMWARE             => new IfdEntry(ExifTag::CAMERA_FIRMWARE, 2, 1, 'FW 2.0'),
             ExifTag::RAW_DEVELOPING_SOFTWARE     => new IfdEntry(ExifTag::RAW_DEVELOPING_SOFTWARE, 2, 1, 'RawLab'),
             ExifTag::IMAGE_EDITING_SOFTWARE      => new IfdEntry(ExifTag::IMAGE_EDITING_SOFTWARE, 2, 1, 'EditLab'),


### PR DESCRIPTION
## Summary
- ensure ExifDocument reads EXIF 3.0 textual tags from IFD0 before legacy fallbacks
- update resolver and document tests to cover IFD0-based fixtures

## Testing
- `composer ci:test:php:unit` *(fails: repository does not include binary fixtures referenced by TruthComparisonTest)*
- `./.build/bin/phpunit tests/Model/Exif/ExifDocumentTest.php`
- `./.build/bin/phpunit tests/Curate/Resolver/ExifTagResolverTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68fcfa9a585c83239a18b32d47ccb18a