### PR TITLE
feat: add EXIF audio APP2 extraction

### DIFF
--- a/src/Curate/StructuredMetadata.php
+++ b/src/Curate/StructuredMetadata.php
@@ -13,6 +13,7 @@ namespace MagicSunday\ImageMeta\Curate;
 
 use MagicSunday\ImageMeta\Value\Apple;
 use MagicSunday\ImageMeta\Value\Audio;
+use MagicSunday\ImageMeta\Value\AudioClip;
 use MagicSunday\ImageMeta\Value\Author;
 use MagicSunday\ImageMeta\Value\Camera;
 use MagicSunday\ImageMeta\Value\Capture;
@@ -74,6 +75,7 @@ final readonly class StructuredMetadata
      * @param Preview             $preview             Embedded preview information.
      * @param Video               $video               Video track metadata when available.
      * @param Audio               $audio               Audio track metadata when available.
+     * @param list<AudioClip>     $audioClips          Raw EXIF audio streams decoded from JPEG APP2 segments.
      * @param ColorProfile        $colorProfile        Colour profile information.
      * @param ProcessingSettings  $processing          Image processing metadata.
      * @param WhiteBalanceDetails $whiteBalanceDetails White balance analysis details.
@@ -111,6 +113,7 @@ final readonly class StructuredMetadata
         public Preview $preview,
         public Video $video,
         public Audio $audio,
+        /** @var list<AudioClip> */ public array $audioClips = [],
         public ColorProfile $colorProfile,
         public ProcessingSettings $processing,
         public WhiteBalanceDetails $whiteBalanceDetails,

--- a/src/Curate/StructuredMetadataBuilder.php
+++ b/src/Curate/StructuredMetadataBuilder.php
@@ -28,6 +28,7 @@ use MagicSunday\ImageMeta\Model\QuickTimeMeta;
 use MagicSunday\ImageMeta\Parse\Icc\IccDecoder;
 use MagicSunday\ImageMeta\Value\Apple;
 use MagicSunday\ImageMeta\Value\Audio;
+use MagicSunday\ImageMeta\Value\AudioClip;
 use MagicSunday\ImageMeta\Value\Author;
 use MagicSunday\ImageMeta\Value\Camera;
 use MagicSunday\ImageMeta\Value\Capture;
@@ -303,15 +304,48 @@ final class StructuredMetadataBuilder
             colorPrimaries: $quickTimeResolver->string('com.apple.quicktime.colorPrimaries'),
         );
 
+        $primaryJpegAudio = $metadata->jpegAudioStreams[0] ?? null;
+
+        $audioChannels = $quickTimeResolver->int(QuickTimeMeta::AUDIO_CHANNELS_KEY);
+        if ($audioChannels === null && $primaryJpegAudio !== null) {
+            $audioChannels = $primaryJpegAudio['channels'];
+        }
+
+        $audioSampleRate = $quickTimeResolver->int(QuickTimeMeta::AUDIO_SAMPLE_RATE_KEY);
+        if ($audioSampleRate === null && $primaryJpegAudio !== null) {
+            $audioSampleRate = $primaryJpegAudio['sampleRate'];
+        }
+
+        $audioCodec = CompositeResolver::first([
+            fn (): ?string => $quickTimeResolver->string(QuickTimeMeta::AUDIO_FORMAT_KEY),
+            fn (): ?string => $quickTimeResolver->string(QuickTimeMeta::AUDIO_CODEC_KEY),
+        ]);
+        if ($audioCodec === null && $primaryJpegAudio !== null) {
+            $audioCodec = $primaryJpegAudio['codec'];
+        }
+
+        $audioBitDepth = $quickTimeResolver->int(QuickTimeMeta::AUDIO_BITS_PER_SAMPLE_KEY);
+        if ($audioBitDepth === null && $primaryJpegAudio !== null) {
+            $audioBitDepth = $primaryJpegAudio['bitDepth'];
+        }
+
         $audio = new Audio(
-            channels: $quickTimeResolver->int(QuickTimeMeta::AUDIO_CHANNELS_KEY),
-            sampleRate: $quickTimeResolver->int(QuickTimeMeta::AUDIO_SAMPLE_RATE_KEY),
-            codec: CompositeResolver::first([
-                fn (): ?string => $quickTimeResolver->string(QuickTimeMeta::AUDIO_FORMAT_KEY),
-                fn (): ?string => $quickTimeResolver->string(QuickTimeMeta::AUDIO_CODEC_KEY),
-            ]),
-            bitDepth: $quickTimeResolver->int(QuickTimeMeta::AUDIO_BITS_PER_SAMPLE_KEY),
+            channels: $audioChannels,
+            sampleRate: $audioSampleRate,
+            codec: $audioCodec,
+            bitDepth: $audioBitDepth,
         );
