### PR TITLE
Add EXIF battery level support to structured capture metadata

### DIFF
--- a/src/Curate/Resolver/CaptureResolver.php
+++ b/src/Curate/Resolver/CaptureResolver.php
@@ -49,6 +49,7 @@ final readonly class CaptureResolver
             temperatureC: null,
             humidityPercent: null,
             pressureHPa: null,
+            batteryLevelPercent: $exifDocument?->batteryLevelPercent(),
             waterDepthM: null,
             accelerationMs2: null,
             cameraElevationAngleDeg: null,

--- a/src/Curate/Resolver/ExifTagResolver.php
+++ b/src/Curate/Resolver/ExifTagResolver.php
@@ -1565,6 +1565,14 @@ final readonly class ExifTagResolver
     }
 
     /**
+     * Returns the camera battery level percentage when available.
+     */
+    public function batteryLevelPercent(): ?float
+    {
+        return $this->document?->batteryLevelPercent();
+    }
+
+    /**
      * Returns the recorded temperature in Celsius.
      */
     public function temperatureCelsius(): ?float

--- a/src/Curate/StructuredMetadataBuilder.php
+++ b/src/Curate/StructuredMetadataBuilder.php
@@ -232,6 +232,7 @@ final class StructuredMetadataBuilder
             temperatureC: $exifResolver->temperatureCelsius(),
             humidityPercent: $exifResolver->humidityPercent(),
             pressureHPa: $exifResolver->pressureHPa(),
+            batteryLevelPercent: $exifResolver->batteryLevelPercent(),
             waterDepthM: $exifResolver->waterDepthMeters(),
             accelerationMs2: $exifResolver->accelerationMs2(),
             cameraElevationAngleDeg: $exifResolver->cameraElevationAngleDeg(),

--- a/src/Model/Exif/ExifDocument.php
+++ b/src/Model/Exif/ExifDocument.php
@@ -821,6 +821,16 @@ final readonly class ExifDocument
     }
 
     /**
+     * Returns the camera battery level as a percentage when provided.
+     */
+    public function batteryLevelPercent(): ?float
+    {
+        $value = $this->value($this->exifIfd, ExifTag::BATTERY_LEVEL);
+
+        return ValueConverters::batteryLevelToPercent($value);
+    }
+
+    /**
      * Returns the recorded temperature in Celsius.
      */
     public function temperatureCelsius(): ?float

--- a/src/Model/Exif/ExifTag.php
+++ b/src/Model/Exif/ExifTag.php
@@ -121,6 +121,8 @@ final readonly class ExifTag
     public const int INTEROPERABILITY_IFD_POINTER = 0xA005;
 
     // EXIF sub IFD
+    public const int BATTERY_LEVEL = 0x828F;
+
     public const int EXPOSURE_TIME = 0x829A;
 
     public const int F_NUMBER = 0x829D;

