### PR TITLE
fix: handle TIFF IFD type pointers

### DIFF
--- a/src/Parse/Tiff/TiffExifReader.php
+++ b/src/Parse/Tiff/TiffExifReader.php
@@ -71,6 +71,8 @@ final class TiffExifReader
 
     private const int TYPE_DOUBLE = 12;
 
+    private const int TYPE_IFD = 13;
+
     private const int TYPE_LONG8 = 16;
 
     private const int TYPE_SLONG8 = 17;
@@ -289,7 +291,8 @@ final class TiffExifReader
                 // SSHORT
                 self::TYPE_SSHORT => $this->unpackS16(substr($bytes, $cursor, 2)),
                 // LONG
-                self::TYPE_LONG => $this->unpackU32(substr($bytes, $cursor, 4)),
+                self::TYPE_LONG,
+                self::TYPE_IFD => $this->unpackU32(substr($bytes, $cursor, 4)),
                 // SLONG
                 self::TYPE_SLONG => $this->unpackS32(substr($bytes, $cursor, 4)),
                 // LONG8 / IFD8
@@ -347,7 +350,7 @@ final class TiffExifReader
         $dataSize        = $unitSize * $count;
         $inlineThreshold = $this->bigTiff ? 8 : 4;
 
-        if ($dataSize <= $inlineThreshold) {
+        if ($type !== self::TYPE_IFD && $dataSize <= $inlineThreshold) {
             $raw = $this->uXToBytes($valueOrOffset, $inlineThreshold);
 
             return [substr($raw, 0, $dataSize), null];
@@ -444,6 +447,7 @@ final class TiffExifReader
 
             // LONG, SLONG, FLOAT
             self::TYPE_LONG,
+            self::TYPE_IFD,
             self::TYPE_SLONG,
             self::TYPE_FLOAT => 4,
 

--- a/tests/Parse/Tiff/TiffExifReaderTest.php
+++ b/tests/Parse/Tiff/TiffExifReaderTest.php
@@ -50,6 +50,8 @@ final class TiffExifReaderTest extends TestCase
 {
     private const int CUSTOM_SIGNED_LONG8_TAG = 0xC7A1;
 
+    private const int SUB_IFDS_TAG = 0x014A;
+
     /**
      * Expected StripOffsets values captured from ExifTool parsing the synthetic BigTIFF LONG8 fixture.
      *
@@ -188,6 +190,21 @@ final class TiffExifReaderTest extends TestCase
         $this->expectException(BoundsError::class);
 
         (new TiffExifReader())->parseFromBlob($blob);
+    }
+
+    /**
+     * Ensures SubIFDs pointers stored using the IFD field type are followed correctly.
+     */
+    #[Test]
+    public function decodesSubIfdPointers(): void
+    {
+        [$blob, $subIfdOffset] = $this->buildClassicSubIfdBlob();
+
+        $document   = (new TiffExifReader())->parseFromBlob($blob);
+        $subIfdsEntry = $document->ifd0->get(self::SUB_IFDS_TAG);
+
+        self::assertNotNull($subIfdsEntry);
+        self::assertSame($subIfdOffset, $subIfdsEntry->value);
     }
 
     /**
@@ -598,6 +615,38 @@ final class TiffExifReaderTest extends TestCase
         $exifIfd = pack('v', count($exifEntries)) . implode('', $exifEntries) . pack('V', 0);
 
         return $header . $ifd0 . $exifIfd;
+    }
+
+    /**
+     * Builds a Classic TIFF blob containing a SubIFDs tag that references an external IFD.
+     *
+     * @return array{0: string, 1: int}
+     */
+    private function buildClassicSubIfdBlob(): array
+    {
+        $header = 'II' . pack('v', 0x002A) . pack('V', 8);
+
+        $ifd0EntryCount         = 1;
+        $ifd0Size               = 2 + ($ifd0EntryCount * 12) + 4;
+        $pointerArrayOffset     = 8 + $ifd0Size;
+        $subIfdOffset           = 64;
+
+        $ifd0Entries = [
+            self::packClassicEntry(self::SUB_IFDS_TAG, 13, 1, $pointerArrayOffset),
+        ];
+
+        $blob = $header;
+        $blob .= pack('v', $ifd0EntryCount) . implode('', $ifd0Entries) . pack('V', 0);
+        $blob .= pack('V', $subIfdOffset);
+
+        $blob = str_pad($blob, $subIfdOffset, "\0", STR_PAD_RIGHT);
+
+        $subIfdEntries = [
+            self::packClassicEntry(ExifTag::ORIENTATION, 3, 1, 1),
+        ];
+        $blob .= pack('v', count($subIfdEntries)) . implode('', $subIfdEntries) . pack('V', 0);
+
+        return [$blob, $subIfdOffset];
     }
 
     /**


### PR DESCRIPTION
## Summary
- add the classic TIFF TYPE_IFD constant and decode it as an unsigned 32-bit offset
- always fetch pointed-to data for TYPE_IFD entries before decoding
- cover SubIFDs with a regression test that ensures type 13 pointers are followed

## Testing
- composer ci:test:php:unit *(fails: truth comparison fixtures are unavailable in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68fd026125a4832382f5daf4572c8238