### PR TITLE
feat: surface EXIF processing software metadata

### DIFF
--- a/src/Curate/Resolver/ExifTagResolver.php
+++ b/src/Curate/Resolver/ExifTagResolver.php
@@ -134,6 +134,7 @@ final readonly class ExifTagResolver
             'interopindex'        => $this->interopIndex(),
             'interopversion'      => $this->interopVersion(),
             'relatedimagefileformat' => $this->relatedImageFileFormat(),
+            'processingsoftware'  => $this->processingSoftware(),
             'hostcomputer'        => $this->hostComputer(),
             default               => null,
         };
@@ -276,16 +277,24 @@ final readonly class ExifTagResolver
     }
 
     /**
+     * Returns the processing software string when recorded.
+     */
+    public function processingSoftware(): ?string
+    {
+        return $this->document?->processingSoftware();
+    }
+
+    /**
      * Returns the software tag value.
      */
     public function software(): ?string
     {
-        $ifd0 = $this->document?->ifd0;
-
-        $processingSoftware = $this->stringValue($ifd0, ExifTag::PROCESSING_SOFTWARE);
+        $processingSoftware = $this->processingSoftware();
         if ($processingSoftware !== null) {
             return $processingSoftware;
         }
+
+        $ifd0 = $this->document?->ifd0;
 
         return $this->stringValue($ifd0, ExifTag::SOFTWARE);
     }

--- a/src/Curate/StructuredMetadataBuilder.php
+++ b/src/Curate/StructuredMetadataBuilder.php
@@ -342,6 +342,7 @@ final class StructuredMetadataBuilder
             clarity: null,
             customRendered: $exifResolver->customRendered()?->value,
             deviceSettingDescription: $exifResolver->deviceSettingDescription(),
+            processingSoftware: $exifResolver->processingSoftware(),
         );
 
         $whiteBalanceKelvin = $apple->colorTemperature;

--- a/src/Model/Exif/ExifDocument.php
+++ b/src/Model/Exif/ExifDocument.php
@@ -347,6 +347,14 @@ final readonly class ExifDocument
     }
 
     /**
+     * Returns the processing software string recorded during final image adjustments.
+     */
+    public function processingSoftware(): ?string
+    {
+        return $this->str($this->ifd0, ExifTag::PROCESSING_SOFTWARE);
+    }
+
+    /**
      * Returns the legacy host computer string retained for pre-EXIF 3.0 metadata.
      */
     public function hostComputer(): ?string

--- a/src/Value/ProcessingSettings.php
+++ b/src/Value/ProcessingSettings.php
@@ -25,6 +25,7 @@ final readonly class ProcessingSettings
      * @param int|null    $clarity                  Clarity adjustment level.
      * @param int|null    $customRendered           Indicates whether a custom rendering was applied in-camera.
      * @param string|null $deviceSettingDescription Binary device setting description payload.
+     * @param string|null $processingSoftware       Final processing software recorded by the camera.
      */
     public function __construct(
         public ?int $sharpness,
@@ -35,6 +36,7 @@ final readonly class ProcessingSettings
         public ?int $clarity,
         public ?int $customRendered,
         public ?string $deviceSettingDescription,
+        public ?string $processingSoftware,
     ) {
     }
 }

--- a/tests/Curate/Resolver/ExifTagResolverTest.php
+++ b/tests/Curate/Resolver/ExifTagResolverTest.php
@@ -319,7 +319,7 @@ final class ExifTagResolverTest extends TestCase
             ExifTag::IMAGE_TITLE       => new IfdEntry(ExifTag::IMAGE_TITLE, 2, 1, 'Evening Glow'),
             ExifTag::PHOTOGRAPHER      => new IfdEntry(ExifTag::PHOTOGRAPHER, 2, 1, 'Jamie Doe'),
             ExifTag::IMAGE_EDITOR      => new IfdEntry(ExifTag::IMAGE_EDITOR, 2, 1, 'Casey Edit'),
