### PR TITLE
Fix EXIF capability mapping for dotted version inputs

### DIFF
--- a/src/Core/ExifCapabilities.php
+++ b/src/Core/ExifCapabilities.php
@@ -47,12 +47,13 @@ final class ExifCapabilities
             $digits = $trimmed;
         }
 
-        if (ctype_digit($digits)) {
-            if (strlen($digits) === 3) {
-                $digits = '0' . $digits;
+        if (ctype_digit($trimmed)) {
+            $normalized = $trimmed;
+            if (strlen($normalized) === 3) {
+                $normalized = '0' . $normalized;
             }
 
-            return match ($digits) {
+            return match ($normalized) {
                 '0100' => '1.0',
                 '0110' => '1.1',
                 '0200' => '2.0',
@@ -66,7 +67,27 @@ final class ExifCapabilities
             };
         }
 
-        return match ($digits) {
+        if (ctype_digit($digits) && strlen($digits) >= 3) {
+            $normalized = $digits;
+            if (strlen($normalized) === 3) {
+                $normalized = '0' . $normalized;
+            }
+
+            return match ($normalized) {
+                '0100' => '1.0',
+                '0110' => '1.1',
+                '0200' => '2.0',
+                '0210' => '2.1',
+                '0221' => '2.21',
+                '0230' => '2.3',
+                '0231' => '2.31',
+                '0232' => '2.32',
+                '0300'  => '3.0',
+                default => '2.2',
+            };
+        }
+
+        return match ($trimmed) {
             '1.00', '1.0' => '1.0',
             '1.10', '1.1' => '1.1',
             '2.00', '2.0' => '2.0',

--- a/tests/Core/ExifCapabilitiesTest.php
+++ b/tests/Core/ExifCapabilitiesTest.php
@@ -35,7 +35,10 @@ final class ExifCapabilitiesTest extends TestCase
     {
         yield 'null defaults to 2.2' => ['2.2', null];
         yield 'empty string defaults to 2.2' => ['2.2', ''];
-        yield 'numeric 0200 maps to 2.0' => ['2.0', '0200'];
+        yield 'raw 0100 maps to 1.0' => ['1.0', '0100'];
+        yield 'raw 0110 maps to 1.1' => ['1.1', '0110'];
+        yield 'decimal 1.00 maps to 1.0' => ['1.0', '1.00'];
+        yield 'raw 0200 maps to 2.0' => ['2.0', '0200'];
         yield 'decimal 2.00 maps to 2.0' => ['2.0', '2.00'];
         yield 'raw 0221 maps to 2.21' => ['2.21', '0221'];
         yield 'decimal 2.21 maps to 2.21' => ['2.21', '2.21'];
@@ -44,5 +47,7 @@ final class ExifCapabilitiesTest extends TestCase
         yield 'raw 0232 maps to 2.32' => ['2.32', '0232'];
         yield 'decimal 2.32 maps to 2.32' => ['2.32', '2.32'];
         yield 'raw 0230 stays grouped as 2.3' => ['2.3', '0230'];
+        yield 'raw 0300 maps to 3.0' => ['3.0', '0300'];
+        yield 'decimal 3.0 maps to 3.0' => ['3.0', '3.0'];
     }
 }

--- a/tests/Core/ValueConvertersTest.php
+++ b/tests/Core/ValueConvertersTest.php
@@ -36,10 +36,14 @@ final class ValueConvertersTest extends TestCase
     #[Test]
     public function normalisesExifVersionAndFlash(): void
     {
+        self::assertSame('1.00', ValueConverters::toExifVersion('0100'));
+        self::assertSame('1.10', ValueConverters::toExifVersion('0110'));
+        self::assertSame('1.00', ValueConverters::toExifVersion('1.00'));
         self::assertSame('2.00', ValueConverters::toExifVersion('0200'));
         self::assertSame('2.20', ValueConverters::toExifVersion('0220'));
         self::assertSame('2.31', ValueConverters::toExifVersion('0231'));
         self::assertSame('3.00', ValueConverters::toExifVersion('0300'));
+        self::assertSame('3.0', ValueConverters::toExifVersion('3.0'));
         self::assertSame('Exif', ValueConverters::toExifVersion("Exif\0\0"));
         self::assertNull(ValueConverters::toExifVersion('0240'));
         self::assertNull(ValueConverters::toExifVersion("\x01\x02\x03\x04"));


### PR DESCRIPTION
## Summary
- extend the EXIF capability provider to cover 1.x identifiers and dotted 3.0 values
- assert ValueConverters keeps the dotted EXIF version format for those inputs
- normalise EXIF capability detection so dotted version strings resolve to the expected profiles

## Testing
- composer ci:test:php:unit *(fails: integration fixtures unavailable in container)*

------
https://chatgpt.com/codex/tasks/task_e_68fe19d461788323b4ad140c6c85ace6