### PR TITLE
feat(jpeg): expose embedded EXIF audio streams

### DIFF
--- a/src/Curate/StructuredMetadata.php
+++ b/src/Curate/StructuredMetadata.php
@@ -13,6 +13,7 @@ namespace MagicSunday\ImageMeta\Curate;
 
 use MagicSunday\ImageMeta\Value\Apple;
 use MagicSunday\ImageMeta\Value\Audio;
+use MagicSunday\ImageMeta\Value\AudioClips;
 use MagicSunday\ImageMeta\Value\Author;
 use MagicSunday\ImageMeta\Value\Camera;
 use MagicSunday\ImageMeta\Value\Capture;
@@ -76,6 +77,7 @@ final readonly class StructuredMetadata
      * @param Preview             $preview             Embedded preview information.
      * @param Video               $video               Video track metadata when available.
      * @param Audio               $audio               Audio track metadata when available.
+     * @param AudioClips          $embeddedAudio       Embedded EXIF audio clips extracted from JPEG containers.
      * @param ColorProfile        $colorProfile        Colour profile information.
      * @param ProcessingSettings  $processing          Image processing metadata.
      * @param WhiteBalanceDetails $whiteBalanceDetails White balance analysis details.
@@ -114,6 +116,7 @@ final readonly class StructuredMetadata
         public Preview $preview,
         public Video $video,
         public Audio $audio,
+        public AudioClips $embeddedAudio,
         public ColorProfile $colorProfile,
         public ProcessingSettings $processing,
         public WhiteBalanceDetails $whiteBalanceDetails,

--- a/src/Curate/StructuredMetadataBuilder.php
+++ b/src/Curate/StructuredMetadataBuilder.php
@@ -28,6 +28,7 @@ use MagicSunday\ImageMeta\Model\Metadata;
 use MagicSunday\ImageMeta\Model\QuickTimeMeta;
 use MagicSunday\ImageMeta\Parse\Icc\IccDecoder;
 use MagicSunday\ImageMeta\Value\Apple;
+use MagicSunday\ImageMeta\Value\AudioClips;
 use MagicSunday\ImageMeta\Value\Audio;
 use MagicSunday\ImageMeta\Value\Author;
 use MagicSunday\ImageMeta\Value\Camera;
@@ -316,6 +317,8 @@ final class StructuredMetadataBuilder
             bitDepth: $quickTimeResolver->int(QuickTimeMeta::AUDIO_BITS_PER_SAMPLE_KEY),
         );
 
