### PR TITLE
Fix Apple maker note version normalisation for integer inputs

### DIFF
--- a/src/MakerNotes/Apple/AppleMakerNotes.php
+++ b/src/MakerNotes/Apple/AppleMakerNotes.php
@@ -32,7 +32,7 @@ final readonly class AppleMakerNotes
      * @param list<float>|null    $accelerationVector  Acceleration vector recorded during capture.
      * @param float|null          $livePhotoTime       Normalised Live Photo timestamp in seconds.
      * @param RunTime|null        $runTime             Capture runtime metadata describing the CMTime payload.
-     * @param string|null         $makerNoteVersion    Maker note version string reported by the device.
+     * @param string|null         $makerNoteVersion    Normalised maker note version string reported by the device.
      * @param string|null         $hdrImageType        HDR image classification (e.g. "HDR").
      * @param string|null         $burstUuid           Identifier referencing the originating burst.
      * @param list<float>|null    $focusDistanceRange  Near and far focus distance bounds in meters.

--- a/src/MakerNotes/AppleDecoder.php
+++ b/src/MakerNotes/AppleDecoder.php
@@ -701,7 +701,7 @@ final class AppleDecoder implements MakerNotesDecoderInterface
         $accelerationVector = $this->floatList($dictionary, 'AccelerationVector');
         $flags              = $this->extractFlags($dictionary);
 
-        $makerNoteVersion   = $this->stringValue($dictionary, 'MakerNoteVersion');
+        $makerNoteVersion   = $this->makerNoteVersionValue($dictionary, 'MakerNoteVersion');
         $hdrImageType       = $this->enumeratedStringValue($dictionary, self::HDR_IMAGE_TYPE_MAP, 'HDRImageType', 'HdrImageType');
         $burstUuid          = $this->stringValue($dictionary, 'BurstUUID');
         $focusDistanceRange = $this->focusDistanceRangeValue($dictionary);
@@ -963,6 +963,64 @@ final class AppleDecoder implements MakerNotesDecoderInterface
         }
 
         return $values !== [] ? $values : null;
+    }
+
+    /**
+     * @param array<int|string, array<int|string, mixed>|bool|float|int|string|null> $dictionary
+     *
+     * @phpstan-param array<int|string, array<int|string, mixed>|bool|float|int|string|null> $dictionary
+     */
+    private function makerNoteVersionValue(array $dictionary, string $key): ?string
+    {
+        if (!array_key_exists($key, $dictionary)) {
+            return null;
+        }
+
+        $scalar = $this->stringOrNumericValue($dictionary, $key);
+        if ($scalar !== null) {
+            return $scalar;
+        }
+
+        $value = $dictionary[$key];
+        if (!is_array($value)) {
+            return null;
+        }
+
+        if (!array_is_list($value) && array_key_exists('values', $value) && is_array($value['values'])) {
+            $value = $value['values'];
+        }
+
+        if (!array_is_list($value)) {
+            return null;
+        }
+
+        $components = [];
+        foreach ($value as $entry) {
+            if (is_int($entry)) {
+                $components[] = (string) $entry;
+                continue;
+            }
+
+            if (is_string($entry)) {
+                $trimmed = trim($entry);
+                if ($trimmed === '' || !is_numeric($trimmed)) {
+                    continue;
+                }
+
+                $components[] = (string) (int) $trimmed;
+                continue;
+            }
+
+            if (is_float($entry) || is_numeric($entry)) {
+                $components[] = (string) (int) $entry;
+            }
+        }
+
+        if ($components === []) {
+            return null;
+        }
+
+        return implode('.', $components);
     }
 
     /**

--- a/tests/MakerNotes/AppleDecoder/AppleDecoderTest.php
+++ b/tests/MakerNotes/AppleDecoder/AppleDecoderTest.php
@@ -244,6 +244,34 @@ final class AppleDecoderTest extends TestCase
     }
 
     #[Test]
+    #[DataProvider('makerNoteVersionProvider')]
+    public function buildAppleMakerNotesNormalisesMakerNoteVersionFromIntegers(array|int $makerNoteVersion, string $expected): void
+    {
+        $decoder = new AppleDecoder();
+        $method  = new ReflectionMethod(AppleDecoder::class, 'buildAppleMakerNotes');
+        $method->setAccessible(true);
+
+        /** @var AppleMakerNotes|null $notes */
+        $notes = $method->invoke($decoder, [
+            'ContentIdentifier' => 'normalised-version',
+            'MakerNoteVersion'  => $makerNoteVersion,
+        ]);
+
+        self::assertInstanceOf(AppleMakerNotes::class, $notes);
+        self::assertSame($expected, $notes->makerNoteVersion);
+    }
+
+    /**
+     * @return iterable<string, array{array{values: list<int>}|list<int>|int, string}>
+     */
+    public static function makerNoteVersionProvider(): iterable
+    {
+        yield 'list of integers' => [[1, 4, 0, 2], '1.4.0.2'];
+        yield 'values wrapper' => [['values' => [3, 1]], '3.1'];
+        yield 'scalar integer' => [7, '7'];
+    }
+
+    #[Test]
     public function buildAppleMakerNotesCombinesFocusDistanceNearAndFar(): void
     {
         $decoder = new AppleDecoder();


### PR DESCRIPTION
## Summary
- normalise Apple maker note versions by accepting integer scalars and lists and formatting them deterministically
- adjust the AppleMakerNotes constructor docs to reflect the normalised maker note version representation
- add unit coverage proving maker note version normalisation for integer inputs

## Testing
- composer ci:test:php:unit *(fails: depends on unavailable truth fixtures and existing comparison expectations)*

------
https://chatgpt.com/codex/tasks/task_e_68fcfbfde8d48323bc1aec05b0dacdb2