### PR TITLE
Add legacy ISO speed ratings alias to EXIF tags

### DIFF
--- a/src/Model/Exif/ExifTag.php
+++ b/src/Model/Exif/ExifTag.php
@@ -129,6 +129,14 @@ final readonly class ExifTag
 
     public const int SPECTRAL_SENSITIVITY = 0x8824;
 
+    /**
+     * Legacy EXIF 2.x identifier retained for backwards compatibility.
+     *
+     * EXIF 3.0 renames the tag to PhotographicSensitivity, exposed via the
+     * PHOTOGRAPHIC_SENSITIVITY alias.
+     */
+    public const int ISO_SPEED_RATINGS_LEGACY = 0x8827;
+
     public const int PHOTOGRAPHIC_SENSITIVITY = 0x8827;
 
     // Opto-Electric Conversion Function

--- a/tests/Model/Exif/ExifTagTest.php
+++ b/tests/Model/Exif/ExifTagTest.php
@@ -111,6 +111,7 @@ final class ExifTagTest extends TestCase
             'F_NUMBER'                                 => 0x829D,
             'EXPOSURE_PROGRAM'                         => 0x8822,
             'SPECTRAL_SENSITIVITY'                     => 0x8824,
+            'ISO_SPEED_RATINGS_LEGACY'                 => 0x8827,
             'PHOTOGRAPHIC_SENSITIVITY'                 => 0x8827,
             'OECF'                                     => 0x8828,
             'INTERLACE'                                => 0x8829,
@@ -239,5 +240,16 @@ final class ExifTagTest extends TestCase
     public function testModifyDateAliasMatchesDateTime(): void
     {
         self::assertSame(ExifTag::DATETIME, ExifTag::MODIFY_DATE);
+    }
+
+    /**
+     * Ensures the ISO Speed Ratings alias shares the PhotographicSensitivity identifier.
+     */
+    public function testIsoSpeedRatingsLegacyAliasMatchesPhotographicSensitivity(): void
+    {
+        self::assertSame(
+            ExifTag::PHOTOGRAPHIC_SENSITIVITY,
+            ExifTag::ISO_SPEED_RATINGS_LEGACY
+        );
     }
 }


### PR DESCRIPTION
## Summary
- add an ISO_SPEED_RATINGS_LEGACY constant mirroring the EXIF 2.x tag name
- document the alias alongside the modern PhotographicSensitivity identifier
- extend the EXIF tag registry test suite to cover the new alias mapping

## Testing
- composer ci:test:php:unit *(fails: known fixture-dependent TruthComparisonTest assertions in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68fd2abac08c83239476948dc1615427