### PR TITLE
Add warm white fluorescent light source enum

### DIFF
--- a/src/Value/Enum/LightSource.php
+++ b/src/Value/Enum/LightSource.php
@@ -28,6 +28,11 @@ enum LightSource: int
     case DAY_WHITE_FLUORESCENT  = 13;
     case COOL_WHITE_FLUORESCENT = 14;
     case WHITE_FLUORESCENT      = 15;
+
+    /**
+     * Warm white fluorescent light source.
+     */
+    case WARM_WHITE_FLUORESCENT = 16;
     case STANDARD_LIGHT_A       = 17;
     case STANDARD_LIGHT_B       = 18;
     case STANDARD_LIGHT_C       = 19;

--- a/tests/Value/Enum/EnumMappingTest.php
+++ b/tests/Value/Enum/EnumMappingTest.php
@@ -16,6 +16,7 @@ use MagicSunday\ImageMeta\Value\Enum\Compression;
 use MagicSunday\ImageMeta\Value\Enum\ExposureMode;
 use MagicSunday\ImageMeta\Value\Enum\FileSource;
 use MagicSunday\ImageMeta\Value\Enum\GainControl;
+use MagicSunday\ImageMeta\Value\Enum\LightSource;
 use MagicSunday\ImageMeta\Value\Enum\Photometric;
 use MagicSunday\ImageMeta\Value\Enum\PlanarConfiguration;
 use MagicSunday\ImageMeta\Value\Enum\ResolutionUnit;
@@ -37,6 +38,7 @@ use PHPUnit\Framework\TestCase;
  * @covers \MagicSunday\ImageMeta\Value\Enum\FileSource
  * @covers \MagicSunday\ImageMeta\Value\Enum\SensingMethod
  * @covers \MagicSunday\ImageMeta\Value\Enum\CompositeImage
+ * @covers \MagicSunday\ImageMeta\Value\Enum\LightSource
  */
 final class EnumMappingTest extends TestCase
 {
@@ -54,6 +56,7 @@ final class EnumMappingTest extends TestCase
         self::assertSame(FileSource::DIGITAL_CAMERA, FileSource::fromExifValue(3));
         self::assertSame(SensingMethod::COLOR_SEQUENTIAL_LINEAR, SensingMethod::fromExifValue(8));
         self::assertSame(CompositeImage::CAPTURED_WHILE_SHOOTING, CompositeImage::fromExifValue(3));
+        self::assertSame(LightSource::WARM_WHITE_FLUORESCENT, LightSource::fromExifValue(16));
     }
 
     #[Test]


### PR DESCRIPTION
## Summary
- add the missing EXIF light source case for warm white fluorescent lighting
- extend the enum mapping test suite to cover the new value

## Testing
- composer ci:test:php:unit *(fails: known TruthComparison fixtures are unavailable in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68fde040be488323ba7be9b3d9abcfba