### PR TITLE
feat: expose EXIF noise reduction metadata

### DIFF
--- a/src/Curate/Resolver/ExifTagResolver.php
+++ b/src/Curate/Resolver/ExifTagResolver.php
@@ -1123,6 +1123,14 @@ final readonly class ExifTagResolver
     }
 
     /**
+     * Returns the noise reduction strength encoded by the camera.
+     */
+    public function noiseReduction(): ?float
+    {
+        return $this->rationalValue($this->document?->exifIfd, ExifTag::NOISE);
+    }
+
+    /**
      * Returns the device setting description payload.
      */
     public function deviceSettingDescription(): ?string

--- a/src/Curate/StructuredMetadataBuilder.php
+++ b/src/Curate/StructuredMetadataBuilder.php
@@ -322,7 +322,7 @@ final class StructuredMetadataBuilder
             contrast: null,
             saturation: null,
             pictureStyle: null,
-            noiseReduction: null,
+            noiseReduction: $exifResolver->noiseReduction(),
             clarity: null,
             customRendered: $exifResolver->customRendered()?->value,
             deviceSettingDescription: $exifResolver->deviceSettingDescription(),

--- a/src/Model/Exif/ExifDocument.php
+++ b/src/Model/Exif/ExifDocument.php
@@ -749,6 +749,14 @@ final readonly class ExifDocument
     }
 
     /**
+     * Returns the noise measurement recorded by the camera.
+     */
+    public function noise(): ?float
+    {
+        return $this->rational($this->exifIfd, ExifTag::NOISE);
+    }
+
+    /**
      * Returns the CFA pattern definition as a list of component identifiers.
      *
      * @return list<int>|null

--- a/src/Model/Exif/ExifTag.php
+++ b/src/Model/Exif/ExifTag.php
@@ -307,6 +307,8 @@ final readonly class ExifTag
 
     public const int SPATIAL_FREQUENCY_RESPONSE = 0xA20C;
 
+    public const int NOISE = 0xA20D;
+
     public const int FOCAL_PLANE_X_RESOLUTION = 0xA20E;
 
     public const int FOCAL_PLANE_Y_RESOLUTION = 0xA20F;

--- a/src/Value/ProcessingSettings.php
+++ b/src/Value/ProcessingSettings.php
@@ -21,7 +21,7 @@ final readonly class ProcessingSettings
      * @param int|null    $contrast                 Contrast adjustment level.
      * @param int|null    $saturation               Saturation adjustment level.
      * @param string|null $pictureStyle             Vendor specific picture style identifier.
-     * @param bool|null   $noiseReduction           Whether noise reduction was applied.
+     * @param float|null  $noiseReduction           Noise reduction strength as reported by the camera.
      * @param int|null    $clarity                  Clarity adjustment level.
      * @param int|null    $customRendered           Indicates whether a custom rendering was applied in-camera.
      * @param string|null $deviceSettingDescription Binary device setting description payload.
@@ -31,7 +31,7 @@ final readonly class ProcessingSettings
         public ?int $contrast,
         public ?int $saturation,
         public ?string $pictureStyle,
-        public ?bool $noiseReduction,
+        public ?float $noiseReduction,
         public ?int $clarity,
         public ?int $customRendered,
         public ?string $deviceSettingDescription,

--- a/tests/Curate/StructuredMetadataBuilderTest.php
+++ b/tests/Curate/StructuredMetadataBuilderTest.php
@@ -158,6 +158,7 @@ final class StructuredMetadataBuilderTest extends TestCase
             ExifTag::CAMERA_ELEVATION_ANGLE      => new IfdEntry(ExifTag::CAMERA_ELEVATION_ANGLE, 10, 1, new ExifRational(150, 10)),
             ExifTag::RELATED_SOUND_FILE          => new IfdEntry(ExifTag::RELATED_SOUND_FILE, 2, 10, 'sound.wav'),
             ExifTag::FLASH_ENERGY                => new IfdEntry(ExifTag::FLASH_ENERGY, 5, 1, new ExifRational(250, 10)),
+            ExifTag::NOISE                       => new IfdEntry(ExifTag::NOISE, 5, 1, new ExifRational(456, 10)),
             ExifTag::SPATIAL_FREQUENCY_RESPONSE  => new IfdEntry(ExifTag::SPATIAL_FREQUENCY_RESPONSE, 7, 12, 'SFR-Curve-01'),
             ExifTag::FOCAL_PLANE_X_RESOLUTION    => new IfdEntry(ExifTag::FOCAL_PLANE_X_RESOLUTION, 5, 1, new ExifRational(4321, 100)),
             ExifTag::FOCAL_PLANE_Y_RESOLUTION    => new IfdEntry(ExifTag::FOCAL_PLANE_Y_RESOLUTION, 5, 1, new ExifRational(4300, 100)),
@@ -309,6 +310,7 @@ final class StructuredMetadataBuilderTest extends TestCase
 
         self::assertSame('Profile:Portrait', $structured->processing->deviceSettingDescription);
         self::assertSame(1, $structured->processing->customRendered);
+        self::assertEqualsWithDelta(45.6, $structured->processing->noiseReduction, 0.0001);
 
         self::assertSame('Jane D. Photographer', $structured->author->photographer);
         self::assertSame('John Editor', $structured->author->imageEditor);

--- a/tests/Model/Exif/ExifDocumentTest.php
+++ b/tests/Model/Exif/ExifDocumentTest.php
@@ -77,6 +77,12 @@ final class ExifDocumentTest extends TestCase
                 1,
                 new ExifRational(50, 1),
             ),
+            ExifTag::NOISE => new IfdEntry(
+                ExifTag::NOISE,
+                5,
+                1,
+                new ExifRational(123, 10),
+            ),
             ExifTag::LENS_MODEL             => new IfdEntry(ExifTag::LENS_MODEL, 2, 1, 'RF50mm F1.2L USM'),
             ExifTag::DATETIME_ORIGINAL      => new IfdEntry(ExifTag::DATETIME_ORIGINAL, 2, 1, '2024:05:01 12:34:56'),
             ExifTag::SUB_SEC_TIME_ORIGINAL  => new IfdEntry(ExifTag::SUB_SEC_TIME_ORIGINAL, 2, 1, '123'),
@@ -126,6 +132,7 @@ final class ExifDocumentTest extends TestCase
         self::assertSame(0.008, $doc->exposureTime());
         self::assertSame(2.8, $doc->fNumber());
         self::assertSame(50.0, $doc->focalLengthMm());
+        self::assertEqualsWithDelta(12.3, $doc->noise(), 0.0001);
         self::assertSame('2024:05:01 12:34:56', $doc->dateTimeOriginalRaw());
         self::assertSame('+02:00', $doc->offsetTimeOriginalRaw());
 

--- a/tests/Model/Exif/ExifTagTest.php
+++ b/tests/Model/Exif/ExifTagTest.php
@@ -154,6 +154,7 @@ final class ExifTagTest extends TestCase
             'RELATED_SOUND_FILE'                       => 0xA004,
             'FLASH_ENERGY'                             => 0xA20B,
             'SPATIAL_FREQUENCY_RESPONSE'               => 0xA20C,
+            'NOISE'                                    => 0xA20D,
             'FOCAL_PLANE_X_RESOLUTION'                 => 0xA20E,
             'FOCAL_PLANE_Y_RESOLUTION'                 => 0xA20F,
             'FOCAL_PLANE_RESOLUTION_UNIT'              => 0xA210,
@@ -232,7 +233,6 @@ final class ExifTagTest extends TestCase
         $constants = array_flip((new ReflectionClass(ExifTag::class))->getConstants());
 
         self::assertArrayNotHasKey(0x013C, $constants);
-        self::assertArrayNotHasKey(0xA20D, $constants);
     }
 
     /**


### PR DESCRIPTION
## Summary
- add the EXIF noise tag constant and expose the decoded rational through `ExifDocument`
- extend the EXIF tag resolver and structured metadata builder to propagate the camera noise reduction strength
- update processing settings and regression tests to cover the new value

## Testing
- composer ci:test:php:unit *(fails: known truth-comparison fixtures are unavailable in the test environment)*
- .build/bin/phpunit tests/Model/Exif/ExifDocumentTest.php tests/Curate/StructuredMetadataBuilderTest.php tests/Model/Exif/ExifTagTest.php


------
https://chatgpt.com/codex/tasks/task_e_68fd394f61808323a9acb39ba75b8cd7