### PR TITLE
feat(exif): propagate maker note safety flag

### DIFF
--- a/src/Curate/Resolver/ExifTagResolver.php
+++ b/src/Curate/Resolver/ExifTagResolver.php
@@ -219,6 +219,14 @@ final readonly class ExifTagResolver
     }
 
     /**
+     * Indicates whether the maker note payload is marked as safe to edit.
+     */
+    public function makerNoteSafety(): ?bool
+    {
+        return $this->document?->makerNoteSafety();
+    }
+
+    /**
      * Returns the camera model when available.
      */
     public function cameraModel(): ?string

--- a/src/Curate/StructuredMetadataBuilder.php
+++ b/src/Curate/StructuredMetadataBuilder.php
@@ -473,13 +473,19 @@ final class StructuredMetadataBuilder
 
         $uav = new Uav(null, null, null, null, null, null, null, null);
 
-        $hasHistory = $xmpResolver->has('http://ns.adobe.com/xap/1.0/mm/', 'History');
-        $integrity  = new Integrity(
+        $hasHistory      = $xmpResolver->has('http://ns.adobe.com/xap/1.0/mm/', 'History');
+        $makerNotesSafe  = $metadata->makerNotes?->isSafe();
+        if ($makerNotesSafe === null) {
+            $makerNotesSafe = $exifResolver->makerNoteSafety();
+        }
+
+        $integrity = new Integrity(
             originalFileName: $xmpResolver->string('http://ns.adobe.com/tiff/1.0/', 'OriginalFileName'),
             originalDigest: null,
             edited: $hasHistory ? true : null,
             historyLastSoftware: null,
             imageHistory: $exifResolver->imageHistory(),
+            makerNotesSafe: $makerNotesSafe,
         );
 
         return new StructuredMetadata(

--- a/src/MakerNotes/MakerNotesMetadata.php
+++ b/src/MakerNotes/MakerNotesMetadata.php
@@ -32,6 +32,7 @@ final readonly class MakerNotesMetadata
         private int $length,
         private string $sha1,
         private ?AppleMakerNotes $apple = null,
+        private ?bool $isSafe = null,
     ) {
         if ($vendor === '') {
             throw new InvalidArgumentException('The vendor must not be empty.');
@@ -76,5 +77,13 @@ final readonly class MakerNotesMetadata
     public function apple(): ?AppleMakerNotes
     {
         return $this->apple;
+    }
+
+    /**
+     * Returns whether the maker note payload is marked safe to edit.
+     */
+    public function isSafe(): ?bool
+    {
+        return $this->isSafe;
     }
 }

--- a/src/Model/Exif/ExifDocument.php
+++ b/src/Model/Exif/ExifDocument.php
@@ -83,6 +83,20 @@ final readonly class ExifDocument
     }
 
     /**
+     * Indicates whether the maker note is considered safe to modify according to EXIF tag 0xC635.
+     */
+    public function makerNoteSafety(): ?bool
+    {
+        $value = $this->int($this->exifIfd, ExifTag::MAKER_NOTE_SAFETY);
+
+        return match ($value) {
+            0       => false,
+            1       => true,
+            default => null,
+        };
+    }
+
+    /**
      * Returns any additional image file directories linked from IFD0.
      *
      * @return list<Ifd>

--- a/src/Model/Exif/ExifTag.php
+++ b/src/Model/Exif/ExifTag.php
@@ -148,6 +148,8 @@ final readonly class ExifTag
     // EXIF sub IFD
     public const int BATTERY_LEVEL = 0x828F;
 
+    public const int MAKER_NOTE_SAFETY = 0xC635;
+
     public const int EXPOSURE_TIME = 0x829A;
 
     public const int F_NUMBER = 0x829D;

--- a/src/Parse/Tiff/TiffExifReader.php
+++ b/src/Parse/Tiff/TiffExifReader.php
@@ -557,33 +557,90 @@ final class TiffExifReader
             return null;
         }
 
+        $safety = $this->makerNoteSafety($exifIfd);
+
         if (!$registry instanceof Registry || !$exifIfd instanceof Ifd) {
-            return $this->makerNotesDigest();
+            return $this->makerNotesDigest($safety);
         }
 
         $make = $this->stringFromIfd($ifd0, ExifTag::MAKE);
         if ($make === null || $make === '') {
-            return $this->makerNotesDigest();
+            return $this->makerNotesDigest($safety);
         }
 
         $decoder = $registry->find($make);
         if (!$decoder instanceof MakerNotesDecoderInterface) {
-            return $this->makerNotesDigest();
+            return $this->makerNotesDigest($safety);
         }
 
         $model = $this->stringFromIfd($ifd0, ExifTag::MODEL);
 
-        return $decoder->decode($this->makerNoteRaw, $make, $model);
+        $metadata = $decoder->decode($this->makerNoteRaw, $make, $model);
+
+        return $this->applyMakerNoteSafety($metadata, $safety);
     }
 
     /**
      * Creates a digest metadata instance for unknown maker notes.
      */
-    private function makerNotesDigest(): MakerNotesMetadata
+    private function makerNotesDigest(?bool $isSafe): MakerNotesMetadata
     {
         $raw = $this->makerNoteRaw ?? '';
 
-        return new MakerNotesMetadata('Unknown', strlen($raw), sha1($raw));
+        return new MakerNotesMetadata('Unknown', strlen($raw), sha1($raw), null, $isSafe);
+    }
+
+    /**
+     * Applies the maker note safety flag to the provided metadata instance.
+     */
+    private function applyMakerNoteSafety(MakerNotesMetadata $metadata, ?bool $isSafe): MakerNotesMetadata
+    {
+        if ($metadata->isSafe() === $isSafe) {
+            return $metadata;
+        }
+
+        return new MakerNotesMetadata(
+            $metadata->vendor(),
+            $metadata->length(),
+            $metadata->sha1(),
+            $metadata->apple(),
+            $isSafe,
+        );
+    }
+
+    /**
+     * Converts the maker note safety numeric flag into a boolean representation.
+     */
+    private function makerNoteSafety(?Ifd $exifIfd): ?bool
+    {
+        if (!$exifIfd instanceof Ifd) {
+            return null;
+        }
+
+        $entry = $exifIfd->get(ExifTag::MAKER_NOTE_SAFETY);
+        if (!$entry instanceof IfdEntry) {
+            return null;
+        }
+
+        $value = $entry->value;
+
+        if ($value instanceof ExifNumericList) {
+            $value = $value->values[0] ?? null;
+        }
+
+        if (is_float($value)) {
+            $value = (int) $value;
+        }
+
+        if (!is_int($value)) {
+            return null;
+        }
+
+        return match ($value) {
+            0       => false,
+            1       => true,
+            default => null,
+        };
     }
 
     /**

--- a/src/Value/Integrity.php
+++ b/src/Value/Integrity.php
@@ -22,6 +22,7 @@ final readonly class Integrity
      * @param bool|null   $edited              Indicates whether editing history is present.
      * @param string|null $historyLastSoftware Last software reported in the editing history.
      * @param string|null $imageHistory        Free-form history description recorded in EXIF.
+     * @param bool|null   $makerNotesSafe      Flag denoting whether the maker notes are safe to edit.
      */
     public function __construct(
         public ?string $originalFileName,
@@ -29,6 +30,7 @@ final readonly class Integrity
         public ?bool $edited,
         public ?string $historyLastSoftware,
         public ?string $imageHistory,
+        public ?bool $makerNotesSafe = null,
     ) {
     }
 }

