### PR TITLE
fix(curate): use jpeg frame precision for image bits-per-sample

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 ### Changed
 - Renamed the diagonal field-of-view helper from `fovDeg` to `fovDiagonalDeg`; consumers should switch to the new property name.
+- Backfilled structured JPEG image bit depth from the start-of-frame precision when the EXIF tag is missing.
 
 ### Removed
 - Dropped the implicit QuickTime video metadata fallback to avoid mixing still-image data with movie track information.

--- a/src/Curate/StructuredMetadataBuilder.php
+++ b/src/Curate/StructuredMetadataBuilder.php
@@ -673,11 +673,16 @@ final class StructuredMetadataBuilder
 
         $orientation = $exif->orientation();
 
+        $bitsPerSample = $exif->bitsPerSample();
+        if ($bitsPerSample === null) {
+            $bitsPerSample = $metadata->jpegBitsPerSample;
+        }
+
         return new Image(
             width: $width,
             height: $height,
             orientation: $orientation,
-            bitsPerSample: $exif->bitsPerSample(),
+            bitsPerSample: $bitsPerSample,
             colorSpace: $this->normalizedColorSpace($exif),
             imageUniqueId: $exif->imageUniqueId(),
             imageNumber: $exif->imageNumber(),

--- a/tests/MetadataReader/MetadataReaderTest.php
+++ b/tests/MetadataReader/MetadataReaderTest.php
@@ -151,6 +151,35 @@ final class MetadataReaderTest extends TestCase
     }
 
     /**
+     * Ensures the structured image aggregate falls back to the SOF precision when EXIF lacks the tag.
+     */
+    #[Test]
+    public function testStructuredImageBitsPerSampleFallbacksToFramePrecision(): void
+    {
+        $sofPayload = $this->buildBaselineStartOfFramePayload(8, 672, 448);
+
+        $jpeg = "\xFF\xD8"
+            . $this->segment(0xC0, $sofPayload)
+            . "\xFF\xD9";
+
+        $path = $this->writeTempFile($jpeg, 'jpg');
+
+        try {
+            $metadata = (new MetadataReader())->read($path);
+        } finally {
+            @unlink($path);
+        }
+
+        self::assertSame(8, $metadata->jpegBitsPerSample);
+
+        $image = $metadata->structured()->image;
+
+        self::assertSame(8, $image->bitsPerSample);
+        self::assertSame(448, $image->width);
+        self::assertSame(672, $image->height);
+    }
+
+    /**
      * Ensures ISO BMFF detection populates EXIF/XMP blobs and QuickTime metadata.
      */
     #[Test]
@@ -300,6 +329,32 @@ final class MetadataReaderTest extends TestCase
             . $modelData
             . $exifIfd
             . $makerNote;
+    }
+
+    /**
+     * Builds a baseline start of frame payload with three colour components.
+     *
+     * @param int $precision Sample precision reported by the SOF marker.
+     * @param int $height    Frame height in image lines.
+     * @param int $width     Frame width in samples per line.
+     *
+     * @return string Serialized SOF payload excluding marker and length fields.
+     */
+    private function buildBaselineStartOfFramePayload(int $precision, int $height, int $width): string
+    {
+        $components = [
+            [1, 0x22, 0],
+            [2, 0x11, 1],
+            [3, 0x11, 1],
+        ];
+
+        $payload = pack('CnnC', $precision, $height, $width, count($components));
+
+        foreach ($components as [$id, $sampling, $table]) {
+            $payload .= pack('CCC', $id, $sampling, $table);
+        }
+
+        return $payload;
     }
 
     /**


### PR DESCRIPTION
## Summary
- fall back to the JPEG start-of-frame precision when EXIF omits BitsPerSample
- cover the fallback with a metadata reader test that builds a synthetic JPEG
- document the change in the changelog

## Testing
- composer ci:test:php:unit *(fails: FormatDetector reports unsupported container for HEIC fixtures in TruthComparisonTest)*
- ./.build/bin/phpunit tests/MetadataReader/MetadataReaderTest.php


------
https://chatgpt.com/codex/tasks/task_e_68fd118d12748323a9bb32f1a3e5f158