### PR TITLE
feat: retain raw GPS speed and distance metadata

### DIFF
--- a/src/Curate/Resolver/GpsResolver.php
+++ b/src/Curate/Resolver/GpsResolver.php
@@ -62,6 +62,8 @@ final readonly class GpsResolver
         $dop         = $this->floatValue($gpsData['dop'] ?? null);
         $speedRef    = $this->uppercase($gpsData['speed_ref'] ?? null);
         $speedMs     = $this->floatValue($gpsData['speed_ms'] ?? null);
+        $speedOriginalRef = $this->stringValue($gpsData['speed_original_ref'] ?? null);
+        $speedOriginal    = $this->floatValue($gpsData['speed_original'] ?? null);
         $trackRef    = $this->uppercase($gpsData['track_ref'] ?? null);
         $track       = $this->floatValue($gpsData['track'] ?? null);
         $imgDirRef   = $this->uppercase($gpsData['img_direction_ref'] ?? null);
@@ -76,6 +78,8 @@ final readonly class GpsResolver
         $destBear      = $this->floatValue($gpsData['dest_bearing'] ?? null);
         $destDistRef   = $this->uppercase($gpsData['dest_distance_ref'] ?? null);
         $destDistMetre = $this->floatValue($gpsData['dest_distance_m'] ?? null);
+        $destDistOriginalRef = $this->stringValue($gpsData['dest_distance_original_ref'] ?? null);
+        $destDistOriginal    = $this->floatValue($gpsData['dest_distance_original'] ?? null);
 
         $processingMethod = $this->stringValue($gpsData['processing_method'] ?? null);
         $areaInformation  = $this->stringValue($gpsData['area_information'] ?? null);
@@ -139,14 +143,42 @@ final readonly class GpsResolver
             }
         }
 
+        $xmpSpeedRef = $this->xmpString($xmpDocument, self::NS_EXIF, 'GPSSpeedRef');
         if ($speedRef === null) {
-            $speedRef = $this->uppercase($this->xmpString($xmpDocument, self::NS_EXIF, 'GPSSpeedRef'));
+            $speedRef = $this->uppercase($xmpSpeedRef);
+        }
+        if ($speedOriginalRef === null) {
+            $speedOriginalRef = $this->stringValue($xmpSpeedRef);
         }
 
