### PR TITLE
Fix TIFF BYTE decoding to remain unsigned

### DIFF
--- a/src/Parse/Tiff/TiffExifReader.php
+++ b/src/Parse/Tiff/TiffExifReader.php
@@ -419,7 +419,7 @@ final class TiffExifReader
         for ($i = 0; $i < $count; ++$i) {
             $vals[] = match ($type) {
                 // BYTE
-                self::TYPE_BYTE,
+                self::TYPE_BYTE => ord($bytes[$cursor]),
                 // SBYTE
                 self::TYPE_SBYTE => $this->toSigned(ord($bytes[$cursor]), 8),
                 // SHORT

--- a/tests/Parse/Tiff/TiffExifReaderTest.php
+++ b/tests/Parse/Tiff/TiffExifReaderTest.php
@@ -336,6 +336,21 @@ final class TiffExifReaderTest extends TestCase
     }
 
     /**
+     * Ensures BYTE tags retain their unsigned interpretation for high-bit values.
+     */
+    #[Test]
+    public function decodesUnsignedByteValues(): void
+    {
+        $blob = $this->buildClassicHighByteTagBlob();
+
+        $document = (new TiffExifReader())->parseFromBlob($blob);
+
+        $entry = $document->ifd0->get(ExifTag::GPS_ALTITUDE_REF);
+        self::assertNotNull($entry);
+        self::assertSame(0xFF, $entry->value);
+    }
+
+    /**
      * Ensures newly introduced scene and software tags are decoded from Classic TIFF payloads.
      */
     #[Test]
@@ -970,6 +985,20 @@ final class TiffExifReaderTest extends TestCase
 
         $inlineValue = $this->inlineBytes([1, 2, 3], 4);
         $entry       = self::packClassicEntry(ExifTag::GPS_ALTITUDE_REF, 1, 3, $inlineValue);
+        $ifd0        = pack('v', 1) . $entry . pack('V', 0);
+
+        return $header . $ifd0;
+    }
+
+    /**
+     * Builds a Classic TIFF blob containing a BYTE tag with a high-bit value.
+     */
+    private function buildClassicHighByteTagBlob(): string
+    {
+        $header = 'II' . pack('v', 0x002A) . pack('V', 8);
+
+        $inlineValue = $this->inlineBytes([0xFF], 4);
+        $entry       = self::packClassicEntry(ExifTag::GPS_ALTITUDE_REF, 1, 1, $inlineValue);
         $ifd0        = pack('v', 1) . $entry . pack('V', 0);
 
         return $header . $ifd0;


### PR DESCRIPTION
## Summary
- keep TIFF BYTE components unsigned when decoding EXIF directory entries
- add regression coverage for BYTE values with the high bit set

## Testing
- .build/bin/phpunit tests/Parse/Tiff/TiffExifReaderTest.php

------
https://chatgpt.com/codex/tasks/task_e_68fe3172d8708323b0a852ac574f1d7a