### PR TITLE
feat: propagate CFA repeat pattern dimensions

### DIFF
--- a/src/Curate/Resolver/ExifTagResolver.php
+++ b/src/Curate/Resolver/ExifTagResolver.php
@@ -645,6 +645,26 @@ final readonly class ExifTagResolver
     }
 
     /**
+     * Returns the width component of the CFA repeat pattern dimensions.
+     */
+    public function cfaRepeatPatternWidth(): ?int
+    {
+        $dimensions = $this->document?->cfaRepeatPatternDim();
+
+        return $dimensions['width'] ?? null;
+    }
+
+    /**
+     * Returns the height component of the CFA repeat pattern dimensions.
+     */
+    public function cfaRepeatPatternHeight(): ?int
+    {
+        $dimensions = $this->document?->cfaRepeatPatternDim();
+
+        return $dimensions['height'] ?? null;
+    }
+
+    /**
      * Returns the image description field.
      */
     public function imageDescription(): ?string

--- a/src/Curate/StructuredMetadataBuilder.php
+++ b/src/Curate/StructuredMetadataBuilder.php
@@ -458,8 +458,8 @@ final class StructuredMetadataBuilder
 
         $sensor = new Sensor(
             pixelPitchUm: null,
-            cfaWidth: null,
-            cfaHeight: null,
+            cfaWidth: $exifResolver->cfaRepeatPatternWidth(),
+            cfaHeight: $exifResolver->cfaRepeatPatternHeight(),
             sensorType: null,
             ibis: null,
             cfaPattern: $exifResolver->cfaPattern(),

--- a/src/Model/Exif/ExifDocument.php
+++ b/src/Model/Exif/ExifDocument.php
@@ -950,6 +950,31 @@ final readonly class ExifDocument
     }
 
     /**
+     * Returns the CFA repeat pattern dimensions when valid.
+     *
+     * @return array{width:int, height:int}|null
+     */
+    public function cfaRepeatPatternDim(): ?array
+    {
+        $values = $this->numericList($this->exifIfd, ExifTag::CFA_REPEAT_PATTERN_DIM);
+
+        if ($values === null || count($values) !== 2) {
+            return null;
+        }
+
+        [$width, $height] = $values;
+
+        if (!is_int($width) || !is_int($height) || $width <= 0 || $height <= 0) {
+            return null;
+        }
+
+        return [
+            'width'  => $width,
+            'height' => $height,
+        ];
+    }
+
+    /**
      * Returns the CFA pattern definition as a list of component identifiers.
      *
      * @return list<int>|null

--- a/src/Model/Exif/ExifTag.php
+++ b/src/Model/Exif/ExifTag.php
@@ -155,6 +155,8 @@ final readonly class ExifTag
     public const int INTEROPERABILITY_IFD_POINTER = 0xA005;
 
     // EXIF sub IFD
+    public const int CFA_REPEAT_PATTERN_DIM = 0x828D;
+
     public const int BATTERY_LEVEL = 0x828F;
 
     public const int MAKER_NOTE_SAFETY = 0xC635;

--- a/tests/Curate/Resolver/ExifTagResolverTest.php
+++ b/tests/Curate/Resolver/ExifTagResolverTest.php
@@ -324,6 +324,7 @@ final class ExifTagResolverTest extends TestCase
         $exifIfd = new Ifd([
             ExifTag::COMPONENTS_CONFIGURATION  => new IfdEntry(ExifTag::COMPONENTS_CONFIGURATION, 7, 4, new ExifNumericList([1, 2, 3, 0])),
             ExifTag::SCENE_TYPE                => new IfdEntry(ExifTag::SCENE_TYPE, 7, 1, chr(1)),
+            ExifTag::CFA_REPEAT_PATTERN_DIM    => new IfdEntry(ExifTag::CFA_REPEAT_PATTERN_DIM, 3, 2, new ExifNumericList([6, 4])),
             ExifTag::CFA_PATTERN               => new IfdEntry(ExifTag::CFA_PATTERN, 7, 4, "\x00\x01\x02\x03"),
             ExifTag::CUSTOM_RENDERED           => new IfdEntry(ExifTag::CUSTOM_RENDERED, 3, 1, 1),
             ExifTag::CAMERA_FIRMWARE           => new IfdEntry(ExifTag::CAMERA_FIRMWARE, 2, 1, 'FW Main'),
@@ -344,6 +345,8 @@ final class ExifTagResolverTest extends TestCase
             CfaPatternColor::BLUE,
             CfaPatternColor::CYAN,
         ], $resolver->cfaPatternColors());
+        self::assertSame(6, $resolver->cfaRepeatPatternWidth());
+        self::assertSame(4, $resolver->cfaRepeatPatternHeight());
         self::assertSame(CustomRendered::CUSTOM_PROCESS, $resolver->customRendered());
         self::assertSame('Evening Glow', $resolver->imageTitle());
         self::assertSame('Jamie Doe', $resolver->photographer());

--- a/tests/Curate/StructuredMetadataBuilderTest.php
+++ b/tests/Curate/StructuredMetadataBuilderTest.php
@@ -176,6 +176,7 @@ final class StructuredMetadataBuilderTest extends TestCase
             ExifTag::FILE_SOURCE                 => new IfdEntry(ExifTag::FILE_SOURCE, 7, 1, chr(FileSource::DIGITAL_CAMERA->value)),
             ExifTag::SENSING_METHOD              => new IfdEntry(ExifTag::SENSING_METHOD, 3, 1, SensingMethod::ONE_CHIP_COLOR_AREA->value),
             ExifTag::GAMMA                       => new IfdEntry(ExifTag::GAMMA, 5, 1, [[22, 10]]),
+            ExifTag::CFA_REPEAT_PATTERN_DIM      => new IfdEntry(ExifTag::CFA_REPEAT_PATTERN_DIM, 3, 2, new ExifNumericList([8, 6])),
             ExifTag::CFA_PATTERN                 => new IfdEntry(ExifTag::CFA_PATTERN, 7, 4, "\x02\x01\x01\x00"),
             ExifTag::CUSTOM_RENDERED             => new IfdEntry(ExifTag::CUSTOM_RENDERED, 3, 1, 1),
             ExifTag::DEVICE_SETTING_DESCRIPTION  => new IfdEntry(ExifTag::DEVICE_SETTING_DESCRIPTION, 7, 12, 'Profile:Portrait'),
@@ -333,6 +334,8 @@ final class StructuredMetadataBuilderTest extends TestCase
         self::assertEqualsWithDelta(0.85, $sensorSfr['values'][1][0] ?? 0.0, 0.0001);
         self::assertEqualsWithDelta(0.7, $sensorSfr['values'][1][1] ?? 0.0, 0.0001);
         self::assertEqualsWithDelta(0.55, $sensorSfr['values'][1][2] ?? 0.0, 0.0001);
+        self::assertSame(8, $structured->sensor->cfaWidth);
+        self::assertSame(6, $structured->sensor->cfaHeight);
         self::assertSame([2, 1, 1, 0], $structured->sensor->cfaPattern);
         self::assertEqualsWithDelta(43.21, $structured->sensor->focalPlaneXResolution, 0.001);
         self::assertEqualsWithDelta(43.0, $structured->sensor->focalPlaneYResolution, 0.001);
@@ -372,6 +375,28 @@ final class StructuredMetadataBuilderTest extends TestCase
         $structured = (new StructuredMetadataBuilder())->build($metadata);
 
         self::assertSame(Orientation::UNKNOWN, $structured->image->orientation);
+    }
+
+    #[Test]
+    public function leavesSensorCfaDimensionsNullWhenInvalid(): void
+    {
+        $ifd0 = new Ifd([]);
+
+        $exifIfd = new Ifd([
+            ExifTag::CFA_REPEAT_PATTERN_DIM => new IfdEntry(
+                ExifTag::CFA_REPEAT_PATTERN_DIM,
+                3,
+                1,
+                new ExifNumericList([5]),
+            ),
+        ]);
+
+        $metadata = new Metadata(['primary'], null, new ExifDocument($ifd0, $exifIfd, null, null, null));
+
+        $structured = (new StructuredMetadataBuilder())->build($metadata);
+
+        self::assertNull($structured->sensor->cfaWidth);
+        self::assertNull($structured->sensor->cfaHeight);
     }
 
     #[Test]

--- a/tests/Model/Exif/ExifDocumentTest.php
+++ b/tests/Model/Exif/ExifDocumentTest.php
@@ -148,6 +148,64 @@ final class ExifDocumentTest extends TestCase
         self::assertEquals(123.0, $gps['alt']);
     }
 
+    #[Test]
+    public function returnsCfaRepeatPatternDimensions(): void
+    {
+        $ifd0 = new Ifd([]);
+
+        $exifIfd = new Ifd([
+            ExifTag::CFA_REPEAT_PATTERN_DIM => new IfdEntry(
+                ExifTag::CFA_REPEAT_PATTERN_DIM,
+                3,
+                2,
+                new ExifNumericList([4, 2]),
+            ),
+        ]);
+
+        $doc = new ExifDocument($ifd0, $exifIfd, null, null, null);
+
+        self::assertSame(
+            ['width' => 4, 'height' => 2],
+            $doc->cfaRepeatPatternDim(),
+        );
+    }
+
+    #[Test]
+    public function returnsNullWhenCfaRepeatPatternDimensionsMissing(): void
+    {
+        $doc = new ExifDocument(new Ifd([]), new Ifd([]), null, null, null);
+
+        self::assertNull($doc->cfaRepeatPatternDim());
+    }
+
+    #[Test]
+    public function returnsNullWhenCfaRepeatPatternDimensionsInvalid(): void
+    {
+        $ifd0 = new Ifd([]);
+
+        $invalidZero = new Ifd([
+            ExifTag::CFA_REPEAT_PATTERN_DIM => new IfdEntry(
+                ExifTag::CFA_REPEAT_PATTERN_DIM,
+                3,
+                2,
+                new ExifNumericList([4, 0]),
+            ),
+        ]);
+
+        self::assertNull((new ExifDocument($ifd0, $invalidZero, null, null, null))->cfaRepeatPatternDim());
+
+        $invalidCount = new Ifd([
+            ExifTag::CFA_REPEAT_PATTERN_DIM => new IfdEntry(
+                ExifTag::CFA_REPEAT_PATTERN_DIM,
+                3,
+                1,
+                new ExifNumericList([4]),
+            ),
+        ]);
+
+        self::assertNull((new ExifDocument($ifd0, $invalidCount, null, null, null))->cfaRepeatPatternDim());
+    }
+
     /**
      * Falls back to DateTimeDigitized when DateTimeOriginal is missing.
      */

