### PR TITLE
Add interoperability related image metadata accessors

### DIFF
--- a/src/Curate/Resolver/ExifTagResolver.php
+++ b/src/Curate/Resolver/ExifTagResolver.php
@@ -88,6 +88,8 @@ final readonly class ExifTagResolver
             'imagewidth'                => $this->numericValue($this->document?->ifd0, ExifTag::IMAGE_WIDTH),
             'exifimageheight'           => $this->numericValue($this->document?->exifIfd, ExifTag::PIXEL_Y_DIMENSION),
             'imagelength'               => $this->numericValue($this->document?->ifd0, ExifTag::IMAGE_HEIGHT),
+            'relatedimagewidth'         => $this->relatedImageWidth(),
+            'relatedimagelength'        => $this->relatedImageLength(),
             'flash'                     => $this->numericValue($this->document?->exifIfd, ExifTag::FLASH),
             'contrast'                  => $this->numericValue($this->document?->exifIfd, ExifTag::CONTRAST),
             'saturation'                => $this->numericValue($this->document?->exifIfd, ExifTag::SATURATION),
@@ -131,6 +133,7 @@ final readonly class ExifTagResolver
             'subsectimedigitized' => $this->subSecTimeDigitized(),
             'interopindex'        => $this->interopIndex(),
             'interopversion'      => $this->interopVersion(),
+            'relatedimagefileformat' => $this->relatedImageFileFormat(),
             default               => null,
         };
     }
@@ -628,6 +631,30 @@ final readonly class ExifTagResolver
     public function relatedSoundFile(): ?string
     {
         return $this->document?->relatedSoundFile();
+    }
+
+    /**
+     * Returns the related image file format from the interoperability IFD.
+     */
+    public function relatedImageFileFormat(): ?string
+    {
+        return $this->document?->relatedImageFileFormat();
+    }
+
+    /**
+     * Returns the related image width from the interoperability IFD.
+     */
+    public function relatedImageWidth(): ?int
+    {
+        return $this->document?->relatedImageWidth();
+    }
+
+    /**
+     * Returns the related image length from the interoperability IFD.
+     */
+    public function relatedImageLength(): ?int
+    {
+        return $this->document?->relatedImageLength();
     }
 
     /**

--- a/src/Curate/StructuredMetadataBuilder.php
+++ b/src/Curate/StructuredMetadataBuilder.php
@@ -151,7 +151,13 @@ final class StructuredMetadataBuilder
         $gpsResolver       = new GpsResolver();
         $regionsResolver   = new RegionsResolver();
 
-        $interop = new Interop(index: $exifResolver->interopIndex(), version: $exifResolver->interopVersion());
+        $interop = new Interop(
+            index: $exifResolver->interopIndex(),
+            version: $exifResolver->interopVersion(),
+            relatedImageFileFormat: $exifResolver->relatedImageFileFormat(),
+            relatedImageWidth: $exifResolver->relatedImageWidth(),
+            relatedImageLength: $exifResolver->relatedImageLength(),
+        );
 
         $bitsPerSample    = $exifResolver->bitsPerSample() ?? $metadata->jpegBitsPerSample;
         $ycbcrSubSampling = $exifResolver->ycbcrSubSampling();

--- a/src/Model/Exif/ExifDocument.php
+++ b/src/Model/Exif/ExifDocument.php
@@ -473,6 +473,30 @@ final readonly class ExifDocument
     }
 
     /**
+     * Returns the related image file format declared in the interoperability IFD.
+     */
+    public function relatedImageFileFormat(): ?string
+    {
+        return $this->str($this->interopIfd, ExifTag::RELATED_IMAGE_FILE_FORMAT);
+    }
+
+    /**
+     * Returns the related image width declared in the interoperability IFD.
+     */
+    public function relatedImageWidth(): ?int
+    {
+        return $this->int($this->interopIfd, ExifTag::RELATED_IMAGE_WIDTH);
+    }
+
+    /**
+     * Returns the related image length declared in the interoperability IFD.
+     */
+    public function relatedImageLength(): ?int
+    {
+        return $this->int($this->interopIfd, ExifTag::RELATED_IMAGE_LENGTH);
+    }
+
+    /**
      * Returns the interlace flag when recorded.
      */
     public function interlace(): ?int

--- a/src/Model/Exif/ExifTag.php
+++ b/src/Model/Exif/ExifTag.php
@@ -433,6 +433,12 @@ final readonly class ExifTag
 
     public const int INTEROPERABILITY_VERSION = 0x0002;
 
+    public const int RELATED_IMAGE_FILE_FORMAT = 0x1000;
+
+    public const int RELATED_IMAGE_WIDTH = 0x1001;
+
+    public const int RELATED_IMAGE_LENGTH = 0x1002;
+
     /**
      * Prevent instantiation of this constants-only utility class.
      */

