### PR TITLE
feat(exif): decode OECF matrices

### DIFF
--- a/src/Curate/Resolver/ExifTagResolver.php
+++ b/src/Curate/Resolver/ExifTagResolver.php
@@ -581,11 +581,21 @@ final readonly class ExifTagResolver
     }
 
     /**
-     * Returns the opto-electronic conversion function payload.
+     * Returns the opto-electronic conversion function data.
+     *
+     * @return array{payload:string, matrix:(array{columns:int, rows:int, labels:array{columns:list<string>, rows:list<string>}, values:list<list<float|null>>}|null)}|null
      */
-    public function oecf(): ?string
+    public function oecf(): ?array
     {
         return $this->document?->oecf();
+    }
+
+    /**
+     * Returns the raw opto-electronic conversion function payload.
+     */
+    public function oecfPayload(): ?string
+    {
+        return $this->document?->oecfPayload();
     }
 
     /**

--- a/src/Model/Exif/ExifDocument.php
+++ b/src/Model/Exif/ExifDocument.php
@@ -694,11 +694,29 @@ final readonly class ExifDocument
     }
 
     /**
-     * Returns the opto-electronic conversion function data as a string.
+     * Returns the opto-electronic conversion function data.
+     *
+     * @return array{payload:string, matrix:(array{columns:int, rows:int, labels:array{columns:list<string>, rows:list<string>}, values:list<list<float|null>>}|null)}|null
      */