-        if ($speedMs === null) {
-            $speedValue = $this->xmpFloat($xmpDocument, self::NS_EXIF, 'GPSSpeed');
-            if ($speedValue !== null && $speedRef !== null) {
+        $speedValue = $this->xmpFloat($xmpDocument, self::NS_EXIF, 'GPSSpeed');
+        if ($speedValue !== null) {
+            if ($speedMs === null && $speedRef !== null) {
                 $speedMs = $this->convertSpeedToMetresPerSecond($speedValue, $speedRef);
+            }
+            if ($speedOriginal === null) {
+                $speedOriginal = $speedValue;
+            }
+        }
+
+        $xmpDestDistRef = $this->xmpString($xmpDocument, self::NS_EXIF, 'GPSDestDistanceRef');
+        if ($destDistRef === null) {
+            $destDistRef = $this->uppercase($xmpDestDistRef);
+        }
+        if ($destDistOriginalRef === null) {
+            $destDistOriginalRef = $this->stringValue($xmpDestDistRef);
+        }
+
+        $destDistValue = $this->xmpFloat($xmpDocument, self::NS_EXIF, 'GPSDestDistance');
+        if ($destDistValue !== null) {
+            if ($destDistMetre === null && $destDistRef !== null) {
+                $convertedDistance = $this->convertDistanceToMetres($destDistValue, $destDistRef);
+                if ($convertedDistance !== null) {
+                    $destDistMetre = $convertedDistance;
+                }
+            }
+            if ($destDistOriginal === null) {
+                $destDistOriginal = $destDistValue;
             }
         }
 
@@ -180,6 +212,8 @@ final readonly class GpsResolver
             $dop,
             $speedRef,
             $speedMs,
+            $speedOriginalRef,
+            $speedOriginal,
             $trackRef,
             $track,
             $imgDirRef,
@@ -193,6 +227,8 @@ final readonly class GpsResolver
             $destBear,
             $destDistRef,
             $destDistMetre,
+            $destDistOriginalRef,
+            $destDistOriginal,
             $processingMethod,
             $areaInformation,
             $date,
@@ -220,6 +256,8 @@ final readonly class GpsResolver
             dop: $dop,
             speedRef: $speedRef,
             speedMs: $speedMs,
+            speedOriginalRef: $speedOriginalRef,
+            speedOriginal: $speedOriginal,
             trackRef: $trackRef,
             track: $track,
             imageDirectionRef: $imgDirRef,
@@ -233,6 +271,8 @@ final readonly class GpsResolver
             destinationBearing: $destBear,
             destinationDistanceRef: $destDistRef,
             destinationDistanceMetres: $destDistMetre,
+            destinationDistanceOriginalRef: $destDistOriginalRef,
+            destinationDistanceOriginal: $destDistOriginal,
             processingMethod: $processingMethod,
             areaInformation: $areaInformation,
             date: $date,
@@ -433,6 +473,19 @@ final readonly class GpsResolver
         }
 
         return $dateTime->setTimezone(new DateTimeZone('UTC'));
+    }
+
+    /**
+     * Converts destination distance into metres using GPSDestDistanceRef semantics.
+     */
+    private function convertDistanceToMetres(float $distance, string $distanceRef): ?float
+    {
+        return match ($distanceRef) {
+            'K'     => $distance * 1000.0,
+            'M'     => $distance * 1609.344,
+            'N'     => $distance * 1852.0,
+            default => null,
+        };
     }
 
     /**

--- a/src/Model/Exif/ValueConverters.php
+++ b/src/Model/Exif/ValueConverters.php
@@ -61,6 +61,8 @@ use function trim;
  *     dop:?float,
  *     speed_ref:?string,
  *     speed_ms:?float,
+ *     speed_original_ref:?string,
+ *     speed_original:?float,
  *     track_ref:?string,
  *     track:?float,
  *     img_direction_ref:?string,
@@ -74,6 +76,8 @@ use function trim;
  *     dest_bearing:?float,
  *     dest_distance_ref:?string,
  *     dest_distance_m:?float,
+ *     dest_distance_original_ref:?string,
+ *     dest_distance_original:?float,
  *     processing_method:?string,
  *     area_information:?string,
  *     date:?string,
@@ -437,6 +441,8 @@ final readonly class ValueConverters
             'dop'                 => null,
             'speed_ref'           => null,
             'speed_ms'            => null,
+            'speed_original_ref'  => null,
+            'speed_original'      => null,
             'track_ref'           => null,
             'track'               => null,
             'img_direction_ref'   => null,
@@ -450,6 +456,8 @@ final readonly class ValueConverters
             'dest_bearing'        => null,
             'dest_distance_ref'   => null,
             'dest_distance_m'     => null,
+            'dest_distance_original_ref' => null,
+            'dest_distance_original'     => null,
             'processing_method'   => null,
             'area_information'    => null,
             'date'                => null,
@@ -544,10 +552,13 @@ final readonly class ValueConverters
         $result['measure_mode'] = self::sanitizeString($measureEntry?->value);
         $result['dop']          = self::rationalToFloat($dopEntry?->value);
 
-        $speedRefValue       = $speedRefEntry?->value;
-        $speedRef            = is_string($speedRefValue) ? strtoupper(trim($speedRefValue)) : null;
-        $result['speed_ref'] = $speedRef;
-        $result['speed_ms']  = self::gpsSpeedToMs($speedRef, $speedEntry?->value);
+        $speedRefValue                = $speedRefEntry?->value;
+        $speedOriginalRef             = self::sanitizeString($speedRefValue);
+        $speedRef                     = is_string($speedRefValue) ? strtoupper(trim($speedRefValue)) : null;
+        $result['speed_ref']          = $speedRef;
+        $result['speed_ms']           = self::gpsSpeedToMs($speedRef, $speedEntry?->value);
+        $result['speed_original_ref'] = $speedOriginalRef;
+        $result['speed_original']     = self::rationalToFloat($speedEntry?->value);
 
         $trackRefValue       = $trackRefEntry?->value;
         $result['track_ref'] = is_string($trackRefValue) ? strtoupper(trim($trackRefValue)) : null;
@@ -578,9 +589,11 @@ final readonly class ValueConverters
         $destBearingValue           = self::rationalToFloat($destBearEntry?->value);
         $result['dest_bearing']     = self::normalizeBearing($destBearingValue);
 
-        $destDistanceRefValue        = $destDistRefEntry?->value;
-        $result['dest_distance_ref'] = is_string($destDistanceRefValue) ? strtoupper(trim($destDistanceRefValue)) : null;
-        $result['dest_distance_m']   = self::gpsDistanceToMetres($result['dest_distance_ref'], $destDistEntry?->value);
+        $destDistanceRefValue                 = $destDistRefEntry?->value;
+        $result['dest_distance_ref']            = is_string($destDistanceRefValue) ? strtoupper(trim($destDistanceRefValue)) : null;
+        $result['dest_distance_original_ref']   = self::sanitizeString($destDistanceRefValue);
+        $result['dest_distance_original']       = self::rationalToFloat($destDistEntry?->value);
+        $result['dest_distance_m']              = self::gpsDistanceToMetres($result['dest_distance_ref'], $destDistEntry?->value);
 
         $result['processing_method'] = self::decodeUndefinedString($processEntry?->value);
         $result['area_information']  = self::decodeUndefinedString($areaEntry?->value);

--- a/src/Value/Gps.php
+++ b/src/Value/Gps.php
@@ -32,6 +32,8 @@ final readonly class Gps
      * @param float|null             $dop                        Dilution of precision.
      * @param string|null            $speedRef                   Speed reference unit (K/M/N).
      * @param float|null             $speedMs                    Ground speed in metres per second.
+     * @param string|null            $speedOriginalRef           Original speed reference unit.
+     * @param float|null             $speedOriginal              Raw ground speed in the original unit.
      * @param string|null            $trackRef                   Course over ground reference (T/M).
      * @param float|null             $track                      Course over ground in degrees.
      * @param string|null            $imageDirectionRef          Image direction reference (T/M).
@@ -45,6 +47,8 @@ final readonly class Gps
      * @param float|null             $destinationBearing         Destination bearing in degrees.
      * @param string|null            $destinationDistanceRef     Destination distance reference (K/M/N).
      * @param float|null             $destinationDistanceMetres  Destination distance in metres.
+     * @param string|null            $destinationDistanceOriginalRef Destination distance reference in original unit.
+     * @param float|null             $destinationDistanceOriginal Raw destination distance in the original unit.
      * @param string|null            $processingMethod           GPS processing method description.
      * @param string|null            $areaInformation            GPS area information description.
      * @param string|null            $date                       GPS date stamp in ISO 8601 calendar format.
@@ -67,6 +71,8 @@ final readonly class Gps
         public ?float $dop = null,
         public ?string $speedRef = null,
         public ?float $speedMs = null,
+        public ?string $speedOriginalRef = null,
+        public ?float $speedOriginal = null,
         public ?string $trackRef = null,
         public ?float $track = null,
         public ?string $imageDirectionRef = null,
@@ -80,6 +86,8 @@ final readonly class Gps
         public ?float $destinationBearing = null,
         public ?string $destinationDistanceRef = null,
         public ?float $destinationDistanceMetres = null,
+        public ?string $destinationDistanceOriginalRef = null,
+        public ?float $destinationDistanceOriginal = null,
         public ?string $processingMethod = null,
         public ?string $areaInformation = null,
         public ?string $date = null,

--- a/tests/Curate/Resolver/GpsResolverTest.php
+++ b/tests/Curate/Resolver/GpsResolverTest.php
@@ -135,6 +135,10 @@ final class GpsResolverTest extends TestCase
         self::assertSame('12:34:56.789', $gps->time);
         self::assertInstanceOf(DateTimeImmutable::class, $gps->timestamp);
         self::assertSame('2024-05-06T12:34:56+00:00', $gps->timestamp?->format(DATE_ATOM));
+        self::assertSame('K', $gps->speedOriginalRef);
+        self::assertEqualsWithDelta(72.0, $gps->speedOriginal, 1e-6);
+        self::assertSame('K', $gps->destinationDistanceOriginalRef);
+        self::assertEqualsWithDelta(42.0, $gps->destinationDistanceOriginal, 1e-6);
         self::assertEqualsWithDelta(42000.0, $gps->destinationDistanceMetres, 1e-6);
         self::assertEqualsWithDelta(1.5, $gps->horizontalPositioningError, 1e-6);
     }
@@ -151,6 +155,8 @@ final class GpsResolverTest extends TestCase
             '{http://ns.adobe.com/exif/1.0/}GPSAltitude'     => ['120.5'],
             '{http://ns.adobe.com/exif/1.0/}GPSSpeedRef'     => ['K'],
             '{http://ns.adobe.com/exif/1.0/}GPSSpeed'        => ['72'],
+            '{http://ns.adobe.com/exif/1.0/}GPSDestDistanceRef' => ['N'],
+            '{http://ns.adobe.com/exif/1.0/}GPSDestDistance'    => ['1.5'],
             '{http://ns.adobe.com/exif/1.0/}GPSDateStamp'    => ['2024-05-06'],
             '{http://ns.adobe.com/exif/1.0/}GPSTimeStamp'    => ['12:34:56'],
             '{http://ns.adobe.com/exif/1.0/}GPSDateTime'     => ['2024-05-06T12:34:56+02:00'],
@@ -167,6 +173,11 @@ final class GpsResolverTest extends TestCase
         self::assertEqualsWithDelta(-120.5, $gps->altitude ?? 0.0, 1e-6);
         self::assertSame('K', $gps->speedRef);
         self::assertEqualsWithDelta(20.0, $gps->speedMs ?? 0.0, 1e-6);
+        self::assertSame('K', $gps->speedOriginalRef);
+        self::assertEqualsWithDelta(72.0, $gps->speedOriginal ?? 0.0, 1e-6);
+        self::assertEqualsWithDelta(2778.0, $gps->destinationDistanceMetres ?? 0.0, 1e-6);
+        self::assertSame('N', $gps->destinationDistanceOriginalRef);
+        self::assertEqualsWithDelta(1.5, $gps->destinationDistanceOriginal ?? 0.0, 1e-6);
         self::assertSame('2024-05-06T10:34:56+00:00', $gps->timestamp?->format(DATE_ATOM));
     }
 }

--- a/tests/Curate/StructuredMetadataBuilderTest.php
+++ b/tests/Curate/StructuredMetadataBuilderTest.php
@@ -1424,6 +1424,8 @@ final class StructuredMetadataBuilderTest extends TestCase
 
         self::assertSame('K', $structured->gps->speedRef);
         self::assertEqualsWithDelta(33.3333333, $structured->gps->speedMs, 1e-6);
+        self::assertSame('K', $structured->gps->speedOriginalRef);
+        self::assertEqualsWithDelta(120.0, $structured->gps->speedOriginal, 1e-6);
     }
 
     /**
@@ -1530,6 +1532,8 @@ final class StructuredMetadataBuilderTest extends TestCase
         self::assertEqualsWithDelta(2.5, $structured->gps->dop, 1e-6);
         self::assertSame('K', $structured->gps->speedRef);
         self::assertEqualsWithDelta(20.0, $structured->gps->speedMs, 1e-6);
+        self::assertSame('K', $structured->gps->speedOriginalRef);
+        self::assertEqualsWithDelta(72.0, $structured->gps->speedOriginal, 1e-6);
         self::assertSame('T', $structured->gps->trackRef);
         self::assertEqualsWithDelta(123.45, $structured->gps->track, 1e-6);
         self::assertSame('M', $structured->gps->imageDirectionRef);
@@ -1543,6 +1547,8 @@ final class StructuredMetadataBuilderTest extends TestCase
         self::assertEqualsWithDelta(123.0, $structured->gps->destinationBearing, 1e-6);
         self::assertSame('K', $structured->gps->destinationDistanceRef);
         self::assertEqualsWithDelta(42000.0, $structured->gps->destinationDistanceMetres, 1e-6);
+        self::assertSame('K', $structured->gps->destinationDistanceOriginalRef);
+        self::assertEqualsWithDelta(42.0, $structured->gps->destinationDistanceOriginal, 1e-6);
         self::assertSame('NETWORK', $structured->gps->processingMethod);
         self::assertSame('AreaName', $structured->gps->areaInformation);
         self::assertSame('2024-05-06', $structured->gps->date);

--- a/tests/Model/Exif/ValueConvertersTest.php
+++ b/tests/Model/Exif/ValueConvertersTest.php
@@ -504,6 +504,8 @@ final class ValueConvertersTest extends TestCase
         self::assertEqualsWithDelta(2.5, $result['dop'], 0.000001);
         self::assertSame('K', $result['speed_ref']);
         self::assertEqualsWithDelta(20.0, $result['speed_ms'], 0.000001);
+        self::assertSame('K', $result['speed_original_ref']);
+        self::assertEqualsWithDelta(72.0, $result['speed_original'], 0.000001);
         self::assertSame('T', $result['track_ref']);
         self::assertEqualsWithDelta(123.45, $result['track'], 0.000001);
         self::assertSame('M', $result['img_direction_ref']);
@@ -517,6 +519,8 @@ final class ValueConvertersTest extends TestCase
         self::assertEqualsWithDelta(123.0, $result['dest_bearing'], 0.000001);
         self::assertSame('K', $result['dest_distance_ref']);
         self::assertEqualsWithDelta(42000.0, $result['dest_distance_m'], 0.000001);
+        self::assertSame('K', $result['dest_distance_original_ref']);
+        self::assertEqualsWithDelta(42.0, $result['dest_distance_original'], 0.000001);
         self::assertSame('NETWORK', $result['processing_method']);
         self::assertSame('AreaName', $result['area_information']);
         self::assertSame('2024-05-06', $result['date']);


### PR DESCRIPTION
## Summary
- add optional raw speed and destination distance fields to the GPS value object
- persist original EXIF and XMP GPS measurements in the converter and resolver, including XMP fallback logic
- extend structured metadata and unit tests to cover both normalised and raw GPS values

## Testing
- composer ci:test:php:unit *(fails: unsupported or unknown container for HEIC fixtures in this environment)*
- .build/bin/phpunit --configuration .build/phpunit.xml tests/Model/Exif/ValueConvertersTest.php
- .build/bin/phpunit --configuration .build/phpunit.xml tests/Curate/Resolver/GpsResolverTest.php
- .build/bin/phpunit --configuration .build/phpunit.xml tests/Curate/StructuredMetadataBuilderTest.php

------
https://chatgpt.com/codex/tasks/task_e_68fd05e62b988323aebc1cd86b205788