+
+        $audioClips = [];
+        foreach ($metadata->jpegAudioStreams as $stream) {
+            $audioClips[] = new AudioClip(
+                data: $stream['data'],
+                channels: $stream['channels'],
+                sampleRate: $stream['sampleRate'],
+                codec: $stream['codec'],
+                bitDepth: $stream['bitDepth'],
+            );
+        }
 
         $iccData = null;
         if ($metadata->iccProfile !== null || $metadata->iccSegments !== []) {
@@ -508,6 +542,7 @@ final class StructuredMetadataBuilder
             preview: $preview,
             video: $video,
             audio: $audio,
+            audioClips: $audioClips,
             colorProfile: $colorProfile,
             processing: $processing,
             whiteBalanceDetails: $whiteBalanceDetails,

--- a/src/MetadataReader.php
+++ b/src/MetadataReader.php
@@ -90,6 +90,7 @@ final class MetadataReader
         $iccProfile       = $jpeg->getIccProfile();
         $iccSegments      = $jpeg->getIccSegments();
         $flashPixStreams  = $jpeg->getFlashPixStreams();
+        $audioStreams     = $jpeg->getExifAudioStreams();
         $bitsPerSample    = $jpeg->getFrameSamplePrecision();
         $frameHeight      = $jpeg->getFrameHeight();
         $frameWidth       = $jpeg->getFrameWidth();
@@ -119,6 +120,7 @@ final class MetadataReader
             $iccProfile,
             $iccSegments,
             $flashPixStreams,
+            $audioStreams,
             $bitsPerSample,
             $sampling,
             $subSampling,
@@ -175,6 +177,7 @@ final class MetadataReader
             $xmpDoc,
             $makerNotes,
             null,
+            [],
             [],
             [],
             null,

--- a/src/Model/Metadata.php
+++ b/src/Model/Metadata.php
@@ -53,6 +53,11 @@ final class Metadata
      */
     public readonly array $flashPixStreams;
 
+    /**
+     * @var list<array{codec:string, channels:int, sampleRate:int, bitDepth:int, data:string}>
+     */
+    public readonly array $jpegAudioStreams;
+
     public readonly ?int $jpegBitsPerSample;
 
     /** @var array<int, array{horizontal:int, vertical:int}>|null */
@@ -87,6 +92,7 @@ final class Metadata
      * @param string|null                                          $iccProfile               Binary ICC profile when available.
      * @param list<string>                                         $iccSegments              Raw ICC APP2 segments in encounter order.
      * @param array<int, string>                                   $flashPixStreams          Concatenated FlashPix extension streams keyed by identifier.
+     * @param list<array{codec:string, channels:int, sampleRate:int, bitDepth:int, data:string}> $jpegAudioStreams        Decoded EXIF audio streams extracted from APP2 segments.
      * @param int|null                                             $jpegBitsPerSample        Sample precision reported by the JPEG frame header.
      * @param array<int, array{horizontal:int, vertical:int}>|null $jpegFrameSamplingFactors Component sampling factors by
      *                                                                                       identifier.
@@ -109,6 +115,7 @@ final class Metadata
         ?string $iccProfile = null,
         array $iccSegments = [],
         array $flashPixStreams = [],
+        array $jpegAudioStreams = [],
         ?int $jpegBitsPerSample = null,
         ?array $jpegFrameSamplingFactors = null,
         ?array $jpegYCbCrSubSampling = null,
@@ -129,6 +136,7 @@ final class Metadata
         $this->iccProfile               = $iccProfile;
         $this->iccSegments              = $iccSegments;
         $this->flashPixStreams          = $flashPixStreams;
+        $this->jpegAudioStreams         = $jpegAudioStreams;
         $this->jpegBitsPerSample        = $jpegBitsPerSample;
         $this->jpegFrameSamplingFactors = $jpegFrameSamplingFactors;
         $this->jpegYCbCrSubSampling     = $jpegYCbCrSubSampling;

--- a/src/Parse/Jpeg/JpegExtractor.php
+++ b/src/Parse/Jpeg/JpegExtractor.php
@@ -19,6 +19,7 @@ use function array_key_exists;
 use function array_keys;
 use function count;
 use function implode;
+use function in_array;
 use function ksort;
 use function min;
 use function ord;
@@ -67,6 +68,25 @@ final class JpegExtractor
 
     private const string FPXR_SIGNATURE = 'FPXR';
 
+    private const string EXIF_AUDIO_SIGNATURE = "Exif\0\0Audio\0";
+
+    private const int EXIF_AUDIO_HEADER_LENGTH = 12;
+
+    /**
+     * Audio codec identifiers permitted by the EXIF audio specification.
+     */
+    private const array EXIF_AUDIO_CODECS = [
+        0x00 => 'pcm',
+        0x01 => 'mulaw',
+        0x02 => 'ima_adpcm',
+    ];
+
+    /** @var list<int> */
+    private const array EXIF_AUDIO_SAMPLE_RATES = [8000, 11025, 22050, 44100];
+
+    /** @var list<int> */
+    private const array EXIF_AUDIO_BIT_DEPTHS = [4, 8, 16];
+
     /**
      * Scan and termination markers that end metadata scanning.
      */
@@ -106,6 +126,16 @@ final class JpegExtractor
 
     /** @var list<string> */
     private array $iptcPayloads = [];
+
+    /**
+     * @var list<array{codec:string, channels:int, sampleRate:int, bitDepth:int, data:string}>
+     */
+    private array $exifAudioStreams = [];
+
+    /**
+     * @var array<int, array{codec:string, channels:int, sampleRate:int, bitDepth:int, expectedCount:int, fragments:array<int,string>}>
+     */
+    private array $exifAudioSequences = [];
 
     private ?int $frameBitsPerSample = null;
 
@@ -201,6 +231,18 @@ final class JpegExtractor
     }
 
     /**
+     * Returns decoded EXIF audio streams extracted from APP2 segments.
+     *
+     * @return list<array{codec:string, channels:int, sampleRate:int, bitDepth:int, data:string}>
+     */
+    public function getExifAudioStreams(): array
+    {
+        $this->parseIfNeeded();
+
+        return $this->exifAudioStreams;
+    }
+
+    /**
      * Returns the precision in bits reported by the primary start of frame segment.
      */
     public function getFrameSamplePrecision(): ?int