--- a/tests/Curate/Resolver/ExifTagResolverTest.php
+++ b/tests/Curate/Resolver/ExifTagResolverTest.php
@@ -424,4 +424,24 @@ final class ExifTagResolverTest extends TestCase
         self::assertSame('RawLab 5.2.1', $resolver->rawDevelopingSoftwareVersion());
         self::assertSame('MetaLab 1.0.0', $resolver->metadataEditingSoftwareVersion());
     }
+
+    #[Test]
+    public function resolvesMakerNoteSafetyFlag(): void
+    {
+        $safeIfd = new Ifd([
+            ExifTag::MAKER_NOTE_SAFETY => new IfdEntry(ExifTag::MAKER_NOTE_SAFETY, 3, 1, 1),
+        ]);
+
+        $unsafeIfd = new Ifd([
+            ExifTag::MAKER_NOTE_SAFETY => new IfdEntry(ExifTag::MAKER_NOTE_SAFETY, 3, 1, 0),
+        ]);
+
+        $safeResolver   = new ExifTagResolver(new ExifDocument(new Ifd([]), $safeIfd, null, null, null));
+        $unsafeResolver = new ExifTagResolver(new ExifDocument(new Ifd([]), $unsafeIfd, null, null, null));
+        $missingResolver = new ExifTagResolver(new ExifDocument(new Ifd([]), null, null, null, null));
+
+        self::assertTrue($safeResolver->makerNoteSafety());
+        self::assertFalse($unsafeResolver->makerNoteSafety());
+        self::assertNull($missingResolver->makerNoteSafety());
+    }
 }

--- a/tests/Curate/StructuredMetadataBuilderTest.php
+++ b/tests/Curate/StructuredMetadataBuilderTest.php
@@ -183,6 +183,7 @@ final class StructuredMetadataBuilderTest extends TestCase
             ExifTag::RAW_DEVELOPING_SOFTWARE     => new IfdEntry(ExifTag::RAW_DEVELOPING_SOFTWARE, 2, 11, 'Raw Studio'),
             ExifTag::IMAGE_EDITING_SOFTWARE      => new IfdEntry(ExifTag::IMAGE_EDITING_SOFTWARE, 2, 13, 'Image Studio'),
             ExifTag::METADATA_EDITING_SOFTWARE   => new IfdEntry(ExifTag::METADATA_EDITING_SOFTWARE, 2, 15, 'Metadata Studio'),
