### PR TITLE
fix: guard EXIF 3.0 software name lookups on legacy data

### DIFF
--- a/src/Model/Exif/ExifDocument.php
+++ b/src/Model/Exif/ExifDocument.php
@@ -1258,9 +1258,15 @@ final readonly class ExifDocument
      */
     public function cameraFirmware(): ?string
     {
-        $value = $this->str($this->exifIfd, ExifTag::CAMERA_FIRMWARE);
+        if ($this->exifThreeOrNewer) {
+            $value = $this->str($this->exifIfd, ExifTag::CAMERA_FIRMWARE);
 
-        return $value ?? $this->str($this->exifIfd, ExifTag::CAMERA_FIRMWARE_LEGACY);
+            if ($value !== null) {
+                return $value;
+            }
+        }
+
+        return $this->str($this->exifIfd, ExifTag::CAMERA_FIRMWARE_LEGACY);
     }
 
     /**
@@ -1309,9 +1315,15 @@ final readonly class ExifDocument
      */
     public function imageEditingSoftware(): ?string
     {
-        $value = $this->str($this->exifIfd, ExifTag::IMAGE_EDITING_SOFTWARE);
+        if ($this->exifThreeOrNewer) {
+            $value = $this->str($this->exifIfd, ExifTag::IMAGE_EDITING_SOFTWARE);
 
-        return $value ?? $this->str($this->exifIfd, ExifTag::IMAGE_EDITING_SOFTWARE_LEGACY);
+            if ($value !== null) {
+                return $value;
+            }
+        }
+
+        return $this->str($this->exifIfd, ExifTag::IMAGE_EDITING_SOFTWARE_LEGACY);
     }
 
     /**
@@ -1319,9 +1331,15 @@ final readonly class ExifDocument
      */
     public function metadataEditingSoftware(): ?string
     {
-        $value = $this->str($this->exifIfd, ExifTag::METADATA_EDITING_SOFTWARE);
+        if ($this->exifThreeOrNewer) {
+            $value = $this->str($this->exifIfd, ExifTag::METADATA_EDITING_SOFTWARE);
 
-        return $value ?? $this->str($this->exifIfd, ExifTag::METADATA_EDITING_SOFTWARE_LEGACY);
+            if ($value !== null) {
+                return $value;
+            }
+        }
+
+        return $this->str($this->exifIfd, ExifTag::METADATA_EDITING_SOFTWARE_LEGACY);
     }
 
     /**

--- a/tests/Curate/Resolver/ExifTagResolverTest.php
+++ b/tests/Curate/Resolver/ExifTagResolverTest.php
@@ -333,6 +333,9 @@ final class ExifTagResolverTest extends TestCase
             ExifTag::RAW_DEVELOPING_SOFTWARE   => new IfdEntry(ExifTag::RAW_DEVELOPING_SOFTWARE, 2, 1, 'Raw Studio'),
             ExifTag::IMAGE_EDITING_SOFTWARE    => new IfdEntry(ExifTag::IMAGE_EDITING_SOFTWARE, 2, 1, 'Pixel Edit'),
             ExifTag::METADATA_EDITING_SOFTWARE => new IfdEntry(ExifTag::METADATA_EDITING_SOFTWARE, 2, 1, 'Meta Desk'),
+            ExifTag::CAMERA_FIRMWARE_LEGACY      => new IfdEntry(ExifTag::CAMERA_FIRMWARE_LEGACY, 2, 1, 'FW Main'),
+            ExifTag::IMAGE_EDITING_SOFTWARE_LEGACY    => new IfdEntry(ExifTag::IMAGE_EDITING_SOFTWARE_LEGACY, 2, 1, 'Pixel Edit'),
+            ExifTag::METADATA_EDITING_SOFTWARE_LEGACY => new IfdEntry(ExifTag::METADATA_EDITING_SOFTWARE_LEGACY, 2, 1, 'Meta Desk'),
         ]);
 
         $document = new ExifDocument($ifd0, $exifIfd, null, null, null);
@@ -400,6 +403,26 @@ final class ExifTagResolverTest extends TestCase
         self::assertSame('Legacy Raw', $resolver->rawDevelopingSoftware());
         self::assertSame('Legacy Edit', $resolver->imageEditingSoftware());
         self::assertSame('Legacy Meta', $resolver->metadataEditingSoftware());
+    }
+
+    #[Test]
+    public function exifTwoResolverPrefersLegacySoftwareNamesOverVersionStrings(): void
+    {
+        $exifIfd = new Ifd([
+            ExifTag::EXIF_VERSION                    => new IfdEntry(ExifTag::EXIF_VERSION, 7, 4, '0221'),
+            ExifTag::CAMERA_FIRMWARE                 => new IfdEntry(ExifTag::CAMERA_FIRMWARE, 2, 1, 'FW 1.2.3'),
+            ExifTag::IMAGE_EDITING_SOFTWARE          => new IfdEntry(ExifTag::IMAGE_EDITING_SOFTWARE, 2, 1, 'Edit Suite 4.5'),
+            ExifTag::METADATA_EDITING_SOFTWARE       => new IfdEntry(ExifTag::METADATA_EDITING_SOFTWARE, 2, 1, 'Meta Suite 6.7'),
+            ExifTag::CAMERA_FIRMWARE_LEGACY          => new IfdEntry(ExifTag::CAMERA_FIRMWARE_LEGACY, 2, 1, 'Legacy Firmware Name'),
+            ExifTag::IMAGE_EDITING_SOFTWARE_LEGACY   => new IfdEntry(ExifTag::IMAGE_EDITING_SOFTWARE_LEGACY, 2, 1, 'Legacy Editor Name'),
+            ExifTag::METADATA_EDITING_SOFTWARE_LEGACY => new IfdEntry(ExifTag::METADATA_EDITING_SOFTWARE_LEGACY, 2, 1, 'Legacy Metadata Name'),
+        ]);
+
+        $resolver = new ExifTagResolver(new ExifDocument(new Ifd([]), $exifIfd, null, null, null));
+
+        self::assertSame('Legacy Firmware Name', $resolver->cameraFirmware());
+        self::assertSame('Legacy Editor Name', $resolver->imageEditingSoftware());
+        self::assertSame('Legacy Metadata Name', $resolver->metadataEditingSoftware());
     }
 
     #[Test]

--- a/tests/Model/Exif/ExifDocumentTest.php
+++ b/tests/Model/Exif/ExifDocumentTest.php
@@ -804,7 +804,9 @@ final class ExifDocumentTest extends TestCase
             ExifTag::RAW_DEVELOPING_SOFTWARE     => new IfdEntry(ExifTag::RAW_DEVELOPING_SOFTWARE, 2, 1, 'RawLab'),
             ExifTag::IMAGE_EDITING_SOFTWARE      => new IfdEntry(ExifTag::IMAGE_EDITING_SOFTWARE, 2, 1, 'EditLab'),
             ExifTag::METADATA_EDITING_SOFTWARE   => new IfdEntry(ExifTag::METADATA_EDITING_SOFTWARE, 2, 1, 'MetaLab'),
-            ExifTag::CAMERA_FIRMWARE_LEGACY      => new IfdEntry(ExifTag::CAMERA_FIRMWARE_LEGACY, 2, 1, 'FW Legacy'),
+            ExifTag::IMAGE_EDITING_SOFTWARE_LEGACY    => new IfdEntry(ExifTag::IMAGE_EDITING_SOFTWARE_LEGACY, 2, 1, 'EditLab'),
+            ExifTag::METADATA_EDITING_SOFTWARE_LEGACY => new IfdEntry(ExifTag::METADATA_EDITING_SOFTWARE_LEGACY, 2, 1, 'MetaLab'),
+            ExifTag::CAMERA_FIRMWARE_LEGACY      => new IfdEntry(ExifTag::CAMERA_FIRMWARE_LEGACY, 2, 1, 'FW 2.0'),
         ]);
 
         $doc = new ExifDocument($ifd0, $exifIfd, null, null, null);
@@ -988,6 +990,26 @@ final class ExifDocumentTest extends TestCase
         self::assertSame('Legacy Raw', $doc->rawDevelopingSoftware());
         self::assertSame('Legacy Edit', $doc->imageEditingSoftware());
         self::assertSame('Legacy Meta', $doc->metadataEditingSoftware());
+    }
+
+    #[Test]
+    public function exifTwoPrefersLegacySoftwareNamesOverVersionStrings(): void
+    {
+        $exifIfd = new Ifd([
+            ExifTag::EXIF_VERSION                    => new IfdEntry(ExifTag::EXIF_VERSION, 7, 4, '0221'),
+            ExifTag::CAMERA_FIRMWARE                 => new IfdEntry(ExifTag::CAMERA_FIRMWARE, 2, 1, 'FW 1.2.3'),
+            ExifTag::IMAGE_EDITING_SOFTWARE          => new IfdEntry(ExifTag::IMAGE_EDITING_SOFTWARE, 2, 1, 'Edit Suite 4.5'),
+            ExifTag::METADATA_EDITING_SOFTWARE       => new IfdEntry(ExifTag::METADATA_EDITING_SOFTWARE, 2, 1, 'Meta Suite 6.7'),
+            ExifTag::CAMERA_FIRMWARE_LEGACY          => new IfdEntry(ExifTag::CAMERA_FIRMWARE_LEGACY, 2, 1, 'Legacy Firmware Name'),
+            ExifTag::IMAGE_EDITING_SOFTWARE_LEGACY   => new IfdEntry(ExifTag::IMAGE_EDITING_SOFTWARE_LEGACY, 2, 1, 'Legacy Editor Name'),
+            ExifTag::METADATA_EDITING_SOFTWARE_LEGACY => new IfdEntry(ExifTag::METADATA_EDITING_SOFTWARE_LEGACY, 2, 1, 'Legacy Metadata Name'),
+        ]);
+
+        $doc = new ExifDocument(new Ifd([]), $exifIfd, null, null, null);
+
+        self::assertSame('Legacy Firmware Name', $doc->cameraFirmware());
+        self::assertSame('Legacy Editor Name', $doc->imageEditingSoftware());
+        self::assertSame('Legacy Metadata Name', $doc->metadataEditingSoftware());
     }
 
     #[Test]


### PR DESCRIPTION
## Summary
- gate cameraFirmware/imageEditingSoftware/metadataEditingSoftware so EXIF 3.0 identifiers are read only for EXIF ≥ 3.0 payloads
- ensure EXIF 2.x fixtures include legacy tags and add regression coverage for version strings in 0xA439/0xA43B/0xA43C
- mirror the new expectations in the ExifTagResolver tests

## Testing
- composer ci:test:php:unit -- --filter ExifDocumentTest
- composer ci:test:php:unit -- --filter ExifTagResolverTest

------
https://chatgpt.com/codex/tasks/task_e_68fe3d9e7cc48323927a9e97f743198b