### PR TITLE
feat: hydrate SubIFDs during TIFF parsing

### DIFF
--- a/src/Model/Exif/ExifDocument.php
+++ b/src/Model/Exif/ExifDocument.php
@@ -58,6 +58,7 @@ final readonly class ExifDocument
      * @param Ifd|null                $ifd1            Optional next IFD, typically thumbnails.
      * @param MakerNotesMetadata|null $makerNotes      Decoded maker note metadata provided by vendor decoders.
      * @param list<Ifd>               $subsequentIfds Additional linked IFDs discovered via the next-pointer chain.
+     * @param array<int, Ifd>         $subIfds         Parsed SubIFDs indexed by their file offsets.
      */
     public function __construct(
         public Ifd $ifd0,
@@ -67,6 +68,7 @@ final readonly class ExifDocument
         public ?Ifd $ifd1,
         public ?MakerNotesMetadata $makerNotes = null,
         public array $subsequentIfds = [],
+        public array $subIfds = [],
     ) {
         $rawVersion        = $this->rawString($this->exifIfd, ExifTag::EXIF_VERSION);
         $this->exifVersion = CoreValueConverters::toExifVersion($rawVersion);
@@ -90,6 +92,16 @@ final readonly class ExifDocument
     public function subsequentIfds(): array
     {
         return $this->subsequentIfds;
+    }
+
+    /**
+     * Returns the parsed SubIFDs keyed by their offset within the TIFF blob.
+     *
+     * @return array<int, Ifd>
+     */
+    public function subIfds(): array
+    {
+        return $this->subIfds;
     }
 
     /**

--- a/src/Model/Exif/ExifTag.php
+++ b/src/Model/Exif/ExifTag.php
@@ -29,6 +29,8 @@ final readonly class ExifTag
 
     public const int IMAGE_DESCRIPTION = 0x010E;
 
+    public const int SUB_IFDS = 0x014A;
+
     public const int IMAGE_TITLE = 0xA436;
 
     /**

--- a/src/Parse/Tiff/TiffExifReader.php
+++ b/src/Parse/Tiff/TiffExifReader.php
@@ -108,6 +108,16 @@ final class TiffExifReader
     private ?string $makerNoteRaw = null;
 
     /**
+     * @var array<int, Ifd>
+     */
+    private array $subIfds = [];
+
+    /**
+     * @var array<int, Ifd>
+     */
+    private array $ifdCache = [];
+
+    /**
      * Parses an EXIF TIFF blob into a structured document model.
      *
      * @param string        $tiffBlob           Raw TIFF data including headers.
@@ -121,6 +131,8 @@ final class TiffExifReader
         $this->buf->seek(0);
 
         $this->makerNoteRaw = null;
+        $this->subIfds      = [];
+        $this->ifdCache     = [];
 
         // byte order
         $boSig    = $this->buf->read(2);
@@ -194,7 +206,16 @@ final class TiffExifReader
 
         $makerNotes = $this->resolveMakerNotes($makerNotesRegistry, $ifd0, $exifIfd);
 
-        return new ExifDocument($ifd0, $exifIfd, $gpsIfd, $interopIfd, $ifd1, $makerNotes, $additionalIfds);
+        return new ExifDocument(
+            $ifd0,
+            $exifIfd,
+            $gpsIfd,
+            $interopIfd,
+            $ifd1,
+            $makerNotes,
+            $additionalIfds,
+            $this->subIfds,
+        );
     }
 
     /**
@@ -228,6 +249,10 @@ final class TiffExifReader
             return new Ifd([]);
         }
 
+        if (isset($this->ifdCache[$offset])) {
+            return $this->ifdCache[$offset];
+        }
+
         $this->buf->seek($offset);
         $entryCount = $this->bigTiff ? $this->readU64() : $this->readU16();
         $entries    = [];
@@ -236,8 +261,11 @@ final class TiffExifReader
         }
 
         $next = $this->bigTiff ? $this->readU64() : $this->readU32();
+        $ifd  = new Ifd($entries, $next > 0 ? $next : null);
 
-        return new Ifd($entries, $next > 0 ? $next : null);
+        $this->ifdCache[$offset] = $ifd;
+
+        return $ifd;
     }
 
     /**
@@ -263,7 +291,74 @@ final class TiffExifReader
             $this->makerNoteRaw = $rawBytes;
         }
 
-        return [$tag => new IfdEntry($tag, $type, $cnt, $value)];
+        $entry = new IfdEntry($tag, $type, $cnt, $value);
+
+        if ($tag === ExifTag::SUB_IFDS) {
+            $this->collectSubIfds($entry);
+        }
+
+        return [$tag => $entry];
+    }
+
+    /**
+     * Collects nested image file directories referenced by a SubIFDs entry.
+     */
+    private function collectSubIfds(IfdEntry $entry): void
+    {
+        if ($entry->type !== self::TYPE_IFD && $entry->type !== self::TYPE_IFD8) {
+            return;
+        }
+
+        $offsets = $this->subIfdOffsets($entry);
+
+        if ($offsets === []) {
+            return;
+        }
+
+        $returnPos = $this->buf->tell();
+
+        foreach ($offsets as $offset) {
+            if ($offset <= 0) {
+                continue;
+            }
+
+            if (isset($this->subIfds[$offset])) {
+                continue;
+            }
+
+            $this->subIfds[$offset] = $this->readIfd($offset);
+        }
+
+        $this->buf->seek($returnPos);
+    }
+
+    /**
+     * Normalises the offsets described by a SubIFDs entry.
+     *
+     * @return list<int>
+     */
+    private function subIfdOffsets(IfdEntry $entry): array
+    {
+        $value = $entry->value;
+
+        if ($value instanceof ExifNumericList) {
+            $offsets = [];
+            foreach ($value->values as $component) {
+                if (!is_int($component)) {
+                    continue;
+                }
+
+                $offsets[] = $component;
+            }
+
+            return $offsets;
+        }
+
+        if (is_int($value)) {
+            return [$value];
+        }
+
+        return [];
     }
 
     /**

--- a/tests/Model/Exif/ExifTagTest.php
+++ b/tests/Model/Exif/ExifTagTest.php
@@ -107,6 +107,7 @@ final class ExifTagTest extends TestCase
             'IMAGE_EDITOR_LEGACY'            => 0xE92E,
 
             // Pointer tags
+            'SUB_IFDS'                    => 0x014A,
             'EXIF_IFD_POINTER'             => 0x8769,
             'GPS_IFD_POINTER'              => 0x8825,
             'INTEROPERABILITY_IFD_POINTER' => 0xA005,

--- a/tests/Parse/Tiff/TiffExifReaderTest.php
+++ b/tests/Parse/Tiff/TiffExifReaderTest.php
@@ -23,6 +23,7 @@ use MagicSunday\ImageMeta\Model\Exif\ExifNumericList;
 use MagicSunday\ImageMeta\Model\Exif\ExifRational;
 use MagicSunday\ImageMeta\Model\Exif\ExifRationalList;
 use MagicSunday\ImageMeta\Model\Exif\ExifTag;
+use MagicSunday\ImageMeta\Model\Exif\Ifd;
 use MagicSunday\ImageMeta\Parse\Tiff\TiffExifReader;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
@@ -49,8 +50,6 @@ use function unpack;
 final class TiffExifReaderTest extends TestCase
 {
     private const int CUSTOM_SIGNED_LONG8_TAG = 0xC7A1;
-
-    private const int SUB_IFDS_TAG = 0x014A;
 
     /**
      * Expected StripOffsets values captured from ExifTool parsing the synthetic BigTIFF LONG8 fixture.
@@ -235,13 +234,23 @@ final class TiffExifReaderTest extends TestCase
         [$blob, $subIfdOffset] = $this->buildClassicSubIfdBlob();
 
         $document   = (new TiffExifReader())->parseFromBlob($blob);
-        $subIfdsEntry = $document->ifd0->get(self::SUB_IFDS_TAG);
+        $subIfdsEntry = $document->ifd0->get(ExifTag::SUB_IFDS);
 
         self::assertNotNull($subIfdsEntry);
 
         $value = $subIfdsEntry->value;
         self::assertInstanceOf(ExifNumericList::class, $value);
         self::assertSame($subIfdOffset, $value->values[0] ?? null);
+
+        $subIfds = $document->subIfds();
+        self::assertArrayHasKey($subIfdOffset, $subIfds);
+
+        $nestedIfd = $subIfds[$subIfdOffset];
+        self::assertInstanceOf(Ifd::class, $nestedIfd);
+
+        $orientation = $nestedIfd->get(ExifTag::ORIENTATION);
+        self::assertNotNull($orientation);
+        self::assertSame(1, $orientation->value);
     }
 
     /**
@@ -253,10 +262,14 @@ final class TiffExifReaderTest extends TestCase
         [$blob, $subIfdOffset] = $this->buildClassicInlineSubIfdBlob();
 
         $document  = (new TiffExifReader())->parseFromBlob($blob);
-        $subIfdEntry = $document->ifd0->get(self::SUB_IFDS_TAG);
+        $subIfdEntry = $document->ifd0->get(ExifTag::SUB_IFDS);
 
         self::assertNotNull($subIfdEntry);
         self::assertSame($subIfdOffset, $subIfdEntry->value);
+
+        $subIfds = $document->subIfds();
+        self::assertArrayHasKey($subIfdOffset, $subIfds);
+        self::assertInstanceOf(Ifd::class, $subIfds[$subIfdOffset]);
     }
 
     /**
@@ -732,7 +745,7 @@ final class TiffExifReaderTest extends TestCase
         $subIfdOffset           = 64;
 
         $ifd0Entries = [
-            self::packClassicEntry(self::SUB_IFDS_TAG, 13, $pointerCount, $pointerArrayOffset),
+            self::packClassicEntry(ExifTag::SUB_IFDS, 13, $pointerCount, $pointerArrayOffset),
         ];
 
         $blob = $header;
@@ -762,7 +775,7 @@ final class TiffExifReaderTest extends TestCase
         $subIfdOffset = 64;
 
         $ifd0Entries = [
-            self::packClassicEntry(self::SUB_IFDS_TAG, 13, 1, $subIfdOffset),
+            self::packClassicEntry(ExifTag::SUB_IFDS, 13, 1, $subIfdOffset),
         ];
 
         $blob = $header;


### PR DESCRIPTION
## Summary
- follow SubIFDs pointers for both Classic TIFF and BigTIFF payloads and hydrate each referenced IFD
- expose the parsed SubIFDs on ExifDocument so resolvers can traverse nested directories
- extend the EXIF tag registry and tests to cover the SubIFDs constant alongside updated TIFF reader expectations

## Testing
- .build/bin/phpunit --configuration .build/phpunit.xml tests/Parse/Tiff/TiffExifReaderTest.php
- .build/bin/phpunit --configuration .build/phpunit.xml tests/Model/Exif/ExifTagTest.php

------
https://chatgpt.com/codex/tasks/task_e_68fdeacaeb9c8323a82f8d28b4182dd6