### PR TITLE
Fix EXIF 3 firmware fallback logic

### DIFF
--- a/src/Curate/Resolver/ExifTagResolver.php
+++ b/src/Curate/Resolver/ExifTagResolver.php
@@ -13,6 +13,7 @@ namespace MagicSunday\ImageMeta\Curate\Resolver;
 
 use BackedEnum;
 use DateTimeImmutable;
+use MagicSunday\ImageMeta\Core\ExifCapabilities;
 use MagicSunday\ImageMeta\Core\ValueConverters as CoreValueConverters;
 use MagicSunday\ImageMeta\Model\Exif\ExifDocument;
 use MagicSunday\ImageMeta\Model\Exif\ExifNumericList;
@@ -871,9 +872,19 @@ final readonly class ExifTagResolver
      */
     public function exifVersion(): ?string
     {
-        $value = $this->stringValue($this->document?->exifIfd, ExifTag::EXIF_VERSION);
+        return $this->document?->exifVersion();
+    }
 
-        return CoreValueConverters::toExifVersion($value);
+    /**
+     * Returns the derived EXIF capability profile identifier.
+     */
+    public function exifProfile(): string
+    {
+        if ($this->document instanceof ExifDocument) {
+            return $this->document->exifProfile();
+        }
+
+        return ExifCapabilities::fromVersion(null);
     }
 
     /**

--- a/src/Curate/StructuredMetadataBuilder.php
+++ b/src/Curate/StructuredMetadataBuilder.php
@@ -14,7 +14,6 @@ namespace MagicSunday\ImageMeta\Curate;
 use DateTimeImmutable;
 use DateTimeZone;
 use Exception;
-use MagicSunday\ImageMeta\Core\ExifCapabilities;
 use MagicSunday\ImageMeta\Core\ValueConverters;
 use MagicSunday\ImageMeta\Curate\Resolver\CompositeResolver;
 use MagicSunday\ImageMeta\Curate\Resolver\ExifTagResolver;
@@ -191,7 +190,7 @@ final class StructuredMetadataBuilder
         );
 
         $exifVersion = $exifResolver->exifVersion();
-        $profile     = ExifCapabilities::fromVersion($exifVersion);
+        $profile     = $exifResolver->exifProfile();
 
         $standards = new Standards(
             exifVersion: $exifVersion,
@@ -596,16 +595,24 @@ final class StructuredMetadataBuilder
      */
     private function buildCamera(ExifTagResolver $exif): Camera
     {
+        $profile = (float) $exif->exifProfile();
+
+        $firmwareCandidates = [
+            $exif->cameraFirmware(...),
+        ];
+
+        if ($profile < 3.0) {
+            $firmwareCandidates[] = $exif->cameraFirmwareVersion(...);
+        }
+
+        $firmwareCandidates[] = $exif->software(...);
+
         return new Camera(
             make: $exif->cameraMake(),
             model: $exif->cameraModel(),
             ownerName: $exif->ownerName(),
             serialNumber: $exif->bodySerialNumber(),
-            firmware: CompositeResolver::first([
-                $exif->cameraFirmware(...),
-                $exif->cameraFirmwareVersion(...),
-                $exif->software(...),
-            ]),
+            firmware: CompositeResolver::first($firmwareCandidates),
             fileSource: $exif->fileSource(),
             sensingMethod: $exif->sensingMethod(),
         );

--- a/src/Model/Exif/ExifDocument.php
+++ b/src/Model/Exif/ExifDocument.php
@@ -14,6 +14,8 @@ namespace MagicSunday\ImageMeta\Model\Exif;
 use DateTimeImmutable;
 use DateTimeZone;
 use Exception;
+use MagicSunday\ImageMeta\Core\ExifCapabilities;
+use MagicSunday\ImageMeta\Core\ValueConverters as CoreValueConverters;
 use MagicSunday\ImageMeta\MakerNotes\MakerNotesMetadata;
 use MagicSunday\ImageMeta\Value\Enum\CfaPatternColor;
 use MagicSunday\ImageMeta\Value\Enum\CustomRendered;
@@ -40,6 +42,12 @@ use function trim;
  */
 final readonly class ExifDocument
 {
+    private ?string $exifVersion;
+
+    private string $exifProfile;
+
+    private bool $exifThreeOrNewer;
+
     /**
      * @param Ifd                     $ifd0       Root IFD of the TIFF structure.
      * @param Ifd|null                $exifIfd    Sub IFD containing EXIF-specific tags.
@@ -56,6 +64,10 @@ final readonly class ExifDocument
         public ?Ifd $ifd1,
         public ?MakerNotesMetadata $makerNotes = null,
     ) {
+        $rawVersion        = $this->rawString($this->exifIfd, ExifTag::EXIF_VERSION);
+        $this->exifVersion = CoreValueConverters::toExifVersion($rawVersion);
+        $this->exifProfile = ExifCapabilities::fromVersion($this->exifVersion);
+        $this->exifThreeOrNewer = (float) $this->exifProfile >= 3.0;
     }
 
     /**
@@ -188,6 +200,22 @@ final readonly class ExifDocument
     public function imageUniqueId(): ?string
     {
         return $this->str($this->exifIfd, ExifTag::IMAGE_UNIQUE_ID);
+    }
+
+    /**
+     * Returns the normalised EXIF version string when present.
+     */
+    public function exifVersion(): ?string
+    {
+        return $this->exifVersion;
+    }
+
+    /**
+     * Returns the derived EXIF capability profile identifier.
+     */
+    public function exifProfile(): string
+    {
+        return $this->exifProfile;
     }
 
     /**
@@ -831,6 +859,10 @@ final readonly class ExifDocument
      */
     public function cameraFirmwareVersion(): ?string
     {
+        if ($this->exifThreeOrNewer) {
+            return null;
+        }
+
         return $this->str($this->exifIfd, ExifTag::CAMERA_FIRMWARE_VERSION_LEGACY);
     }
 
@@ -852,6 +884,10 @@ final readonly class ExifDocument
      */
     public function rawDevelopingSoftwareVersion(): ?string
     {
+        if ($this->exifThreeOrNewer) {
+            return null;
+        }
+
         return $this->str($this->exifIfd, ExifTag::RAW_DEVELOPING_SOFTWARE_VERSION_LEGACY);
     }
 
@@ -883,6 +919,10 @@ final readonly class ExifDocument
      */
     public function metadataEditingSoftwareVersion(): ?string
     {
+        if ($this->exifThreeOrNewer) {
+            return null;
+        }
+
         return $this->str($this->exifIfd, ExifTag::METADATA_EDITING_SOFTWARE_VERSION_LEGACY);
     }
 

--- a/tests/Curate/StructuredMetadataBuilderTest.php
+++ b/tests/Curate/StructuredMetadataBuilderTest.php
@@ -1624,6 +1624,35 @@ final class StructuredMetadataBuilderTest extends TestCase
         self::assertSame([0.1, 0.2, 0.3], $structured->apple->accelerationVector);
     }
 
+    #[Test]
+    public function exifThreeKeepsLegacyVersionFieldsEmpty(): void
+    {
+        $ifd0 = new Ifd([
+            ExifTag::MAKE        => new IfdEntry(ExifTag::MAKE, 2, 1, 'Contoso'),
+            ExifTag::MODEL       => new IfdEntry(ExifTag::MODEL, 2, 1, 'Model X'),
+            ExifTag::IMAGE_TITLE => new IfdEntry(ExifTag::IMAGE_TITLE, 2, 1, 'Autumn Sunset'),
+        ]);
+
+        $exifIfd = new Ifd([
+            ExifTag::EXIF_VERSION              => new IfdEntry(ExifTag::EXIF_VERSION, 7, 4, '0300'),
+            ExifTag::RAW_DEVELOPING_SOFTWARE   => new IfdEntry(ExifTag::RAW_DEVELOPING_SOFTWARE, 2, 1, 'Raw Developer X'),
+            ExifTag::IMAGE_EDITING_SOFTWARE    => new IfdEntry(ExifTag::IMAGE_EDITING_SOFTWARE, 2, 1, 'Image Editor Y'),
+            ExifTag::METADATA_EDITING_SOFTWARE => new IfdEntry(ExifTag::METADATA_EDITING_SOFTWARE, 2, 1, 'Metadata Tool Z'),
+        ]);
+
+        $metadata = new Metadata(['primary'], null, new ExifDocument($ifd0, $exifIfd, null, null, null));
+
+        $structured = (new StructuredMetadataBuilder())->build($metadata);
+
+        self::assertSame('3.00', $structured->standards->exifVersion);
+        self::assertSame('3.0', $structured->standards->profile);
+        self::assertSame('Autumn Sunset', $structured->image->title);
+        self::assertNull($structured->camera->firmware);
+        self::assertSame('Raw Developer X', $structured->device->rawDevelopingSoftware);
+        self::assertSame('Image Editor Y', $structured->device->imageEditingSoftware);
+        self::assertSame('Metadata Tool Z', $structured->device->metadataEditingSoftware);
+    }
+
     /**
      * Ensures JPEG frame metadata backfills TIFF characteristics when EXIF is absent.
      */

--- a/tests/Model/Exif/ExifDocumentTest.php
+++ b/tests/Model/Exif/ExifDocumentTest.php
@@ -712,6 +712,35 @@ final class ExifDocumentTest extends TestCase
         self::assertSame('MetaLab 1.0.0', $doc->metadataEditingSoftwareVersion());
     }
 