-    public function oecf(): ?string
+    public function oecf(): ?array
     {
-        return $this->binaryString($this->exifIfd, ExifTag::OECF);
+        $payload = $this->oecfPayload();
+        if ($payload === null) {
+            return null;
+        }
+
+        return [
+            'payload' => $payload,
+            'matrix' => ValueConverters::decodeOecf($payload),
+        ];
+    }
+
+    /**
+     * Returns the raw opto-electronic conversion function payload.
+     */
+    public function oecfPayload(): ?string
+    {
+        return $this->rawString($this->exifIfd, ExifTag::OECF);
     }
 
     /**

--- a/src/Model/Exif/ValueConverters.php
+++ b/src/Model/Exif/ValueConverters.php
@@ -94,9 +94,9 @@ use function trim;
  */
 final readonly class ValueConverters
 {
-    private const MAX_SFR_DIMENSION = 64;
-    private const MAX_SFR_LABEL_LENGTH = 255;
-    private const SFR_VALUE_SIZE = 8;
+    private const MAX_SRATIONAL_MATRIX_DIMENSION = 64;
+    private const MAX_SRATIONAL_MATRIX_LABEL_LENGTH = 255;
+    private const SRATIONAL_VALUE_SIZE = 8;
     private const MAX_PRINT_IMAGE_MATCHING_PARAMETERS = 512;
 
     /**
@@ -251,13 +251,37 @@ final readonly class ValueConverters
     }
 
     /**
-     * Decodes the Spatial Frequency Response payload as defined by EXIF figure 14.
+     * Decodes the spatial frequency response payload as defined by EXIF figure 14.
      *
      * @param string|null $payload Raw UNDEFINED payload captured from the EXIF tag.
      *
      * @return array{columns:int, rows:int, labels:array{columns:list<string>, rows:list<string>}, values:list<list<float|null>>}|null
      */
     public static function decodeSpatialFrequencyResponse(?string $payload): ?array
+    {
+        return self::decodeSrationalMatrix($payload);
+    }
+
+    /**
+     * Decodes the opto-electronic conversion function payload as defined by EXIF table 15.
+     *
+     * @param string|null $payload Raw UNDEFINED payload captured from the EXIF tag.
+     *
+     * @return array{columns:int, rows:int, labels:array{columns:list<string>, rows:list<string>}, values:list<list<float|null>>}|null
+     */
+    public static function decodeOecf(?string $payload): ?array
+    {
+        return self::decodeSrationalMatrix($payload);
+    }
+
+    /**
+     * Decodes an EXIF SRATIONAL matrix that contains labelled columns and rows.
+     *
+     * @param string|null $payload Raw UNDEFINED payload captured from the EXIF tag.
+     *
+     * @return array{columns:int, rows:int, labels:array{columns:list<string>, rows:list<string>}, values:list<list<float|null>>}|null
+     */
+    private static function decodeSrationalMatrix(?string $payload): ?array
     {
         if ($payload === null || $payload === '') {
             return null;
@@ -280,7 +304,7 @@ final readonly class ValueConverters
             return null;
         }
 
-        if ($columns > self::MAX_SFR_DIMENSION || $rows > self::MAX_SFR_DIMENSION) {
+        if ($columns > self::MAX_SRATIONAL_MATRIX_DIMENSION || $rows > self::MAX_SRATIONAL_MATRIX_DIMENSION) {
             return null;
         }
 
@@ -291,7 +315,7 @@ final readonly class ValueConverters
         $offset = 4;
         $columnLabels = [];
         for ($i = 0; $i < $columns; $i++) {
-            $labelData = self::consumeSfrLabel($payload, $offset, $length);
+            $labelData = self::consumeSrationalMatrixLabel($payload, $offset, $length);
             if ($labelData === null) {
                 return null;
             }
@@ -302,7 +326,7 @@ final readonly class ValueConverters
 
         $rowLabels = [];
         for ($i = 0; $i < $rows; $i++) {
-            $labelData = self::consumeSfrLabel($payload, $offset, $length);
+            $labelData = self::consumeSrationalMatrixLabel($payload, $offset, $length);
             if ($labelData === null) {
                 return null;
             }
@@ -312,11 +336,11 @@ final readonly class ValueConverters
         }
 
         $cells = $columns * $rows;
-        if ($cells > intdiv(PHP_INT_MAX, self::SFR_VALUE_SIZE)) {
+        if ($cells > intdiv(PHP_INT_MAX, self::SRATIONAL_VALUE_SIZE)) {
             return null;
         }
 
-        $required = $cells * self::SFR_VALUE_SIZE;
+        $required = $cells * self::SRATIONAL_VALUE_SIZE;
         if ($required > $length - $offset) {
             return null;
         }
@@ -326,13 +350,13 @@ final readonly class ValueConverters
             $rowValues = [];
 
             for ($colIndex = 0; $colIndex < $columns; $colIndex++) {
-                $numerator = self::readSfrInt32($payload, $offset, $length);
-                $denominator = self::readSfrInt32($payload, $offset + 4, $length);
+                $numerator = self::readSrationalInt32($payload, $offset, $length);
+                $denominator = self::readSrationalInt32($payload, $offset + 4, $length);
                 if ($numerator === null || $denominator === null) {
                     return null;
                 }
 
-                $offset += self::SFR_VALUE_SIZE;
+                $offset += self::SRATIONAL_VALUE_SIZE;
 
                 if ($denominator === 0) {
                     $rowValues[] = null;
@@ -889,11 +913,11 @@ final readonly class ValueConverters
     }
 
     /**
-     * Extracts a null-terminated label from the SFR payload.
+     * Extracts a null-terminated label from the SRATIONAL matrix payload.
      *
      * @return array{0:string,1:int}|null
      */
-    private static function consumeSfrLabel(string $payload, int $offset, int $length): ?array
+    private static function consumeSrationalMatrixLabel(string $payload, int $offset, int $length): ?array
     {
         if ($offset >= $length) {
             return null;
@@ -905,7 +929,7 @@ final readonly class ValueConverters
         }
 
         $labelLength = $end - $offset;
-        if ($labelLength < 0 || $labelLength > self::MAX_SFR_LABEL_LENGTH) {
+        if ($labelLength < 0 || $labelLength > self::MAX_SRATIONAL_MATRIX_LABEL_LENGTH) {
             return null;
         }
 
@@ -916,9 +940,9 @@ final readonly class ValueConverters
     }
 
     /**
-     * Reads a signed 32-bit integer from the SFR payload.
+     * Reads a signed 32-bit integer from the SRATIONAL matrix payload.
      */
-    private static function readSfrInt32(string $payload, int $offset, int $length): ?int
+    private static function readSrationalInt32(string $payload, int $offset, int $length): ?int
     {
         if ($offset + 4 > $length) {
             return null;

--- a/src/Value/Sensor.php
+++ b/src/Value/Sensor.php
@@ -26,7 +26,7 @@ final readonly class Sensor
      * @param bool|null           $ibis                     Indicates in-body image stabilisation support.
      * @param list<int>|null      $cfaPattern               Colour filter array pattern definition.
      * @param string|null         $spectralSensitivity      Spectral sensitivity description.
-     * @param string|null         $oecf                     Opto-electronic conversion function payload.
+     * @param array{payload:string, matrix:(array{columns:int, rows:int, labels:array{columns:list<string>, rows:list<string>}, values:list<list<float|null>>}|null)}|null $oecf Opto-electronic conversion function payload and decoded matrix.
      * @param array{columns:int, rows:int, labels:array{columns:list<string>, rows:list<string>}, values:list<list<float|null>>}|null $spatialFrequencyResponse Spatial frequency response table decoded from the EXIF payload.
      * @param float|null          $focalPlaneXResolution    Focal plane X resolution.
      * @param float|null          $focalPlaneYResolution    Focal plane Y resolution.
@@ -40,7 +40,7 @@ final readonly class Sensor
         public ?bool $ibis,
         public ?array $cfaPattern,
         public ?string $spectralSensitivity,
-        public ?string $oecf,
+        public ?array $oecf,
         public ?array $spatialFrequencyResponse,
         public ?float $focalPlaneXResolution,
         public ?float $focalPlaneYResolution,

--- a/tests/Curate/StructuredMetadataBuilderTest.php
+++ b/tests/Curate/StructuredMetadataBuilderTest.php
@@ -73,7 +73,8 @@ final class StructuredMetadataBuilderTest extends TestCase
     #[Test]
     public function buildsStructuredAggregateForDslrJpeg(): void
     {
-        $sfrPayload = self::buildSpatialFrequencyResponsePayload();
+        $oecfPayload = self::buildOecfPayload();
+        $sfrPayload  = self::buildSpatialFrequencyResponsePayload();
 
         $ifd0 = new Ifd([
             ExifTag::IMAGE_WIDTH                    => new IfdEntry(ExifTag::IMAGE_WIDTH, 4, 1, 6720),
@@ -146,7 +147,7 @@ final class StructuredMetadataBuilderTest extends TestCase
             ExifTag::LENS_MAKE                   => new IfdEntry(ExifTag::LENS_MAKE, 2, 5, 'Canon'),
             ExifTag::LENS_SERIAL_NUMBER          => new IfdEntry(ExifTag::LENS_SERIAL_NUMBER, 2, 10, '1234ABC'),
             ExifTag::SPECTRAL_SENSITIVITY        => new IfdEntry(ExifTag::SPECTRAL_SENSITIVITY, 2, 16, 'Standard Spectral'),
-            ExifTag::OECF                        => new IfdEntry(ExifTag::OECF, 7, 12, 'OECF-DATA-01'),
+            ExifTag::OECF                        => new IfdEntry(ExifTag::OECF, 7, strlen($oecfPayload), $oecfPayload),
             ExifTag::USER_COMMENT                => new IfdEntry(ExifTag::USER_COMMENT, 7, 28, "ASCII\0\0\0Shot with ND filter\0"),
             ExifTag::SUB_SEC_TIME                => new IfdEntry(ExifTag::SUB_SEC_TIME, 2, 3, '321'),
             ExifTag::SUB_SEC_TIME_ORIGINAL       => new IfdEntry(ExifTag::SUB_SEC_TIME_ORIGINAL, 2, 3, '123'),
@@ -351,7 +352,17 @@ final class StructuredMetadataBuilderTest extends TestCase
         self::assertSame('sound.wav', $structured->related->relatedSoundFile);
 
         self::assertSame('Standard Spectral', $structured->sensor->spectralSensitivity);
-        self::assertSame('OECF-DATA-01', $structured->sensor->oecf);
+        $sensorOecf = $structured->sensor->oecf;
+        self::assertNotNull($sensorOecf);
+        self::assertSame($oecfPayload, $sensorOecf['payload']);
+        $sensorOecfMatrix = $sensorOecf['matrix'];
+        self::assertNotNull($sensorOecfMatrix);
+        self::assertSame(['Input 0', 'Input 1'], $sensorOecfMatrix['labels']['columns']);
+        self::assertSame(['Channel R', 'Channel G'], $sensorOecfMatrix['labels']['rows']);
+        self::assertEqualsWithDelta(0.1, $sensorOecfMatrix['values'][0][0] ?? 0.0, 0.0001);
+        self::assertEqualsWithDelta(0.2, $sensorOecfMatrix['values'][0][1] ?? 0.0, 0.0001);
+        self::assertEqualsWithDelta(0.3, $sensorOecfMatrix['values'][1][0] ?? 0.0, 0.0001);
+        self::assertEqualsWithDelta(0.4, $sensorOecfMatrix['values'][1][1] ?? 0.0, 0.0001);
         $sensorSfr = $structured->sensor->spatialFrequencyResponse;
         self::assertNotNull($sensorSfr);
         self::assertSame(['10lp/mm', '20lp/mm', '40lp/mm'], $sensorSfr['labels']['columns']);
@@ -2120,6 +2131,25 @@ final class StructuredMetadataBuilderTest extends TestCase
         $value = unpack('V', $bytes);
 
         return (int) ($value[1] ?? 0);
+    }
+
+    private static function buildOecfPayload(): string
+    {
+        $columns = 2;
+        $rows    = 2;
+
+        $payload = pack('n', $columns) . pack('n', $rows);
+        $payload .= "Input 0\0";
+        $payload .= "Input 1\0";
+        $payload .= "Channel R\0";
+        $payload .= "Channel G\0";
+
+        $payload .= self::packSrational(1, 10);
+        $payload .= self::packSrational(2, 10);
+        $payload .= self::packSrational(3, 10);
+        $payload .= self::packSrational(4, 10);
+
+        return $payload;
     }
 
     private static function buildSpatialFrequencyResponsePayload(): string

--- a/tests/Model/Exif/ExifDocumentTest.php
+++ b/tests/Model/Exif/ExifDocumentTest.php
@@ -734,7 +734,8 @@ final class ExifDocumentTest extends TestCase
     #[Test]
     public function exposesTable65Extensions(): void
     {
-        $sfrPayload = self::buildSpatialFrequencyResponsePayload();
+        $oecfPayload = self::buildOecfPayload();
+        $sfrPayload  = self::buildSpatialFrequencyResponsePayload();
 
         $ifd0 = new Ifd([
             ExifTag::IMAGE_DESCRIPTION => new IfdEntry(ExifTag::IMAGE_DESCRIPTION, 2, 1, 'Coastal cliffs'),
@@ -748,7 +749,7 @@ final class ExifDocumentTest extends TestCase
             ExifTag::COMPRESSED_BITS_PER_PIXEL   => new IfdEntry(ExifTag::COMPRESSED_BITS_PER_PIXEL, 5, 1, new ExifRational(45, 10)),
             ExifTag::USER_COMMENT                => new IfdEntry(ExifTag::USER_COMMENT, 7, 1, "ASCII\0\0\0Calibrated output\0"),
             ExifTag::SPECTRAL_SENSITIVITY        => new IfdEntry(ExifTag::SPECTRAL_SENSITIVITY, 2, 1, 'Spectral A'),
-            ExifTag::OECF                        => new IfdEntry(ExifTag::OECF, 7, 1, 'OECF Blob'),
+            ExifTag::OECF                        => new IfdEntry(ExifTag::OECF, 7, strlen($oecfPayload), $oecfPayload),
             ExifTag::ISO_SPEED_LATITUDE_YYY      => new IfdEntry(ExifTag::ISO_SPEED_LATITUDE_YYY, 3, 1, 200),
             ExifTag::ISO_SPEED_LATITUDE_ZZZ      => new IfdEntry(ExifTag::ISO_SPEED_LATITUDE_ZZZ, 3, 1, 400),
             ExifTag::IMAGE_NUMBER                => new IfdEntry(ExifTag::IMAGE_NUMBER, 3, 1, 512),
@@ -788,7 +789,20 @@ final class ExifDocumentTest extends TestCase
         self::assertSame(4.5, $doc->compressedBitsPerPixel());
         self::assertSame('Calibrated output', $doc->userComment());
         self::assertSame('Spectral A', $doc->spectralSensitivity());
-        self::assertSame('OECF Blob', $doc->oecf());
+        $oecf = $doc->oecf();
+        self::assertNotNull($oecf);
+        self::assertSame($oecfPayload, $oecf['payload']);
+        $oecfMatrix = $oecf['matrix'];
+        self::assertNotNull($oecfMatrix);
+        self::assertSame(2, $oecfMatrix['columns']);
+        self::assertSame(2, $oecfMatrix['rows']);
+        self::assertSame(['Input 0', 'Input 1'], $oecfMatrix['labels']['columns']);
+        self::assertSame(['Channel R', 'Channel G'], $oecfMatrix['labels']['rows']);
+        self::assertEqualsWithDelta(0.1, $oecfMatrix['values'][0][0] ?? 0.0, 0.0001);
+        self::assertEqualsWithDelta(0.2, $oecfMatrix['values'][0][1] ?? 0.0, 0.0001);
+        self::assertEqualsWithDelta(0.3, $oecfMatrix['values'][1][0] ?? 0.0, 0.0001);
+        self::assertEqualsWithDelta(0.4, $oecfMatrix['values'][1][1] ?? 0.0, 0.0001);
+        self::assertSame($oecfPayload, $doc->oecfPayload());
         self::assertSame(200, $doc->isoSpeedLatitudeYyy());
         self::assertSame(400, $doc->isoSpeedLatitudeZzz());
         self::assertSame(512, $doc->imageNumber());
@@ -1143,6 +1157,25 @@ final class ExifDocumentTest extends TestCase
         self::assertEqualsWithDelta(32.1, $document->gimbalYawDeg(), 0.0001);
         self::assertEqualsWithDelta(-21.0, $document->gimbalPitchDeg(), 0.0001);
         self::assertEqualsWithDelta(-0.5, $document->gimbalRollDeg(), 0.0001);
+    }
+
+    private static function buildOecfPayload(): string
+    {
+        $columns = 2;
+        $rows    = 2;
+
+        $payload = pack('n', $columns) . pack('n', $rows);
+        $payload .= "Input 0\0";
+        $payload .= "Input 1\0";
+        $payload .= "Channel R\0";
+        $payload .= "Channel G\0";
+
+        $payload .= self::packSrational(1, 10);
+        $payload .= self::packSrational(2, 10);
+        $payload .= self::packSrational(3, 10);
+        $payload .= self::packSrational(4, 10);
+
+        return $payload;
     }
 
     private static function buildSpatialFrequencyResponsePayload(): string


### PR DESCRIPTION
## Summary
- add a shared SRATIONAL matrix decoder for OECF/SPF payloads and expose ValueConverters::decodeOecf()
- return decoded OECF matrices alongside the raw payload in ExifDocument, resolver, and sensor value objects
- extend PHPUnit coverage to assert the decoded OECF structure in ExifDocument and structured metadata aggregation

## Testing
- composer ci:test:php:unit *(fails: fixture-based TruthComparison suite expects unavailable assets in this environment)*
- composer ci:test:php:phpstan *(fails: pre-existing phpstan findings reported against unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68fe318a9c3483238c0b70051e17288f