### PR TITLE
Fix Apple maker note flag defaults

### DIFF
--- a/src/MakerNotes/AppleDecoder.php
+++ b/src/MakerNotes/AppleDecoder.php
@@ -1200,8 +1200,8 @@ final class AppleDecoder implements MakerNotesDecoderInterface
                 continue;
             }
 
-            $enabledBits = $this->bitPositions($dictionary[$makerKey]);
-            $enabledLookup = $enabledBits !== null ? array_flip($enabledBits) : null;
+            $enabledBits   = $this->bitPositions($dictionary[$makerKey]);
+            $enabledLookup = $enabledBits === null ? null : array_flip($enabledBits);
 
             foreach ($bitMap as $bitPosition => $normalized) {
                 $hasExisting = array_key_exists($normalized, $flags);
@@ -1213,7 +1213,7 @@ final class AppleDecoder implements MakerNotesDecoderInterface
                     continue;
                 }
 
-                if (!$hasExisting || $flags[$normalized] === false) {
+                if (!$hasExisting) {
                     $flags[$normalized] = true;
                 }
             }

--- a/tests/MakerNotes/AppleDecoder/AppleDecoderTest.php
+++ b/tests/MakerNotes/AppleDecoder/AppleDecoderTest.php
@@ -176,6 +176,36 @@ final class AppleDecoderTest extends TestCase
     }
 
     #[Test]
+    public function decodeRecordsDisabledFlagsFromZeroBitMasks(): void
+    {
+        $raw = '{ ContentIdentifier = "flags-zero"; SceneFlags = 0; ImageProcessingFlags = 0; PhotosAppFeatureFlags = 0; }';
+
+        $decoder = new AppleDecoder();
+
+        $metadata = $decoder->decode($raw, 'Apple', 'iPhone');
+
+        self::assertInstanceOf(MakerNotesMetadata::class, $metadata);
+
+        $apple = $metadata->apple();
+        self::assertInstanceOf(AppleMakerNotes::class, $apple);
+        self::assertSame('flags-zero', $apple->contentIdentifier);
+
+        self::assertArrayHasKey('nightMode', $apple->flags);
+        self::assertArrayHasKey('longExposure', $apple->flags);
+        self::assertArrayHasKey('hdrEnabled', $apple->flags);
+        self::assertArrayHasKey('hdrAuto', $apple->flags);
+        self::assertArrayHasKey('personInPhoto', $apple->flags);
+        self::assertArrayHasKey('petInPhoto', $apple->flags);
+
+        self::assertFalse($apple->flags['nightMode']);
+        self::assertFalse($apple->flags['longExposure']);
+        self::assertFalse($apple->flags['hdrEnabled']);
+        self::assertFalse($apple->flags['hdrAuto']);
+        self::assertFalse($apple->flags['personInPhoto']);
+        self::assertFalse($apple->flags['petInPhoto']);
+    }
+
+    #[Test]
     public function decodeResolvesLivePhotoMovieIndex(): void
     {
         $raw     = $this->buildMakerNotesBlobWithMovieIndex();
@@ -629,6 +659,7 @@ final class AppleDecoderTest extends TestCase
         self::assertSame(
             [
                 'livePhotoLongExposure' => false,
+                'longExposure'          => false,
                 'nightMode'             => false,
                 'personInPhoto'         => false,
                 'petInPhoto'            => false,


### PR DESCRIPTION
## Summary
- ensure Apple maker note bitmask decoding creates explicit `false` entries for unset bits without overriding scalar-provided values
- cover zeroed Scene and ImageProcessing flag masks in the Apple decoder tests and update overrides to expect explicit `longExposure` defaults

## Testing
- .build/bin/phpunit tests/MakerNotes/AppleDecoder/AppleDecoderTest.php
- composer ci:test:php:unit *(fails: TruthComparison fixtures are unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68fcfbdaef208323b6632a25d668b731