### PR TITLE
fix: fallback image bits per sample to jpeg precision

### DIFF
--- a/src/Curate/StructuredMetadataBuilder.php
+++ b/src/Curate/StructuredMetadataBuilder.php
@@ -153,7 +153,12 @@ final class StructuredMetadataBuilder
 
         $interop = new Interop(index: $exifResolver->interopIndex());
 
-        $bitsPerSample    = $exifResolver->bitsPerSample() ?? $metadata->jpegBitsPerSample;
+        $jpegBitsPerSample = $metadata->jpegBitsPerSample;
+
+        $bitsPerSample    = $exifResolver->bitsPerSample();
+        if ($bitsPerSample === null) {
+            $bitsPerSample = $jpegBitsPerSample;
+        }
         $ycbcrSubSampling = $exifResolver->ycbcrSubSampling();
         if ($ycbcrSubSampling === null) {
             $ycbcrSubSampling = $metadata->jpegYCbCrSubSampling;
@@ -201,7 +206,7 @@ final class StructuredMetadataBuilder
 
         $camera = $this->buildCamera($exifResolver);
         $lens   = $this->buildLens($exifResolver);
-        $image  = $this->buildImage($exifResolver);
+        $image  = $this->buildImage($exifResolver, $jpegBitsPerSample);
 
         $exposure = new Exposure(
             iso: CompositeResolver::intISO($exifResolver),
@@ -644,19 +649,25 @@ final class StructuredMetadataBuilder
     /**
      * Builds the image value object using EXIF metadata.
      *
-     * @param ExifTagResolver $exif Resolver exposing image related EXIF tags.
+     * @param ExifTagResolver $exif             Resolver exposing image related EXIF tags.
+     * @param int|null        $jpegBitsPerSample Sample precision reported by the JPEG frame header.
      *
      * @return Image Normalised image metadata aggregate.
      */
-    private function buildImage(ExifTagResolver $exif): Image
+    private function buildImage(ExifTagResolver $exif, ?int $jpegBitsPerSample): Image
     {
         [$width, $height] = CompositeResolver::dimensions($exif);
+
+        $bitsPerSample = $exif->bitsPerSample();
+        if ($bitsPerSample === null) {
+            $bitsPerSample = $jpegBitsPerSample;
+        }
 
         return new Image(
             width: $width,
             height: $height,
             orientation: $exif->orientation(),
-            bitsPerSample: $exif->bitsPerSample(),
+            bitsPerSample: $bitsPerSample,
             colorSpace: $this->normalizedColorSpace($exif),
             imageUniqueId: $exif->imageUniqueId(),
             imageNumber: $exif->imageNumber(),

--- a/tests/TruthComparisonTest.php
+++ b/tests/TruthComparisonTest.php
@@ -80,6 +80,26 @@ final class TruthComparisonTest extends TestCase
     }
 
     #[Test]
+    public function test_landscape_bits_per_sample_matches_exiftool_file_precision(): void
+    {
+        $file = 'Landscape_0.jpg';
+        $exif = $this->loadExifToolJson($file);
+
+        self::assertArrayHasKey('File:BitsPerSample', $exif);
+        self::assertNull($exif['EXIF:BitsPerSample'] ?? null);
+
+        $meta = (new MetadataReader())
+            ->read(self::IMAGES . '/' . $file)
+            ->structured();
+
+        self::assertSame(
+            (int) $exif['File:BitsPerSample'],
+            $meta->image->bitsPerSample,
+            $file . ': bitsPerSample',
+        );
+    }
+
+    #[Test]
     #[DataProvider('provideFiles')]
     public function test_core_fields_match_exiftool(string $file): void
     {


### PR DESCRIPTION
## Summary
- reuse the JPEG frame precision as fallback when EXIF bits per sample is missing in the structured image data
- add a truth comparison to ensure Landscape_0.jpg reports the expected bitsPerSample value from ExifTool

## Testing
- .build/bin/phpunit --configuration .build/phpunit.xml --filter test_landscape_bits_per_sample_matches_exiftool_file_precision

------
https://chatgpt.com/codex/tasks/task_e_68fd05c8f59c8323b6b4fbed7b7ee4bf