### PR TITLE
fix: normalise FlashPix version output

### DIFF
--- a/src/Curate/Resolver/ExifTagResolver.php
+++ b/src/Curate/Resolver/ExifTagResolver.php
@@ -1007,7 +1007,16 @@ final readonly class ExifTagResolver
     {
         $value = $this->stringValue($this->document?->exifIfd, ExifTag::FLASHPIX_VERSION);
 
-        return $value !== null ? trim($value, "\0") : null;
+        if ($value === null) {
+            return null;
+        }
+
+        $trimmed = trim($value, "\0");
+        if ($trimmed === '') {
+            return null;
+        }
+
+        return CoreValueConverters::toExifVersion($trimmed);
     }
 
     /**

--- a/tests/Core/ValueConvertersTest.php
+++ b/tests/Core/ValueConvertersTest.php
@@ -36,6 +36,8 @@ final class ValueConvertersTest extends TestCase
     #[Test]
     public function normalisesExifVersionAndFlash(): void
     {
+        self::assertSame('1.00', ValueConverters::toExifVersion('0100'));
+        self::assertSame('1.00', ValueConverters::toExifVersion("0100\0\0"));
         self::assertSame('2.00', ValueConverters::toExifVersion('0200'));
         self::assertSame('2.20', ValueConverters::toExifVersion('0220'));
         self::assertSame('2.31', ValueConverters::toExifVersion('0231'));

--- a/tests/Curate/StructuredMetadataBuilderTest.php
+++ b/tests/Curate/StructuredMetadataBuilderTest.php
@@ -305,7 +305,7 @@ final class StructuredMetadataBuilderTest extends TestCase
 
         self::assertSame('3.00', $structured->standards->exifVersion);
         self::assertSame('3.0', $structured->standards->profile);
-        self::assertSame('0100', $structured->standards->flashpixVersion);
+        self::assertSame('1.00', $structured->standards->flashpixVersion);
         self::assertSame([1, 0, 0, 0], $structured->standards->tiffEpStandardId);
 
         self::assertEqualsWithDelta(1.9965, $structured->lens->maxApertureFNumber, 0.001);
@@ -445,7 +445,7 @@ final class StructuredMetadataBuilderTest extends TestCase
         $standards  = $structured->standards;
 
         self::assertSame('2.32', $standards->exifVersion);
-        self::assertSame('0100', $standards->flashpixVersion);
+        self::assertSame('1.00', $standards->flashpixVersion);
         self::assertSame('2.32', $standards->profile);
     }
 

--- a/tests/Parse/Tiff/TiffExifReaderTest.php
+++ b/tests/Parse/Tiff/TiffExifReaderTest.php
@@ -190,7 +190,7 @@ final class TiffExifReaderTest extends TestCase
         $resolver = new ExifTagResolver($document);
 
         self::assertSame('2.32', $resolver->exifVersion());
-        self::assertSame('0100', $resolver->flashpixVersion());
+        self::assertSame('1.00', $resolver->flashpixVersion());
     }
 
     /**


### PR DESCRIPTION
## Summary
- normalise the FlashPix version via `ValueConverters::toExifVersion()` when resolving EXIF tags
- update structured metadata expectations to use dotted FlashPix versions
- extend the EXIF version converter tests to cover FlashPix inputs

## Testing
- composer ci:test:php:unit *(fails: known fixture-based TruthComparison expectations in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68fe19ceb5908323b01b8dc4906f1d3b