### PR TITLE
feat: expose FlashPix APP2 streams

### DIFF
--- a/src/Curate/StructuredMetadata.php
+++ b/src/Curate/StructuredMetadata.php
@@ -23,6 +23,7 @@ use MagicSunday\ImageMeta\Value\Derived;
 use MagicSunday\ImageMeta\Value\Device;
 use MagicSunday\ImageMeta\Value\Exposure;
 use MagicSunday\ImageMeta\Value\File;
+use MagicSunday\ImageMeta\Value\FlashPix;
 use MagicSunday\ImageMeta\Value\Focus;
 use MagicSunday\ImageMeta\Value\Gps;
 use MagicSunday\ImageMeta\Value\Image;
@@ -58,6 +59,7 @@ final readonly class StructuredMetadata
      * @param TiffData            $tiff                TIFF-related imaging parameters.
      * @param CompositeImageInfo  $composite           Composite capture information for multi-image scenes.
      * @param Standards           $standards           Metadata standard identifiers and versions.
+     * @param FlashPix            $flashPix            FlashPix extension streams extracted from APP2 markers.
      * @param Camera              $camera              Camera manufacturer and model information.
      * @param Lens                $lens                Lens identification and optical properties.
      * @param Image               $image               Image dimensions and orientation details.
@@ -94,6 +96,7 @@ final readonly class StructuredMetadata
         public TiffData $tiff,
         public CompositeImageInfo $composite,
         public Standards $standards,
+        public FlashPix $flashPix,
         public Camera $camera,
         public Lens $lens,
         public Image $image,

--- a/src/Curate/StructuredMetadataBuilder.php
+++ b/src/Curate/StructuredMetadataBuilder.php
@@ -40,6 +40,7 @@ use MagicSunday\ImageMeta\Value\Enum\ColorSpace;
 use MagicSunday\ImageMeta\Value\Exposure;
 use MagicSunday\ImageMeta\Value\File;
 use MagicSunday\ImageMeta\Value\Focus;
+use MagicSunday\ImageMeta\Value\FlashPix;
 use MagicSunday\ImageMeta\Value\Gps;
 use MagicSunday\ImageMeta\Value\Image;
 use MagicSunday\ImageMeta\Value\Integrity;
@@ -198,6 +199,8 @@ final class StructuredMetadataBuilder
             flashpixVersion: $exifResolver->flashpixVersion(),
             tiffEpStandardId: $exifResolver->tiffEpStandardId(),
         );
+
+        $flashPix = new FlashPix($metadata->flashPixStreams);
 
         $camera = $this->buildCamera($exifResolver);
         $lens   = $this->buildLens($exifResolver);
@@ -468,6 +471,7 @@ final class StructuredMetadataBuilder
             tiff: $tiff,
             composite: $composite,
             standards: $standards,
+            flashPix: $flashPix,
             camera: $camera,
             lens: $lens,
             image: $image,

