### PR TITLE
Add DocumentName fallback for legacy EXIF metadata

### DIFF
--- a/src/Model/Exif/ExifDocument.php
+++ b/src/Model/Exif/ExifDocument.php
@@ -311,6 +311,18 @@ final readonly class ExifDocument
      */
     public function documentName(): ?string
     {
+        $value = $this->str($this->ifd0, ExifTag::DOCUMENT_NAME);
+
+        if ($value !== null) {
+            return $value;
+        }
+
+        $value = $this->str($this->exifIfd, ExifTag::DOCUMENT_NAME);
+
+        if ($value !== null) {
+            return $value;
+        }
+
         $value = $this->str($this->ifd0, ExifTag::IMAGE_TITLE);
 
         if ($value !== null) {

--- a/src/Model/Exif/ExifTag.php
+++ b/src/Model/Exif/ExifTag.php
@@ -32,6 +32,13 @@ final readonly class ExifTag
 
     public const int PHOTOMETRIC_INTERPRETATION = 0x0106;
 
+    /**
+     * Legacy EXIF ≤ 2.x tag storing the document name within IFD0.
+     *
+     * Retained for backwards compatibility alongside the EXIF 3.0 IMAGE_TITLE tag.
+     */
+    public const int DOCUMENT_NAME = 0x010D;
+
     public const int IMAGE_DESCRIPTION = 0x010E;
 
     public const int SUB_IFDS = 0x014A;

--- a/tests/Curate/Resolver/ExifTagResolverTest.php
+++ b/tests/Curate/Resolver/ExifTagResolverTest.php
@@ -402,6 +402,19 @@ final class ExifTagResolverTest extends TestCase
     }
 
     #[Test]
+    public function resolvesDocumentNameTag(): void
+    {
+        $ifd0 = new Ifd([
+            ExifTag::DOCUMENT_NAME => new IfdEntry(ExifTag::DOCUMENT_NAME, 2, 1, 'Scan 42'),
+        ]);
+
+        $document = new ExifDocument($ifd0, null, null, null, null);
+        $resolver = new ExifTagResolver($document);
+
+        self::assertSame('Scan 42', $resolver->documentName());
+    }
+
+    #[Test]
     public function resolvesXpStringFallbacks(): void
     {
         $ifd0 = new Ifd([

--- a/tests/Curate/StructuredMetadataBuilderTest.php
+++ b/tests/Curate/StructuredMetadataBuilderTest.php
@@ -469,6 +469,19 @@ final class StructuredMetadataBuilderTest extends TestCase
     }
 
     #[Test]
+    public function usesDocumentNameTagWhenAvailable(): void
+    {
+        $ifd0 = new Ifd([
+            ExifTag::DOCUMENT_NAME => new IfdEntry(ExifTag::DOCUMENT_NAME, 2, 1, 'Legacy Document'),
+        ]);
+
+        $structured = (new StructuredMetadataBuilder())
+            ->build(new Metadata(['primary'], null, new ExifDocument($ifd0, null, null, null, null)));
+
+        self::assertSame('Legacy Document', $structured->image->documentName);
+    }
+
+    #[Test]
     public function populatesXpMetadataWhenExif30FieldsMissing(): void
     {
         $ifd0 = new Ifd([

--- a/tests/Model/Exif/ExifDocumentTest.php
+++ b/tests/Model/Exif/ExifDocumentTest.php
@@ -728,6 +728,31 @@ final class ExifDocumentTest extends TestCase
         self::assertNull($missingDoc->makerNoteSafety());
     }
 
+    #[Test]
+    public function documentNameUsesLegacyDocumentNameWhenAlone(): void
+    {
+        $ifd0 = new Ifd([
+            ExifTag::DOCUMENT_NAME => new IfdEntry(ExifTag::DOCUMENT_NAME, 2, 1, 'Archive Page'),
+        ]);
+
+        $doc = new ExifDocument($ifd0, null, null, null, null);
+
+        self::assertSame('Archive Page', $doc->documentName());
+    }
+
+    #[Test]
+    public function documentNamePrefersLegacyDocumentNameTag(): void
+    {
+        $ifd0 = new Ifd([
+            ExifTag::DOCUMENT_NAME => new IfdEntry(ExifTag::DOCUMENT_NAME, 2, 1, "Scan 001\0"),
+            ExifTag::XP_SUBJECT    => new IfdEntry(ExifTag::XP_SUBJECT, 1, 1, 'XP Subject'),
+        ]);
+
+        $doc = new ExifDocument($ifd0, null, null, null, null);
+
+        self::assertSame('Scan 001', $doc->documentName());
+    }
+
     /**
      * Ensures Table 65 extension tags are exposed via dedicated getters.
      */

--- a/tests/Model/Exif/ExifTagTest.php
+++ b/tests/Model/Exif/ExifTagTest.php
@@ -69,6 +69,7 @@ final class ExifTagTest extends TestCase
             'BITS_PER_SAMPLE'                => 0x0102,
             'COMPRESSION'                    => 0x0103,
             'PHOTOMETRIC_INTERPRETATION'     => 0x0106,
+            'DOCUMENT_NAME'                   => 0x010D,
             'IMAGE_DESCRIPTION'              => 0x010E,
             'IMAGE_TITLE'                    => 0xA436,
             'XP_TITLE'                       => 0x9C9B,


### PR DESCRIPTION
## Summary
- add the EXIF DOCUMENT_NAME constant to keep the registry aligned with the specification ordering
- prefer the legacy DocumentName tag before ImageTitle/XP fallbacks when resolving document names
- cover resolvers and structured metadata so legacy-only payloads still surface the document name

## Testing
- composer ci:test:php:unit *(fails: HEIC fixtures require unsupported container detection in this environment and several truth-comparison fixtures are unavailable)*
- .build/bin/phpunit --configuration .build/phpunit.xml tests/Model/Exif/ExifTagTest.php tests/Model/Exif/ExifDocumentTest.php tests/Curate/Resolver/ExifTagResolverTest.php tests/Curate/StructuredMetadataBuilderTest.php

------
https://chatgpt.com/codex/tasks/task_e_68fe3795465c83239a1340875e080c9f