### PR TITLE
Expose interoperability version metadata

### DIFF
--- a/src/Curate/Resolver/ExifTagResolver.php
+++ b/src/Curate/Resolver/ExifTagResolver.php
@@ -130,8 +130,21 @@ final readonly class ExifTagResolver
             'subsectimeoriginal'  => $this->subSecTimeOriginal(),
             'subsectimedigitized' => $this->subSecTimeDigitized(),
             'interopindex'        => $this->interopIndex(),
+            'interopversion'      => $this->interopVersion(),
             default               => null,
         };
+    }
+
+    /**
+     * Returns the interoperability version string.
+     */
+    public function interopVersion(): ?string
+    {
+        if ($this->document instanceof ExifDocument) {
+            return $this->document->interopVersion();
+        }
+
+        return null;
     }
 
     /**

--- a/src/Curate/StructuredMetadataBuilder.php
+++ b/src/Curate/StructuredMetadataBuilder.php
@@ -151,7 +151,7 @@ final class StructuredMetadataBuilder
         $gpsResolver       = new GpsResolver();
         $regionsResolver   = new RegionsResolver();
 
-        $interop = new Interop(index: $exifResolver->interopIndex());
+        $interop = new Interop(index: $exifResolver->interopIndex(), version: $exifResolver->interopVersion());
 
         $bitsPerSample    = $exifResolver->bitsPerSample() ?? $metadata->jpegBitsPerSample;
         $ycbcrSubSampling = $exifResolver->ycbcrSubSampling();

--- a/src/Model/Exif/ExifDocument.php
+++ b/src/Model/Exif/ExifDocument.php
@@ -457,6 +457,22 @@ final readonly class ExifDocument
     }
 
     /**
+     * Returns the interoperability version string when present.
+     */
+    public function interopVersion(): ?string
+    {
+        $raw = $this->rawString($this->interopIfd, ExifTag::INTEROPERABILITY_VERSION);
+
+        if ($raw === null) {
+            return null;
+        }
+
+        $trimmed = trim($raw, "\0 ");
+
+        return $trimmed === '' ? null : $trimmed;
+    }
+
+    /**
      * Returns the interlace flag when recorded.
      */
     public function interlace(): ?int

--- a/src/Model/Exif/ExifTag.php
+++ b/src/Model/Exif/ExifTag.php
@@ -423,6 +423,8 @@ final readonly class ExifTag
     // Interoperability IFD
     public const int INTEROPERABILITY_INDEX = 0x0001;
 
+    public const int INTEROPERABILITY_VERSION = 0x0002;
+
     /**
      * Prevent instantiation of this constants-only utility class.
      */

--- a/src/Value/Interop.php
+++ b/src/Value/Interop.php
@@ -17,9 +17,10 @@ namespace MagicSunday\ImageMeta\Value;
 final readonly class Interop
 {
     /**
-     * @param string|null $index Interoperability index identifier such as "R98".
+     * @param string|null $index   Interoperability index identifier such as "R98".
+     * @param string|null $version Interoperability version string such as "0100".
      */
-    public function __construct(public ?string $index)
+    public function __construct(public ?string $index, public ?string $version)
     {
     }
 }

--- a/tests/Curate/StructuredMetadataBuilderTest.php
+++ b/tests/Curate/StructuredMetadataBuilderTest.php
@@ -181,7 +181,8 @@ final class StructuredMetadataBuilderTest extends TestCase
         ]);
 
         $interopIfd = new Ifd([
-            ExifTag::INTEROPERABILITY_INDEX => new IfdEntry(ExifTag::INTEROPERABILITY_INDEX, 2, 4, 'R98'),
+            ExifTag::INTEROPERABILITY_INDEX   => new IfdEntry(ExifTag::INTEROPERABILITY_INDEX, 2, 4, 'R98'),
+            ExifTag::INTEROPERABILITY_VERSION => new IfdEntry(ExifTag::INTEROPERABILITY_VERSION, 7, 6, "0100\0 "),
         ]);
 
         $exifDocument = new ExifDocument($ifd0, $exifIfd, null, $interopIfd, null);
@@ -205,7 +206,7 @@ final class StructuredMetadataBuilderTest extends TestCase
 
         $structured = (new StructuredMetadataBuilder())->build($metadata);
 
-        self::assertSame(['index' => 'R98'], get_object_vars($structured->interop));
+        self::assertSame(['index' => 'R98', 'version' => '0100'], get_object_vars($structured->interop));
 
         self::assertSame(Compression::JPEG, $structured->tiff->compression);
         self::assertSame(Photometric::YCBCR, $structured->tiff->photometric);
@@ -1028,7 +1029,7 @@ final class StructuredMetadataBuilderTest extends TestCase
 
         $structured = (new StructuredMetadataBuilder())->build($metadata);
 
-        self::assertSame(['index' => null], get_object_vars($structured->interop));
+        self::assertSame(['index' => null, 'version' => null], get_object_vars($structured->interop));
         self::assertNull($structured->tiff->compression);
         self::assertNull($structured->camera->make);
         self::assertSame('2.2', $structured->standards->profile);

--- a/tests/Model/Exif/ExifTagTest.php
+++ b/tests/Model/Exif/ExifTagTest.php
@@ -211,7 +211,8 @@ final class ExifTagTest extends TestCase
             'METADATA_EDITING_SOFTWARE_LEGACY' => 0xE932,
 
             // Interoperability IFD
-            'INTEROPERABILITY_INDEX' => 0x0001,
+            'INTEROPERABILITY_INDEX'   => 0x0001,
+            'INTEROPERABILITY_VERSION' => 0x0002,
         ];
 
         $reflection = new ReflectionClass(ExifTag::class);


### PR DESCRIPTION
## Summary
- add the EXIF interoperability version constant and cover it in the tag registry test
- expose a trimmed interoperability version via the EXIF document, resolver, and structured metadata value object
- extend the interoperability value object and builder tests to surface both index and version

## Testing
- composer ci:test:php:unit *(fails: unsupported HEIC fixtures and missing truth data in the existing suite)*
- .build/bin/phpunit tests/Model/Exif/ExifTagTest.php tests/Curate/StructuredMetadataBuilderTest.php

------
https://chatgpt.com/codex/tasks/task_e_68fd2a992ed48323877a3e7f1171d476