### PR TITLE
Fix EXIF capability mapping for unknown revisions

### DIFF
--- a/src/Core/ExifCapabilities.php
+++ b/src/Core/ExifCapabilities.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace MagicSunday\ImageMeta\Core;
 
+use function ctype_digit;
 use function preg_replace;
 use function rtrim;
 use function strlen;
@@ -47,6 +48,7 @@ final class ExifCapabilities
             '1.10', '1.1' => '1.1',
             '2.00', '2.0' => '2.0',
             '2.10', '2.1' => '2.1',
+            '2.20', '2.2' => '2.2',
             '2.21' => '2.21',
             '2.30', '2.3' => '2.3',
             '2.31' => '2.31',
@@ -69,20 +71,25 @@ final class ExifCapabilities
                 $digits = '0' . $digits;
             }
 
-            return match ($digits) {
+            $profile = match ($digits) {
                 '0100' => '1.0',
                 '0110' => '1.1',
                 '0200' => '2.0',
                 '0210' => '2.1',
+                '0220' => '2.2',
                 '0221' => '2.21',
                 '0230' => '2.3',
                 '0231' => '2.31',
                 '0232' => '2.32',
                 '0300'  => '3.0',
-                default => '2.2',
+                default => null,
             };
+
+            if ($profile !== null) {
+                return $profile;
+            }
         }
 
-        return '2.2';
+        return 'unknown';
     }
 }

--- a/tests/Core/ExifCapabilitiesTest.php
+++ b/tests/Core/ExifCapabilitiesTest.php
@@ -42,7 +42,8 @@ final class ExifCapabilitiesTest extends TestCase
         yield 'decimal 2.00 maps to 2.0' => ['2.0', '2.00'];
         yield 'numeric 0210 maps to 2.1' => ['2.1', '0210'];
         yield 'decimal 2.1 maps to 2.1' => ['2.1', '2.1'];
-        yield 'decimal 2.2 defaults to 2.2' => ['2.2', '2.2'];
+        yield 'decimal 2.2 maps to 2.2' => ['2.2', '2.2'];
+        yield 'raw 0220 maps to 2.2' => ['2.2', '0220'];
         yield 'raw 0221 maps to 2.21' => ['2.21', '0221'];
         yield 'decimal 2.21 maps to 2.21' => ['2.21', '2.21'];
         yield 'raw 0230 stays grouped as 2.3' => ['2.3', '0230'];
@@ -53,5 +54,7 @@ final class ExifCapabilitiesTest extends TestCase
         yield 'decimal 2.32 maps to 2.32' => ['2.32', '2.32'];
         yield 'numeric 0300 maps to 3.0' => ['3.0', '0300'];
         yield 'decimal 3.0 maps to 3.0' => ['3.0', '3.0'];
+        yield 'unknown when digits do not match revision' => ['unknown', '9999'];
+        yield 'unknown when format malformed' => ['unknown', 'abc'];
     }
 }


### PR DESCRIPTION
## Summary
- ensure ExifCapabilities normalises 2.2 markers and reports a distinct sentinel when version digits are unrecognised
- extend ExifCapabilities tests to cover 0220 inputs and malformed values hitting the unknown branch

## Testing
- composer ci:test:php:unit *(fails: fixture set for truth comparison tests is unavailable in this environment)*
- ./.build/bin/phpunit tests/Core/ExifCapabilitiesTest.php


------
https://chatgpt.com/codex/tasks/task_e_68fe295a92508323865cd67ae16a66e5