### PR TITLE
Fix EXIF JIS user comment decoding

### DIFF
--- a/src/Model/Exif/ExifDocument.php
+++ b/src/Model/Exif/ExifDocument.php
@@ -1609,8 +1609,47 @@ final readonly class ExifDocument
         return match ($encoding) {
             'ASCII', 'UTF8', '' => $content !== '' ? $content : null,
             'UNICODE' => $this->decodeUnicodeComment($content),
+            'JIS'     => $this->decodeJisComment($content),
             default   => $content !== '' ? $content : null,
         };
+    }
+
+    /**
+     * Decodes a Shift-JIS encoded user comment.
+     */
+    private function decodeJisComment(string $content): ?string
+    {
+        if ($content === '') {
+            return null;
+        }
+
+        $sources = ['SJIS', 'SJIS-win', 'CP932'];
+        $targets = ['UTF-8', 'UTF-8//IGNORE', 'UTF-8//TRANSLIT'];
+
+        foreach ($sources as $source) {
+            foreach ($targets as $target) {
+                $converted = @iconv($source, $target, $content);
+                if ($converted === false) {
+                    continue;
+                }
+
+                $trimmed = trim($converted);
+                if ($trimmed === '') {
+                    continue;
+                }
+
+                return $trimmed;
+            }
+        }
+
+        $stripped = preg_replace('/[^\x20-\x7E]/', '', $content);
+        if ($stripped === null) {
+            return null;
+        }
+
+        $trimmed = trim($stripped);
+
+        return $trimmed === '' ? null : $trimmed;
     }
 
     /**

--- a/tests/Model/Exif/ExifDocumentTest.php
+++ b/tests/Model/Exif/ExifDocumentTest.php
@@ -25,6 +25,7 @@ use MagicSunday\ImageMeta\Tests\Support\GpsTiffBuilder;
 use MagicSunday\ImageMeta\Value\Enum\CfaPatternColor;
 use MagicSunday\ImageMeta\Value\Enum\CustomRendered;
 use MagicSunday\ImageMeta\Value\Enum\SceneType;
+use function iconv;
 use function pack;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
@@ -689,6 +690,58 @@ final class ExifDocumentTest extends TestCase
         self::assertSame('RawLab', $doc->rawDevelopingSoftware());
         self::assertSame('EditLab', $doc->imageEditingSoftware());
         self::assertSame('MetaLab', $doc->metadataEditingSoftware());
+    }
+
+    /**
+     * Decodes user comments tagged as Shift-JIS into UTF-8 strings.
+     */
+    #[Test]
+    public function decodesShiftJisUserComments(): void
+    {
+        $ifd0 = new Ifd([]);
+
+        $commentUtf8 = '富士山でのテスト';
+        $encoded = iconv('UTF-8', 'SJIS', $commentUtf8);
+        self::assertNotFalse($encoded, 'Expected iconv to produce Shift-JIS bytes');
+
+        // Shift-JIS bytes produced from the UTF-8 phrase ensure the documented round-trip behaviour.
+        $payload = "JIS\0\0\0\0\0" . $encoded . "\0";
+
+        $exifIfd = new Ifd([
+            ExifTag::USER_COMMENT => new IfdEntry(ExifTag::USER_COMMENT, 7, 1, $payload),
+        ]);
+
+        $doc = new ExifDocument($ifd0, $exifIfd, null, null, null);
+
+        self::assertSame(
+            $commentUtf8,
+            $doc->userComment(),
+            'Expected Shift-JIS encoded bytes to decode to the documented UTF-8 phrase',
+        );
+    }
+
+    /**
+     * Falls back to a sanitized ASCII string when Shift-JIS decoding fails.
+     */
+    #[Test]
+    public function fallsBackWhenShiftJisDecodingFails(): void
+    {
+        $ifd0 = new Ifd([]);
+
+        // Leading 0xFF bytes cannot be decoded via Shift-JIS and trigger the ASCII fallback behaviour.
+        $payload = "JIS\0\0\0\0\0\xFF\xFF Invalid metadata\0";
+
+        $exifIfd = new Ifd([
+            ExifTag::USER_COMMENT => new IfdEntry(ExifTag::USER_COMMENT, 7, 1, $payload),
+        ]);
+
+        $doc = new ExifDocument($ifd0, $exifIfd, null, null, null);
+
+        self::assertSame(
+            'Invalid metadata',
+            $doc->userComment(),
+            'Fallback should strip non-ASCII bytes and trim the decoded output',
+        );
     }
 
     /**


### PR DESCRIPTION
## Summary
- add Shift-JIS handling with iconv-based fallbacks to EXIF user comment decoding
- document expected UTF-8 output via new PHPUnit coverage for positive and fallback cases

## Testing
- composer exec -- phpunit tests/Model/Exif/ExifDocumentTest.php

------
https://chatgpt.com/codex/tasks/task_e_68fde05f298883239d0a8b93d649dcfd