--- a/tests/Model/Exif/ExifTagTest.php
+++ b/tests/Model/Exif/ExifTagTest.php
@@ -113,6 +113,7 @@ final class ExifTagTest extends TestCase
             'INTEROPERABILITY_IFD_POINTER' => 0xA005,
 
             // EXIF sub IFD
+            'CFA_REPEAT_PATTERN_DIM'                 => 0x828D,
             'BATTERY_LEVEL'                          => 0x828F,
             'EXPOSURE_TIME'                            => 0x829A,
             'F_NUMBER'                                 => 0x829D,


### PR DESCRIPTION
## Summary
- add the CFA repeat pattern dimension constant and parsing to the EXIF model
- expose the parsed dimensions through the EXIF resolver and structured metadata builder
- cover successful, missing, and invalid CFA dimension scenarios in unit tests

## Testing
- composer ci:test:php:unit *(fails: requires proprietary truth fixtures not present in this environment)*
- ./.build/bin/phpunit --configuration .build/phpunit.xml tests/Model/Exif/ExifDocumentTest.php tests/Curate/Resolver/ExifTagResolverTest.php tests/Curate/StructuredMetadataBuilderTest.php


------
https://chatgpt.com/codex/tasks/task_e_68fe19a8e6d48323937e0d8bc15964aa