### PR TITLE
Fix BigTIFF offset overflow handling

### DIFF
--- a/src/Core/Util/Unpack.php
+++ b/src/Core/Util/Unpack.php
@@ -60,7 +60,31 @@ final class Unpack
      */
     public static function combineUint32(int $hi, int $lo): int
     {
-        return (($hi & 0xFFFFFFFF) << 32) | ($lo & 0xFFFFFFFF);
+        if (PHP_INT_SIZE < 8) {
+            throw new ParseError('64-bit integers are not supported on this platform.');
+        }
+
+        $hiUnsigned = $hi & 0xFFFFFFFF;
+        $loUnsigned = $lo & 0xFFFFFFFF;
+
+        $isNegative = ($hiUnsigned & 0x80000000) !== 0;
+
+        if ($isNegative) {
+            $hiComplement = (~$hiUnsigned) & 0xFFFFFFFF;
+            $loComplement = (~$loUnsigned) & 0xFFFFFFFF;
+            $magnitude    = ($hiComplement << 32) | $loComplement;
+
+            return -1 - $magnitude;
+        }
+
+        $maxHi = PHP_INT_MAX >> 32;
+        $maxLo = PHP_INT_MAX & 0xFFFFFFFF;
+
+        if ($hiUnsigned > $maxHi || ($hiUnsigned === $maxHi && $loUnsigned > $maxLo)) {
+            throw new ParseError('64-bit unsigned value exceeds PHP_INT_MAX.');
+        }
+
+        return ($hiUnsigned << 32) | $loUnsigned;
     }
 
     /**

--- a/src/Parse/Tiff/TiffExifReader.php
+++ b/src/Parse/Tiff/TiffExifReader.php
@@ -30,6 +30,7 @@ use function chr;
 use function function_exists;
 use function iconv;
 use function in_array;
+use function is_finite;
 use function is_float;
 use function is_int;
 use function is_string;
@@ -278,7 +279,7 @@ final class TiffExifReader
         $tag      = $this->readU16();
         $type     = $this->readU16();
         $cnt      = $this->bigTiff ? $this->readU64() : $this->readU32();
-        $valOrOff = $this->bigTiff ? $this->readU64() : $this->readU32();
+        $valOrOff = $this->bigTiff ? $this->readValueOrOffset($type, $cnt) : $this->readU32();
 
         [$rawBytes] = $this->valueBytes($type, $cnt, $valOrOff);
         $value      = $this->decodeBytes($type, $cnt, $rawBytes);
@@ -620,6 +621,33 @@ final class TiffExifReader
     }
 
     /**
+     * Reads the 4- or 8-byte value/offset field for a directory entry.
+     *
+     * @param int $type  TIFF field type code.
+     * @param int $count Number of values represented.
+     *
+     * @return int
+     */
+    private function readValueOrOffset(int $type, int $count): int
+    {
+        if (!$this->bigTiff) {
+            return $this->readU32();
+        }
+
+        $componentSize    = $this->bytesPerComponent($type);
+        $inlineThreshold  = 8;
+        $inlineValueBytes = $componentSize * $count;
+
+        if ($inlineValueBytes <= $inlineThreshold && $type === self::TYPE_SLONG8) {
+            $bytes = $this->buf->read($inlineThreshold);
+
+            return $this->unpackS64($bytes);
+        }
+
+        return $this->readU64();
+    }
+
+    /**
      * Extracts the raw bytes addressed by a directory entry.
      *
      * @param int $type          TIFF field type code.
@@ -831,7 +859,13 @@ final class TiffExifReader
      */
     private function readU64(): int
     {
-        return $this->bo === Endian::Little ? $this->buf->readU64LE() : $this->buf->readU64BE();
+        $value = $this->bo === Endian::Little ? $this->buf->readU64LE() : $this->buf->readU64BE();
+
+        if ($value < 0) {
+            throw new ParseError('64-bit unsigned value exceeds PHP_INT_MAX.');
+        }
+
+        return $value;
     }
 
     /**
@@ -1048,24 +1082,66 @@ final class TiffExifReader
         $value = $entry->value;
 
         if (is_int($value)) {
-            return $value;
+            return $this->validatePointerOffset($value, $entry->tag);
         }
 
         if (is_float($value)) {
-            return (int) $value;
+            return $this->pointerOffsetFromFloat($value, $entry->tag);
         }
 
         if ($value instanceof ExifNumericList) {
             $first = $value->values[0] ?? null;
             if (is_int($first)) {
-                return $first;
+                return $this->validatePointerOffset($first, $entry->tag);
             }
 
             if (is_float($first)) {
-                return (int) $first;
+                return $this->pointerOffsetFromFloat($first, $entry->tag);
             }
         }
 
         throw new ParseError(sprintf('IFD pointer tag 0x%04X must contain a numeric offset.', $entry->tag));
+    }
+
+    /**
+     * Validates that an offset fits within the supported integer range.
+     *
+     * @param int $offset Candidate offset.
+     * @param int $tag    Tag identifier emitting the offset.
+     *
+     * @return int
+     */
+    private function validatePointerOffset(int $offset, int $tag): int
+    {
+        if ($offset < 0) {
+            throw new ParseError(sprintf('IFD pointer tag 0x%04X must not be negative.', $tag));
+        }
+
+        if ($offset > PHP_INT_MAX) {
+            throw new ParseError(sprintf('IFD pointer tag 0x%04X is out of range.', $tag));
+        }
+
+        return $offset;
+    }
+
+    /**
+     * Normalises a floating-point offset representation to a validated integer.
+     *
+     * @param float $value Floating-point representation to normalise.
+     * @param int   $tag   Tag identifier emitting the offset.
+     *
+     * @return int
+     */
+    private function pointerOffsetFromFloat(float $value, int $tag): int
+    {
+        if (!is_finite($value) || (float) (int) $value !== $value) {
+            throw new ParseError(sprintf('IFD pointer tag 0x%04X must contain an integer offset.', $tag));
+        }
+
+        if ($value < 0.0 || $value > PHP_INT_MAX) {
+            throw new ParseError(sprintf('IFD pointer tag 0x%04X is out of range.', $tag));
+        }
+
+        return $this->validatePointerOffset((int) $value, $tag);
     }
 }