--- a/src/MetadataReader.php
+++ b/src/MetadataReader.php
@@ -84,16 +84,17 @@ final class MetadataReader
         ?string $digestSha1,
         ?string $digestMd5,
     ): Metadata {
-        $jpeg          = new JpegExtractor($stream);
-        $exifBlobs     = $jpeg->extractExifBlobs();
-        $xmpBlobs      = $jpeg->extractXmpPackets();
-        $iccProfile    = $jpeg->getIccProfile();
-        $iccSegments   = $jpeg->getIccSegments();
-        $bitsPerSample = $jpeg->getFrameSamplePrecision();
-        $frameHeight   = $jpeg->getFrameHeight();
-        $frameWidth    = $jpeg->getFrameWidth();
-        $sampling      = $jpeg->getFrameComponentSamplingFactors();
-        $subSampling   = $jpeg->getFrameYCbCrSubSampling();
+        $jpeg             = new JpegExtractor($stream);
+        $exifBlobs        = $jpeg->extractExifBlobs();
+        $xmpBlobs         = $jpeg->extractXmpPackets();
+        $iccProfile       = $jpeg->getIccProfile();
+        $iccSegments      = $jpeg->getIccSegments();
+        $flashPixStreams  = $jpeg->getFlashPixStreams();
+        $bitsPerSample    = $jpeg->getFrameSamplePrecision();
+        $frameHeight      = $jpeg->getFrameHeight();
+        $frameWidth       = $jpeg->getFrameWidth();
+        $sampling         = $jpeg->getFrameComponentSamplingFactors();
+        $subSampling      = $jpeg->getFrameYCbCrSubSampling();
 
         $exifDoc    = null;
         $xmpDoc     = null;
@@ -117,6 +118,7 @@ final class MetadataReader
             $makerNotes,
             $iccProfile,
             $iccSegments,
+            $flashPixStreams,
             $bitsPerSample,
             $sampling,
             $subSampling,
@@ -173,6 +175,7 @@ final class MetadataReader
             $xmpDoc,
             $makerNotes,
             null,
+            [],
             [],
             null,
             null,

--- a/src/Model/Metadata.php
+++ b/src/Model/Metadata.php
@@ -48,6 +48,11 @@ final class Metadata
      */
     public readonly array $iccSegments;
 
+    /**
+     * @var array<int, string>
+     */
+    public readonly array $flashPixStreams;
+
     public readonly ?int $jpegBitsPerSample;
 
     /** @var array<int, array{horizontal:int, vertical:int}>|null */
@@ -81,6 +86,7 @@ final class Metadata
      * @param MakerNotesMetadata|null                              $makerNotes               Decoded maker notes metadata for the primary EXIF blob.
      * @param string|null                                          $iccProfile               Binary ICC profile when available.
      * @param list<string>                                         $iccSegments              Raw ICC APP2 segments in encounter order.
+     * @param array<int, string>                                   $flashPixStreams          Concatenated FlashPix extension streams keyed by identifier.
      * @param int|null                                             $jpegBitsPerSample        Sample precision reported by the JPEG frame header.
      * @param array<int, array{horizontal:int, vertical:int}>|null $jpegFrameSamplingFactors Component sampling factors by
      *                                                                                       identifier.
@@ -102,6 +108,7 @@ final class Metadata
         ?MakerNotesMetadata $makerNotes = null,
         ?string $iccProfile = null,
         array $iccSegments = [],
+        array $flashPixStreams = [],
         ?int $jpegBitsPerSample = null,
         ?array $jpegFrameSamplingFactors = null,
         ?array $jpegYCbCrSubSampling = null,
@@ -121,6 +128,7 @@ final class Metadata
         $this->makerNotes               = $makerNotes;
         $this->iccProfile               = $iccProfile;
         $this->iccSegments              = $iccSegments;
+        $this->flashPixStreams          = $flashPixStreams;
         $this->jpegBitsPerSample        = $jpegBitsPerSample;
         $this->jpegFrameSamplingFactors = $jpegFrameSamplingFactors;
         $this->jpegYCbCrSubSampling     = $jpegYCbCrSubSampling;

--- a/src/Parse/Jpeg/JpegExtractor.php
+++ b/src/Parse/Jpeg/JpegExtractor.php
@@ -65,6 +65,8 @@ final class JpegExtractor
 
     private const string IPTC_SIGNATURE = "Photoshop 3.0\0";
 
+    private const string FPXR_SIGNATURE = 'FPXR';
+
     /**
      * Scan and termination markers that end metadata scanning.
      */
@@ -92,6 +94,15 @@ final class JpegExtractor
     private ?int $iccExpectedCount = null;
 
     private ?string $iccProfile = null;
+
+    /** @var array<int, array<int, string>> */
+    private array $flashPixSequences = [];
+
+    /** @var array<int, int> */
+    private array $flashPixExpectedCounts = [];
+
+    /** @var array<int, string> */
+    private array $flashPixStreams = [];
 
     /** @var list<string> */
     private array $iptcPayloads = [];
@@ -178,6 +189,18 @@ final class JpegExtractor
     }
 
     /**
+     * Returns concatenated FlashPix extension streams keyed by their stream identifier.
+     *
+     * @return array<int, string>
+     */
+    public function getFlashPixStreams(): array
+    {
+        $this->parseIfNeeded();
+
+        return $this->flashPixStreams;
+    }
+
+    /**
      * Returns the precision in bits reported by the primary start of frame segment.
      */
     public function getFrameSamplePrecision(): ?int
@@ -251,8 +274,11 @@ final class JpegExtractor
         $this->iccSequence            = [];
         $this->iccExpectedCount       = null;
         $this->iccProfile             = null;
-        $this->iptcPayloads           = [];
-        $this->xmpPacketHashes        = [];
+        $this->flashPixSequences       = [];
+        $this->flashPixExpectedCounts  = [];
+        $this->flashPixStreams         = [];
+        $this->iptcPayloads            = [];
+        $this->xmpPacketHashes         = [];
         $this->frameBitsPerSample      = null;
         $this->frameComponentSampling  = null;
         $this->frameYCbCrSubSampling   = null;