-            ExifTag::PROCESSING_SOFTWARE => new IfdEntry(ExifTag::PROCESSING_SOFTWARE, 2, 1, 'ImageMeta Studio'),
+            ExifTag::PROCESSING_SOFTWARE => new IfdEntry(ExifTag::PROCESSING_SOFTWARE, 2, 1, "ImageMeta Studio\0\0"),
             ExifTag::SOFTWARE            => new IfdEntry(ExifTag::SOFTWARE, 2, 1, 'Legacy Writer'),
         ]);
 
@@ -357,6 +357,7 @@ final class ExifTagResolverTest extends TestCase
         self::assertSame('Raw Studio', $resolver->rawDevelopingSoftware());
         self::assertSame('Pixel Edit', $resolver->imageEditingSoftware());
         self::assertSame('Meta Desk', $resolver->metadataEditingSoftware());
+        self::assertSame('ImageMeta Studio', $resolver->processingSoftware());
         self::assertSame('ImageMeta Studio', $resolver->software());
     }
 

--- a/tests/Curate/StructuredMetadataBuilderTest.php
+++ b/tests/Curate/StructuredMetadataBuilderTest.php
@@ -102,6 +102,7 @@ final class StructuredMetadataBuilderTest extends TestCase
             ExifTag::MAKE                           => new IfdEntry(ExifTag::MAKE, 2, 5, 'Canon'),
             ExifTag::MODEL                          => new IfdEntry(ExifTag::MODEL, 2, 8, 'EOS R6 II'),
             ExifTag::SOFTWARE                       => new IfdEntry(ExifTag::SOFTWARE, 2, 8, 'Firmware1'),
+            ExifTag::PROCESSING_SOFTWARE            => new IfdEntry(ExifTag::PROCESSING_SOFTWARE, 2, 18, "ImageMeta Studio\0\0"),
             ExifTag::IMAGE_DESCRIPTION              => new IfdEntry(ExifTag::IMAGE_DESCRIPTION, 2, 16, 'Sunset over Alps'),
             ExifTag::ORIENTATION                    => new IfdEntry(ExifTag::ORIENTATION, 3, 1, Orientation::RIGHT_TOP->value),
             ExifTag::ARTIST                         => new IfdEntry(ExifTag::ARTIST, 2, 12, 'Jane Doe'),
@@ -383,6 +384,7 @@ final class StructuredMetadataBuilderTest extends TestCase
 
         self::assertSame('Profile:Portrait', $structured->processing->deviceSettingDescription);
         self::assertSame(1, $structured->processing->customRendered);
+        self::assertSame('ImageMeta Studio', $structured->processing->processingSoftware);
         self::assertEqualsWithDelta(45.6, $structured->processing->noiseReduction, 0.0001);
 
         self::assertSame('Jane D. Photographer', $structured->author->photographer);

--- a/tests/Model/Exif/ExifDocumentTest.php
+++ b/tests/Model/Exif/ExifDocumentTest.php
@@ -925,6 +925,18 @@ final class ExifDocumentTest extends TestCase
     }
 
     #[Test]
+    public function processingSoftwareReturnsTrimmedString(): void
+    {
+        $ifd0 = new Ifd([
+            ExifTag::PROCESSING_SOFTWARE => new IfdEntry(ExifTag::PROCESSING_SOFTWARE, 2, 1, "PixelLab\0\0"),
+        ]);
+
+        $doc = new ExifDocument($ifd0, null, null, null, null);
+
+        self::assertSame('PixelLab', $doc->processingSoftware());
+    }
+
+    #[Test]
     public function textualSoftwareTagsFallbackToLegacyIdentifiers(): void
     {
         $ifd0 = new Ifd([


### PR DESCRIPTION
## Summary
- add an ExifDocument accessor for the EXIF processing software tag and expose it via the resolver
- extend ProcessingSettings and the structured metadata builder to carry the processing software string
- expand unit coverage to confirm the processing software metadata flows through to the structured aggregate

## Testing
- composer ci:test:php:unit *(fails: known fixture-dependent TruthComparison tests in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68fe3799ab988323b5d39b3eaf968308