### PR TITLE
fix: distinguish unknown EXIF capability revisions

### DIFF
--- a/src/Core/ExifCapabilities.php
+++ b/src/Core/ExifCapabilities.php
@@ -21,6 +21,8 @@ use function trim;
  */
 final class ExifCapabilities
 {
+    public const UNKNOWN = 'unknown';
+
     /**
      * Maps a raw or normalised EXIF version string to the capability profile identifier.
      */
@@ -57,12 +59,13 @@ final class ExifCapabilities
                 '0110' => '1.1',
                 '0200' => '2.0',
                 '0210' => '2.1',
+                '0220' => '2.2',
                 '0221' => '2.21',
                 '0230' => '2.3',
                 '0231' => '2.31',
                 '0232' => '2.32',
                 '0300'  => '3.0',
-                default => '2.2',
+                default => self::UNKNOWN,
             };
         }
 
@@ -71,12 +74,13 @@ final class ExifCapabilities
             '1.10', '1.1' => '1.1',
             '2.00', '2.0' => '2.0',
             '2.10', '2.1' => '2.1',
+            '2.20', '2.2' => '2.2',
             '2.21' => '2.21',
             '2.30', '2.3' => '2.3',
             '2.31' => '2.31',
             '2.32' => '2.32',
             '3.00', '3.0' => '3.0',
-            default => '2.2',
+            default => self::UNKNOWN,
         };
     }
 }

--- a/tests/Core/ExifCapabilitiesTest.php
+++ b/tests/Core/ExifCapabilitiesTest.php
@@ -35,6 +35,8 @@ final class ExifCapabilitiesTest extends TestCase
     {
         yield 'null defaults to 2.2' => ['2.2', null];
         yield 'empty string defaults to 2.2' => ['2.2', ''];
+        yield 'raw 0220 maps to 2.2' => ['2.2', '0220'];
+        yield 'decimal 2.20 maps to 2.2' => ['2.2', '2.20'];
         yield 'numeric 0200 maps to 2.0' => ['2.0', '0200'];
         yield 'decimal 2.00 maps to 2.0' => ['2.0', '2.00'];
         yield 'raw 0221 maps to 2.21' => ['2.21', '0221'];
@@ -44,5 +46,7 @@ final class ExifCapabilitiesTest extends TestCase
         yield 'raw 0232 maps to 2.32' => ['2.32', '0232'];
         yield 'decimal 2.32 maps to 2.32' => ['2.32', '2.32'];
         yield 'raw 0230 stays grouped as 2.3' => ['2.3', '0230'];
+        yield 'malformed digits return sentinel' => [ExifCapabilities::UNKNOWN, '9999'];
+        yield 'non numeric strings return sentinel' => [ExifCapabilities::UNKNOWN, 'foo'];
     }
 }


### PR DESCRIPTION
## Summary
- map the packed 0220 EXIF version to the legacy 2.2 capability profile and surface an explicit unknown sentinel for unrecognised revisions
- expand the ExifCapabilities test matrix to cover recognised decimal/packed inputs and the new sentinel branch

## Testing
- .build/bin/phpunit --configuration .build/phpunit.xml tests/Core/ExifCapabilitiesTest.php

------
https://chatgpt.com/codex/tasks/task_e_68fe1a157764832387669c5882c4ba0d