### PR TITLE
feat: expose composite image helpers

### DIFF
--- a/src/Curate/Resolver/ExifTagResolver.php
+++ b/src/Curate/Resolver/ExifTagResolver.php
@@ -1991,9 +1991,11 @@ final readonly class ExifTagResolver
      */
     public function compositeImage(): ?CompositeImage
     {
-        $value = $this->numericValue($this->document?->exifIfd, ExifTag::COMPOSITE_IMAGE);
+        if ($this->document instanceof ExifDocument) {
+            return $this->document->compositeImage();
+        }
 
-        return $value !== null ? CompositeImage::fromExifValue($value) : null;
+        return null;
     }
 
     /**
@@ -2003,14 +2005,11 @@ final readonly class ExifTagResolver
      */
     public function sourceImageNumberOfCompositeImage(): ?array
     {
-        $values = $this->normalizeNumericList(
-            $this->getValue($this->document?->exifIfd, ExifTag::SOURCE_IMAGE_NUMBER_OF_COMPOSITE_IMAGE),
-        );
-        if (count($values) !== 2) {
-            return null;
+        if ($this->document instanceof ExifDocument) {
+            return $this->document->sourceImageNumberOfCompositeImage();
         }
 
-        return [(int) $values[0], (int) $values[1]];
+        return null;
     }
 
     /**
@@ -2020,11 +2019,11 @@ final readonly class ExifTagResolver
      */
     public function sourceExposureTimesOfCompositeImage(): ?array
     {
-        $values = $this->normalizeRationalList(
-            $this->getValue($this->document?->exifIfd, ExifTag::SOURCE_EXPOSURE_TIMES_OF_COMPOSITE_IMAGE),
-        );
+        if ($this->document instanceof ExifDocument) {
+            return $this->document->sourceExposureTimesOfCompositeImage();
+        }
 
-        return $values !== [] ? $values : null;
+        return null;
     }
 
     /**

--- a/src/Model/Exif/ExifDocument.php
+++ b/src/Model/Exif/ExifDocument.php
@@ -18,12 +18,14 @@ use MagicSunday\ImageMeta\Core\ExifCapabilities;
 use MagicSunday\ImageMeta\Core\ValueConverters as CoreValueConverters;
 use MagicSunday\ImageMeta\MakerNotes\MakerNotesMetadata;
 use MagicSunday\ImageMeta\Value\Enum\CfaPatternColor;
+use MagicSunday\ImageMeta\Value\Enum\CompositeImage;
 use MagicSunday\ImageMeta\Value\Enum\CustomRendered;
 use MagicSunday\ImageMeta\Value\Enum\SceneType;
 
 use function array_key_exists;
 use function array_map;
 use function array_values;
+use function count;
 use function iconv;
 use function is_float;
 use function is_int;
@@ -1024,6 +1026,48 @@ final readonly class ExifDocument
     public function noise(): ?float
     {
         return $this->rational($this->exifIfd, ExifTag::NOISE);
+    }
+
+    /**
+     * Returns the composite image classification when available.
+     */
+    public function compositeImage(): ?CompositeImage
+    {
+        $value = $this->int($this->exifIfd, ExifTag::COMPOSITE_IMAGE);
+
+        return $value !== null ? CompositeImage::fromExifValue($value) : null;
+    }
+
+    /**
+     * Returns the number of source images contributing to the composite result.
+     *
+     * @return array{0:int,1:int}|null
+     */
+    public function sourceImageNumberOfCompositeImage(): ?array
+    {
+        $values = $this->numericList($this->exifIfd, ExifTag::SOURCE_IMAGE_NUMBER_OF_COMPOSITE_IMAGE);
+
+        if ($values === null || count($values) !== 2) {
+            return null;
+        }
+
+        return [(int) $values[0], (int) $values[1]];
+    }
+
+    /**
+     * Returns the exposure times for each source image used in the composite.
+     *
+     * @return list<float>|null
+     */
+    public function sourceExposureTimesOfCompositeImage(): ?array
+    {
+        $values = $this->rationalList($this->exifIfd, ExifTag::SOURCE_EXPOSURE_TIMES_OF_COMPOSITE_IMAGE);
+
+        if ($values === null || $values === []) {
+            return null;
+        }
+
+        return $values;
     }
 
     /**

--- a/tests/Model/Exif/ExifDocumentTest.php
+++ b/tests/Model/Exif/ExifDocumentTest.php
@@ -23,6 +23,7 @@ use MagicSunday\ImageMeta\Model\Exif\ValueConverters;
 use MagicSunday\ImageMeta\Parse\Tiff\TiffExifReader;
 use MagicSunday\ImageMeta\Tests\Support\GpsTiffBuilder;
 use MagicSunday\ImageMeta\Value\Enum\CfaPatternColor;
+use MagicSunday\ImageMeta\Value\Enum\CompositeImage;
 use MagicSunday\ImageMeta\Value\Enum\CustomRendered;
 use MagicSunday\ImageMeta\Value\Enum\SceneType;
 use function iconv;
@@ -148,6 +149,45 @@ final class ExifDocumentTest extends TestCase
         self::assertEqualsWithDelta(40.441666, $gps['lat'], 0.000001);
         self::assertEqualsWithDelta(79.983333, $gps['lon'], 0.000001);
         self::assertEquals(123.0, $gps['alt']);
+    }
+
+    #[Test]
+    public function exposesCompositeImageMetadata(): void
+    {
+        $ifd0 = new Ifd([]);
+
+        $exifIfd = new Ifd([
+            ExifTag::COMPOSITE_IMAGE                          => new IfdEntry(
+                ExifTag::COMPOSITE_IMAGE,
+                3,
+                1,
+                CompositeImage::GENERAL_COMPOSITE->value,
+            ),
+            ExifTag::SOURCE_IMAGE_NUMBER_OF_COMPOSITE_IMAGE   => new IfdEntry(
+                ExifTag::SOURCE_IMAGE_NUMBER_OF_COMPOSITE_IMAGE,
+                3,
+                2,
+                new ExifNumericList([5, 2]),
+            ),
+            ExifTag::SOURCE_EXPOSURE_TIMES_OF_COMPOSITE_IMAGE => new IfdEntry(
+                ExifTag::SOURCE_EXPOSURE_TIMES_OF_COMPOSITE_IMAGE,
+                5,
+                3,
+                [[1, 30], [1, 15], [1, 8]],
+            ),
+        ]);
+
+        $doc = new ExifDocument($ifd0, $exifIfd, null, null, null);
+
+        self::assertSame(CompositeImage::GENERAL_COMPOSITE, $doc->compositeImage());
+        self::assertSame([5, 2], $doc->sourceImageNumberOfCompositeImage());
+
+        $exposureTimes = $doc->sourceExposureTimesOfCompositeImage();
+        self::assertNotNull($exposureTimes);
+        self::assertCount(3, $exposureTimes);
+        self::assertEqualsWithDelta(0.0333333333, $exposureTimes[0], 1e-10);
+        self::assertEqualsWithDelta(0.0666666666, $exposureTimes[1], 1e-10);
+        self::assertEqualsWithDelta(0.125, $exposureTimes[2], 1e-10);
     }
 
     #[Test]


### PR DESCRIPTION
## Summary
- add composite image accessors on `ExifDocument` returning enum and normalised lists
- delegate `ExifTagResolver` composite helpers to the document methods
- cover the new accessors with unit tests using the structured metadata sample payload

## Testing
- composer ci:test:php:unit *(fails: TruthComparisonTest fixtures unavailable in container)*
- .build/bin/phpunit tests/Model/Exif/ExifDocumentTest.php


------
https://chatgpt.com/codex/tasks/task_e_68fe3d69a54c83239f8d9b1cc5d870ae