--- a/src/Value/Interop.php
+++ b/src/Value/Interop.php
@@ -17,10 +17,18 @@ namespace MagicSunday\ImageMeta\Value;
 final readonly class Interop
 {
     /**
-     * @param string|null $index   Interoperability index identifier such as "R98".
-     * @param string|null $version Interoperability version string such as "0100".
+     * @param string|null $index                  Interoperability index identifier such as "R98".
+     * @param string|null $version                Interoperability version string such as "0100".
+     * @param string|null $relatedImageFileFormat Declared file format for the related image asset.
+     * @param int|null    $relatedImageWidth      Pixel width of the related image asset.
+     * @param int|null    $relatedImageLength     Pixel length of the related image asset.
      */
-    public function __construct(public ?string $index, public ?string $version)
-    {
+    public function __construct(
+        public ?string $index,
+        public ?string $version,
+        public ?string $relatedImageFileFormat = null,
+        public ?int $relatedImageWidth = null,
+        public ?int $relatedImageLength = null,
+    ) {
     }
 }

--- a/tests/Curate/StructuredMetadataBuilderTest.php
+++ b/tests/Curate/StructuredMetadataBuilderTest.php
@@ -183,6 +183,9 @@ final class StructuredMetadataBuilderTest extends TestCase
         $interopIfd = new Ifd([
             ExifTag::INTEROPERABILITY_INDEX   => new IfdEntry(ExifTag::INTEROPERABILITY_INDEX, 2, 4, 'R98'),
             ExifTag::INTEROPERABILITY_VERSION => new IfdEntry(ExifTag::INTEROPERABILITY_VERSION, 7, 6, "0100\0 "),
+            ExifTag::RELATED_IMAGE_FILE_FORMAT => new IfdEntry(ExifTag::RELATED_IMAGE_FILE_FORMAT, 2, 4, 'JPEG'),
+            ExifTag::RELATED_IMAGE_WIDTH       => new IfdEntry(ExifTag::RELATED_IMAGE_WIDTH, 4, 1, 4000),
+            ExifTag::RELATED_IMAGE_LENGTH      => new IfdEntry(ExifTag::RELATED_IMAGE_LENGTH, 4, 1, 3000),
         ]);
 
         $exifDocument = new ExifDocument($ifd0, $exifIfd, null, $interopIfd, null);
@@ -206,7 +209,16 @@ final class StructuredMetadataBuilderTest extends TestCase
 
         $structured = (new StructuredMetadataBuilder())->build($metadata);
 
-        self::assertSame(['index' => 'R98', 'version' => '0100'], get_object_vars($structured->interop));
+        self::assertSame(
+            [
+                'index' => 'R98',
+                'version' => '0100',
+                'relatedImageFileFormat' => 'JPEG',
+                'relatedImageWidth' => 4000,
+                'relatedImageLength' => 3000,
+            ],
+            get_object_vars($structured->interop),
+        );
 
         self::assertSame(Compression::JPEG, $structured->tiff->compression);
         self::assertSame(Photometric::YCBCR, $structured->tiff->photometric);
@@ -1029,7 +1041,16 @@ final class StructuredMetadataBuilderTest extends TestCase
 
         $structured = (new StructuredMetadataBuilder())->build($metadata);
 
-        self::assertSame(['index' => null, 'version' => null], get_object_vars($structured->interop));
+        self::assertSame(
+            [
+                'index' => null,
+                'version' => null,
+                'relatedImageFileFormat' => null,
+                'relatedImageWidth' => null,
+                'relatedImageLength' => null,
+            ],
+            get_object_vars($structured->interop),
+        );
         self::assertNull($structured->tiff->compression);
         self::assertNull($structured->camera->make);
         self::assertSame('2.2', $structured->standards->profile);

--- a/tests/Model/Exif/ExifDocumentTest.php
+++ b/tests/Model/Exif/ExifDocumentTest.php
@@ -209,6 +209,23 @@ final class ExifDocumentTest extends TestCase
         self::assertSame('2022-08-09T10:11:12.321-03:00', $capture->format(self::ISO_8601_MILLISECONDS));
     }
 
+    #[Test]
+    public function exposesRelatedImageMetadataFromInteroperabilityIfd(): void
+    {
+        $ifd0       = new Ifd([]);
+        $interopIfd = new Ifd([
+            ExifTag::RELATED_IMAGE_FILE_FORMAT => new IfdEntry(ExifTag::RELATED_IMAGE_FILE_FORMAT, 2, 4, "JPEG\0"),
+            ExifTag::RELATED_IMAGE_WIDTH       => new IfdEntry(ExifTag::RELATED_IMAGE_WIDTH, 4, 1, 4000),
+            ExifTag::RELATED_IMAGE_LENGTH      => new IfdEntry(ExifTag::RELATED_IMAGE_LENGTH, 4, 1, 3000),
+        ]);
+
+        $doc = new ExifDocument($ifd0, null, null, $interopIfd, null);
+
+        self::assertSame('JPEG', $doc->relatedImageFileFormat());
+        self::assertSame(4000, $doc->relatedImageWidth());
+        self::assertSame(3000, $doc->relatedImageLength());
+    }
+
     /**
      * Uses the legacy ModifyDate tag when original and digitised timestamps are absent.
      */

--- a/tests/Model/Exif/ExifTagTest.php
+++ b/tests/Model/Exif/ExifTagTest.php
@@ -214,6 +214,9 @@ final class ExifTagTest extends TestCase
             // Interoperability IFD
             'INTEROPERABILITY_INDEX'   => 0x0001,
             'INTEROPERABILITY_VERSION' => 0x0002,
+            'RELATED_IMAGE_FILE_FORMAT' => 0x1000,
+            'RELATED_IMAGE_WIDTH'       => 0x1001,
+            'RELATED_IMAGE_LENGTH'      => 0x1002,
         ];
 
         $reflection = new ReflectionClass(ExifTag::class);


### PR DESCRIPTION
## Summary
- add EXIF interoperability constants for related image metadata
- expose related image file format, width, and length via the Exif document and resolver
- extend structured metadata interop payload and tests to cover the new fields

## Testing
- composer exec phpunit -- tests/Model/Exif/ExifDocumentTest.php tests/Model/Exif/ExifTagTest.php tests/Curate/StructuredMetadataBuilderTest.php

------
https://chatgpt.com/codex/tasks/task_e_68fd3952c2fc8323bcd5a71e15135396