+        $embeddedAudio = AudioClips::fromJpegAudioStreams($metadata->jpegAudioStreams);
+
         $iccData = null;
         if ($metadata->iccProfile !== null || $metadata->iccSegments !== []) {
             $iccData = (new IccDecoder())->decode($metadata->iccProfile, $metadata->iccSegments);
@@ -512,6 +515,7 @@ final class StructuredMetadataBuilder
             preview: $preview,
             video: $video,
             audio: $audio,
+            embeddedAudio: $embeddedAudio,
             colorProfile: $colorProfile,
             processing: $processing,
             whiteBalanceDetails: $whiteBalanceDetails,

--- a/src/MetadataReader.php
+++ b/src/MetadataReader.php
@@ -90,6 +90,7 @@ final class MetadataReader
         $iccProfile       = $jpeg->getIccProfile();
         $iccSegments      = $jpeg->getIccSegments();
         $flashPixStreams  = $jpeg->getFlashPixStreams();
+        $audioStreams     = $jpeg->getAudioStreams();
         $mpfDocument      = $jpeg->getMpfDocument();
         $bitsPerSample    = $jpeg->getFrameSamplePrecision();
         $frameHeight      = $jpeg->getFrameHeight();
@@ -121,6 +122,7 @@ final class MetadataReader
             $iccSegments,
             $flashPixStreams,
             $mpfDocument,
+            $audioStreams,
             $bitsPerSample,
             $sampling,
             $subSampling,
@@ -180,6 +182,7 @@ final class MetadataReader
             [],
             [],
             null,
+            [],
             null,
             null,
             null,

--- a/src/Model/Jpeg/JpegAudioStream.php
+++ b/src/Model/Jpeg/JpegAudioStream.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\ImageMeta\Model\Jpeg;
+
+/**
+ * Represents an embedded EXIF audio stream carried within JPEG APP2 segments.
+ */
+final readonly class JpegAudioStream
+{
+    /**
+     * @param string $format     Audio encoding identifier (e.g. PCM, MU_LAW_PCM, IMA_ADPCM).
+     * @param int    $channels   Channel count (1 for mono, 2 for stereo).
+     * @param int    $sampleRate Sample rate in Hertz.
+     * @param int    $bitDepth   Bit depth per sample.
+     * @param string $data       Raw audio payload extracted from the segment.
+     * @param string $version    Version string reported by the segment header.
+     */
+    public function __construct(
+        public string $format,
+        public int $channels,
+        public int $sampleRate,
+        public int $bitDepth,
+        public string $data,
+        public string $version,
+    ) {
+    }
+}

--- a/src/Model/Metadata.php
+++ b/src/Model/Metadata.php
@@ -15,6 +15,7 @@ use MagicSunday\ImageMeta\Curate\StructuredMetadata;
 use MagicSunday\ImageMeta\Curate\StructuredMetadataBuilder;
 use MagicSunday\ImageMeta\MakerNotes\MakerNotesMetadata;
 use MagicSunday\ImageMeta\Model\Exif\ExifDocument;
+use MagicSunday\ImageMeta\Model\Jpeg\JpegAudioStream;
 use MagicSunday\ImageMeta\Model\Mpf\MpfDocument;
 use MagicSunday\ImageMeta\Model\Xmp\XmpDocument;
 use MagicSunday\ImageMeta\Parse\Xmp\XmpParser;
@@ -56,6 +57,11 @@ final class Metadata
 
     public readonly ?MpfDocument $mpfDocument;
 
+    /**
+     * @var list<JpegAudioStream>
+     */
+    public readonly array $jpegAudioStreams;
+
     public readonly ?int $jpegBitsPerSample;
 
     /** @var array<int, array{horizontal:int, vertical:int}>|null */
@@ -91,6 +97,7 @@ final class Metadata
      * @param list<string>                                         $iccSegments              Raw ICC APP2 segments in encounter order.
      * @param array<int, string>                                   $flashPixStreams          Concatenated FlashPix extension streams keyed by identifier.
      * @param MpfDocument|null                                     $mpfDocument              Parsed MPF document derived from APP2 segments.
+     * @param list<JpegAudioStream>                                $jpegAudioStreams         EXIF audio streams embedded in JPEG APP2 markers.
      * @param int|null                                             $jpegBitsPerSample        Sample precision reported by the JPEG frame header.
      * @param array<int, array{horizontal:int, vertical:int}>|null $jpegFrameSamplingFactors Component sampling factors by
      *                                                                                       identifier.
@@ -114,6 +121,7 @@ final class Metadata
         array $iccSegments = [],
         array $flashPixStreams = [],
         ?MpfDocument $mpfDocument = null,
+        array $jpegAudioStreams = [],
         ?int $jpegBitsPerSample = null,
         ?array $jpegFrameSamplingFactors = null,
         ?array $jpegYCbCrSubSampling = null,
@@ -135,6 +143,7 @@ final class Metadata
         $this->iccSegments              = $iccSegments;
         $this->flashPixStreams          = $flashPixStreams;
         $this->mpfDocument              = $mpfDocument;
+        $this->jpegAudioStreams         = $jpegAudioStreams;
         $this->jpegBitsPerSample        = $jpegBitsPerSample;
         $this->jpegFrameSamplingFactors = $jpegFrameSamplingFactors;
         $this->jpegYCbCrSubSampling     = $jpegYCbCrSubSampling;

--- a/src/Parse/Jpeg/JpegExtractor.php
+++ b/src/Parse/Jpeg/JpegExtractor.php
@@ -14,6 +14,7 @@ namespace MagicSunday\ImageMeta\Parse\Jpeg;
 use MagicSunday\ImageMeta\Core\BoundsError;
 use MagicSunday\ImageMeta\Core\ParseError;
 use MagicSunday\ImageMeta\Core\Stream;
+use MagicSunday\ImageMeta\Model\Jpeg\JpegAudioStream;
 use MagicSunday\ImageMeta\Model\Mpf\MpfDocument;
 
 use function array_key_exists;
@@ -66,6 +67,16 @@ final class JpegExtractor
 
     private const string MPF_SIGNATURE = "MPF\0";
 
+    private const string AUDIO_SIGNATURE = "Exif\0\0Audio";
+
+    private const int AUDIO_HEADER_LENGTH = 24;
+
+    private const int AUDIO_FORMAT_PCM = 0;
+
+    private const int AUDIO_FORMAT_MU_LAW = 1;
+
+    private const int AUDIO_FORMAT_IMA_ADPCM = 2;
+
     private const string IPTC_SIGNATURE = "Photoshop 3.0\0";
 
     private const string FPXR_SIGNATURE = 'FPXR';
@@ -113,6 +124,9 @@ final class JpegExtractor
     private ?int $mpfFirstOffset = null;
 
     private ?MpfDocument $mpfDocument = null;
+
+    /** @var list<\MagicSunday\ImageMeta\Model\Jpeg\JpegAudioStream> */
+    private array $audioStreams = [];
 
     /** @var list<string> */
     private array $iptcPayloads = [];
@@ -210,6 +224,18 @@ final class JpegExtractor
         return $this->flashPixStreams;
     }
 
