### PR TITLE
feat: prefer EXIF processing software tag

### DIFF
--- a/src/Curate/Resolver/ExifTagResolver.php
+++ b/src/Curate/Resolver/ExifTagResolver.php
@@ -280,7 +280,14 @@ final readonly class ExifTagResolver
      */
     public function software(): ?string
     {
-        return $this->stringValue($this->document?->ifd0, ExifTag::SOFTWARE);
+        $ifd0 = $this->document?->ifd0;
+
+        $processingSoftware = $this->stringValue($ifd0, ExifTag::PROCESSING_SOFTWARE);
+        if ($processingSoftware !== null) {
+            return $processingSoftware;
+        }
+
+        return $this->stringValue($ifd0, ExifTag::SOFTWARE);
     }
 
     /**

--- a/src/Model/Exif/ExifTag.php
+++ b/src/Model/Exif/ExifTag.php
@@ -17,6 +17,11 @@ namespace MagicSunday\ImageMeta\Model\Exif;
 final readonly class ExifTag
 {
     // Image file directory (IFD0)
+    /**
+     * EXIF 3.0 tag recording the software responsible for final image processing.
+     */
+    public const int PROCESSING_SOFTWARE = 0x000B;
+
     public const int IMAGE_WIDTH = 0x0100;
 
     public const int IMAGE_HEIGHT = 0x0101;

--- a/tests/Curate/Resolver/ExifTagResolverTest.php
+++ b/tests/Curate/Resolver/ExifTagResolverTest.php
@@ -319,6 +319,8 @@ final class ExifTagResolverTest extends TestCase
             ExifTag::IMAGE_TITLE       => new IfdEntry(ExifTag::IMAGE_TITLE, 2, 1, 'Evening Glow'),
             ExifTag::PHOTOGRAPHER      => new IfdEntry(ExifTag::PHOTOGRAPHER, 2, 1, 'Jamie Doe'),
             ExifTag::IMAGE_EDITOR      => new IfdEntry(ExifTag::IMAGE_EDITOR, 2, 1, 'Casey Edit'),
+            ExifTag::PROCESSING_SOFTWARE => new IfdEntry(ExifTag::PROCESSING_SOFTWARE, 2, 1, 'ImageMeta Studio'),
+            ExifTag::SOFTWARE            => new IfdEntry(ExifTag::SOFTWARE, 2, 1, 'Legacy Writer'),
         ]);
 
         $exifIfd = new Ifd([
@@ -355,6 +357,19 @@ final class ExifTagResolverTest extends TestCase
         self::assertSame('Raw Studio', $resolver->rawDevelopingSoftware());
         self::assertSame('Pixel Edit', $resolver->imageEditingSoftware());
         self::assertSame('Meta Desk', $resolver->metadataEditingSoftware());
+        self::assertSame('ImageMeta Studio', $resolver->software());
+    }
+
+    #[Test]
+    public function fallsBackToLegacySoftwareTag(): void
+    {
+        $ifd0 = new Ifd([
+            ExifTag::SOFTWARE => new IfdEntry(ExifTag::SOFTWARE, 2, 1, 'Legacy Writer'),
+        ]);
+
+        $resolver = new ExifTagResolver(new ExifDocument($ifd0, null, null, null, null));
+
+        self::assertSame('Legacy Writer', $resolver->software());
     }
 
     #[Test]

--- a/tests/Curate/StructuredMetadataBuilderTest.php
+++ b/tests/Curate/StructuredMetadataBuilderTest.php
@@ -597,6 +597,29 @@ final class StructuredMetadataBuilderTest extends TestCase
     }
 
     #[Test]
+    public function prefersProcessingSoftwareOverLegacyTag(): void
+    {
+        $ifd0 = new Ifd([
+            ExifTag::PROCESSING_SOFTWARE => new IfdEntry(ExifTag::PROCESSING_SOFTWARE, 2, 1, 'ImageMeta Studio'),
+            ExifTag::SOFTWARE            => new IfdEntry(ExifTag::SOFTWARE, 2, 1, 'Legacy Writer'),
+        ]);
+
+        $exifDocument = new ExifDocument($ifd0, null, null, null, null);
+
+        $metadata = new Metadata(
+            ['primary'],
+            new QuickTimeMeta([]),
+            $exifDocument,
+            [],
+            new XmpDocument([]),
+        );
+
+        $structured = (new StructuredMetadataBuilder())->build($metadata);
+
+        self::assertSame('ImageMeta Studio', $structured->device->software);
+    }
+
+    #[Test]
     public function usesHostComputerWhenSoftwareResolversEmpty(): void
     {
         $ifd0 = new Ifd([

--- a/tests/Model/Exif/ExifTagTest.php
+++ b/tests/Model/Exif/ExifTagTest.php
@@ -63,6 +63,7 @@ final class ExifTagTest extends TestCase
             'GPS_H_POSITIONING_ERROR' => 0x001F,
 
             // Image file directory (IFD0)
+            'PROCESSING_SOFTWARE'           => 0x000B,
             'IMAGE_WIDTH'                    => 0x0100,
             'IMAGE_HEIGHT'                   => 0x0101,
             'BITS_PER_SAMPLE'                => 0x0102,


### PR DESCRIPTION
## Summary
- add the EXIF 3.0 PROCESSING_SOFTWARE identifier to the central tag registry
- prefer the processing software tag in the EXIF resolver while keeping legacy fallbacks
- exercise the new priority inside the structured metadata builder tests to ensure EXIF wins when present

## Testing
- composer ci:test:php:unit *(fails: missing HEIC fixtures in TruthComparisonTest)*
- .build/bin/phpunit --configuration .build/phpunit.xml tests/Model/Exif/ExifTagTest.php tests/Curate/Resolver/ExifTagResolverTest.php tests/Curate/StructuredMetadataBuilderTest.php


------
https://chatgpt.com/codex/tasks/task_e_68fe31942ab88323a42b0696e84ac42a