--- a/tests/Parse/Tiff/TiffExifReaderTest.php
+++ b/tests/Parse/Tiff/TiffExifReaderTest.php
@@ -255,6 +255,25 @@ final class TiffExifReaderTest extends TestCase
     }
 
     /**
+     * Ensures BigTIFF headers with an overflowing first IFD offset are rejected.
+     */
+    #[Test]
+    public function rejectsBigTiffFirstIfdOffsetOverflow(): void
+    {
+        $blob = 'II'
+            . pack('v', 0x002B)
+            . pack('v', 8)
+            . pack('v', 0)
+            . pack('V', 0x00000000)
+            . pack('V', 0x80000000);
+
+        $this->expectException(ParseError::class);
+        $this->expectExceptionMessage('exceeds PHP_INT_MAX');
+
+        (new TiffExifReader())->parseFromBlob($blob);
+    }
+
+    /**
      * Ensures that invalid pointer offsets trigger bounds checking errors.
      */
     #[Test]


### PR DESCRIPTION
## Summary
- guard `Unpack::combineUint32()` against unsigned 64-bit values that exceed `PHP_INT_MAX`
- raise a `ParseError` when BigTIFF offsets overflow while normalising pointer values
- add regression coverage to ensure BigTIFF headers with overflowing first IFD offsets are rejected

## Testing
- `composer ci:test:php:unit` *(fails: existing truth-comparison fixtures are unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68fe3d87d8308323b30b7a683649ec0f