@@ -277,6 +319,8 @@ final class JpegExtractor
         $this->flashPixSequences       = [];
         $this->flashPixExpectedCounts  = [];
         $this->flashPixStreams         = [];
+        $this->exifAudioStreams        = [];
+        $this->exifAudioSequences      = [];
         $this->iptcPayloads            = [];
         $this->xmpPacketHashes         = [];
         $this->frameBitsPerSample      = null;
@@ -479,9 +523,145 @@ final class JpegExtractor
             return;
         }
 
+        if (str_starts_with($payload, self::EXIF_AUDIO_SIGNATURE)) {
+            $this->handleExifAudioSegment($payload, $offset);
+
+            return;
+        }
+
         if (str_starts_with($payload, self::FPXR_SIGNATURE)) {
             $this->handleFlashPixSegment($payload, $offset);
         }
+    }
+
+    /**
+     * Processes EXIF audio segments contained within APP2 markers.
+     *
+     * @param string $payload Raw segment payload including signature.
+     * @param int    $offset  Offset in the stream where the marker begins.
+     */
+    private function handleExifAudioSegment(string $payload, int $offset): void
+    {
+        $signatureLength = strlen(self::EXIF_AUDIO_SIGNATURE);
+        $minimumLength   = $signatureLength + self::EXIF_AUDIO_HEADER_LENGTH;
+        if (strlen($payload) < $minimumLength) {
+            throw new ParseError(sprintf('EXIF audio segment at offset %d is too short', $offset));
+        }
+
+        $header = substr($payload, $signatureLength, self::EXIF_AUDIO_HEADER_LENGTH);
+        /** @var array{stream:int,sequence:int,count:int,codec:int,channels:int,sampleRate:int,bitDepth:int,reserved:int}|false $fields */
+        $fields = unpack('nstream/Csequence/Ccount/Ccodec/Cchannels/NsampleRate/CbitDepth/Creserved', $header);
+        if ($fields === false) {
+            throw new ParseError(sprintf('Unable to parse EXIF audio header at offset %d', $offset));
+        }
+
+        $streamId       = (int) $fields['stream'];
+        $sequenceNumber = (int) $fields['sequence'];
+        $sequenceCount  = (int) $fields['count'];
+        $codecId        = (int) $fields['codec'];
+        $channels       = (int) $fields['channels'];
+        $sampleRate     = (int) $fields['sampleRate'];
+        $bitDepth       = (int) $fields['bitDepth'];
+        $reserved       = (int) $fields['reserved'];
+
+        if ($streamId === 0) {
+            throw new ParseError(sprintf('EXIF audio segment at offset %d uses invalid stream identifier 0', $offset));
+        }
+
+        if ($sequenceNumber === 0 || $sequenceCount === 0 || $sequenceNumber > $sequenceCount) {
+            $this->exifAudioSequences[$streamId] = [
+                'codec'         => '',
+                'channels'      => 0,
+                'sampleRate'    => 0,
+                'bitDepth'      => 0,
+                'expectedCount' => 0,
+                'fragments'     => [],
+            ];
+
+            return;
+        }
+
+        if (!array_key_exists($codecId, self::EXIF_AUDIO_CODECS)) {
+            throw new ParseError(sprintf('EXIF audio segment at offset %d declares unsupported codec 0x%02X', $offset, $codecId));
+        }
+
+        if ($channels <= 0) {
+            throw new ParseError(sprintf('EXIF audio segment at offset %d declares invalid channel count %d', $offset, $channels));
+        }
+
+        if (!in_array($sampleRate, self::EXIF_AUDIO_SAMPLE_RATES, true)) {
+            throw new ParseError(sprintf('EXIF audio segment at offset %d declares unsupported sample rate %d', $offset, $sampleRate));
+        }
+
+        if (!in_array($bitDepth, self::EXIF_AUDIO_BIT_DEPTHS, true)) {
+            throw new ParseError(sprintf('EXIF audio segment at offset %d declares unsupported bit depth %d', $offset, $bitDepth));
+        }
+
+        if ($reserved !== 0) {
+            throw new ParseError(sprintf('EXIF audio segment at offset %d uses non-zero reserved field %d', $offset, $reserved));
+        }
+
+        $audioData = substr($payload, $minimumLength);
+        if ($audioData === '') {
+            throw new ParseError(sprintf('EXIF audio segment at offset %d contains no payload data', $offset));
+        }
+
+        $codec = self::EXIF_AUDIO_CODECS[$codecId];
+
+        $sequence = $this->exifAudioSequences[$streamId] ?? null;
+        if ($sequence === null || $sequence['expectedCount'] === 0) {
+            $sequence = [
+                'codec'         => $codec,
+                'channels'      => $channels,
+                'sampleRate'    => $sampleRate,
+                'bitDepth'      => $bitDepth,
+                'expectedCount' => $sequenceCount,
+                'fragments'     => [],
+            ];
+        } else {
+            if (
+                $sequence['codec'] !== $codec
+                || $sequence['channels'] !== $channels
+                || $sequence['sampleRate'] !== $sampleRate
+                || $sequence['bitDepth'] !== $bitDepth
+                || $sequence['expectedCount'] !== $sequenceCount
+            ) {
+                $this->exifAudioSequences[$streamId] = [
+                    'codec'         => '',
+                    'channels'      => 0,
+                    'sampleRate'    => 0,
+                    'bitDepth'      => 0,
+                    'expectedCount' => 0,
+                    'fragments'     => [],
+                ];
+
+                return;
+            }
+        }
+
+        if (!array_key_exists($sequenceNumber, $sequence['fragments'])) {
+            $sequence['fragments'][$sequenceNumber] = $audioData;
+        }
+
+        $this->exifAudioSequences[$streamId] = $sequence;
+
+        if (count($sequence['fragments']) !== $sequence['expectedCount']) {
+            return;
+        }
+
+        $fragments = $sequence['fragments'];
+        ksort($fragments);
+        $data = implode('', $fragments);
+
+        $this->exifAudioStreams[] = [
+            'codec'      => $sequence['codec'],
+            'channels'   => $sequence['channels'],
+            'sampleRate' => $sequence['sampleRate'],
+            'bitDepth'   => $sequence['bitDepth'],
+            'data'       => $data,
+        ];
+
+        unset($this->exifAudioSequences[$streamId]);
     }
 
     /**

--- a/src/Value/AudioClip.php
+++ b/src/Value/AudioClip.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\ImageMeta\Value;
+
+/**
+ * Represents a decoded EXIF audio stream extracted from JPEG APP2 segments.
+ */
+final readonly class AudioClip
+{
+    /**
+     * @param string $data       Raw audio payload (typically PCM or container-specific data).
+     * @param int    $channels   Number of audio channels.
+     * @param int    $sampleRate Sampling rate in Hertz.
+     * @param string $codec      Codec identifier declared by the EXIF audio header.
+     * @param int    $bitDepth   Bits per audio sample when applicable.
+     */
+    public function __construct(
+        public string $data,
+        public int $channels,
+        public int $sampleRate,
+        public string $codec,
+        public int $bitDepth,
+    ) {
+    }
+}

