### PR TITLE
feat: expose JPEG frame dimensions for fallbacks

### DIFF
--- a/src/Curate/StructuredMetadataBuilder.php
+++ b/src/Curate/StructuredMetadataBuilder.php
@@ -201,7 +201,7 @@ final class StructuredMetadataBuilder
 
         $camera = $this->buildCamera($exifResolver);
         $lens   = $this->buildLens($exifResolver);
-        $image  = $this->buildImage($exifResolver);
+        $image  = $this->buildImage($exifResolver, $metadata->jpegFrameWidth, $metadata->jpegFrameHeight);
 
         $exposure = new Exposure(
             iso: CompositeResolver::intISO($exifResolver),
@@ -644,13 +644,23 @@ final class StructuredMetadataBuilder
     /**
      * Builds the image value object using EXIF metadata.
      *
-     * @param ExifTagResolver $exif Resolver exposing image related EXIF tags.
+     * @param ExifTagResolver $exif        Resolver exposing image related EXIF tags.
+     * @param int|null        $frameWidth  Optional JPEG frame width used as fallback when EXIF is missing dimensions.
+     * @param int|null        $frameHeight Optional JPEG frame height used as fallback when EXIF is missing dimensions.
      *
      * @return Image Normalised image metadata aggregate.
      */
-    private function buildImage(ExifTagResolver $exif): Image
+    private function buildImage(ExifTagResolver $exif, ?int $frameWidth, ?int $frameHeight): Image
     {
         [$width, $height] = CompositeResolver::dimensions($exif);
+
+        if ($width === null) {
+            $width = $frameWidth;
+        }
+
+        if ($height === null) {
+            $height = $frameHeight;
+        }
 
         return new Image(
             width: $width,

--- a/src/MetadataReader.php
+++ b/src/MetadataReader.php
@@ -90,6 +90,8 @@ final class MetadataReader
         $iccProfile    = $jpeg->getIccProfile();
         $iccSegments   = $jpeg->getIccSegments();
         $bitsPerSample = $jpeg->getFrameSamplePrecision();
+        $frameHeight   = $jpeg->getFrameHeight();
+        $frameWidth    = $jpeg->getFrameWidth();
         $sampling      = $jpeg->getFrameComponentSamplingFactors();
         $subSampling   = $jpeg->getFrameYCbCrSubSampling();
 
@@ -123,6 +125,8 @@ final class MetadataReader
             $extension,
             $digestSha1,
             $digestMd5,
+            $frameWidth,
+            $frameHeight,
         );
     }
 

--- a/src/Model/Metadata.php
+++ b/src/Model/Metadata.php
@@ -56,6 +56,10 @@ final class Metadata
     /** @var array{0:int,1:int}|null */
     public readonly ?array $jpegYCbCrSubSampling;
 
+    public readonly ?int $jpegFrameWidth;
+
+    public readonly ?int $jpegFrameHeight;
+
     public readonly ?string $mimeType;
 
     public readonly ?int $fileSize;
@@ -81,6 +85,8 @@ final class Metadata
      * @param array<int, array{horizontal:int, vertical:int}>|null $jpegFrameSamplingFactors Component sampling factors by
      *                                                                                       identifier.
      * @param array{0:int,1:int}|null                              $jpegYCbCrSubSampling     Derived YCbCr subsampling from the JPEG frame header.
+     * @param int|null                                             $jpegFrameWidth           Frame width reported by the JPEG start of frame marker.
+     * @param int|null                                             $jpegFrameHeight          Frame height reported by the JPEG start of frame marker.
      * @param string|null                                          $mimeType                 Detected mime type for the source file.
      * @param int|null                                             $fileSize                 Size of the source file in bytes.
      * @param string|null                                          $extension                Lowercase file extension extracted from the path.
@@ -104,6 +110,8 @@ final class Metadata
         ?string $extension = null,
         ?string $digestSha1 = null,
         ?string $digestMd5 = null,
+        ?int $jpegFrameWidth = null,
+        ?int $jpegFrameHeight = null,
     ) {
         $this->exifBlobs                = $exifBlobs;
         $this->quickTime                = $quickTime;
@@ -121,6 +129,8 @@ final class Metadata
         $this->extension                = $extension;
         $this->digestSha1               = $digestSha1;
         $this->digestMd5                = $digestMd5;
+        $this->jpegFrameWidth           = $jpegFrameWidth;
+        $this->jpegFrameHeight          = $jpegFrameHeight;
     }
 
     /**

--- a/src/Parse/Jpeg/JpegExtractor.php
+++ b/src/Parse/Jpeg/JpegExtractor.php
@@ -97,6 +97,10 @@ final class JpegExtractor
 
     private ?int $frameBitsPerSample = null;
 
+    private ?int $frameHeight = null;
+
+    private ?int $frameWidth = null;
+
     /** @var array<int, array{horizontal: int, vertical: int}>|null */
     private ?array $frameComponentSampling = null;
 