@@ -297,6 +323,29 @@ final class JpegExtractor
             if ($presentSequence === $expectedSequence) {
                 ksort($this->iccSequence);
                 $this->iccProfile = implode('', $this->iccSequence);
+            }
+        }
+
+        if ($this->flashPixSequences !== []) {
+            foreach ($this->flashPixSequences as $streamId => $fragments) {
+                $expectedCount = $this->flashPixExpectedCounts[$streamId] ?? 0;
+                if ($expectedCount === 0 || count($fragments) !== $expectedCount) {
+                    continue;
+                }
+
+                $sequenceNumbers = array_keys($fragments);
+                sort($sequenceNumbers);
+
+                if ($sequenceNumbers !== range(1, $expectedCount)) {
+                    continue;
+                }
+
+                ksort($fragments);
+                $this->flashPixStreams[$streamId] = implode('', $fragments);
+            }
+
+            if ($this->flashPixStreams !== []) {
+                ksort($this->flashPixStreams);
             }
         }
 
@@ -424,10 +473,25 @@ final class JpegExtractor
      */
     private function handleApp2(string $payload, int $offset): void
     {
-        if (!str_starts_with($payload, self::ICC_SIGNATURE)) {
+        if (str_starts_with($payload, self::ICC_SIGNATURE)) {
+            $this->handleIccSegment($payload, $offset);
+
             return;
         }
 
+        if (str_starts_with($payload, self::FPXR_SIGNATURE)) {
+            $this->handleFlashPixSegment($payload, $offset);
+        }
+    }
+
+    /**
+     * Processes ICC profile segments contained within APP2 markers.
+     *
+     * @param string $payload Raw segment payload including signature.
+     * @param int    $offset  Offset in the stream where the marker begins.
+     */
+    private function handleIccSegment(string $payload, int $offset): void
+    {
         $signatureLength = strlen(self::ICC_SIGNATURE);
         if (strlen($payload) < $signatureLength + 2) {
             throw new ParseError(sprintf('ICC segment at offset %d is too short', $offset));
@@ -455,6 +519,55 @@ final class JpegExtractor
 
         if (!array_key_exists($sequenceNumber, $this->iccSequence)) {
             $this->iccSequence[$sequenceNumber] = $iccData;
+        }
+    }
+
+    /**
+     * Processes FlashPix extension segments contained within APP2 markers.
+     *
+     * @param string $payload Raw segment payload including signature.
+     * @param int    $offset  Offset in the stream where the marker begins.
+     */
+    private function handleFlashPixSegment(string $payload, int $offset): void
+    {
+        $signatureLength = strlen(self::FPXR_SIGNATURE);
+        if (strlen($payload) < $signatureLength + 4) {
+            throw new ParseError(sprintf('FlashPix segment at offset %d is too short', $offset));
+        }
+
+        $header = substr($payload, $signatureLength, 4);
+        $unpacked = unpack('nstream/Csequence/Ccount', $header);
+        if ($unpacked === false) {
+            throw new ParseError(sprintf('Unable to parse FlashPix segment header at offset %d', $offset));
+        }
+
+        $streamId = (int) $unpacked['stream'];
+        $sequenceNumber = (int) $unpacked['sequence'];
+        $sequenceCount = (int) $unpacked['count'];
+        $data = substr($payload, $signatureLength + 4);
+
+        if ($sequenceNumber === 0 || $sequenceCount === 0 || $sequenceNumber > $sequenceCount) {
+            $this->flashPixExpectedCounts[$streamId] = 0;
+            unset($this->flashPixSequences[$streamId]);
+
+            return;
+        }
+
+        if (!array_key_exists($streamId, $this->flashPixExpectedCounts)) {
+            $this->flashPixExpectedCounts[$streamId] = $sequenceCount;
+        } elseif ($this->flashPixExpectedCounts[$streamId] !== $sequenceCount) {
+            $this->flashPixExpectedCounts[$streamId] = 0;
+            unset($this->flashPixSequences[$streamId]);
+
+            return;
+        }
+
+        if (!array_key_exists($streamId, $this->flashPixSequences)) {
+            $this->flashPixSequences[$streamId] = [];
+        }
+
+        if (!array_key_exists($sequenceNumber, $this->flashPixSequences[$streamId])) {
+            $this->flashPixSequences[$streamId][$sequenceNumber] = $data;
         }
     }
 

--- a/src/Value/FlashPix.php
+++ b/src/Value/FlashPix.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\ImageMeta\Value;
+
+/**
+ * Represents FlashPix extension streams aggregated from APP2 segments.
+ */
+final readonly class FlashPix
+{
+    /**
+     * @param array<int, string> $streams Concatenated FlashPix extension streams keyed by stream identifier.
+     */
+    public function __construct(public array $streams)
+    {
+    }
+}

--- a/tests/Curate/StructuredMetadataBuilderTest.php
+++ b/tests/Curate/StructuredMetadataBuilderTest.php
@@ -229,6 +229,7 @@ final class StructuredMetadataBuilderTest extends TestCase
         self::assertSame('1.2.3', $structured->camera->firmware);
         self::assertSame(FileSource::DIGITAL_CAMERA, $structured->camera->fileSource);
         self::assertSame(SensingMethod::ONE_CHIP_COLOR_AREA, $structured->camera->sensingMethod);
+        self::assertSame([], $structured->flashPix->streams);
 
         self::assertSame('EF 85mm f/1.4L', $structured->lens->lensModel);
         self::assertSame(85.0, $structured->lens->focalLengthMm);
@@ -356,6 +357,7 @@ final class StructuredMetadataBuilderTest extends TestCase
             null,
             null,
             null,
+            [],
             [],
             null,
             null,
@@ -1607,6 +1609,31 @@ final class StructuredMetadataBuilderTest extends TestCase
     }
 
     /**
+     * Ensures FlashPix streams collected on the metadata aggregate are forwarded into the structured view.
+     */
+    #[Test]
+    public function forwardsFlashPixStreams(): void
+    {
+        $flashPix = [7 => 'flashpix-stream'];
+
+        $metadata = new Metadata(
+            [],
+            null,
+            null,
+            [],
+            null,
+            null,
+            null,
+            [],
+            $flashPix,
+        );
+
+        $structured = (new StructuredMetadataBuilder())->build($metadata);
+
+        self::assertSame($flashPix, $structured->flashPix->streams);
+    }
+
+    /**
      * Ensures XMP region metadata is propagated to the structured output including face counts.
      */
     #[Test]
@@ -1801,6 +1828,7 @@ final class StructuredMetadataBuilderTest extends TestCase
             null,
             null,
             null,
+            [],
             [],
             8,
             [

--- a/tests/MetadataReader/MetadataReaderTest.php
+++ b/tests/MetadataReader/MetadataReaderTest.php
@@ -85,6 +85,7 @@ final class MetadataReaderTest extends TestCase
         self::assertSame(sha1($makerNote), $metadata->makerNotes->sha1());
         self::assertNull($metadata->iccProfile);
         self::assertSame([], $metadata->iccSegments);
+        self::assertSame([], $metadata->flashPixStreams);
         self::assertSame('image/jpeg', $metadata->mimeType);
         self::assertSame(strlen($jpeg), $metadata->fileSize);
         self::assertSame('jpg', $metadata->extension);

--- a/tests/Model/Metadata/MetadataTest.php
+++ b/tests/Model/Metadata/MetadataTest.php
@@ -83,6 +83,7 @@ final class MetadataTest extends TestCase
             null,
             $iccProfile,
             $iccSegments,
+            [],
             12,
             $sampling,
             [2, 1],

--- a/tests/Parse/Jpeg/JpegExtractorTest.php
+++ b/tests/Parse/Jpeg/JpegExtractorTest.php
@@ -42,6 +42,8 @@ final class JpegExtractorTest extends TestCase
 
     private const string IPTC_SIGNATURE = "Photoshop 3.0\0";
 
+    private const string FPXR_SIGNATURE = 'FPXR';
+
     private const int MARKER_APP1 = 0xE1;
 
     private const int MARKER_APP2 = 0xE2;
@@ -173,6 +175,63 @@ final class JpegExtractorTest extends TestCase
     }
 
     /**
+     * Confirms FlashPix APP2 segments are reordered and merged per stream identifier.
+     */
+    #[Test]
+    public function testFlashPixSegmentsAreMerged(): void
+    {
+        $streamId = 3;
+        $partOne  = 'flashpix-part-one';
+        $partTwo  = 'flashpix-part-two';
+
+        $segment1 = self::segment(self::MARKER_APP2, self::fpxrPayload($streamId, 1, 2, $partOne));
+        $segment2 = self::segment(self::MARKER_APP2, self::fpxrPayload($streamId, 2, 2, $partTwo));
+
+        $jpeg = $this->jpeg($segment2, $segment1);
+
+        $extractor = $this->createExtractor($jpeg);
+
+        self::assertSame([$streamId => $partOne . $partTwo], $extractor->getFlashPixStreams());
+    }
+
+    /**
+     * Ensures multiple FlashPix streams are merged independently and keyed by identifier.
+     */
+    #[Test]
+    public function testFlashPixMultipleStreamsAreHandled(): void
+    {
+        $streamOne = self::segment(self::MARKER_APP2, self::fpxrPayload(1, 1, 1, 'stream-one'));
+        $streamTwoA = self::segment(self::MARKER_APP2, self::fpxrPayload(2, 1, 3, 'alpha-'));
+        $streamTwoB = self::segment(self::MARKER_APP2, self::fpxrPayload(2, 2, 3, 'beta-'));
+        $streamTwoC = self::segment(self::MARKER_APP2, self::fpxrPayload(2, 3, 3, 'gamma'));
+
+        $jpeg = $this->jpeg($streamTwoB, $streamOne, $streamTwoC, $streamTwoA);
+
+        $extractor = $this->createExtractor($jpeg);
+
+        self::assertSame([
+            1 => 'stream-one',
+            2 => 'alpha-beta-gamma',
+        ], $extractor->getFlashPixStreams());
+    }
+
+    /**
+     * Ensures inconsistent FlashPix sequence counts discard accumulated fragments.
+     */
+    #[Test]
+    public function testFlashPixInvalidSequenceDiscardsStream(): void
+    {
+        $segment1 = self::segment(self::MARKER_APP2, self::fpxrPayload(5, 1, 2, 'first'));
+        $segment2 = self::segment(self::MARKER_APP2, self::fpxrPayload(5, 2, 3, 'second'));
+
+        $jpeg = $this->jpeg($segment1, $segment2);
+
+        $extractor = $this->createExtractor($jpeg);
+
+        self::assertSame([], $extractor->getFlashPixStreams());
+    }
+
+    /**
      * Ensures APP13 segments with the Photoshop signature are stored verbatim.
      */
     #[Test]
@@ -237,9 +296,11 @@ final class JpegExtractorTest extends TestCase
     {
         $lengthTooSmall   = "\xFF\xD8\xFF\xE1\x00\x01\xFF\xD9";
         $truncatedPayload = "\xFF\xD8\xFF\xE1" . pack('n', 10) . 'abcde' . "\xFF\xD9";
+        $shortFlashPix    = "\xFF\xD8" . self::segment(self::MARKER_APP2, self::FPXR_SIGNATURE . "\x00\x01\x02") . "\xFF\xD9";
 
         yield 'length-smaller-than-two' => [$lengthTooSmall, '/length/i'];
         yield 'truncated-payload' => [$truncatedPayload, '/truncated/i'];
+        yield 'flashpix-short-header' => [$shortFlashPix, '/FlashPix segment/i'];
     }
 
     #[Test]
@@ -310,6 +371,14 @@ final class JpegExtractorTest extends TestCase
     private static function segment(int $marker, string $payload): string
     {
         return "\xFF" . chr($marker) . pack('n', strlen($payload) + 2) . $payload;
+    }
+
+    /**
+     * Builds a FlashPix APP2 payload with the provided header parameters.
+     */
+    private static function fpxrPayload(int $streamId, int $sequence, int $count, string $data): string
+    {
+        return self::FPXR_SIGNATURE . pack('n', $streamId) . chr($sequence) . chr($count) . $data;
     }
 
     /**


### PR DESCRIPTION
## Summary
- detect FPXR FlashPix APP2 segments, merge validated fragment sequences, and expose the concatenated streams from the JPEG extractor
- surface FlashPix streams via the metadata aggregate and structured metadata builder using a dedicated value object
- add unit coverage for FlashPix extraction, propagation, and metadata reader defaults

## Testing
- .build/bin/phpunit tests/Parse/Jpeg/JpegExtractorTest.php
- .build/bin/phpunit tests/Curate/StructuredMetadataBuilderTest.php
- .build/bin/phpunit tests/Model/Metadata/MetadataTest.php

------
https://chatgpt.com/codex/tasks/task_e_68fd397020608323a70afe5e14abcef9