--- a/tests/Curate/StructuredMetadataBuilderTest.php
+++ b/tests/Curate/StructuredMetadataBuilderTest.php
@@ -412,6 +412,7 @@ final class StructuredMetadataBuilderTest extends TestCase
             null,
             [],
             [],
+            [],
             null,
             null,
             null,
@@ -1675,6 +1676,12 @@ final class StructuredMetadataBuilderTest extends TestCase
         $structured = (new StructuredMetadataBuilder())->build(new Metadata([], null, null, []));
 
         foreach (get_object_vars($structured) as $name => $value) {
+            if ($name === 'audioClips') {
+                self::assertIsArray($value);
+
+                continue;
+            }
+
             self::assertIsObject($value, sprintf('Expected %s to be an object value object', $name));
 
             foreach (get_object_vars($value) as $field => $fieldValue) {
@@ -1901,6 +1908,7 @@ final class StructuredMetadataBuilderTest extends TestCase
         self::assertSame(48000, $structured->audio->sampleRate);
         self::assertSame('lpcm', $structured->audio->codec);
         self::assertSame(24, $structured->audio->bitDepth);
+        self::assertSame([], $structured->audioClips);
     }
 
     /**
@@ -1919,6 +1927,7 @@ final class StructuredMetadataBuilderTest extends TestCase
             null,
             [],
             [],
+            [],
             8,
             [
                 1 => ['horizontal' => 2, 'vertical' => 2],
@@ -1932,6 +1941,49 @@ final class StructuredMetadataBuilderTest extends TestCase
 
         self::assertSame(8, $structured->tiff->bitsPerSample);
         self::assertSame([2, 2], $structured->tiff->ycbcrSubSampling);
+    }
+
+    /**
+     * Falls back to JPEG-derived audio metadata when QuickTime lacks audio information.
+     */
+    #[Test]
+    public function derivesAudioFromJpegAudioStreamsWhenQuickTimeMissing(): void
+    {
+        $jpegAudio = [[
+            'codec'      => 'pcm',
+            'channels'   => 1,
+            'sampleRate' => 8000,
+            'bitDepth'   => 8,
+            'data'       => 'pcm-audio',
+        ]];
+
+        $metadata = new Metadata(
+            [],
+            null,
+            null,
+            [],
+            null,
+            null,
+            null,
+            [],
+            [],
+            $jpegAudio,
+        );
+
+        $structured = (new StructuredMetadataBuilder())->build($metadata);
+
+        self::assertSame(1, $structured->audio->channels);
+        self::assertSame(8000, $structured->audio->sampleRate);
+        self::assertSame('pcm', $structured->audio->codec);
+        self::assertSame(8, $structured->audio->bitDepth);
+        self::assertCount(1, $structured->audioClips);
+
+        $clip = $structured->audioClips[0];
+        self::assertSame('pcm-audio', $clip->data);
+        self::assertSame(1, $clip->channels);
+        self::assertSame(8000, $clip->sampleRate);
+        self::assertSame('pcm', $clip->codec);
+        self::assertSame(8, $clip->bitDepth);
     }
 
     /**

--- a/tests/Model/Metadata/MetadataTest.php
+++ b/tests/Model/Metadata/MetadataTest.php
@@ -84,6 +84,7 @@ final class MetadataTest extends TestCase
             $iccProfile,
             $iccSegments,
             [],
+            [],
             12,
             $sampling,
             [2, 1],
@@ -103,6 +104,7 @@ final class MetadataTest extends TestCase
         self::assertSame($xmpDoc, $metadata->xmpDoc);
         self::assertSame($iccProfile, $metadata->iccProfile);
         self::assertSame($iccSegments, $metadata->iccSegments);
+        self::assertSame([], $metadata->jpegAudioStreams);
         self::assertSame(12, $metadata->jpegBitsPerSample);
         self::assertSame($sampling, $metadata->jpegFrameSamplingFactors);
         self::assertSame([2, 1], $metadata->jpegYCbCrSubSampling);
@@ -128,6 +130,7 @@ final class MetadataTest extends TestCase
         self::assertNull($metadata->exifDoc);
         self::assertSame([], $metadata->xmpBlobs);
         self::assertNull($metadata->xmpDoc);
+        self::assertSame([], $metadata->jpegAudioStreams);
         self::assertNull($metadata->jpegBitsPerSample);
         self::assertNull($metadata->jpegFrameSamplingFactors);
         self::assertNull($metadata->jpegYCbCrSubSampling);

--- a/tests/Parse/Jpeg/JpegExtractorTest.php
+++ b/tests/Parse/Jpeg/JpegExtractorTest.php
@@ -44,6 +44,8 @@ final class JpegExtractorTest extends TestCase
 
     private const string FPXR_SIGNATURE = 'FPXR';
 
+    private const string EXIF_AUDIO_SIGNATURE = "Exif\0\0Audio\0";
+
     private const int MARKER_APP1 = 0xE1;
 
     private const int MARKER_APP2 = 0xE2;
@@ -192,6 +194,44 @@ final class JpegExtractorTest extends TestCase
         $extractor = $this->createExtractor($jpeg);
 
         self::assertSame([$streamId => $partOne . $partTwo], $extractor->getFlashPixStreams());
+    }
+
+    /**
+     * Confirms EXIF audio APP2 fragments are reassembled and exposed via the accessor.
+     */
+    #[Test]
+    public function testExifAudioSegmentsAreMerged(): void
+    {
+        $first  = self::segment(self::MARKER_APP2, self::exifAudioPayload(5, 1, 2, 0, 1, 8000, 8, 'pcm-a'));
+        $second = self::segment(self::MARKER_APP2, self::exifAudioPayload(5, 2, 2, 0, 1, 8000, 8, 'pcm-b'));
+
+        $jpeg = $this->jpeg($second, $first);
+
+        $extractor = $this->createExtractor($jpeg);
+
+        self::assertSame([
+            [
+                'codec'      => 'pcm',
+                'channels'   => 1,
+                'sampleRate' => 8000,
+                'bitDepth'   => 8,
+                'data'       => 'pcm-apcm-b',
+            ],
+        ], $extractor->getExifAudioStreams());
+    }
+
+    /**
+     * Ensures malformed EXIF audio headers raise a parse error.
+     */
+    #[Test]
+    public function testExifAudioSegmentWithUnsupportedSampleRateThrows(): void
+    {
+        $payload = self::segment(self::MARKER_APP2, self::exifAudioPayload(1, 1, 1, 0, 1, 12_000, 8, 'pcm'));
+
+        $extractor = $this->createExtractor($this->jpeg($payload));
+
+        $this->expectException(ParseError::class);
+        $extractor->getExifAudioStreams();
     }
 
     /**
@@ -371,6 +411,25 @@ final class JpegExtractorTest extends TestCase
     private static function segment(int $marker, string $payload): string
     {
         return "\xFF" . chr($marker) . pack('n', strlen($payload) + 2) . $payload;
+    }
+
+    /**
+     * Builds an EXIF audio APP2 payload for tests.
+     */
+    private static function exifAudioPayload(
+        int $streamId,
+        int $sequenceNumber,
+        int $sequenceCount,
+        int $codecId,
+        int $channels,
+        int $sampleRate,
+        int $bitDepth,
+        string $data,
+        int $reserved = 0,
+    ): string {
+        $header = pack('nCCCCNCC', $streamId, $sequenceNumber, $sequenceCount, $codecId, $channels, $sampleRate, $bitDepth, $reserved);
+
+        return self::EXIF_AUDIO_SIGNATURE . $header . $data;
     }
 
     /**


### PR DESCRIPTION
## Summary
- parse EXIF audio APP2 streams in the JPEG extractor, validate their headers, and expose the merged payloads
- thread decoded JPEG audio streams through Metadata and StructuredMetadata, including a dedicated AudioClip value object
- extend unit coverage for the extractor, metadata aggregate, and structured metadata builder to cover EXIF audio flows and error handling

## Testing
- composer ci:test:php:unit *(fails: truth comparison fixtures for HEIC/JPEG samples are unavailable in the container)*
- .build/bin/phpunit --configuration .build/phpunit.xml tests/Parse/Jpeg/JpegExtractorTest.php
- .build/bin/phpunit --configuration .build/phpunit.xml tests/Curate/StructuredMetadataBuilderTest.php
- .build/bin/phpunit --configuration .build/phpunit.xml tests/Model/Metadata/MetadataTest.php
- .build/bin/phpunit --configuration .build/phpunit.xml tests/MetadataReader/MetadataReaderTest.php

------
https://chatgpt.com/codex/tasks/task_e_68fe1a1443d48323ab2317792995b154