--- a/src/Model/Exif/ValueConverters.php
+++ b/src/Model/Exif/ValueConverters.php
@@ -132,6 +132,74 @@ final readonly class ValueConverters
     }
 
     /**
+     * Normalises EXIF battery level readings to a percentage.
+     *
+     * @param int|float|string|ExifRational|ExifRationalList|ExifNumericList|null $value Raw battery level value.
+     */
+    public static function batteryLevelToPercent(int|float|string|ExifRational|ExifRationalList|ExifNumericList|null $value): ?float
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        $numeric = self::rationalToFloat($value);
+        if ($numeric !== null) {
+            return self::normaliseBatteryPercent($numeric);
+        }
+
+        if (!is_string($value)) {
+            return null;
+        }
+
+        $normalized = trim($value);
+        if ($normalized === '') {
+            return null;
+        }
+
+        if (preg_match('/^(-?\d+(?:\.\d+)?)\s*\/\s*(-?\d+(?:\.\d+)?)$/', $normalized, $matches) === 1) {
+            $denominator = (float) $matches[2];
+            if ($denominator == 0.0) {
+                return null;
+            }
+
+            return self::normaliseBatteryPercent((float) $matches[1] / $denominator);
+        }
+
+        if ($normalized !== '' && $normalized[strlen($normalized) - 1] === '%') {
+            $numericPart = rtrim(substr($normalized, 0, -1));
+            if ($numericPart === '') {
+                return null;
+            }
+
+            if (preg_match('/^(-?\d+(?:\.\d+)?)$/', $numericPart, $matches) !== 1) {
+                return null;
+            }
+
+            return (float) $matches[1];
+        }
+
+        if (preg_match('/^(-?\d+(?:\.\d+)?)$/', $normalized, $matches) === 1) {
+            $numericValue = (float) $matches[1];
+
+            return self::normaliseBatteryPercent($numericValue);
+        }
+
+        return null;
+    }
+
+    /**
+     * Scales ratios to percentages when battery readings are encoded as fractions.
+     */
+    private static function normaliseBatteryPercent(float $value): float
+    {
+        if ($value >= -1.0 && $value <= 1.0) {
+            return $value * 100.0;
+        }
+
+        return $value;
+    }
+
+    /**
      * Converts a stored APEX aperture value into a traditional f-number.
      *
      * @param ExifScalar $value The APEX value to convert.

--- a/src/Value/Capture.php
+++ b/src/Value/Capture.php
@@ -23,6 +23,7 @@ final readonly class Capture
      * @param float|null             $temperatureC            Recorded temperature in Celsius.
      * @param float|null             $humidityPercent         Relative humidity percentage.
      * @param float|null             $pressureHPa             Ambient pressure in hPa.
+     * @param float|null             $batteryLevelPercent      Battery level percentage.
      * @param float|null             $waterDepthM             Water depth in metres.
      * @param float|null             $accelerationMs2         Camera acceleration in metres per second squared.
      * @param float|null             $cameraElevationAngleDeg Camera elevation angle in degrees.
@@ -33,6 +34,7 @@ final readonly class Capture
         public ?float $temperatureC,
         public ?float $humidityPercent,
         public ?float $pressureHPa,
+        public ?float $batteryLevelPercent,
         public ?float $waterDepthM,
         public ?float $accelerationMs2,
         public ?float $cameraElevationAngleDeg,

--- a/tests/Curate/Resolver/ExifTagResolverTest.php
+++ b/tests/Curate/Resolver/ExifTagResolverTest.php
@@ -268,6 +268,7 @@ final class ExifTagResolverTest extends TestCase
             ExifTag::OFFSET_TIME_DIGITIZED  => new IfdEntry(ExifTag::OFFSET_TIME_DIGITIZED, 2, 6, '+01:45'),
             ExifTag::TIME_ZONE_OFFSET       => new IfdEntry(ExifTag::TIME_ZONE_OFFSET, 8, 2, new ExifNumericList([-1, 2])),
             ExifTag::SELF_TIMER_MODE        => new IfdEntry(ExifTag::SELF_TIMER_MODE, 3, 1, 7),
+            ExifTag::BATTERY_LEVEL          => new IfdEntry(ExifTag::BATTERY_LEVEL, 2, 3, '85%'),
             ExifTag::INTERLACE              => new IfdEntry(ExifTag::INTERLACE, 3, 1, 1),
         ]);
 
@@ -282,6 +283,9 @@ final class ExifTagResolverTest extends TestCase
         self::assertSame('+01:45', $resolver->offsetTimeDigitized());
         self::assertSame([-60, 120], $resolver->timeZoneOffsetMinutes());
         self::assertSame(7, $resolver->selfTimerModeSeconds());
+        $battery = $resolver->batteryLevelPercent();
+        self::assertNotNull($battery);
+        self::assertEqualsWithDelta(85.0, $battery, 0.0001);
         self::assertSame(1, $resolver->interlace());
     }
 

--- a/tests/Curate/StructuredMetadataBuilderTest.php
+++ b/tests/Curate/StructuredMetadataBuilderTest.php
@@ -153,6 +153,7 @@ final class StructuredMetadataBuilderTest extends TestCase
             ExifTag::TEMPERATURE                 => new IfdEntry(ExifTag::TEMPERATURE, 10, 1, new ExifRational(215, 10)),
             ExifTag::HUMIDITY                    => new IfdEntry(ExifTag::HUMIDITY, 10, 1, new ExifRational(600, 10)),
             ExifTag::PRESSURE                    => new IfdEntry(ExifTag::PRESSURE, 10, 1, new ExifRational(101325, 100)),
+            ExifTag::BATTERY_LEVEL               => new IfdEntry(ExifTag::BATTERY_LEVEL, 5, 1, new ExifRational(82, 100)),
             ExifTag::WATER_DEPTH                 => new IfdEntry(ExifTag::WATER_DEPTH, 10, 1, new ExifRational(150, 10)),
             ExifTag::ACCELERATION                => new IfdEntry(ExifTag::ACCELERATION, 10, 1, new ExifRational(98, 10)),
             ExifTag::CAMERA_ELEVATION_ANGLE      => new IfdEntry(ExifTag::CAMERA_ELEVATION_ANGLE, 10, 1, new ExifRational(150, 10)),
@@ -291,6 +292,7 @@ final class StructuredMetadataBuilderTest extends TestCase
         self::assertEqualsWithDelta(1.9965, $structured->lens->maxApertureFNumber, 0.001);
 
         self::assertEqualsWithDelta(21.5, $structured->capture->temperatureC, 0.001);
+        self::assertEqualsWithDelta(82.0, $structured->capture->batteryLevelPercent, 0.001);
         self::assertEqualsWithDelta(60.0, $structured->capture->humidityPercent, 0.001);
         self::assertEqualsWithDelta(1013.25, $structured->capture->pressureHPa, 0.001);
         self::assertEqualsWithDelta(15.0, $structured->capture->waterDepthM, 0.001);

--- a/tests/Model/Exif/ExifDocumentTest.php
+++ b/tests/Model/Exif/ExifDocumentTest.php
@@ -580,6 +580,7 @@ final class ExifDocumentTest extends TestCase
             ExifTag::TEMPERATURE                 => new IfdEntry(ExifTag::TEMPERATURE, 10, 1, new ExifRational(200, 10)),
             ExifTag::HUMIDITY                    => new IfdEntry(ExifTag::HUMIDITY, 10, 1, new ExifRational(550, 10)),
             ExifTag::PRESSURE                    => new IfdEntry(ExifTag::PRESSURE, 10, 1, new ExifRational(100000, 100)),
+            ExifTag::BATTERY_LEVEL               => new IfdEntry(ExifTag::BATTERY_LEVEL, 5, 1, new ExifRational(3, 4)),
             ExifTag::WATER_DEPTH                 => new IfdEntry(ExifTag::WATER_DEPTH, 10, 1, new ExifRational(30, 10)),
             ExifTag::ACCELERATION                => new IfdEntry(ExifTag::ACCELERATION, 10, 1, new ExifRational(10, 1)),
             ExifTag::CAMERA_ELEVATION_ANGLE      => new IfdEntry(ExifTag::CAMERA_ELEVATION_ANGLE, 10, 1, new ExifRational(50, 10)),
@@ -617,6 +618,7 @@ final class ExifDocumentTest extends TestCase
         self::assertSame('Confidential', $doc->securityClassification());
         self::assertSame('Processed in RawLab', $doc->imageHistory());
         self::assertEqualsWithDelta(20.0, $doc->temperatureCelsius(), 0.0001);
+        self::assertEqualsWithDelta(75.0, $doc->batteryLevelPercent() ?? 0.0, 0.0001);
         self::assertEqualsWithDelta(55.0, $doc->humidityPercent(), 0.0001);
         self::assertEqualsWithDelta(1000.0, $doc->pressureHPa(), 0.0001);
         self::assertEqualsWithDelta(3.0, $doc->waterDepthMeters(), 0.0001);

--- a/tests/Model/Exif/ExifTagTest.php
+++ b/tests/Model/Exif/ExifTagTest.php
@@ -107,6 +107,7 @@ final class ExifTagTest extends TestCase
             'INTEROPERABILITY_IFD_POINTER' => 0xA005,
 
             // EXIF sub IFD
+            'BATTERY_LEVEL'                          => 0x828F,
             'EXPOSURE_TIME'                            => 0x829A,
             'F_NUMBER'                                 => 0x829D,
             'EXPOSURE_PROGRAM'                         => 0x8822,

--- a/tests/Model/Exif/ValueConvertersTest.php
+++ b/tests/Model/Exif/ValueConvertersTest.php
@@ -170,6 +170,33 @@ final class ValueConvertersTest extends TestCase
     }
 
     /**
+     * @param mixed      $value    Raw battery level value.
+     * @param float|null $expected Normalised percentage value.
+     */
+    #[Test]
+    #[DataProvider('provideBatteryLevelValues')]
+    public function normalisesBatteryLevelToPercent(mixed $value, ?float $expected): void
+    {
+        self::assertSame($expected, ValueConverters::batteryLevelToPercent($value));
+    }
+
+    /**
+     * @return iterable<string, array{mixed, float|null}>
+     */
+    public static function provideBatteryLevelValues(): iterable
+    {
+        yield 'rational fraction' => [new ExifRational(1, 2), 50.0];
+        yield 'rational percent' => [new ExifRational(75, 1), 75.0];
+        yield 'string fraction' => ['1/4', 25.0];
+        yield 'string percent' => ['80%', 80.0];
+        yield 'ratio string' => ['0.2', 20.0];
+        yield 'numeric percent string' => ['55.5', 55.5];
+        yield 'invalid string' => ['battery low', null];
+        yield 'empty string' => ['', null];
+        yield 'null value' => [null, null];
+    }
+
+    /**
      * @param string|null $ref      The speed reference.
      * @param mixed       $value    The raw speed value.
      * @param float|null  $expected The expected metres per second.


### PR DESCRIPTION
## Summary
- add the EXIF BatteryLevel tag constant and expose it through ExifDocument and ExifTagResolver
- normalise raw battery readings to percentages in ValueConverters and cover the new behaviour with unit tests
- extend the Capture value object and structured metadata builder to surface the battery level in structured output

## Testing
- composer ci:test:php:unit *(fails: TruthComparisonTest requires media fixtures that are unavailable in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68fd3967781883239034439c25550b9f