### PR TITLE
feat(quicktime): normalise container track metadata

### DIFF
--- a/src/Curate/Resolver/QuickTimeResolver.php
+++ b/src/Curate/Resolver/QuickTimeResolver.php
@@ -13,6 +13,7 @@ namespace MagicSunday\ImageMeta\Curate\Resolver;
 
 use MagicSunday\ImageMeta\Model\QuickTimeMeta;
 
+use function array_key_exists;
 use function is_bool;
 use function is_float;
 use function is_int;
@@ -27,6 +28,48 @@ use function trim;
 final readonly class QuickTimeResolver
 {
     /**
+     * Mapping of shorthand lookup keys to canonical QuickTime metadata identifiers.
+     *
+     * @var array<string, list<string>>
+     */
+    private const array KEY_ALIASES = [
+        QuickTimeMeta::MAJOR_BRAND_KEY          => [QuickTimeMeta::MAJOR_BRAND_KEY, 'MajorBrand'],
+        'MajorBrand'                            => ['MajorBrand', QuickTimeMeta::MAJOR_BRAND_KEY],
+        QuickTimeMeta::MINOR_VERSION_KEY        => [QuickTimeMeta::MINOR_VERSION_KEY, 'MinorVersion'],
+        'MinorVersion'                          => ['MinorVersion', QuickTimeMeta::MINOR_VERSION_KEY],
+        QuickTimeMeta::COMPATIBLE_BRANDS_KEY    => [QuickTimeMeta::COMPATIBLE_BRANDS_KEY, 'CompatibleBrands'],
+        'CompatibleBrands'                      => ['CompatibleBrands', QuickTimeMeta::COMPATIBLE_BRANDS_KEY],
+        QuickTimeMeta::HANDLER_DESCRIPTION_KEY  => [QuickTimeMeta::HANDLER_DESCRIPTION_KEY, 'HandlerDescription'],
+        'HandlerDescription'                    => ['HandlerDescription', QuickTimeMeta::HANDLER_DESCRIPTION_KEY],
+        QuickTimeMeta::VIDEO_WIDTH_KEY          => [QuickTimeMeta::VIDEO_WIDTH_KEY, 'ImageWidth', 'VideoWidth'],
+        'ImageWidth'                            => ['ImageWidth', QuickTimeMeta::VIDEO_WIDTH_KEY, 'VideoWidth'],
+        QuickTimeMeta::VIDEO_HEIGHT_KEY         => [QuickTimeMeta::VIDEO_HEIGHT_KEY, 'ImageHeight', 'VideoHeight'],
+        'ImageHeight'                           => ['ImageHeight', QuickTimeMeta::VIDEO_HEIGHT_KEY, 'VideoHeight'],
+        QuickTimeMeta::VIDEO_CODEC_KEY          => [QuickTimeMeta::VIDEO_CODEC_KEY, 'CompressorID', 'VideoCodecID'],
+        'CompressorID'                          => ['CompressorID', QuickTimeMeta::VIDEO_CODEC_KEY, 'VideoCodecID'],
+        QuickTimeMeta::COMPRESSOR_NAME_KEY      => [QuickTimeMeta::COMPRESSOR_NAME_KEY, 'CompressorName'],
+        'CompressorName'                        => ['CompressorName', QuickTimeMeta::COMPRESSOR_NAME_KEY],
+        QuickTimeMeta::AUDIO_FORMAT_KEY         => [QuickTimeMeta::AUDIO_FORMAT_KEY, QuickTimeMeta::AUDIO_CODEC_KEY, 'AudioFormat', 'AudioCodecID'],
+        QuickTimeMeta::AUDIO_CODEC_KEY          => [QuickTimeMeta::AUDIO_CODEC_KEY, QuickTimeMeta::AUDIO_FORMAT_KEY, 'AudioCodecID', 'AudioFormat'],
+        'AudioFormat'                           => ['AudioFormat', QuickTimeMeta::AUDIO_FORMAT_KEY, QuickTimeMeta::AUDIO_CODEC_KEY, 'AudioCodecID'],
+        'AudioCodecID'                          => ['AudioCodecID', QuickTimeMeta::AUDIO_CODEC_KEY, QuickTimeMeta::AUDIO_FORMAT_KEY, 'AudioFormat'],
+        QuickTimeMeta::AUDIO_CHANNELS_KEY       => [QuickTimeMeta::AUDIO_CHANNELS_KEY, 'AudioChannels'],
+        'AudioChannels'                         => ['AudioChannels', QuickTimeMeta::AUDIO_CHANNELS_KEY],
+        QuickTimeMeta::AUDIO_SAMPLE_RATE_KEY    => [QuickTimeMeta::AUDIO_SAMPLE_RATE_KEY, 'AudioSampleRate'],
+        'AudioSampleRate'                       => ['AudioSampleRate', QuickTimeMeta::AUDIO_SAMPLE_RATE_KEY],
+        QuickTimeMeta::AUDIO_BITS_PER_SAMPLE_KEY => [QuickTimeMeta::AUDIO_BITS_PER_SAMPLE_KEY, 'AudioBitsPerSample'],
+        'AudioBitsPerSample'                    => ['AudioBitsPerSample', QuickTimeMeta::AUDIO_BITS_PER_SAMPLE_KEY],
+        'Encoder'                               => ['Encoder', 'com.apple.quicktime.encoder'],
+        'AvgBitrate'                            => ['AvgBitrate', 'com.apple.quicktime.avgBitrate'],
+        'Bitrate'                               => ['Bitrate', 'com.apple.quicktime.bitrate', 'com.apple.quicktime.dataRate'],
+        'Duration'                              => ['Duration', 'com.apple.quicktime.duration'],
+        'VideoFrameRate'                        => ['VideoFrameRate', 'com.apple.quicktime.videoFrameRate'],
+        'HDRFormat'                             => ['HDRFormat', 'com.apple.quicktime.hdrFormat'],
+        'TransferFunction'                      => ['TransferFunction', 'com.apple.quicktime.transferFunction'],
+        'ColorPrimaries'                        => ['ColorPrimaries', 'com.apple.quicktime.colorPrimaries'],
+        'AudioBitsPerChannel'                   => ['AudioBitsPerChannel', QuickTimeMeta::AUDIO_BITS_PER_SAMPLE_KEY],
+    ];
+    /**
      * Wraps an optional QuickTime metadata container for convenient lookups.
      *
      * @param QuickTimeMeta|null $meta Parsed QuickTime metadata aggregate.
@@ -40,7 +83,7 @@ final readonly class QuickTimeResolver
      */
     public function string(string $key): ?string
     {
-        $value = $this->meta?->keys[$key] ?? null;
+        $value = $this->lookupValue($key);
 
         return is_string($value) ? trim($value) : null;
     }
@@ -50,7 +93,7 @@ final readonly class QuickTimeResolver
      */
     public function int(string $key): ?int
     {
-        $value = $this->meta?->keys[$key] ?? null;
+        $value = $this->lookupValue($key);
 
         if (is_int($value)) {
             return $value;
@@ -68,7 +111,7 @@ final readonly class QuickTimeResolver
      */
     public function float(string $key): ?float
     {
-        $value = $this->meta?->keys[$key] ?? null;
+        $value = $this->lookupValue($key);
 
         if (is_float($value)) {
             return $value;
@@ -86,7 +129,7 @@ final readonly class QuickTimeResolver
      */
     public function bool(string $key): ?bool
     {
-        $value = $this->meta?->keys[$key] ?? null;
+        $value = $this->lookupValue($key);
 
         if (is_bool($value)) {
             return $value;
@@ -104,6 +147,28 @@ final readonly class QuickTimeResolver
 
         if (is_numeric($value)) {
             return (bool) $value;
+        }
+
+        return null;
+    }
+
+    /**
+     * Resolves a raw metadata value using the alias map.
+     *
+     * @return string|int|float|bool|null
+     */
+    private function lookupValue(string $key): string|int|float|bool|null
+    {
+        if ($this->meta === null) {
+            return null;
+        }
+
+        $candidates = self::KEY_ALIASES[$key] ?? [$key];
+
+        foreach ($candidates as $candidate) {
+            if (array_key_exists($candidate, $this->meta->keys)) {
+                return $this->meta->keys[$candidate];
+            }
         }
 
         return null;

--- a/src/Curate/StructuredMetadataBuilder.php
+++ b/src/Curate/StructuredMetadataBuilder.php
@@ -254,43 +254,53 @@ final class StructuredMetadataBuilder
         );
 
         $container = new Container(
-            format: $quickTimeResolver->string('MajorBrand'),
-            encoder: $quickTimeResolver->string('Encoder'),
+            format: $quickTimeResolver->string(QuickTimeMeta::MAJOR_BRAND_KEY),
+            encoder: CompositeResolver::first([
+                fn (): ?string => $quickTimeResolver->string('com.apple.quicktime.encoder'),
+                fn (): ?string => $quickTimeResolver->string('Encoder'),
+            ]),
             bitrate: CompositeResolver::first([
+                fn (): ?int => $quickTimeResolver->int('com.apple.quicktime.avgBitrate'),
+                fn (): ?int => $quickTimeResolver->int('com.apple.quicktime.bitrate'),
+                fn (): ?int => $quickTimeResolver->int('com.apple.quicktime.dataRate'),
                 fn (): ?int => $quickTimeResolver->int('AvgBitrate'),
                 fn (): ?int => $quickTimeResolver->int('Bitrate'),
             ]),
             videoCodec: CompositeResolver::first([
-                fn (): ?string => $quickTimeResolver->string('CompressorID'),
-                fn (): ?string => $quickTimeResolver->string('HandlerDescription'),
+                fn (): ?string => $quickTimeResolver->string(QuickTimeMeta::COMPRESSOR_NAME_KEY),
+                fn (): ?string => $quickTimeResolver->string(QuickTimeMeta::VIDEO_CODEC_KEY),
+                fn (): ?string => $quickTimeResolver->string(QuickTimeMeta::HANDLER_DESCRIPTION_KEY),
             ]),
             audioCodec: CompositeResolver::first([
-                fn (): ?string => $quickTimeResolver->string('AudioFormat'),
-                fn (): ?string => $quickTimeResolver->string('AudioCodecID'),
+                fn (): ?string => $quickTimeResolver->string(QuickTimeMeta::AUDIO_FORMAT_KEY),
+                fn (): ?string => $quickTimeResolver->string(QuickTimeMeta::AUDIO_CODEC_KEY),
             ]),
         );
 
         $preview = new Preview(null, null, null, null);
 
         $video = new Video(
-            durationSec: $quickTimeResolver->float('Duration'),
-            frameRate: $quickTimeResolver->float('VideoFrameRate'),
-            width: $quickTimeResolver->int('ImageWidth'),
-            height: $quickTimeResolver->int('ImageHeight'),
-            codec: $quickTimeResolver->string('CompressorID'),
-            hdr: $quickTimeResolver->bool('HDRFormat'),
-            transferFunction: $quickTimeResolver->string('TransferFunction'),
-            colorPrimaries: $quickTimeResolver->string('ColorPrimaries'),
+            durationSec: $quickTimeResolver->float('com.apple.quicktime.duration'),
+            frameRate: $quickTimeResolver->float('com.apple.quicktime.videoFrameRate'),
+            width: $quickTimeResolver->int(QuickTimeMeta::VIDEO_WIDTH_KEY),
+            height: $quickTimeResolver->int(QuickTimeMeta::VIDEO_HEIGHT_KEY),
+            codec: CompositeResolver::first([
+                fn (): ?string => $quickTimeResolver->string(QuickTimeMeta::COMPRESSOR_NAME_KEY),
+                fn (): ?string => $quickTimeResolver->string(QuickTimeMeta::VIDEO_CODEC_KEY),
+            ]),
+            hdr: $quickTimeResolver->bool('com.apple.quicktime.hdrFormat'),
+            transferFunction: $quickTimeResolver->string('com.apple.quicktime.transferFunction'),
+            colorPrimaries: $quickTimeResolver->string('com.apple.quicktime.colorPrimaries'),
         );
 
         $audio = new Audio(
-            channels: $quickTimeResolver->int('AudioChannels'),
-            sampleRate: $quickTimeResolver->int('AudioSampleRate'),
+            channels: $quickTimeResolver->int(QuickTimeMeta::AUDIO_CHANNELS_KEY),
+            sampleRate: $quickTimeResolver->int(QuickTimeMeta::AUDIO_SAMPLE_RATE_KEY),
             codec: CompositeResolver::first([
-                fn (): ?string => $quickTimeResolver->string('AudioFormat'),
-                fn (): ?string => $quickTimeResolver->string('AudioCodecID'),
+                fn (): ?string => $quickTimeResolver->string(QuickTimeMeta::AUDIO_FORMAT_KEY),
+                fn (): ?string => $quickTimeResolver->string(QuickTimeMeta::AUDIO_CODEC_KEY),
             ]),
-            bitDepth: $quickTimeResolver->int('AudioBitsPerSample'),
+            bitDepth: $quickTimeResolver->int(QuickTimeMeta::AUDIO_BITS_PER_SAMPLE_KEY),
         );
 
         $iccData = null;

--- a/src/Model/QuickTimeMeta.php
+++ b/src/Model/QuickTimeMeta.php
@@ -22,6 +22,71 @@ final readonly class QuickTimeMeta
     public const string CONTENT_IDENTIFIER_KEY = 'com.apple.quicktime.content.identifier';
 
     /**
+     * QuickTime metadata key representing the declared container major brand.
+     */
+    public const string MAJOR_BRAND_KEY = 'com.apple.quicktime.majorBrand';
+
+    /**
+     * QuickTime metadata key exposing the minor version of the container brand.
+     */
+    public const string MINOR_VERSION_KEY = 'com.apple.quicktime.minorVersion';
+
+    /**
+     * QuickTime metadata key listing compatible brands.
+     */
+    public const string COMPATIBLE_BRANDS_KEY = 'com.apple.quicktime.compatibleBrands';
+
+    /**
+     * QuickTime metadata key describing the handler for a media track.
+     */
+    public const string HANDLER_DESCRIPTION_KEY = 'com.apple.quicktime.handlerDescription';
+
+    /**
+     * QuickTime metadata key exposing the display width of the primary video track.
+     */
+    public const string VIDEO_WIDTH_KEY = 'com.apple.quicktime.videoWidth';
+
+    /**
+     * QuickTime metadata key exposing the display height of the primary video track.
+     */
+    public const string VIDEO_HEIGHT_KEY = 'com.apple.quicktime.videoHeight';
+
+    /**
+     * QuickTime metadata key describing the codec four-character code for video.
+     */
+    public const string VIDEO_CODEC_KEY = 'com.apple.quicktime.videoCodec';
+
+    /**
+     * QuickTime metadata key exposing the human readable compressor name.
+     */
+    public const string COMPRESSOR_NAME_KEY = 'com.apple.quicktime.compressorName';
+
+    /**
+     * QuickTime metadata key describing the audio format four-character code.
+     */
+    public const string AUDIO_FORMAT_KEY = 'com.apple.quicktime.audioFormat';
+
+    /**
+     * QuickTime metadata key describing the audio codec identifier.
+     */
+    public const string AUDIO_CODEC_KEY = 'com.apple.quicktime.audioCodec';
+
+    /**
+     * QuickTime metadata key exposing the audio channel count.
+     */
+    public const string AUDIO_CHANNELS_KEY = 'com.apple.quicktime.audioChannels';
+
+    /**
+     * QuickTime metadata key exposing the audio sample rate in Hz.
+     */
+    public const string AUDIO_SAMPLE_RATE_KEY = 'com.apple.quicktime.audioSampleRate';
+
+    /**
+     * QuickTime metadata key exposing the audio bit depth per sample.
+     */
+    public const string AUDIO_BITS_PER_SAMPLE_KEY = 'com.apple.quicktime.audioBitsPerSample';
+
+    /**
      * Creates a new instance of QuickTime metadata information.
      *
      * @param array<string, string|int|float|bool> $keys Map of QuickTime metadata keys and their values.

--- a/src/Parse/IsoBmff/IsoBmffExtractor.php
+++ b/src/Parse/IsoBmff/IsoBmffExtractor.php
@@ -21,10 +21,13 @@ use function array_key_exists;
 use function array_unique;
 use function array_unshift;
 use function array_values;
+use function bin2hex;
 use function explode;
+use function implode;
 use function iconv;
 use function is_string;
 use function preg_match;
+use function round;
 use function rtrim;
 use function sha1;
 use function sprintf;
@@ -32,6 +35,7 @@ use function str_starts_with;
 use function strcasecmp;
 use function strlen;
 use function strtolower;
+use function strtoupper;
 use function substr;
 use function trim;
 
@@ -50,6 +54,11 @@ final readonly class IsoBmffExtractor
      * FourCC for QuickTime metadata box.
      */
     private const string BOX_META = 'meta';
+
+    /**
+     * FourCC for file type box describing the major brand.
+     */
+    private const string BOX_FTYP = 'ftyp';
 
     /**
      * FourCC for QuickTime movie box.
@@ -100,6 +109,41 @@ final readonly class IsoBmffExtractor
      * FourCC for QuickTime user data box.
      */
     private const string BOX_UDTA = 'udta';
+
+    /**
+     * FourCC for QuickTime track container.
+     */
+    private const string BOX_TRAK = 'trak';
+
+    /**
+     * FourCC for track header box.
+     */
+    private const string BOX_TKHD = 'tkhd';
+
+    /**
+     * FourCC for media container box.
+     */
+    private const string BOX_MDIA = 'mdia';
+
+    /**
+     * FourCC for handler reference box.
+     */
+    private const string BOX_HDLR = 'hdlr';
+
+    /**
+     * FourCC for media information box.
+     */
+    private const string BOX_MINF = 'minf';
+
+    /**
+     * FourCC for sample table box.
+     */
+    private const string BOX_STBL = 'stbl';
+
+    /**
+     * FourCC for sample description box.
+     */
+    private const string BOX_STSD = 'stsd';
 
     /**
      * FourCC for item information entry box.
@@ -169,7 +213,9 @@ final readonly class IsoBmffExtractor
         $xmpHashes     = [];
 
         foreach ($this->walkTopLevelBoxes() as $box) {
-            if ($box->type === self::BOX_META) {
+            if ($box->type === self::BOX_FTYP) {
+                $qtKeys = $this->mergeAssociative($qtKeys, $this->parseFtyp($box));
+            } elseif ($box->type === self::BOX_META) {
                 $this->parseMetaBox($box, $exifBlobs, $xmpBlobs, $qtKeys, $xmpHashes);
             } elseif ($box->type === self::BOX_MOOV) {
                 $this->parseMoovBox($box, $exifBlobs, $xmpBlobs, $qtKeys, $xmpHashes);
@@ -224,8 +270,41 @@ final readonly class IsoBmffExtractor
                 $this->parseMetaBox($child, $exifBlobs, $xmpBlobs, $qtKeys, $xmpHashes);
             } elseif ($child->type === self::BOX_UDTA) {
                 $this->parseUdtaBox($child, $exifBlobs, $xmpBlobs, $qtKeys, $xmpHashes);
+            } elseif ($child->type === self::BOX_TRAK) {
+                $qtKeys = $this->mergeAssociative($qtKeys, $this->parseTrak($child));
             }
         }
+    }
+
+    /**
+     * Parses the file type box (`ftyp`) and exposes container brands as metadata keys.
+     *
+     * @param BoxDescriptor $ftyp Box descriptor representing the file type declaration.
+     *
+     * @return array<string, string|int>
+     */
+    private function parseFtyp(BoxDescriptor $ftyp): array
+    {
+        $win = $ftyp->window;
+        $win->seek(0);
+
+        if ($ftyp->contentSize < 8) {
+            return [];
+        }
+
+        $majorBrand = $this->normaliseFourcc($win->read(4));
+        $minor      = $win->readU32BE();
+
+        $brands = [];
+        while ($win->tell() + 4 <= $ftyp->contentSize) {
+            $brands[] = $this->normaliseFourcc($win->read(4));
+        }
+
+        return [
+            QuickTimeMeta::MAJOR_BRAND_KEY        => $majorBrand,
+            QuickTimeMeta::MINOR_VERSION_KEY      => $minor,
+            QuickTimeMeta::COMPATIBLE_BRANDS_KEY  => $brands === [] ? '' : implode(' ', $brands),
+        ];
     }
 
     /**
@@ -244,6 +323,335 @@ final readonly class IsoBmffExtractor
                 $this->parseMetaBox($child, $exifBlobs, $xmpBlobs, $qtKeys, $xmpHashes);
             }
         }
+    }
+
+    /**
+     * Parses a track box and surfaces relevant video/audio details as QuickTime keys.
+     *
+     * @param BoxDescriptor $trak Box descriptor for the track container.
+     *
+     * @return array<string, string|int>
+     */
+    private function parseTrak(BoxDescriptor $trak): array
+    {
+        $tkhdWidth  = null;
+        $tkhdHeight = null;
+        $handler    = null;
+        $handlerName = null;
+        $sampleInfo = [];
+
+        foreach ($this->walkChildren($trak) as $child) {
+            if ($child->type === self::BOX_TKHD) {
+                [$tkhdWidth, $tkhdHeight] = $this->parseTkhd($child);
+            } elseif ($child->type === self::BOX_MDIA) {
+                [$handler, $handlerName, $sampleInfo] = $this->parseMdia($child);
+            }
+        }
+
+        if ($handler === null) {
+            return [];
+        }
+
+        $result = [];
+
+        if ($handlerName !== null && $handlerName !== '') {
+            $result[QuickTimeMeta::HANDLER_DESCRIPTION_KEY] = $handlerName;
+        }
+
+        if ($handler === 'vide') {
+            $width  = $sampleInfo['width'] ?? $tkhdWidth;
+            $height = $sampleInfo['height'] ?? $tkhdHeight;
+
+            if ($width !== null && $width > 0) {
+                $result[QuickTimeMeta::VIDEO_WIDTH_KEY] = $width;
+            }
+
+            if ($height !== null && $height > 0) {
+                $result[QuickTimeMeta::VIDEO_HEIGHT_KEY] = $height;
+            }
+
+            if (isset($sampleInfo['format']) && $sampleInfo['format'] !== '') {
+                $result[QuickTimeMeta::VIDEO_CODEC_KEY] = $sampleInfo['format'];
+            }
+
+            if (isset($sampleInfo['compressorName']) && $sampleInfo['compressorName'] !== '') {
+                $result[QuickTimeMeta::COMPRESSOR_NAME_KEY] = $sampleInfo['compressorName'];
+            }
+        } elseif ($handler === 'soun') {
+            if (isset($sampleInfo['format']) && $sampleInfo['format'] !== '') {
+                $result[QuickTimeMeta::AUDIO_FORMAT_KEY] = $sampleInfo['format'];
+                $result[QuickTimeMeta::AUDIO_CODEC_KEY]  = $sampleInfo['format'];
+            }
+
+            if (isset($sampleInfo['channels'])) {
+                $result[QuickTimeMeta::AUDIO_CHANNELS_KEY] = $sampleInfo['channels'];
+            }
+
+            if (isset($sampleInfo['bitsPerSample'])) {
+                $result[QuickTimeMeta::AUDIO_BITS_PER_SAMPLE_KEY] = $sampleInfo['bitsPerSample'];
+            }
+
+            if (isset($sampleInfo['sampleRate'])) {
+                $result[QuickTimeMeta::AUDIO_SAMPLE_RATE_KEY] = $sampleInfo['sampleRate'];
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * Parses the track header box (`tkhd`) and extracts display width/height.
+     *
+     * @param BoxDescriptor $tkhd Track header descriptor.
+     *
+     * @return array{0: ?int, 1: ?int}
+     */
+    private function parseTkhd(BoxDescriptor $tkhd): array
+    {
+        $win = $tkhd->window;
+        $win->seek(0);
+
+        if ($tkhd->contentSize < 84) {
+            throw new ParseError('tkhd box truncated');
+        }
+
+        $version = $win->readU8();
+        $this->readUInt24($win); // flags
+
+        if ($version === 1) {
+            if ($tkhd->contentSize < 96) {
+                throw new ParseError('tkhd version 1 box truncated');
+            }
+
+            $win->read(8 + 8 + 4 + 4 + 8); // creation, modification, track id, reserved, duration
+        } else {
+            $win->read(4 + 4 + 4 + 4 + 4); // creation, modification, track id, reserved, duration
+        }
+
+        $win->read(8); // reserved
+        $win->read(2); // layer
+        $win->read(2); // alternate group
+        $win->read(2); // volume
+        $win->read(2); // reserved
+        $win->read(36); // matrix
+
+        $widthFixed  = $win->readU32BE();
+        $heightFixed = $win->readU32BE();
+
+        $width  = $widthFixed > 0 ? intdiv($widthFixed, 1 << 16) : null;
+        $height = $heightFixed > 0 ? intdiv($heightFixed, 1 << 16) : null;
+
+        return [$width, $height];
+    }
+
+    /**
+     * Parses the media box (`mdia`) and returns handler/sample information.
+     *
+     * @param BoxDescriptor $mdia Media box descriptor.
+     *
+     * @return array{0: ?string, 1: ?string, 2: array<string, int|string>}
+     */
+    private function parseMdia(BoxDescriptor $mdia): array
+    {
+        $handler    = null;
+        $handlerName = null;
+        $sampleInfo = [];
+
+        foreach ($this->walkChildren($mdia) as $child) {
+            if ($child->type === self::BOX_HDLR) {
+                [$handler, $handlerName] = $this->parseHdlr($child);
+            } elseif ($child->type === self::BOX_MINF) {
+                $sampleInfo = $this->parseMinf($child, $handler);
+            }
+        }
+
+        return [$handler, $handlerName, $sampleInfo];
+    }
+
+    /**
+     * Parses the handler reference box (`hdlr`).
+     *
+     * @param BoxDescriptor $hdlr Handler box descriptor.
+     *
+     * @return array{0: ?string, 1: ?string}
+     */
+    private function parseHdlr(BoxDescriptor $hdlr): array
+    {
+        $win = $hdlr->window;
+        $win->seek(0);
+
+        if ($hdlr->contentSize < 24) {
+            throw new ParseError('hdlr box truncated');
+        }
+
+        $win->read(4); // version/flags
+        $win->read(4); // pre-defined
+        $handler = $win->read(4);
+        $win->read(12); // reserved
+
+        $nameBytes = '';
+        if ($win->tell() < $hdlr->contentSize) {
+            $nameBytes = $win->read($hdlr->contentSize - $win->tell());
+        }
+
+        $handlerType = $this->normaliseFourcc($handler);
+        $name        = trim($nameBytes, "\0");
+
+        return [$handlerType === '' ? null : $handlerType, $name === '' ? null : $name];
+    }
+
+    /**
+     * Parses the media information box (`minf`) to find sample table details.
+     *
+     * @param BoxDescriptor $minf        Media information descriptor.
+     * @param string|null   $handlerType Declared handler type for the media.
+     *
+     * @return array<string, int|string>
+     */
+    private function parseMinf(BoxDescriptor $minf, ?string $handlerType): array
+    {
+        if ($handlerType === null) {
+            return [];
+        }
+
+        foreach ($this->walkChildren($minf) as $child) {
+            if ($child->type === self::BOX_STBL) {
+                return $this->parseStbl($child, $handlerType);
+            }
+        }
+
+        return [];
+    }
+
+    /**
+     * Parses the sample table box (`stbl`).
+     *
+     * @param BoxDescriptor $stbl        Sample table descriptor.
+     * @param string        $handlerType Media handler type.
+     *
+     * @return array<string, int|string>
+     */
+    private function parseStbl(BoxDescriptor $stbl, string $handlerType): array
+    {
+        foreach ($this->walkChildren($stbl) as $child) {
+            if ($child->type === self::BOX_STSD) {
+                return $this->parseStsd($child, $handlerType);
+            }
+        }
+
+        return [];
+    }
+
+    /**
+     * Parses the sample description box (`stsd`).
+     *
+     * @param BoxDescriptor $stsd        Sample description descriptor.
+     * @param string        $handlerType Handler type describing the media kind.
+     *
+     * @return array<string, int|string>
+     */
+    private function parseStsd(BoxDescriptor $stsd, string $handlerType): array
+    {
+        $win = $stsd->window;
+        $win->seek(0);
+
+        if ($stsd->contentSize < 8) {
+            throw new ParseError('stsd box truncated');
+        }
+
+        $win->read(4); // version/flags
+        $entryCount = $win->readU32BE();
+        $result     = [];
+        $pos        = $win->tell();
+
+        for ($i = 0; $i < $entryCount; ++$i) {
+            if ($pos + 8 > $stsd->contentSize) {
+                throw new ParseError('stsd entry truncated');
+            }
+
+            $win->seek($pos);
+            $entrySize = $win->readU32BE();
+            $format    = $win->read(4);
+
+            if ($entrySize < 16 || $pos + $entrySize > $stsd->contentSize) {
+                throw new ParseError('invalid stsd entry size');
+            }
+
+            $entryStart = $win->tell();
+            $entryEnd   = $pos + $entrySize;
+
+            $win->read(6); // reserved
+            $win->readU16BE(); // data reference index
+
+            if ($handlerType === 'vide') {
+                if ($win->tell() + 70 > $entryEnd) {
+                    throw new ParseError('video sample entry truncated');
+                }
+
+                $win->read(16); // pre-defined/reserved
+                $width  = $win->readU16BE();
+                $height = $win->readU16BE();
+                $win->readU32BE(); // horiz resolution
+                $win->readU32BE(); // vert resolution
+                $win->read(4); // reserved
+                $win->readU16BE(); // frame count
+
+                $nameLength = $win->readU8();
+                $nameData   = $win->read(31);
+                $compressor = substr($nameData, 0, min($nameLength, 31));
+                $compressor = trim($compressor);
+
+                $win->readU16BE(); // depth
+                $win->readU16BE(); // pre-defined
+
+                $result = [
+                    'format'         => $this->normaliseFourcc($format),
+                    'width'          => $width,
+                    'height'         => $height,
+                    'compressorName' => $compressor,
+                ];
+            } elseif ($handlerType === 'soun') {
+                if ($win->tell() + 20 > $entryEnd) {
+                    throw new ParseError('audio sample entry truncated');
+                }
+
+                $win->read(8); // reserved
+                $channels = $win->readU16BE();
+                $sampleSize = $win->readU16BE();
+                $win->readU16BE(); // pre-defined
+                $win->readU16BE(); // reserved
+                $sampleRate = $win->readU32BE();
+
+                $result = [
+                    'format'        => $this->normaliseFourcc($format),
+                    'channels'      => $channels,
+                    'bitsPerSample' => $sampleSize,
+                    'sampleRate'    => (int) round($sampleRate / 65536),
+                ];
+            }
+
+            $pos += $entrySize;
+        }
+
+        if ($pos !== $stsd->contentSize) {
+            throw new ParseError('stsd entries do not fill container');
+        }
+
+        return $result;
+    }
+
+    /**
+     * Normalises a four-character code into a printable identifier.
+     *
+     * @param string $fourcc Raw four-character code bytes.
+     */
+    private function normaliseFourcc(string $fourcc): string
+    {
+        if ($this->isPrintableFourcc($fourcc)) {
+            return $fourcc;
+        }
+
+        return strtoupper(bin2hex($fourcc));
     }
 
     /**

--- a/tests/Curate/StructuredMetadataBuilderTest.php
+++ b/tests/Curate/StructuredMetadataBuilderTest.php
@@ -1716,6 +1716,55 @@ final class StructuredMetadataBuilderTest extends TestCase
         self::assertSame('Metadata Tool Z', $structured->device->metadataEditingSoftware);
     }
 
+    #[Test]
+    public function mapsQuickTimeMetadataIntoContainerVideoAndAudio(): void
+    {
+        $quickTime = new QuickTimeMeta([
+            QuickTimeMeta::MAJOR_BRAND_KEY            => 'qt  ',
+            QuickTimeMeta::COMPATIBLE_BRANDS_KEY      => 'qt  iso2',
+            QuickTimeMeta::MINOR_VERSION_KEY          => 512,
+            QuickTimeMeta::COMPRESSOR_NAME_KEY        => 'Apple ProRes 422',
+            QuickTimeMeta::VIDEO_CODEC_KEY            => 'apcn',
+            QuickTimeMeta::VIDEO_WIDTH_KEY            => 1920,
+            QuickTimeMeta::VIDEO_HEIGHT_KEY           => 1080,
+            QuickTimeMeta::AUDIO_FORMAT_KEY           => 'lpcm',
+            QuickTimeMeta::AUDIO_CHANNELS_KEY         => 2,
+            QuickTimeMeta::AUDIO_SAMPLE_RATE_KEY      => 48000,
+            QuickTimeMeta::AUDIO_BITS_PER_SAMPLE_KEY  => 24,
+            QuickTimeMeta::HANDLER_DESCRIPTION_KEY    => 'Apple Video Media Handler',
+            'com.apple.quicktime.encoder'             => 'Apple Encoder',
+            'com.apple.quicktime.avgBitrate'          => 22000000,
+            'com.apple.quicktime.duration'            => 12.5,
+            'com.apple.quicktime.videoFrameRate'      => 24.0,
+            'com.apple.quicktime.hdrFormat'           => true,
+            'com.apple.quicktime.transferFunction'    => 'PQ',
+            'com.apple.quicktime.colorPrimaries'      => 'BT2020',
+        ]);
+
+        $metadata   = new Metadata([], $quickTime);
+        $structured = (new StructuredMetadataBuilder())->build($metadata);
+
+        self::assertSame('qt', $structured->container->format);
+        self::assertSame('Apple Encoder', $structured->container->encoder);
+        self::assertSame(22000000, $structured->container->bitrate);
+        self::assertSame('Apple ProRes 422', $structured->container->videoCodec);
+        self::assertSame('lpcm', $structured->container->audioCodec);
+
+        self::assertEqualsWithDelta(12.5, $structured->video->durationSec, 1e-6);
+        self::assertSame(24.0, $structured->video->frameRate);
+        self::assertSame(1920, $structured->video->width);
+        self::assertSame(1080, $structured->video->height);
+        self::assertSame('Apple ProRes 422', $structured->video->codec);
+        self::assertTrue($structured->video->hdr);
+        self::assertSame('PQ', $structured->video->transferFunction);
+        self::assertSame('BT2020', $structured->video->colorPrimaries);
+
+        self::assertSame(2, $structured->audio->channels);
+        self::assertSame(48000, $structured->audio->sampleRate);
+        self::assertSame('lpcm', $structured->audio->codec);
+        self::assertSame(24, $structured->audio->bitDepth);
+    }
+
     /**
      * Ensures JPEG frame metadata backfills TIFF characteristics when EXIF is absent.
      */


### PR DESCRIPTION
## Summary
- expose QuickTime brand and track metadata by parsing ftyp, tkhd and stsd boxes
- normalise QuickTime metadata aliases and consume canonical Apple keys in the structured builder
- cover container/video/audio extraction with a dedicated QuickTime metadata test

## Testing
- .build/bin/phpunit --configuration .build/phpunit.xml --filter mapsQuickTimeMetadataIntoContainerVideoAndAudio

------
https://chatgpt.com/codex/tasks/task_e_68fd062701a483239d06aba7c4b9a599