+    /**
+     * Returns EXIF audio streams discovered in APP2 markers.
+     *
+     * @return list<JpegAudioStream>
+     */
+    public function getAudioStreams(): array
+    {
+        $this->parseIfNeeded();
+
+        return $this->audioStreams;
+    }
+
     public function getMpfDocument(): ?MpfDocument
     {
         $this->parseIfNeeded();
@@ -297,6 +323,7 @@ final class JpegExtractor
         $this->mpfSegments             = [];
         $this->mpfFirstOffset          = null;
         $this->mpfDocument             = null;
+        $this->audioStreams            = [];
         $this->iptcPayloads            = [];
         $this->xmpPacketHashes         = [];
         $this->frameBitsPerSample      = null;
@@ -523,6 +550,12 @@ final class JpegExtractor
 
         if (str_starts_with($payload, self::FPXR_SIGNATURE)) {
             $this->handleFlashPixSegment($payload, $offset);
+
+            return;
+        }
+
+        if (str_starts_with($payload, self::AUDIO_SIGNATURE)) {
+            $this->handleAudioSegment($payload, $offset);
         }
     }
 
@@ -562,6 +595,97 @@ final class JpegExtractor
         if (!array_key_exists($sequenceNumber, $this->iccSequence)) {
             $this->iccSequence[$sequenceNumber] = $iccData;
         }
