### PR TITLE
feat: restore legacy host computer fallback

### DIFF
--- a/src/Curate/Resolver/ExifTagResolver.php
+++ b/src/Curate/Resolver/ExifTagResolver.php
@@ -134,6 +134,7 @@ final readonly class ExifTagResolver
             'interopindex'        => $this->interopIndex(),
             'interopversion'      => $this->interopVersion(),
             'relatedimagefileformat' => $this->relatedImageFileFormat(),
+            'hostcomputer'        => $this->hostComputer(),
             default               => null,
         };
     }
@@ -256,6 +257,14 @@ final readonly class ExifTagResolver
     public function software(): ?string
     {
         return $this->stringValue($this->document?->ifd0, ExifTag::SOFTWARE);
+    }
+
+    /**
+     * Returns the legacy host computer tag when available.
+     */
+    public function hostComputer(): ?string
+    {
+        return $this->document?->hostComputer();
     }
 
     /**

--- a/src/Curate/StructuredMetadataBuilder.php
+++ b/src/Curate/StructuredMetadataBuilder.php
@@ -250,7 +250,7 @@ final class StructuredMetadataBuilder
 
         $gps = $gpsResolver->resolve($metadata->exifDoc, $xmpDocument) ?? new Gps();
 
-        $device = $this->buildDevice($exifResolver, $quickTimeResolver);
+        $device = $this->buildDevice($exifResolver, $quickTimeResolver, $xmpResolver);
 
         $apple = $this->buildApple($appleMakerNotes, $quickTimeResolver, $metadata->quickTime);
         $xmp   = $xmpResolver->value();
@@ -522,18 +522,21 @@ final class StructuredMetadataBuilder
     }
 
     /**
-     * Builds the device metadata aggregate by combining EXIF and QuickTime sources.
+     * Builds the device metadata aggregate by combining EXIF, QuickTime and XMP sources.
      *
      * @param ExifTagResolver   $exif              Resolver exposing EXIF tag helpers.
      * @param QuickTimeResolver $quickTimeResolver Resolver exposing QuickTime metadata fields.
+     * @param XmpResolver       $xmpResolver       Resolver exposing XMP metadata fields.
      *
      * @return Device Device value object describing capture hardware and software.
      */
-    private function buildDevice(ExifTagResolver $exif, QuickTimeResolver $quickTimeResolver): Device
+    private function buildDevice(ExifTagResolver $exif, QuickTimeResolver $quickTimeResolver, XmpResolver $xmpResolver): Device
     {
         $softwareChain = CompositeResolver::first([
             fn (): ?string => $quickTimeResolver->string('com.apple.quicktime.software'),
+            fn (): ?string => $xmpResolver->string('http://ns.adobe.com/xap/1.0/', 'CreatorTool'),
             $exif->software(...),
+            $exif->hostComputer(...),
         ]);
 
         return new Device(

--- a/src/Model/Exif/ExifDocument.php
+++ b/src/Model/Exif/ExifDocument.php
@@ -305,6 +305,18 @@ final readonly class ExifDocument
     }
 
     /**
+     * Returns the legacy host computer string retained for pre-EXIF 3.0 metadata.
+     */
+    public function hostComputer(): ?string
+    {
+        if ($this->exifThreeOrNewer) {
+            return null;
+        }
+
+        return $this->str($this->ifd0, ExifTag::HOST_COMPUTER);
+    }
+
+    /**
      * Returns the photographer name if present.
      */
     public function photographer(): ?string

--- a/src/Model/Exif/ExifTag.php
+++ b/src/Model/Exif/ExifTag.php
@@ -104,6 +104,13 @@ final readonly class ExifTag
 
     public const int ARTIST = 0x013B;
 
+    /**
+     * Legacy EXIF 2.x identifier retained for backwards compatibility.
+     *
+     * Removed from the EXIF 3.0 registry but still exposed for older files.
+     */
+    public const int HOST_COMPUTER = 0x013C;
+
     public const int PHOTOGRAPHER = 0xA437;
 
     /**

--- a/tests/Curate/StructuredMetadataBuilderTest.php
+++ b/tests/Curate/StructuredMetadataBuilderTest.php
@@ -511,6 +511,32 @@ final class StructuredMetadataBuilderTest extends TestCase
         self::assertSame('+01:00', $structured->temporal->original?->format('P'));
     }
 
+    #[Test]
+    public function usesHostComputerWhenSoftwareResolversEmpty(): void
+    {
+        $ifd0 = new Ifd([
+            ExifTag::HOST_COMPUTER => new IfdEntry(ExifTag::HOST_COMPUTER, 2, 1, 'PowerMac G4'),
+        ]);
+
+        $exifIfd = new Ifd([
+            ExifTag::EXIF_VERSION => new IfdEntry(ExifTag::EXIF_VERSION, 7, 4, '0221'),
+        ]);
+
+        $exifDocument = new ExifDocument($ifd0, $exifIfd, null, null, null);
+
+        $metadata = new Metadata(
+            ['primary'],
+            new QuickTimeMeta([]),
+            $exifDocument,
+            [],
+            new XmpDocument([]),
+        );
+
+        $structured = (new StructuredMetadataBuilder())->build($metadata);
+
+        self::assertSame('PowerMac G4', $structured->device->software);
+    }
+
     /**
      * Ensures maker notes Apple data is preferred over QuickTime metadata and propagates to white balance and motion.
      */

--- a/tests/Model/Exif/ExifDocumentTest.php
+++ b/tests/Model/Exif/ExifDocumentTest.php
@@ -807,6 +807,38 @@ final class ExifDocumentTest extends TestCase
     }
 
     #[Test]
