### PR TITLE
fix: ensure JPEG image bit depth uses frame precision fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 ### Changed
 - Renamed the diagonal field-of-view helper from `fovDeg` to `fovDiagonalDeg`; consumers should switch to the new property name.
+- Ensured structured JPEG image bit depth falls back to the frame sample precision when the EXIF `BitsPerSample` tag is absent.
 
 ### Removed
 - Dropped the implicit QuickTime video metadata fallback to avoid mixing still-image data with movie track information.

--- a/src/Curate/StructuredMetadataBuilder.php
+++ b/src/Curate/StructuredMetadataBuilder.php
@@ -201,7 +201,12 @@ final class StructuredMetadataBuilder
 
         $camera = $this->buildCamera($exifResolver);
         $lens   = $this->buildLens($exifResolver);
-        $image  = $this->buildImage($exifResolver, $metadata->jpegFrameWidth, $metadata->jpegFrameHeight);
+        $image  = $this->buildImage(
+            $exifResolver,
+            $metadata->jpegFrameWidth,
+            $metadata->jpegFrameHeight,
+            $metadata->jpegBitsPerSample,
+        );
 
         $exposure = new Exposure(
             iso: CompositeResolver::intISO($exifResolver),
@@ -654,14 +659,19 @@ final class StructuredMetadataBuilder
     /**
      * Builds the image value object using EXIF metadata.
      *
-     * @param ExifTagResolver $exif        Resolver exposing image related EXIF tags.
-     * @param int|null        $frameWidth  Optional JPEG frame width used as fallback when EXIF is missing dimensions.
-     * @param int|null        $frameHeight Optional JPEG frame height used as fallback when EXIF is missing dimensions.
+     * @param ExifTagResolver $exif          Resolver exposing image related EXIF tags.
+     * @param int|null        $frameWidth    Optional JPEG frame width used as fallback when EXIF is missing dimensions.
+     * @param int|null        $frameHeight   Optional JPEG frame height used as fallback when EXIF is missing dimensions.
+     * @param int|null        $bitsPerSample Optional JPEG sample precision used when EXIF lacks bit depth information.
      *
      * @return Image Normalised image metadata aggregate.
      */
-    private function buildImage(ExifTagResolver $exif, ?int $frameWidth, ?int $frameHeight): Image
-    {
+    private function buildImage(
+        ExifTagResolver $exif,
+        ?int $frameWidth,
+        ?int $frameHeight,
+        ?int $bitsPerSample,
+    ): Image {
         [$width, $height] = CompositeResolver::dimensions($exif);
 
         $orientation = $exif->orientation();
@@ -673,11 +683,16 @@ final class StructuredMetadataBuilder
             $height = $frameHeight;
         }
 
+        $imageBitsPerSample = $exif->bitsPerSample();
+        if ($imageBitsPerSample === null) {
+            $imageBitsPerSample = $bitsPerSample;
+        }
+
         return new Image(
             width: $width,
             height: $height,
             orientation: $orientation,
-            bitsPerSample: $exif->bitsPerSample(),
+            bitsPerSample: $imageBitsPerSample,
             colorSpace: $this->normalizedColorSpace($exif),
             imageUniqueId: $exif->imageUniqueId(),
             imageNumber: $exif->imageNumber(),

--- a/tests/MetadataReader/MetadataReaderTest.php
+++ b/tests/MetadataReader/MetadataReaderTest.php
@@ -46,6 +46,8 @@ final class MetadataReaderTest extends TestCase
 
     private const int MARKER_APP1 = 0xE1;
 
+    private const int MARKER_SOF0 = 0xC0;
+
     /**
      * Ensures JPEG detection extracts EXIF and XMP payloads with parsed documents.
      */
@@ -129,6 +131,39 @@ final class MetadataReaderTest extends TestCase
         $structured = $metadata->structured();
         self::assertSame($expectedSha1, $structured->file->digestSha1);
         self::assertSame($expectedMd5, $structured->file->digestMd5);
+    }
+
+    #[Test]
+    public function testStructuredImageBitsPerSampleFallsBackToFramePrecision(): void
+    {
+        $makerNote = 'sof-maker-note';
+        $tiff      = $this->littleEndianTiffWithMakerNote('Fallback', 'Sample', $makerNote);
+
+        $sofPayload = chr(12)
+            . pack('n', 64)
+            . pack('n', 80)
+            . chr(3)
+            . chr(1) . chr(0x22) . chr(0)
+            . chr(2) . chr(0x11) . chr(1)
+            . chr(3) . chr(0x11) . chr(1);
+
+        $jpeg = "\xFF\xD8"
+            . $this->segment(self::MARKER_APP1, self::EXIF_SIGNATURE . $tiff)
+            . $this->segment(self::MARKER_SOF0, $sofPayload)
+            . "\xFF\xD9";
+
+        $path = $this->writeTempFile($jpeg);
+
+        try {
+            $metadata = (new MetadataReader())->read($path);
+        } finally {
+            @unlink($path);
+        }
+
+        self::assertSame(12, $metadata->jpegBitsPerSample);
+
+        $structured = $metadata->structured();
+        self::assertSame(12, $structured->image->bitsPerSample);
     }
 
     /**


### PR DESCRIPTION
## Summary
- allow the structured metadata image builder to fall back to JPEG frame precision when EXIF omits BitsPerSample
- add a metadata reader integration test covering the SOF precision fallback and record the behaviour in the changelog

## Testing
- composer ci:test:php:unit *(fails: truth comparison suite depends on unavailable fixture media in this environment)*
- ./.build/bin/phpunit tests/MetadataReader/MetadataReaderTest.php


------
https://chatgpt.com/codex/tasks/task_e_68fd0e2481588323b2888a0d518a0ced