+            ExifTag::MAKER_NOTE_SAFETY           => new IfdEntry(ExifTag::MAKER_NOTE_SAFETY, 3, 1, 1),
         ]);
 
         $interopIfd = new Ifd([
@@ -274,6 +275,7 @@ final class StructuredMetadataBuilderTest extends TestCase
         self::assertSame(1, $structured->image->interlace);
         self::assertSame('Shot with ND filter', $structured->image->userComment);
         self::assertSame('Developed in Raw Studio', $structured->integrity->imageHistory);
+        self::assertTrue($structured->integrity->makerNotesSafe);
 
         self::assertSame(400, $structured->exposure->iso);
         self::assertSame(0.008, $structured->exposure->exposureTimeSec);
@@ -552,7 +554,7 @@ final class StructuredMetadataBuilderTest extends TestCase
             afConfidence: 0.76,
         );
 
-        $makerNotes = new MakerNotesMetadata('Apple', 64, str_repeat('a', 40), $appleMakerNotes);
+        $makerNotes = new MakerNotesMetadata('Apple', 64, str_repeat('a', 40), $appleMakerNotes, false);
 
         $ifd0         = new Ifd([]);
         $exifDocument = new ExifDocument($ifd0, null, null, null, null, $makerNotes);
@@ -612,6 +614,7 @@ final class StructuredMetadataBuilderTest extends TestCase
         self::assertEqualsWithDelta(0.1, $structured->motion->accelY, 1e-12);
         self::assertEqualsWithDelta(-0.1, $structured->motion->accelZ, 1e-12);
         self::assertFalse($structured->scene->nightMode);
+        self::assertFalse($structured->integrity->makerNotesSafe);
     }
 
     #[Test]

--- a/tests/MakerNotes/MakerNotesMetadata/MakerNotesMetadataTest.php
+++ b/tests/MakerNotes/MakerNotesMetadata/MakerNotesMetadataTest.php
@@ -36,6 +36,11 @@ final class MakerNotesMetadataTest extends TestCase
         self::assertSame(123, $metadata->length());
         self::assertSame('0123456789abcdef0123456789abcdef01234567', $metadata->sha1());
         self::assertNull($metadata->apple());
+        self::assertNull($metadata->isSafe());
+
+        $safeMetadata = new MakerNotesMetadata('Contoso', 123, '0123456789abcdef0123456789abcdef01234567', null, true);
+
+        self::assertTrue($safeMetadata->isSafe());
     }
 
     /**

--- a/tests/Model/Exif/ExifDocumentTest.php
+++ b/tests/Model/Exif/ExifDocumentTest.php
@@ -579,6 +579,26 @@ final class ExifDocumentTest extends TestCase
         self::assertSame('2024-05-02T09:10:11.500+01:30', $fileDate->format(self::ISO_8601_MILLISECONDS));
     }
 
+    #[Test]
+    public function makerNoteSafetyMapsNumericValues(): void
+    {
+        $safeExifIfd = new Ifd([
+            ExifTag::MAKER_NOTE_SAFETY => new IfdEntry(ExifTag::MAKER_NOTE_SAFETY, 3, 1, 1),
+        ]);
+
+        $unsafeExifIfd = new Ifd([
+            ExifTag::MAKER_NOTE_SAFETY => new IfdEntry(ExifTag::MAKER_NOTE_SAFETY, 3, 1, 0),
+        ]);
+
+        $safeDoc   = new ExifDocument(new Ifd([]), $safeExifIfd, null, null, null);
+        $unsafeDoc = new ExifDocument(new Ifd([]), $unsafeExifIfd, null, null, null);
+        $missingDoc = new ExifDocument(new Ifd([]), null, null, null, null);
+
+        self::assertTrue($safeDoc->makerNoteSafety());
+        self::assertFalse($unsafeDoc->makerNoteSafety());
+        self::assertNull($missingDoc->makerNoteSafety());
+    }
+
     /**
      * Ensures Table 65 extension tags are exposed via dedicated getters.
      */

--- a/tests/Model/Exif/ExifTagTest.php
+++ b/tests/Model/Exif/ExifTagTest.php
@@ -149,6 +149,7 @@ final class ExifTagTest extends TestCase
             'FOCAL_LENGTH'                             => 0x920A,
             'SUBJECT_AREA'                             => 0x9214,
             'MAKER_NOTE'                               => 0x927C,
