### PR TITLE
Surface JPEG frame dimensions for metadata fallbacks

### DIFF
--- a/src/Curate/StructuredMetadataBuilder.php
+++ b/src/Curate/StructuredMetadataBuilder.php
@@ -201,7 +201,7 @@ final class StructuredMetadataBuilder
 
         $camera = $this->buildCamera($exifResolver);
         $lens   = $this->buildLens($exifResolver);
-        $image  = $this->buildImage($exifResolver, $metadata->jpegFrameWidth, $metadata->jpegFrameHeight);
+        $image  = $this->buildImage($metadata, $exifResolver);
 
         $exposure = new Exposure(
             iso: CompositeResolver::intISO($exifResolver),
@@ -654,24 +654,24 @@ final class StructuredMetadataBuilder
     /**
      * Builds the image value object using EXIF metadata.
      *
-     * @param ExifTagResolver $exif        Resolver exposing image related EXIF tags.
-     * @param int|null        $frameWidth  Optional JPEG frame width used as fallback when EXIF is missing dimensions.
-     * @param int|null        $frameHeight Optional JPEG frame height used as fallback when EXIF is missing dimensions.
+     * @param Metadata        $metadata Metadata container supplying JPEG frame fallbacks.
+     * @param ExifTagResolver $exif      Resolver exposing image related EXIF tags.
      *
      * @return Image Normalised image metadata aggregate.
      */
-    private function buildImage(ExifTagResolver $exif, ?int $frameWidth, ?int $frameHeight): Image
+    private function buildImage(Metadata $metadata, ExifTagResolver $exif): Image
     {
         [$width, $height] = CompositeResolver::dimensions($exif);
 
-        $orientation = $exif->orientation();
         if ($width === null) {
-            $width = $frameWidth;
+            $width = $metadata->jpegFrameWidth;
         }
 
         if ($height === null) {
-            $height = $frameHeight;
+            $height = $metadata->jpegFrameHeight;
         }
+
+        $orientation = $exif->orientation();
 
         return new Image(
             width: $width,

--- a/src/MetadataReader.php
+++ b/src/MetadataReader.php
@@ -120,13 +120,13 @@ final class MetadataReader
             $bitsPerSample,
             $sampling,
             $subSampling,
-            $mimeType,
-            $fileSize,
-            $extension,
-            $digestSha1,
-            $digestMd5,
-            $frameWidth,
-            $frameHeight,
+            mimeType: $mimeType,
+            fileSize: $fileSize,
+            extension: $extension,
+            digestSha1: $digestSha1,
+            digestMd5: $digestMd5,
+            jpegFrameWidth: $frameWidth,
+            jpegFrameHeight: $frameHeight,
         );
     }
 

--- a/src/Parse/Jpeg/JpegExtractor.php
+++ b/src/Parse/Jpeg/JpegExtractor.php
@@ -29,6 +29,7 @@ use function sprintf;
 use function str_starts_with;
 use function strlen;
 use function substr;
+use function unpack;
 
 /**
  * Parses JPEG streams to extract metadata-bearing APP segments.
@@ -97,9 +98,9 @@ final class JpegExtractor
 
     private ?int $frameBitsPerSample = null;
 
-    private ?int $frameHeight = null;
+    private ?int $frameLines = null;
 
-    private ?int $frameWidth = null;
+    private ?int $frameSamplesPerLine = null;
 
     /** @var array<int, array{horizontal: int, vertical: int}>|null */
     private ?array $frameComponentSampling = null;
@@ -193,7 +194,7 @@ final class JpegExtractor
     {
         $this->parseIfNeeded();
 
-        return $this->frameHeight;
+        return $this->frameLines;
     }
 
     /**
@@ -203,7 +204,7 @@ final class JpegExtractor
     {
         $this->parseIfNeeded();
 
-        return $this->frameWidth;
+        return $this->frameSamplesPerLine;
     }
 
     /**
@@ -252,11 +253,11 @@ final class JpegExtractor
         $this->iccProfile             = null;
         $this->iptcPayloads           = [];
         $this->xmpPacketHashes        = [];
-        $this->frameBitsPerSample     = null;
-        $this->frameComponentSampling = null;
-        $this->frameYCbCrSubSampling  = null;
-        $this->frameHeight            = null;
-        $this->frameWidth             = null;
+        $this->frameBitsPerSample      = null;
+        $this->frameComponentSampling  = null;
+        $this->frameYCbCrSubSampling   = null;
+        $this->frameLines              = null;
+        $this->frameSamplesPerLine     = null;
 
         while (true) {
             [$marker, $offset] = $this->nextMarkerWithOffset();
@@ -520,12 +521,15 @@ final class JpegExtractor
             $index += 3;
         }
 
-        if ($this->frameHeight === null) {
-            $this->frameHeight = (ord($payload[1]) << 8) | ord($payload[2]);
+        /** @var array{lines:int,samples:int} $fields */
+        $fields = unpack('nlines/nsamples', substr($payload, 1, 4));
+
+        if ($this->frameLines === null) {
+            $this->frameLines = $fields['lines'];
         }
 
-        if ($this->frameWidth === null) {
-            $this->frameWidth = (ord($payload[3]) << 8) | ord($payload[4]);
+        if ($this->frameSamplesPerLine === null) {
+            $this->frameSamplesPerLine = $fields['samples'];
         }
 
         $this->frameBitsPerSample     = ord($payload[0]);

--- a/tests/MetadataReader/MetadataReaderTest.php
+++ b/tests/MetadataReader/MetadataReaderTest.php
@@ -132,6 +132,25 @@ final class MetadataReaderTest extends TestCase
     }
 
     /**
+     * Ensures JPEG frame dimensions extracted from the SOF marker fill structured fallbacks.
+     */
+    #[Test]
+    public function testStructuredImageDimensionsFallbackToFrameHeader(): void
+    {
+        $path = __DIR__ . '/../Fixtures/Images/Landscape_5.jpg';
+
+        $metadata = (new MetadataReader())->read($path);
+
+        self::assertSame(1200, $metadata->jpegFrameWidth);
+        self::assertSame(1800, $metadata->jpegFrameHeight);
+
+        $image = $metadata->structured()->image;
+
+        self::assertSame(1200, $image->width);
+        self::assertSame(1800, $image->height);
+    }
+
+    /**
      * Ensures ISO BMFF detection populates EXIF/XMP blobs and QuickTime metadata.
      */
     #[Test]

--- a/tests/Model/Metadata/MetadataTest.php
+++ b/tests/Model/Metadata/MetadataTest.php
@@ -91,6 +91,8 @@ final class MetadataTest extends TestCase
             'heic',
             'abc123',
             'def456',
+            4096,
+            2730,
         );
 
         self::assertSame($exifBlobs, $metadata->exifBlobs);
