### PR TITLE
feat(gps): expose raw GPS version and date metadata

### DIFF
--- a/src/Curate/Resolver/GpsResolver.php
+++ b/src/Curate/Resolver/GpsResolver.php
@@ -56,6 +56,10 @@ final readonly class GpsResolver
         $altitudeRef  = $this->intValue($gpsData['alt_ref'] ?? null);
 
         $version     = $this->stringValue($gpsData['version'] ?? null);
+        $versionRaw  = $gpsData['version_raw'] ?? null;
+        if (!is_string($versionRaw)) {
+            $versionRaw = null;
+        }
         $satellites  = $this->stringValue($gpsData['satellites'] ?? null);
         $status      = $this->stringValue($gpsData['status'] ?? null);
         $measureMode = $this->stringValue($gpsData['measure_mode'] ?? null);
@@ -80,7 +84,11 @@ final readonly class GpsResolver
         $processingMethod = $this->stringValue($gpsData['processing_method'] ?? null);
         $areaInformation  = $this->stringValue($gpsData['area_information'] ?? null);
 
-        $date = $this->normaliseDate($this->stringValue($gpsData['date'] ?? null));
+        $date    = $this->normaliseDate($this->stringValue($gpsData['date'] ?? null));
+        $dateRaw = $gpsData['date_raw'] ?? null;
+        if (!is_string($dateRaw)) {
+            $dateRaw = null;
+        }
         $time = $this->stringValue($gpsData['time'] ?? null);
 
         $timestamp = $exifDocument?->gpsTimestamp();
@@ -174,6 +182,7 @@ final readonly class GpsResolver
             $altitude,
             $altitudeRef,
             $version,
+            $versionRaw,
             $satellites,
             $status,
             $measureMode,
@@ -196,6 +205,7 @@ final readonly class GpsResolver
             $processingMethod,
             $areaInformation,
             $date,
+            $dateRaw,
             $time,
             $timestamp,
             $differential,
@@ -214,6 +224,7 @@ final readonly class GpsResolver
             altitude: $altitude,
             altitudeRef: $altitudeRef,
             version: $version,
+            versionRaw: $versionRaw,
             satellites: $satellites,
             status: $status,
             measureMode: $measureMode,
@@ -236,6 +247,7 @@ final readonly class GpsResolver
             processingMethod: $processingMethod,
             areaInformation: $areaInformation,
             date: $date,
+            dateRaw: $dateRaw,
             time: $time,
             timestamp: $timestamp,
             differential: $differential,

--- a/src/Model/Exif/ValueConverters.php
+++ b/src/Model/Exif/ValueConverters.php
@@ -538,7 +538,9 @@ final readonly class ValueConverters
         $dateEntry        = $gps->get(ExifTag::GPS_DATE_STAMP);
         $timeEntry        = $gps->get(ExifTag::GPS_TIME_STAMP);
 
-        $result['version']      = self::formatGpsVersion($versionEntry?->value);
+        $versionParts            = self::formatGpsVersion($versionEntry?->value);
+        $result['version']      = $versionParts['normalized'];
+        $result['version_raw']  = $versionParts['raw'];
         $result['satellites']   = self::sanitizeString($satellitesEntry?->value);
         $result['status']       = self::sanitizeString($statusEntry?->value);
         $result['measure_mode'] = self::sanitizeString($measureEntry?->value);
@@ -585,7 +587,9 @@ final readonly class ValueConverters
         $result['processing_method'] = self::decodeUndefinedString($processEntry?->value);
         $result['area_information']  = self::decodeUndefinedString($areaEntry?->value);
 
-        $result['date'] = self::normalizeGpsDate($dateEntry?->value);
+        $dateParts       = self::normalizeGpsDate($dateEntry?->value);
+        $result['date'] = $dateParts['normalized'];
+        $result['date_raw'] = $dateParts['raw'];
         $timeParts      = $timeEntry instanceof IfdEntry && $timeEntry->value instanceof ExifRationalList
             ? self::parseGpsTime($timeEntry->value)
             : null;
@@ -641,33 +645,60 @@ final readonly class ValueConverters
      * Converts a GPS version payload into a dotted string.
      *
      * @param ExifScalar $value Raw value extracted from the IFD entry.
+     *
+     * @return array{normalized: ?string, raw: ?string}
      */