+    }
+
+    /**
+     * Processes EXIF audio APP2 segments and validates their headers.
+     *
+     * @param string $payload Raw segment payload including signature.
+     * @param int    $offset  Offset in the stream where the marker begins.
+     */
+    private function handleAudioSegment(string $payload, int $offset): void
+    {
+        $length = strlen($payload);
+        if ($length < self::AUDIO_HEADER_LENGTH) {
+            throw new ParseError(sprintf('Audio segment at offset %d is too short', $offset));
+        }
+
+        $signatureLength = strlen(self::AUDIO_SIGNATURE);
+        $major           = ord($payload[$signatureLength]);
+        $minor           = ord($payload[$signatureLength + 1]);
+        $format          = ord($payload[$signatureLength + 2]);
+        $channels        = ord($payload[$signatureLength + 3]);
+
+        $sampleRateData = substr($payload, $signatureLength + 4, 4);
+        $sampleRateUnpack = unpack('Nrate', $sampleRateData);
+        if ($sampleRateUnpack === false) {
+            throw new ParseError(sprintf('Audio segment at offset %d has invalid sample rate field', $offset));
+        }
+
+        $sampleRate = (int) $sampleRateUnpack['rate'];
+        $bitDepth   = ord($payload[$signatureLength + 8]);
+
+        $sampleCountData = substr($payload, $signatureLength + 9, 4);
+        $sampleCountUnpack = unpack('Ncount', $sampleCountData);
+        if ($sampleCountUnpack === false) {
+            throw new ParseError(sprintf('Audio segment at offset %d has invalid sample count field', $offset));
+        }
+
+        $sampleCount = (int) $sampleCountUnpack['count'];
+        $data        = substr($payload, self::AUDIO_HEADER_LENGTH);
+
+        if ($channels === 0 || $channels > 2) {
+            throw new ParseError(sprintf('Audio segment at offset %d has unsupported channel count %d', $offset, $channels));
+        }
+
+        $allowedSampleRates = [8_000, 11_025, 22_050, 44_100];
+        if (!in_array($sampleRate, $allowedSampleRates, true)) {
+            throw new ParseError(sprintf('Audio segment at offset %d uses unsupported sample rate %d', $offset, $sampleRate));
+        }
+
+        $formatName = match ($format) {
+            self::AUDIO_FORMAT_PCM       => 'PCM',
+            self::AUDIO_FORMAT_MU_LAW    => 'MU_LAW_PCM',
+            self::AUDIO_FORMAT_IMA_ADPCM => 'IMA_ADPCM',
+            default => null,
+        };
+
+        if ($formatName === null) {
+            throw new ParseError(sprintf('Audio segment at offset %d uses unknown format %d', $offset, $format));
+        }
+
+        if ($format === self::AUDIO_FORMAT_PCM && !in_array($bitDepth, [8, 16], true)) {
+            throw new ParseError(sprintf('Audio segment at offset %d has invalid PCM bit depth %d', $offset, $bitDepth));
+        }
+
+        if ($format === self::AUDIO_FORMAT_MU_LAW && $bitDepth !== 8) {
+            throw new ParseError(sprintf('Audio segment at offset %d has invalid μ-law bit depth %d', $offset, $bitDepth));
+        }
+
+        if ($format === self::AUDIO_FORMAT_IMA_ADPCM && $bitDepth !== 4) {
+            throw new ParseError(sprintf('Audio segment at offset %d has invalid IMA-ADPCM bit depth %d', $offset, $bitDepth));
+        }
+
+        if ($sampleCount > 0 && $format !== self::AUDIO_FORMAT_IMA_ADPCM) {
+            $bytesPerSample = (int) (($bitDepth / 8) * $channels);
+            if ($bytesPerSample > 0) {
+                $expectedLength = (int) ($sampleCount * $bytesPerSample);
+                if ($expectedLength !== strlen($data)) {
+                    throw new ParseError(sprintf('Audio segment at offset %d has inconsistent data length', $offset));
+                }
+            }
+        }
+
+        $version = sprintf('%d.%02d', $major, $minor);
+
+        $this->audioStreams[] = new JpegAudioStream(
+            $formatName,
+            $channels,
+            $sampleRate,
+            $bitDepth,
+            $data,
+            $version,
+        );
     }
 
     /**

--- a/src/Value/AudioClip.php
+++ b/src/Value/AudioClip.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\ImageMeta\Value;
+
+/**
+ * Represents a single embedded audio clip extracted from a JPEG container.
+ */
+final readonly class AudioClip
+{
+    /**
+     * @param string $format     Audio encoding identifier (e.g. PCM, MU_LAW_PCM, IMA_ADPCM).
+     * @param int    $channels   Channel count for the clip.
+     * @param int    $sampleRate Sample rate in Hertz.
+     * @param int    $bitDepth   Bit depth per sample.
+     * @param string $data       Raw audio payload.
+     * @param string $version    Version string reported by the EXIF audio header.
+     */
+    public function __construct(
+        public string $format,
+        public int $channels,
+        public int $sampleRate,
+        public int $bitDepth,
+        public string $data,
+        public string $version,
+    ) {
+    }
+}