@@ -108,6 +110,8 @@ final class MetadataTest extends TestCase
         self::assertSame('heic', $metadata->extension);
         self::assertSame('abc123', $metadata->digestSha1);
         self::assertSame('def456', $metadata->digestMd5);
+        self::assertSame(4096, $metadata->jpegFrameWidth);
+        self::assertSame(2730, $metadata->jpegFrameHeight);
     }
 
     /**
@@ -126,6 +130,8 @@ final class MetadataTest extends TestCase
         self::assertNull($metadata->jpegBitsPerSample);
         self::assertNull($metadata->jpegFrameSamplingFactors);
         self::assertNull($metadata->jpegYCbCrSubSampling);
+        self::assertNull($metadata->jpegFrameWidth);
+        self::assertNull($metadata->jpegFrameHeight);
         self::assertNull($metadata->mimeType);
         self::assertNull($metadata->fileSize);
         self::assertNull($metadata->extension);

--- a/tests/Parse/Jpeg/JpegExtractorTest.php
+++ b/tests/Parse/Jpeg/JpegExtractorTest.php
@@ -206,6 +206,8 @@ final class JpegExtractorTest extends TestCase
         $extractor = $this->createExtractor($jpeg);
 
         self::assertSame(8, $extractor->getFrameSamplePrecision());
+        self::assertSame(32, $extractor->getFrameHeight());
+        self::assertSame(64, $extractor->getFrameWidth());
         self::assertSame(
             [
                 1 => ['horizontal' => 2, 'vertical' => 2],


### PR DESCRIPTION
## Summary
- parse JPEG SOF height/width fields into dedicated properties and expose them via the metadata aggregate
- fall back to the frame-reported dimensions when structured image dimensions are otherwise unavailable
- extend the unit tests to cover the new metadata plumbing and JPEG extractor behaviour

## Testing
- composer exec phpunit -- tests/Parse/Jpeg/JpegExtractorTest.php tests/MetadataReader/MetadataReaderTest.php tests/Model/Metadata/MetadataTest.php
- composer ci:test:php:unit *(fails: TruthComparisonTest expects optional truth fixtures and HEIC support)*

------
https://chatgpt.com/codex/tasks/task_e_68fd0e24375c8323a5500262087ccaf3