### PR TITLE
feat: surface EXIF acceleration vectors

### DIFF
--- a/src/Curate/Resolver/ExifTagResolver.php
+++ b/src/Curate/Resolver/ExifTagResolver.php
@@ -1794,6 +1794,16 @@ final readonly class ExifTagResolver
     }
 
     /**
+     * Returns the camera acceleration vector in m/s².
+     *
+     * @return array{0:float,1:float,2:float}|null
+     */
+    public function accelerationVector(): ?array
+    {
+        return $this->document?->accelerationVector();
+    }
+
+    /**
      * Returns the camera acceleration in m/s².
      */
     public function accelerationMs2(): ?float

--- a/src/Model/Exif/ExifDocument.php
+++ b/src/Model/Exif/ExifDocument.php
@@ -32,6 +32,7 @@ use function ord;
 use function preg_replace;
 use function preg_split;
 use function rtrim;
+use function sqrt;
 use function str_pad;
 use function str_replace;
 use function strlen;
@@ -1166,11 +1167,38 @@ final readonly class ExifDocument
     }
 
     /**
+     * Returns the camera acceleration vector in metres per second squared.
+     *
+     * @return array{0:float,1:float,2:float}|null
+     */
+    public function accelerationVector(): ?array
+    {
+        $value = $this->value($this->exifIfd, ExifTag::ACCELERATION);
+
+        if (!$value instanceof ExifRationalList) {
+            return null;
+        }
+
+        return ValueConverters::srationalTripletToFloatVector($value);
+    }
+
+    /**
      * Returns the camera acceleration in metres per second squared.
      */
     public function accelerationMs2(): ?float
     {
-        return $this->rational($this->exifIfd, ExifTag::ACCELERATION);
+        $value = $this->value($this->exifIfd, ExifTag::ACCELERATION);
+
+        if ($value instanceof ExifRationalList) {
+            $vector = ValueConverters::srationalTripletToFloatVector($value);
+            if ($vector === null) {
+                return null;
+            }
+
+            return sqrt(($vector[0] ** 2) + ($vector[1] ** 2) + ($vector[2] ** 2));
+        }
+
+        return ValueConverters::rationalToFloat($value);
     }
 
     /**

--- a/src/Model/Exif/ValueConverters.php
+++ b/src/Model/Exif/ValueConverters.php
@@ -142,6 +142,29 @@ final readonly class ValueConverters
     }
 
     /**
+     * Converts a SRATIONAL[3] list into a three-element float vector.
+     *
+     * @return array{0:float,1:float,2:float}|null
+     */
+    public static function srationalTripletToFloatVector(ExifRationalList $value): ?array
+    {
+        if (count($value->values) !== 3) {
+            return null;
+        }
+
+        $vector = [];
+        foreach ($value->values as $index => $component) {
+            if ($component->denominator === 0) {
+                return null;
+            }
+
+            $vector[$index] = (float) $component->numerator / (float) $component->denominator;
+        }
+
+        return $vector;
+    }
+
+    /**
      * Normalises EXIF battery level readings to a percentage.
      *
      * @param int|float|string|ExifRational|ExifRationalList|ExifNumericList|null $value Raw battery level value.

--- a/tests/Curate/Resolver/ExifTagResolverTest.php
+++ b/tests/Curate/Resolver/ExifTagResolverTest.php
@@ -29,6 +29,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
+use function sqrt;
 
 /**
  * @covers \MagicSunday\ImageMeta\Curate\Resolver\ExifTagResolver
@@ -475,5 +476,32 @@ final class ExifTagResolverTest extends TestCase
         self::assertTrue($safeResolver->makerNoteSafety());
         self::assertFalse($unsafeResolver->makerNoteSafety());
         self::assertNull($missingResolver->makerNoteSafety());
+    }
+
+    #[Test]
+    public function exposesAccelerationVector(): void
+    {
+        $exifIfd = new Ifd([
+            ExifTag::ACCELERATION => new IfdEntry(
+                ExifTag::ACCELERATION,
+                10,
+                3,
+                new ExifRationalList([
+                    new ExifRational(1, 10),
+                    new ExifRational(2, 10),
+                    new ExifRational(-3, 10),
+                ]),
+            ),
+        ]);
+
+        $resolver = new ExifTagResolver(new ExifDocument(new Ifd([]), $exifIfd, null, null, null));
+
+        $vector = $resolver->accelerationVector();
+        self::assertNotNull($vector);
+        self::assertSame([0.1, 0.2, -0.3], $vector);
+
+        $magnitude = $resolver->accelerationMs2();
+        self::assertNotNull($magnitude);
+        self::assertEqualsWithDelta(sqrt(0.14), $magnitude, 0.000001);
     }
 }

--- a/tests/Model/Exif/ExifDocumentTest.php
+++ b/tests/Model/Exif/ExifDocumentTest.php
@@ -880,6 +880,33 @@ final class ExifDocumentTest extends TestCase
         self::assertSame('MetaLab', $doc->metadataEditingSoftware());
     }
 
+    #[Test]
+    public function exposesAccelerationVectorWhenPresent(): void
+    {
+        $exifIfd = new Ifd([
+            ExifTag::ACCELERATION => new IfdEntry(
+                ExifTag::ACCELERATION,
+                10,
+                3,
+                new ExifRationalList([
+                    new ExifRational(-3, 1),
+                    new ExifRational(4, 1),
+                    new ExifRational(0, 1),
+                ]),
+            ),
+        ]);
+
+        $doc = new ExifDocument(new Ifd([]), $exifIfd, null, null, null);
+
+        $vector = $doc->accelerationVector();
+        self::assertNotNull($vector);
+        self::assertSame([-3.0, 4.0, 0.0], $vector);
+
+        $magnitude = $doc->accelerationMs2();
+        self::assertNotNull($magnitude);
+        self::assertEqualsWithDelta(5.0, $magnitude, 0.0001);
+    }
+
     /**
      * Decodes user comments tagged as Shift-JIS into UTF-8 strings.
      */


### PR DESCRIPTION
## Summary
- add a ValueConverters helper to decode SRATIONAL[3] acceleration triplets safely
- expose the EXIF acceleration vector alongside a magnitude helper in ExifDocument and ExifTagResolver
- extend ExifDocument and resolver tests with synthetic SRATIONAL vectors to verify axis preservation

## Testing
- composer ci:test:php:unit

------
https://chatgpt.com/codex/tasks/task_e_68fe3d75e2348323b62a5e6f43775423