### PR TITLE
feat: follow TIFF IFD chains

### DIFF
--- a/src/Model/Exif/ExifDocument.php
+++ b/src/Model/Exif/ExifDocument.php
@@ -49,12 +49,13 @@ final readonly class ExifDocument
     private bool $exifThreeOrNewer;
 
     /**
-     * @param Ifd                     $ifd0       Root IFD of the TIFF structure.
-     * @param Ifd|null                $exifIfd    Sub IFD containing EXIF-specific tags.
-     * @param Ifd|null                $gpsIfd     Sub IFD containing GPS-related tags.
-     * @param Ifd|null                $interopIfd Sub IFD containing interoperability tags.
-     * @param Ifd|null                $ifd1       Optional next IFD, typically thumbnails.
-     * @param MakerNotesMetadata|null $makerNotes Decoded maker note metadata provided by vendor decoders.
+     * @param Ifd                     $ifd0            Root IFD of the TIFF structure.
+     * @param Ifd|null                $exifIfd         Sub IFD containing EXIF-specific tags.
+     * @param Ifd|null                $gpsIfd          Sub IFD containing GPS-related tags.
+     * @param Ifd|null                $interopIfd      Sub IFD containing interoperability tags.
+     * @param Ifd|null                $ifd1            Optional next IFD, typically thumbnails.
+     * @param MakerNotesMetadata|null $makerNotes      Decoded maker note metadata provided by vendor decoders.
+     * @param list<Ifd>               $subsequentIfds Additional linked IFDs discovered via the next-pointer chain.
      */
     public function __construct(
         public Ifd $ifd0,
@@ -63,6 +64,7 @@ final readonly class ExifDocument
         public ?Ifd $interopIfd,
         public ?Ifd $ifd1,
         public ?MakerNotesMetadata $makerNotes = null,
+        public array $subsequentIfds = [],
     ) {
         $rawVersion        = $this->rawString($this->exifIfd, ExifTag::EXIF_VERSION);
         $this->exifVersion = CoreValueConverters::toExifVersion($rawVersion);
@@ -76,6 +78,16 @@ final readonly class ExifDocument
     public function makerNotes(): ?MakerNotesMetadata
     {
         return $this->makerNotes;
+    }
+
+    /**
+     * Returns any additional image file directories linked from IFD0.
+     *
+     * @return list<Ifd>
+     */
+    public function subsequentIfds(): array
+    {
+        return $this->subsequentIfds;
     }
 
     /**

--- a/src/Parse/Tiff/TiffExifReader.php
+++ b/src/Parse/Tiff/TiffExifReader.php
@@ -149,14 +149,30 @@ final class TiffExifReader
             $gpsIfd = $this->readIfd($this->pointerOffset($gpsPointer));
         }
 
+        $additionalIfds = [];
+        $visitedOffsets  = [];
+
         $nextOffset = $ifd0->nextIfdOffset;
-        if ($nextOffset !== null && $nextOffset > 0) {
-            $ifd1 = $this->readIfd($nextOffset);
+        while ($nextOffset !== null && $nextOffset > 0) {
+            if (isset($visitedOffsets[$nextOffset])) {
+                break;
+            }
+
+            $visitedOffsets[$nextOffset] = true;
+
+            $nextIfd       = $this->readIfd($nextOffset);
+            $additionalIfds[] = $nextIfd;
+
+            if ($ifd1 === null) {
+                $ifd1 = $nextIfd;
+            }
+
+            $nextOffset = $nextIfd->nextIfdOffset;
         }
 
         $makerNotes = $this->resolveMakerNotes($makerNotesRegistry, $ifd0, $exifIfd);
 
-        return new ExifDocument($ifd0, $exifIfd, $gpsIfd, $interopIfd, $ifd1, $makerNotes);
+        return new ExifDocument($ifd0, $exifIfd, $gpsIfd, $interopIfd, $ifd1, $makerNotes, $additionalIfds);
     }
 
     /**

--- a/tests/Parse/Tiff/TiffExifReaderTest.php
+++ b/tests/Parse/Tiff/TiffExifReaderTest.php
@@ -134,6 +134,26 @@ final class TiffExifReaderTest extends TestCase
         self::assertSame('Jane Doe', $resolver->copyright());
     }
 
+    #[Test]
+    public function parsesLinkedIfdChain(): void
+    {
+        $blob      = $this->buildClassicLinkedIfdBlob();
+        $document = (new TiffExifReader())->parseFromBlob($blob);
+
+        $subsequentIfds = $document->subsequentIfds();
+
+        self::assertCount(2, $subsequentIfds);
+        self::assertSame($document->ifd1, $subsequentIfds[0]);
+
+        $firstIfdEntry = $subsequentIfds[0]->get(ExifTag::IMAGE_HEIGHT);
+        self::assertNotNull($firstIfdEntry);
+        self::assertSame(200, $firstIfdEntry->value);
+
+        $secondIfdEntry = $subsequentIfds[1]->get(ExifTag::BITS_PER_SAMPLE);
+        self::assertNotNull($secondIfdEntry);
+        self::assertSame(16, $secondIfdEntry->value);
+    }
+
     /**
      * Ensures printable UNDEFINED payloads are normalised to strings.
      */
@@ -574,6 +594,33 @@ final class TiffExifReaderTest extends TestCase
         $blob .= $gpsAltData;
 
         return $blob;
+    }
+
+    /**
+     * Builds a Classic TIFF blob that chains multiple subsequent IFDs.
+     */
+    private function buildClassicLinkedIfdBlob(): string
+    {
+        $header = 'II' . pack('v', 0x002A) . pack('V', 8);
+
+        $ifdEntryCount = 1;
+        $ifdLength     = 2 + ($ifdEntryCount * 12) + 4;
+        $ifd1Offset    = 8 + $ifdLength;
+        $ifd2Offset    = $ifd1Offset + $ifdLength;
+
+        $ifd0 = pack('v', $ifdEntryCount)
+            . self::packClassicEntry(ExifTag::IMAGE_WIDTH, 3, 1, 100)
+            . pack('V', $ifd1Offset);
+
+        $ifd1 = pack('v', $ifdEntryCount)
+            . self::packClassicEntry(ExifTag::IMAGE_HEIGHT, 3, 1, 200)
+            . pack('V', $ifd2Offset);
+
+        $ifd2 = pack('v', $ifdEntryCount)
+            . self::packClassicEntry(ExifTag::BITS_PER_SAMPLE, 3, 1, 16)
+            . pack('V', 0);
+
+        return $header . $ifd0 . $ifd1 . $ifd2;
     }
 
     /**


### PR DESCRIPTION
## Summary
- iterate over the TIFF next-IFD chain so every linked directory is parsed
- surface the collected IFDs from ExifDocument for downstream consumers
- cover the behaviour with a synthetic TIFF fixture that links more than two IFDs

## Testing
- composer ci:test:php:unit *(fails: truth comparison fixtures are unavailable in the container)*
- composer ci:test:php:phpstan *(fails: existing baseline issues reported across the codebase)*

------
https://chatgpt.com/codex/tasks/task_e_68fd02a4c29c8323ac4a9cedaad913f7