+            'MAKER_NOTE_SAFETY'                        => 0xC635,
             'USER_COMMENT'                             => 0x9286,
             'SUB_SEC_TIME'                             => 0x9290,
             'SUB_SEC_TIME_ORIGINAL'                    => 0x9291,

--- a/tests/Parse/Tiff/TiffExifReaderTest.php
+++ b/tests/Parse/Tiff/TiffExifReaderTest.php
@@ -362,6 +362,7 @@ final class TiffExifReaderTest extends TestCase
         self::assertSame('DATA', $makerNotes->vendor());
         self::assertSame(strlen($makerNoteData), $makerNotes->length());
         self::assertSame(sha1($makerNoteData), $makerNotes->sha1());
+        self::assertNull($makerNotes->isSafe());
     }
 
     /**
@@ -387,6 +388,55 @@ final class TiffExifReaderTest extends TestCase
         self::assertSame('Unknown', $makerNotes->vendor());
         self::assertSame(strlen($makerNoteData), $makerNotes->length());
         self::assertSame(sha1($makerNoteData), $makerNotes->sha1());
+        self::assertNull($makerNotes->isSafe());
+    }
+
+    /**
+     * Ensures the maker note safety flag propagates when the metadata is decoded via a registry.
+     */
+    #[Test]
+    public function propagatesMakerNoteSafetyForRegisteredDecoder(): void
+    {
+        [$blob] = $this->buildClassicMakerNoteBlob(1);
+
+        $decoder = new class implements MakerNotesDecoderInterface {
+            public function decode(string $raw, string $make, ?string $model): MakerNotesMetadata
+            {
+                return new MakerNotesMetadata('SafeVendor', strlen($raw), sha1($raw));
+            }
+        };
+
+        $registry = new Registry();
+        $registry->register('AcmeCam', $decoder);
+
+        $document   = (new TiffExifReader())->parseFromBlob($blob, $registry);
+        $makerNotes = $document->makerNotes();
+
+        self::assertInstanceOf(MakerNotesMetadata::class, $makerNotes);
+        self::assertTrue($document->makerNoteSafety());
+        self::assertTrue($makerNotes->isSafe());
+
+        $resolver = new ExifTagResolver($document);
+        self::assertTrue($resolver->makerNoteSafety());
+    }
+
+    /**
+     * Ensures the maker note safety flag propagates when falling back to a digest.
+     */
+    #[Test]
+    public function propagatesMakerNoteSafetyForDigestFallback(): void
+    {
+        [$blob] = $this->buildClassicMakerNoteBlob(0);
+
+        $document   = (new TiffExifReader())->parseFromBlob($blob);
+        $makerNotes = $document->makerNotes();
+
+        self::assertInstanceOf(MakerNotesMetadata::class, $makerNotes);
+        self::assertFalse($document->makerNoteSafety());
+        self::assertFalse($makerNotes->isSafe());
+
+        $resolver = new ExifTagResolver($document);
+        self::assertFalse($resolver->makerNoteSafety());
     }
 
     /**
@@ -1015,7 +1065,7 @@ final class TiffExifReaderTest extends TestCase
      *
      * @return array{0: string, 1: string}
      */
-    private function buildClassicMakerNoteBlob(): array
+    private function buildClassicMakerNoteBlob(?int $safety = null): array
     {
         $header = 'II' . pack('v', 0x002A) . pack('V', 8);
 
@@ -1040,12 +1090,15 @@ final class TiffExifReaderTest extends TestCase
         $blob .= $makeString;
         $blob .= $modelString;
 
-        $exifEntryCount  = 1;
-        $exifIfdSize     = 2 + 12 + 4;
+        $exifEntryCount  = $safety === null ? 1 : 2;
+        $exifIfdSize     = 2 + $exifEntryCount * 12 + 4;
         $makerNoteOffset = $exifOffset + $exifIfdSize;
         $exifEntries     = [
             self::packClassicEntry(ExifTag::MAKER_NOTE, 7, strlen($makerNote), $makerNoteOffset),
         ];
+        if ($safety !== null) {
+            $exifEntries[] = self::packClassicEntry(ExifTag::MAKER_NOTE_SAFETY, 3, 1, $safety);
+        }
         $blob .= pack('v', $exifEntryCount) . implode('', $exifEntries) . pack('V', 0);
         $blob .= $makerNote;
 


### PR DESCRIPTION
## Summary
- add the MAKER_NOTE_SAFETY constant and expose it through ExifDocument and ExifTagResolver
- carry the maker note safety flag via MakerNotesMetadata, the TIFF reader, and the structured Integrity aggregate
- exercise safe and unsafe maker note scenarios in the resolver, builder, and TIFF reader tests

## Testing
- composer ci:test:php:unit *(fails: TruthComparison fixtures reference external media that is not available in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68fdeab526d083239195cfd7a8e74eea