--- a/src/Value/AudioClips.php
+++ b/src/Value/AudioClips.php
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\ImageMeta\Value;
+
+use MagicSunday\ImageMeta\Model\Jpeg\JpegAudioStream;
+
+/**
+ * Aggregates audio clips extracted from EXIF audio APP2 segments.
+ */
+final readonly class AudioClips
+{
+    /**
+     * @param list<AudioClip> $clips
+     */
+    public function __construct(public array $clips)
+    {
+    }
+
+    /**
+     * Builds an audio clip aggregate from JPEG audio stream descriptors.
+     *
+     * @param list<JpegAudioStream> $streams
+     */
+    public static function fromJpegAudioStreams(array $streams): self
+    {
+        $clips = [];
+        foreach ($streams as $stream) {
+            $clips[] = new AudioClip(
+                $stream->format,
+                $stream->channels,
+                $stream->sampleRate,
+                $stream->bitDepth,
+                $stream->data,
+                $stream->version,
+            );
+        }
+
+        return new self($clips);
+    }
+}

--- a/tests/Curate/StructuredMetadataBuilderTest.php
+++ b/tests/Curate/StructuredMetadataBuilderTest.php
@@ -24,6 +24,7 @@ use MagicSunday\ImageMeta\Model\Exif\ExifRationalList;
 use MagicSunday\ImageMeta\Model\Exif\ExifTag;
 use MagicSunday\ImageMeta\Model\Exif\Ifd;
 use MagicSunday\ImageMeta\Model\Exif\IfdEntry;
+use MagicSunday\ImageMeta\Model\Jpeg\JpegAudioStream;
 use MagicSunday\ImageMeta\Model\Metadata;
 use MagicSunday\ImageMeta\Model\Mpf\MpfAttributes;
 use MagicSunday\ImageMeta\Model\Mpf\MpfDocument;
@@ -1979,6 +1980,25 @@ final class StructuredMetadataBuilderTest extends TestCase
         self::assertSame(48000, $structured->audio->sampleRate);
         self::assertSame('lpcm', $structured->audio->codec);
         self::assertSame(24, $structured->audio->bitDepth);