-    private static function formatGpsVersion(string|int|float|ExifRational|ExifRationalList|ExifNumericList|null $value): ?string
-    {
+    private static function formatGpsVersion(
+        string|int|float|ExifRational|ExifRationalList|ExifNumericList|null $value,
+    ): array {
+        $raw = is_string($value) ? $value : null;
+        $normalized = null;
+
         if ($value instanceof ExifNumericList) {
             $components = array_map(static fn (int|float $component): int => (int) $component, $value->values);
 
-            return implode('.', $components);
+            $normalized = implode('.', $components);
+
+            return [
+                'normalized' => $normalized,
+                'raw' => $raw,
+            ];
         }
 
         if (is_string($value)) {
-            $value = trim(str_replace("\0", '', $value));
-            if ($value === '') {
-                return null;
+            $clean = trim(str_replace("\0", '', $value));
+            if ($clean !== '') {
+                $normalized = $clean;
             }
 
-            return $value;
+            return [
+                'normalized' => $normalized,
+                'raw' => $raw,
+            ];
         }
 
         if (is_int($value)) {
-            return (string) $value;
+            $normalized = (string) $value;
+
+            return [
+                'normalized' => $normalized,
+                'raw' => null,
+            ];
         }
 
         if (is_float($value)) {
-            return (string) $value;
+            $normalized = (string) $value;
+
+            return [
+                'normalized' => $normalized,
+                'raw' => null,
+            ];
         }
 
-        return null;
+        return [
+            'normalized' => null,
+            'raw' => $raw,
+        ];
     }
 
     /**
@@ -723,24 +754,39 @@ final readonly class ValueConverters
      * Normalises a GPS date stamp into an ISO 8601 calendar date.
      *
      * @param ExifScalar $value Raw value extracted from the IFD entry.
+     *
+     * @return array{normalized: ?string, raw: ?string}
      */
     private static function normalizeGpsDate(
         string|int|float|ExifRational|ExifRationalList|ExifNumericList|null $value,
-    ): ?string {
+    ): array {
+        $raw = is_string($value) ? $value : null;
         if (!is_string($value)) {
-            return null;
+            return [
+                'normalized' => null,
+                'raw' => $raw,
+            ];
         }
 
-        $value = trim(str_replace("\0", '', $value));
-        if ($value === '') {
-            return null;
+        $clean = trim(str_replace("\0", '', $value));
+        if ($clean === '') {
+            return [
+                'normalized' => null,
+                'raw' => $raw,
+            ];
         }
 
-        if (preg_match('/^\d{4}:\d{2}:\d{2}$/', $value) !== 1) {
-            return null;
+        if (preg_match('/^\d{4}:\d{2}:\d{2}$/', $clean) !== 1) {
+            return [
+                'normalized' => null,
+                'raw' => $raw,
+            ];
         }
 
-        return str_replace(':', '-', $value);
+        return [
+            'normalized' => str_replace(':', '-', $clean),
+            'raw' => $raw,
+        ];
     }
 
     /**

--- a/src/Value/Gps.php
+++ b/src/Value/Gps.php
@@ -26,6 +26,7 @@ final readonly class Gps
      * @param float|null             $altitude                   Altitude in metres relative to sea level.
      * @param int|null               $altitudeRef                Altitude reference (0 = above, 1 = below sea level).
      * @param string|null            $version                    GPS metadata version string.
+     * @param string|null            $versionRaw                 Raw GPS version payload without normalisation.
      * @param string|null            $satellites                 Satellites used for measurement.
      * @param string|null            $status                     Receiver status at capture time.
      * @param string|null            $measureMode                Measurement mode (2 = 2D, 3 = 3D).
@@ -48,6 +49,7 @@ final readonly class Gps
      * @param string|null            $processingMethod           GPS processing method description.
      * @param string|null            $areaInformation            GPS area information description.
      * @param string|null            $date                       GPS date stamp in ISO 8601 calendar format.
+     * @param string|null            $dateRaw                    Raw GPS date payload without normalisation.
      * @param string|null            $time                       GPS time stamp in HH:MM:SS(.sss) format.
      * @param DateTimeImmutable|null $timestamp                  Combined UTC timestamp when available.
      * @param int|null               $differential               Differential GPS indicator.
@@ -61,6 +63,7 @@ final readonly class Gps
         public ?float $altitude = null,
         public ?int $altitudeRef = null,
         public ?string $version = null,
+        public ?string $versionRaw = null,
         public ?string $satellites = null,
         public ?string $status = null,
         public ?string $measureMode = null,
@@ -83,6 +86,7 @@ final readonly class Gps
         public ?string $processingMethod = null,
         public ?string $areaInformation = null,
         public ?string $date = null,
+        public ?string $dateRaw = null,
         public ?string $time = null,
         public ?DateTimeImmutable $timestamp = null,
         public ?int $differential = null,

--- a/tests/Curate/Resolver/GpsResolverTest.php
+++ b/tests/Curate/Resolver/GpsResolverTest.php
@@ -33,7 +33,7 @@ final class GpsResolverTest extends TestCase
     public function resolvesCompleteGpsDatasetFromExif(): void
     {
         $gpsIfd = new Ifd([
-            ExifTag::GPS_VERSION_ID   => new IfdEntry(ExifTag::GPS_VERSION_ID, 1, 4, [3, 0, 0, 0]),
+            ExifTag::GPS_VERSION_ID   => new IfdEntry(ExifTag::GPS_VERSION_ID, 2, 9, '3.0.0.0' . chr(0)),
             ExifTag::GPS_LATITUDE_REF => new IfdEntry(ExifTag::GPS_LATITUDE_REF, 2, 2, 'N'),
             ExifTag::GPS_LATITUDE     => new IfdEntry(
                 ExifTag::GPS_LATITUDE,
@@ -128,10 +128,13 @@ final class GpsResolverTest extends TestCase
         self::assertSame('N', $gps->latitudeRef);
         self::assertSame('E', $gps->longitudeRef);
         self::assertEqualsWithDelta(150.0, $gps->altitude, 1e-6);
+        self::assertSame('3.0.0.0', $gps->version);
+        self::assertSame('3.0.0.0' . chr(0), $gps->versionRaw);
         self::assertSame('05', $gps->satellites);
         self::assertSame('NETWORK', $gps->processingMethod);
         self::assertSame('AreaName', $gps->areaInformation);
         self::assertSame('2024-05-06', $gps->date);
+        self::assertSame('2024:05:06', $gps->dateRaw);
         self::assertSame('12:34:56.789', $gps->time);
         self::assertInstanceOf(DateTimeImmutable::class, $gps->timestamp);
         self::assertSame('2024-05-06T12:34:56+00:00', $gps->timestamp?->format(DATE_ATOM));

--- a/tests/Model/Exif/ValueConvertersTest.php
+++ b/tests/Model/Exif/ValueConvertersTest.php
@@ -413,7 +413,7 @@ final class ValueConvertersTest extends TestCase
     public function extractsExtendedGpsMetadata(): void
     {
         $gps = new Ifd([
-            ExifTag::GPS_VERSION_ID   => new IfdEntry(ExifTag::GPS_VERSION_ID, 1, 4, [3, 0, 0, 0]),
+            ExifTag::GPS_VERSION_ID   => new IfdEntry(ExifTag::GPS_VERSION_ID, 2, 9, '3.0.0.0' . chr(0)),
             ExifTag::GPS_LATITUDE_REF => new IfdEntry(ExifTag::GPS_LATITUDE_REF, 2, 2, 'N'),
             ExifTag::GPS_LATITUDE     => new IfdEntry(
                 ExifTag::GPS_LATITUDE,
@@ -498,6 +498,7 @@ final class ValueConvertersTest extends TestCase
         self::assertEqualsWithDelta(8.5, $result['lon'], 0.000001);
         self::assertEqualsWithDelta(150.0, $result['alt'], 0.000001);
         self::assertSame('3.0.0.0', $result['version']);
+        self::assertSame('3.0.0.0' . chr(0), $result['version_raw']);
         self::assertSame('05', $result['satellites']);
         self::assertSame('A', $result['status']);
         self::assertSame('3', $result['measure_mode']);
@@ -518,6 +519,7 @@ final class ValueConvertersTest extends TestCase
         self::assertSame('K', $result['dest_distance_ref']);
         self::assertEqualsWithDelta(42000.0, $result['dest_distance_m'], 0.000001);
         self::assertSame('NETWORK', $result['processing_method']);
+        self::assertSame('2024:05:06', $result['date_raw']);
         self::assertSame('AreaName', $result['area_information']);
         self::assertSame('2024-05-06', $result['date']);
         self::assertSame('12:34:56.789', $result['time']);
@@ -529,5 +531,18 @@ final class ValueConvertersTest extends TestCase
 
         self::assertSame(2, $result['differential']);
         self::assertEqualsWithDelta(1.5, $result['h_positioning_error'], 0.000001);
+    }
+
+    #[Test]
+    public function formatsGpsVersionFromNumericList(): void
+    {
+        $gps = new Ifd([
+            ExifTag::GPS_VERSION_ID => new IfdEntry(ExifTag::GPS_VERSION_ID, 1, 4, [2, 3, 4, 5]),
+        ]);
+
+        $result = ValueConverters::gpsFromIfd($gps);
+
+        self::assertSame('2.3.4.5', $result['version']);
+        self::assertNull($result['version_raw']);
     }
 }

--- a/tests/Support/GpsTiffBuilder.php
+++ b/tests/Support/GpsTiffBuilder.php
@@ -42,7 +42,7 @@ final class GpsTiffBuilder
             . pack('V', 0);
 
         $definitions = [
-            [ExifTag::GPS_VERSION_ID, 1, 4, 'bytes', [3, 0, 0, 0]],
+            [ExifTag::GPS_VERSION_ID, 2, 9, 'string', '3.0.0.0' . chr(0)],
             [ExifTag::GPS_LATITUDE_REF, 2, 2, 'string', "N\0"],
             [ExifTag::GPS_LATITUDE, 5, 3, 'rationals', [[51, 1], [30, 1], [0, 1]]],
             [ExifTag::GPS_LONGITUDE_REF, 2, 2, 'string', "E\0"],


### PR DESCRIPTION
## Summary
- capture both normalized and raw GPS version/date strings when decoding EXIF metadata
- surface the raw payloads on the Gps value and resolver so structured metadata retains unmodified values
- adjust synthetic builders and PHPUnit coverage to assert normalized versus raw representations

## Testing
- .build/bin/phpunit tests/Model/Exif/ValueConvertersTest.php
- .build/bin/phpunit tests/Curate/Resolver/GpsResolverTest.php
- composer ci:test:php:unit *(fails: fixture set requires proprietary samples not present in CI)*

------
https://chatgpt.com/codex/tasks/task_e_68fd05f71d4483238d1f0637c95f2636