+    #[Test]
+    public function exifThreeOmitsLegacySoftwareVersions(): void
+    {
+        $ifd0 = new Ifd([
+            ExifTag::IMAGE_TITLE => new IfdEntry(ExifTag::IMAGE_TITLE, 2, 1, 'Autumn Sunset'),
+        ]);
+
+        $exifIfd = new Ifd([
+            ExifTag::EXIF_VERSION               => new IfdEntry(ExifTag::EXIF_VERSION, 7, 4, '0300'),
+            ExifTag::CAMERA_FIRMWARE            => new IfdEntry(ExifTag::CAMERA_FIRMWARE, 2, 1, 'Firmware Build 5'),
+            ExifTag::RAW_DEVELOPING_SOFTWARE    => new IfdEntry(ExifTag::RAW_DEVELOPING_SOFTWARE, 2, 1, 'Raw Developer X'),
+            ExifTag::IMAGE_EDITING_SOFTWARE     => new IfdEntry(ExifTag::IMAGE_EDITING_SOFTWARE, 2, 1, 'Image Editor Y'),
+            ExifTag::METADATA_EDITING_SOFTWARE  => new IfdEntry(ExifTag::METADATA_EDITING_SOFTWARE, 2, 1, 'Metadata Tool Z'),
+        ]);
+
+        $doc = new ExifDocument($ifd0, $exifIfd, null, null, null);
+
+        self::assertSame('3.00', $doc->exifVersion());
+        self::assertSame('3.0', $doc->exifProfile());
+        self::assertSame('Autumn Sunset', $doc->imageTitle());
+        self::assertSame('Firmware Build 5', $doc->cameraFirmware());
+        self::assertNull($doc->cameraFirmwareVersion());
+        self::assertSame('Raw Developer X', $doc->rawDevelopingSoftware());
+        self::assertNull($doc->rawDevelopingSoftwareVersion());
+        self::assertSame('Image Editor Y', $doc->imageEditingSoftware());
+        self::assertSame('Metadata Tool Z', $doc->metadataEditingSoftware());
+        self::assertNull($doc->metadataEditingSoftwareVersion());
+    }
+
     /**
      * Ensures the ISO getter prefers EXIF 3.0 sensitivity tags before falling back to photographic sensitivity.
      */


### PR DESCRIPTION
## Summary
- cache the parsed EXIF version/profile inside `ExifDocument` and suppress legacy version getters once the profile is 3.0 or newer
- expose the EXIF profile through `ExifTagResolver` and skip `cameraFirmwareVersion()` in the camera firmware fallback chain for EXIF 3.0 payloads
- add EXIF 3.0 unit fixtures asserting that structured metadata no longer reuses legacy firmware/software version strings

## Testing
- composer ci:test:php:unit *(fails: truth-comparison fixtures not available in the container)*
- .build/bin/phpunit tests/Model/Exif/ExifDocumentTest.php tests/Curate/StructuredMetadataBuilderTest.php


------
https://chatgpt.com/codex/tasks/task_e_68fcfff289e083239cd90707832d6ffb