+    }
+
+    #[Test]
+    public function forwardsJpegAudioStreamsIntoStructuredMetadata(): void
+    {
+        $audioStream = new JpegAudioStream('PCM', 2, 44_100, 16, 'DATA', '1.00');
+        $metadata    = new Metadata([], null, jpegAudioStreams: [$audioStream]);
+
+        $structured = (new StructuredMetadataBuilder())->build($metadata);
+
+        self::assertCount(1, $structured->embeddedAudio->clips);
+
+        $clip = $structured->embeddedAudio->clips[0];
+        self::assertSame('PCM', $clip->format);
+        self::assertSame(2, $clip->channels);
+        self::assertSame(44_100, $clip->sampleRate);
+        self::assertSame(16, $clip->bitDepth);
+        self::assertSame('DATA', $clip->data);
+        self::assertSame('1.00', $clip->version);
     }
 
     /**

--- a/tests/Parse/Jpeg/JpegExtractorTest.php
+++ b/tests/Parse/Jpeg/JpegExtractorTest.php
@@ -48,6 +48,8 @@ final class JpegExtractorTest extends TestCase
 
     private const string FPXR_SIGNATURE = 'FPXR';
 
+    private const string AUDIO_SIGNATURE = "Exif\0\0Audio";
+
     private const int MARKER_APP1 = 0xE1;
 
     private const int MARKER_APP2 = 0xE2;
@@ -217,6 +219,56 @@ final class JpegExtractorTest extends TestCase
             1 => 'stream-one',
             2 => 'alpha-beta-gamma',
         ], $extractor->getFlashPixStreams());
+    }
+
+    /**
+     * Ensures EXIF audio APP2 segments are decoded and exposed with metadata.
+     */
+    #[Test]
+    public function testAudioSegmentsAreCollected(): void
+    {
+        $muLawData   = str_repeat("\x01\x02", 4);
+        $pcmData     = pack('n*', 0x0102, 0x0304, 0x0506, 0x0708);
+        $muLawSegment = self::segment(self::MARKER_APP2, self::audioPayload(1, 1, 8_000, 8, $muLawData));
+        $pcmSegment   = self::segment(self::MARKER_APP2, self::audioPayload(0, 2, 44_100, 16, $pcmData));
+
+        $jpeg      = $this->jpeg($muLawSegment . $pcmSegment);
+        $extractor = $this->createExtractor($jpeg);
+
+        $streams = $extractor->getAudioStreams();
+        self::assertCount(2, $streams);
+
+        $muLaw = $streams[0];
+        self::assertSame('MU_LAW_PCM', $muLaw->format);
+        self::assertSame(1, $muLaw->channels);
+        self::assertSame(8_000, $muLaw->sampleRate);
+        self::assertSame(8, $muLaw->bitDepth);
+        self::assertSame('1.00', $muLaw->version);
+        self::assertSame($muLawData, $muLaw->data);
+
+        $pcm = $streams[1];
+        self::assertSame('PCM', $pcm->format);
+        self::assertSame(2, $pcm->channels);
+        self::assertSame(44_100, $pcm->sampleRate);
+        self::assertSame(16, $pcm->bitDepth);
+        self::assertSame('1.00', $pcm->version);
+        self::assertSame($pcmData, $pcm->data);
+    }
+
+    /**
+     * Ensures unsupported sampling rates raise parse errors for audio APP2 segments.
+     */
+    #[Test]
+    public function testAudioSegmentWithUnsupportedSampleRateThrows(): void
+    {
+        $payload = self::segment(self::MARKER_APP2, self::audioPayload(0, 1, 12_000, 16, str_repeat("\x00", 4)));
+        $jpeg    = $this->jpeg($payload);
+
+        $extractor = $this->createExtractor($jpeg);
+
+        $this->expectException(ParseError::class);
+
+        $extractor->getAudioStreams();
     }
 
     /**
@@ -507,6 +559,31 @@ final class JpegExtractorTest extends TestCase
     private static function fpxrPayload(int $streamId, int $sequence, int $count, string $data): string
     {
         return self::FPXR_SIGNATURE . pack('n', $streamId) . chr($sequence) . chr($count) . $data;
+    }
+
+    /**
+     * Builds an EXIF audio APP2 payload with the provided metadata fields.
+     */
+    private static function audioPayload(int $format, int $channels, int $sampleRate, int $bitDepth, string $data): string
+    {
+        $sampleCount = 0;
+        if ($format !== 2) {
+            $bytesPerSample = (int) (($bitDepth / 8) * $channels);
+            if ($bytesPerSample > 0) {
+                $sampleCount = (int) (strlen($data) / $bytesPerSample);
+            }
+        }
+
+        $header = self::AUDIO_SIGNATURE
+            . chr(1) // major version
+            . chr(0) // minor version
+            . chr($format)
+            . chr($channels)
+            . pack('N', $sampleRate)
+            . chr($bitDepth)
+            . pack('N', $sampleCount);
+
+        return $header . $data;
     }
 
     /**


### PR DESCRIPTION
## Summary
- parse EXIF audio APP2 segments in the JPEG extractor with header validation and buffering
- surface embedded audio streams through the metadata model and structured metadata aggregate
- add value objects for audio clips and extend PHPUnit coverage for happy and error paths

## Testing
- .build/bin/phpunit tests/Parse/Jpeg/JpegExtractorTest.php
- .build/bin/phpunit tests/Curate/StructuredMetadataBuilderTest.php

------
https://chatgpt.com/codex/tasks/task_e_68fe29520e0c8323b7b4e40ea1f96677