### PR TITLE
feat: decode Apple stability flags

### DIFF
--- a/src/MakerNotes/AppleDecoder.php
+++ b/src/MakerNotes/AppleDecoder.php
@@ -51,6 +51,8 @@ final class AppleDecoder implements MakerNotesDecoderInterface
      * @var array<string, string>
      */
     private const array FLAG_MAP = [
+        'AEStable'             => 'aeStable',
+        'AFStable'             => 'afStable',
         'LivePhotoAuto'         => 'livePhotoAuto',
         'LivePhotoEnabled'      => 'livePhotoEnabled',
         'LivePhotoActive'       => 'livePhotoActive',

--- a/tests/Curate/StructuredMetadataBuilderTest.php
+++ b/tests/Curate/StructuredMetadataBuilderTest.php
@@ -564,6 +564,8 @@ final class StructuredMetadataBuilderTest extends TestCase
             'SceneFlags'            => [0, 1],
             'ImageProcessingFlags'  => ['values' => [0, 1]],
             'PhotosAppFeatureFlags' => [0],
+            'AEStable'             => 1,
+            'AFStable'             => 0,
         ]);
 
         self::assertInstanceOf(AppleMakerNotes::class, $appleMakerNotes);
@@ -584,6 +586,8 @@ final class StructuredMetadataBuilderTest extends TestCase
         self::assertTrue($structured->apple->flags['hdrAuto']);
         self::assertTrue($structured->apple->flags['personInPhoto']);
         self::assertFalse($structured->apple->flags['petInPhoto']);
+        self::assertTrue($structured->apple->flags['aeStable']);
+        self::assertFalse($structured->apple->flags['afStable']);
     }
 
     /**

--- a/tests/MakerNotes/AppleDecoder/AppleDecoderTest.php
+++ b/tests/MakerNotes/AppleDecoder/AppleDecoderTest.php
@@ -458,6 +458,36 @@ final class AppleDecoderTest extends TestCase
         self::assertSame(5, $notes->runTime?->flags);
     }
 
+    #[Test]
+    #[DataProvider('stabilityFlagProvider')]
+    public function buildAppleMakerNotesParsesStabilityFlags(string $makerKey, string|int $value, string $expectedFlag, bool $expected): void
+    {
+        $decoder = new AppleDecoder();
+        $method  = new ReflectionMethod(AppleDecoder::class, 'buildAppleMakerNotes');
+        $method->setAccessible(true);
+
+        /** @var AppleMakerNotes|null $notes */
+        $notes = $method->invoke($decoder, [
+            'ContentIdentifier' => 'stability',
+            $makerKey           => $value,
+        ]);
+
+        self::assertInstanceOf(AppleMakerNotes::class, $notes);
+        self::assertArrayHasKey($expectedFlag, $notes->flags);
+        self::assertSame($expected, $notes->flags[$expectedFlag]);
+    }
+
+    /**
+     * @return iterable<string, array{string, string|int, string, bool}>
+     */
+    public static function stabilityFlagProvider(): iterable
+    {
+        yield 'ae-stable numeric enabled' => ['AEStable', 1, 'aeStable', true];
+        yield 'ae-stable string disabled' => ['AEStable', '0', 'aeStable', false];
+        yield 'af-stable numeric disabled' => ['AFStable', 0, 'afStable', false];
+        yield 'af-stable string enabled' => ['AFStable', '1', 'afStable', true];
+    }
+
     private function buildMakerNotesBlobWithMovieIndex(): string
     {
         return str_replace('LivePhotoVideoIndex', 'LivePhotoMovieIndex', $this->buildMakerNotesBlob());
@@ -501,6 +531,8 @@ final class AppleDecoderTest extends TestCase
             'LongExposure'          => true,
             'PersonInPhoto'         => true,
             'PetInPhoto'            => false,
+            'AEStable'             => 1,
+            'AFStable'             => '0',
         ]);
 
         $maskNotes = $method->invoke($decoder, [
@@ -540,6 +572,8 @@ final class AppleDecoderTest extends TestCase
         self::assertTrue($scalarFlags['livePhotoEnabled']);
         self::assertTrue($scalarFlags['livePhotoActive']);
         self::assertTrue($scalarFlags['livePhotoLongExposure']);
+        self::assertTrue($scalarFlags['aeStable']);
+        self::assertFalse($scalarFlags['afStable']);
     }
 
     #[Test]


### PR DESCRIPTION
## Summary
- map the AEStable and AFStable maker note keys to normalized Apple stability flags
- exercise AppleDecoder with numeric and string stability payloads and keep scalar flag parity
- ensure StructuredMetadataBuilder propagates the stability flags into aggregated Apple metadata

## Testing
- composer ci:test:php:unit *(fails: integration fixtures are unavailable in the sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68fcfa49b3108323aa5b4d9dbad4e2f5