### PR TITLE
Fix GPS undefined string decoding for Unicode and JIS payloads

### DIFF
--- a/src/Model/Exif/ValueConverters.php
+++ b/src/Model/Exif/ValueConverters.php
@@ -23,6 +23,7 @@ use function ctype_digit;
 use function explode;
 use function floor;
 use function fmod;
+use function iconv;
 use function implode;
 use function intdiv;
 use function is_array;
@@ -33,6 +34,7 @@ use function is_string;
 use function ltrim;
 use function ord;
 use function preg_match;
+use function preg_replace;
 use function round;
 use function rtrim;
 use function sprintf;
@@ -973,24 +975,71 @@ final readonly class ValueConverters
             return null;
         }
 
-        $data     = $value;
+        $payload  = $value;
+        $encoding = null;
+
         $prefixes = [
-            "ASCII\0\0\0",
-            "UNICODE\0",
-            "JIS\0\0\0\0\0",
+            "ASCII\0\0\0"    => 'ASCII',
+            "UNICODE\0"        => 'UNICODE',
+            "JIS\0\0\0\0\0" => 'JIS',
         ];
 
-        foreach ($prefixes as $prefix) {
-            if (str_starts_with($data, $prefix)) {
-                $data = substr($data, strlen($prefix));
+        foreach ($prefixes as $prefix => $label) {
+            if (str_starts_with($payload, $prefix)) {
+                $payload  = substr($payload, strlen($prefix));
+                $encoding = $label;
                 break;
             }
         }
 
-        $data = str_replace("\0", '', $data);
-        $data = trim($data);
+        return match ($encoding) {
+            'UNICODE' => self::decodeUndefinedUnicode($payload),
+            'JIS'     => self::decodeUndefinedJis($payload),
+            default   => self::sanitizeString($payload),
+        };
+    }
 
-        return $data === '' ? null : $data;
+    /**
+     * Decodes a UTF-16 encoded undefined GPS string into UTF-8.
+     */
+    private static function decodeUndefinedUnicode(string $payload): ?string
+    {
+        if ($payload === '') {
+            return null;
+        }
+
+        $converted = @iconv('UTF-16LE', 'UTF-8', $payload);
+        if ($converted === false) {
+            $converted = @iconv('UTF-16BE', 'UTF-8', $payload);
+        }
+
+        if ($converted !== false) {
+            return self::sanitizeString($converted);
+        }
+
+        $stripped = preg_replace('/\x00/u', '', $payload);
+        if ($stripped === null) {
+            return null;
+        }
+
+        return self::sanitizeString($stripped);
+    }
+
+    /**
+     * Decodes a Shift-JIS encoded undefined GPS string into UTF-8.
+     */
+    private static function decodeUndefinedJis(string $payload): ?string
+    {
+        if ($payload === '') {
+            return null;
+        }
+
+        $converted = @iconv('SJIS', 'UTF-8', $payload);
+        if ($converted !== false) {
+            return self::sanitizeString($converted);
+        }
+
+        return self::sanitizeString($payload);
     }
 
     /**

--- a/tests/Model/Exif/ValueConvertersTest.php
+++ b/tests/Model/Exif/ValueConvertersTest.php
@@ -567,6 +567,52 @@ final class ValueConvertersTest extends TestCase
     }
 
     #[Test]
+    public function decodesGpsUndefinedStringsWithEncodings(): void
+    {
+        $unicodePayload = "UNICODE\0" . pack('v*', 0x6E2C, 0x4F4D, 0x65B9, 0x5F0F) . "\0\0";
+        $jisPayload     = "JIS\0\0\0\0\0" . pack('C*', 0x93, 0x8C, 0x8B, 0x9E) . "\0";
+
+        $gps = new Ifd([
+            ExifTag::GPS_PROCESSING_METHOD => new IfdEntry(
+                ExifTag::GPS_PROCESSING_METHOD,
+                7,
+                strlen($unicodePayload),
+                $unicodePayload,
+            ),
+            ExifTag::GPS_AREA_INFORMATION => new IfdEntry(
+                ExifTag::GPS_AREA_INFORMATION,
+                7,
+                strlen($jisPayload),
+                $jisPayload,
+            ),
+        ]);
+
+        $result = ValueConverters::gpsFromIfd($gps);
+
+        self::assertSame('測位方式', $result['processing_method']);
+        self::assertSame('東京', $result['area_information']);
+    }
+
+    #[Test]
+    public function returnsNullWhenGpsUndefinedStringEmptyAfterDecoding(): void
+    {
+        $payload = "UNICODE\0\0\0";
+
+        $gps = new Ifd([
+            ExifTag::GPS_PROCESSING_METHOD => new IfdEntry(
+                ExifTag::GPS_PROCESSING_METHOD,
+                7,
+                strlen($payload),
+                $payload,
+            ),
+        ]);
+
+        $result = ValueConverters::gpsFromIfd($gps);
+
+        self::assertNull($result['processing_method']);
+    }
+
+    #[Test]
     public function formatsGpsVersionFromNumericList(): void
     {
         $gps = new Ifd([


### PR DESCRIPTION
## Summary
- add encoding aware handling for GPS undefined strings including UTF-16 and Shift-JIS payloads
- provide Unicode and JIS fixtures for GPS processing method and area information decoding
- ensure empty decoded payloads still return null

## Testing
- ./.build/bin/phpunit tests/Model/Exif/ValueConvertersTest.php

------
https://chatgpt.com/codex/tasks/task_e_68fde06e31808323afe288c465cb8b1a