+    public function hostComputerReturnsLegacyValue(): void
+    {
+        $ifd0 = new Ifd([
+            ExifTag::HOST_COMPUTER => new IfdEntry(ExifTag::HOST_COMPUTER, 2, 1, 'PowerMac G4'),
+        ]);
+
+        $exifIfd = new Ifd([
+            ExifTag::EXIF_VERSION => new IfdEntry(ExifTag::EXIF_VERSION, 7, 4, '0221'),
+        ]);
+
+        $doc = new ExifDocument($ifd0, $exifIfd, null, null, null);
+
+        self::assertSame('PowerMac G4', $doc->hostComputer());
+    }
+
+    #[Test]
+    public function hostComputerOmittedForExifThree(): void
+    {
+        $ifd0 = new Ifd([
+            ExifTag::HOST_COMPUTER => new IfdEntry(ExifTag::HOST_COMPUTER, 2, 1, 'Workstation'),
+        ]);
+
+        $exifIfd = new Ifd([
+            ExifTag::EXIF_VERSION => new IfdEntry(ExifTag::EXIF_VERSION, 7, 4, '0300'),
+        ]);
+
+        $doc = new ExifDocument($ifd0, $exifIfd, null, null, null);
+
+        self::assertNull($doc->hostComputer());
+    }
+
+    #[Test]
     public function exifThreeOmitsLegacySoftwareVersions(): void
     {
         $ifd0 = new Ifd([

--- a/tests/Model/Exif/ExifTagTest.php
+++ b/tests/Model/Exif/ExifTagTest.php
@@ -23,7 +23,7 @@ use ReflectionClass;
 final class ExifTagTest extends TestCase
 {
     /**
-     * Ensures the constant map exactly reflects the EXIF 3.0 tag registry.
+     * Ensures the constant map matches the EXIF 3.0 tag registry with legacy additions.
      */
     public function testConstantsMatchExif30(): void
     {
@@ -231,17 +231,22 @@ final class ExifTagTest extends TestCase
         ksort($constants);
         ksort($expected);
 
-        self::assertSame($expected, $constants);
+        $legacyOnly = [
+            'HOST_COMPUTER' => 0x013C,
+        ];
+
+        $combined = $expected + $legacyOnly;
+        ksort($combined);
+
+        self::assertSame($combined, $constants);
     }
 
     /**
-     * Ensures removed EXIF tags such as HostComputer stay absent from the registry.
+     * Ensures the legacy HostComputer tag remains available for EXIF 2.x images.
      */
-    public function testRemovedTagsAreNotDeclared(): void
+    public function testHostComputerConstantIsRetained(): void
     {
-        $constants = array_flip((new ReflectionClass(ExifTag::class))->getConstants());
-
-        self::assertArrayNotHasKey(0x013C, $constants);
+        self::assertSame(0x013C, ExifTag::HOST_COMPUTER);
     }
 
     /**


### PR DESCRIPTION
## Summary
- restore the legacy HOST_COMPUTER tag constant and expose a hostComputer accessor gated for EXIF < 3.0
- surface the host computer accessor through the EXIF resolver and structured metadata device software chain with QuickTime/XMP fallbacks
- extend unit coverage for the legacy constant, host computer accessor, and structured metadata fallback behaviour

## Testing
- .build/bin/phpunit tests/Model/Exif/ExifTagTest.php tests/Model/Exif/ExifDocumentTest.php tests/Curate/StructuredMetadataBuilderTest.php

------
https://chatgpt.com/codex/tasks/task_e_68fdeadefa38832397a9405d546f1a2e