@@ -183,6 +187,26 @@ final class JpegExtractor
     }
 
     /**
+     * Returns the frame height reported by the primary start of frame segment.
+     */
+    public function getFrameHeight(): ?int
+    {
+        $this->parseIfNeeded();
+
+        return $this->frameHeight;
+    }
+
+    /**
+     * Returns the frame width reported by the primary start of frame segment.
+     */
+    public function getFrameWidth(): ?int
+    {
+        $this->parseIfNeeded();
+
+        return $this->frameWidth;
+    }
+
+    /**
      * Returns the horizontal and vertical sampling factors for components identified in the SOF.
      *
      * @return array<int, array{horizontal:int, vertical:int}>|null
@@ -231,6 +255,8 @@ final class JpegExtractor
         $this->frameBitsPerSample     = null;
         $this->frameComponentSampling = null;
         $this->frameYCbCrSubSampling  = null;
+        $this->frameHeight            = null;
+        $this->frameWidth             = null;
 
         while (true) {
             [$marker, $offset] = $this->nextMarkerWithOffset();
@@ -492,6 +518,14 @@ final class JpegExtractor
             ];
 
             $index += 3;
+        }
+
+        if ($this->frameHeight === null) {
+            $this->frameHeight = (ord($payload[1]) << 8) | ord($payload[2]);
+        }
+
+        if ($this->frameWidth === null) {
+            $this->frameWidth = (ord($payload[3]) << 8) | ord($payload[4]);
         }
 
         $this->frameBitsPerSample     = ord($payload[0]);

--- a/tests/TruthComparisonTest.php
+++ b/tests/TruthComparisonTest.php
@@ -98,6 +98,13 @@ final class TruthComparisonTest extends TestCase
         $this->assertSame((int)($exif['File:ImageWidth'] ?? 0), $meta->image->width ?? 0, "$file: width");
         $this->assertSame((int)($exif['File:ImageHeight'] ?? 0), $meta->image->height ?? 0, "$file: height");
 
+        if ($file === 'Landscape_0.jpg') {
+            $this->assertNotNull($meta->image->width, 'Landscape_0.jpg: width fallback expected non-null value');
+            $this->assertNotNull($meta->image->height, 'Landscape_0.jpg: height fallback expected non-null value');
+            $this->assertSame((int)($exif['File:ImageWidth'] ?? 0), $meta->image->width, 'Landscape_0.jpg: width fallback matches ExifTool');
+            $this->assertSame((int)($exif['File:ImageHeight'] ?? 0), $meta->image->height, 'Landscape_0.jpg: height fallback matches ExifTool');
+        }
+
         // Orientation
         if (isset($exif['IFD0:Orientation'], $this->map['Orientation'])) {
             $ok = $this->norm->compareEnum('Orientation', (int)$exif['IFD0:Orientation'], $meta->image->orientation ?? null);


### PR DESCRIPTION
## Summary
- capture JPEG frame dimensions from SOF markers and expose them via the metadata aggregate
- fall back to the captured frame dimensions when curated image metadata lacks EXIF width/height
- extend the truth comparison to assert the Landscape_0.jpg fallback against ExifTool output

## Testing
- composer ci:test:php:unit *(fails: unsupported HEIC fixtures in current environment and existing orientation mismatches)*
- composer ci:test:php:phpstan *(fails: pre-existing baseline violations outside the change scope)*

------
https://chatgpt.com/codex/tasks/task_e_68fd05c8db908323ad8a6298e018fbb6