### PR TITLE
fix: handle SFR label terminators explicitly

### DIFF
--- a/src/Model/Exif/ValueConverters.php
+++ b/src/Model/Exif/ValueConverters.php
@@ -821,7 +821,7 @@ final readonly class ValueConverters
             return null;
         }
 
-        $end = strpos($payload, " ", $offset);
+        $end = strpos($payload, "\0", $offset);
         if ($end === false) {
             return null;
         }

--- a/tests/Model/Exif/ValueConvertersTest.php
+++ b/tests/Model/Exif/ValueConvertersTest.php
@@ -626,6 +626,21 @@ final class ValueConvertersTest extends TestCase
     }
 
     #[Test]
+    public function decodeSpatialFrequencyResponseReturnsLabels(): void
+    {
+        $payload = pack('n', 1) . pack('n', 1);
+        $payload .= "Alpha\0";
+        $payload .= "Beta\0";
+        $payload .= self::packSrational(1, 1);
+
+        $result = ValueConverters::decodeSpatialFrequencyResponse($payload);
+
+        self::assertNotNull($result);
+        self::assertSame(['Alpha'], $result['labels']['columns']);
+        self::assertSame(['Beta'], $result['labels']['rows']);
+    }
+
+    #[Test]
     public function decodeSpatialFrequencyResponseParsesTable(): void
     {
         $payload = self::buildSpatialFrequencyResponsePayload();


### PR DESCRIPTION
## Summary
- update the SFR label parser to search for the null terminator explicitly
- add a regression test covering non-empty row and column labels in the SFR payload

## Testing
- composer ci:test:php:unit *(fails: TruthComparisonTest fixtures are unavailable in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68fe19be41cc832387ca350f4b8c0d32