### PR TITLE
feat: expose legacy image editing software version

### DIFF
--- a/src/Curate/Resolver/ExifTagResolver.php
+++ b/src/Curate/Resolver/ExifTagResolver.php
@@ -348,6 +348,14 @@ final readonly class ExifTagResolver
     }
 
     /**
+     * Returns the image editing software version string when recorded via legacy tags.
+     */
+    public function imageEditingSoftwareVersion(): ?string
+    {
+        return $this->document?->imageEditingSoftwareVersion();
+    }
+
+    /**
      * Returns the metadata editing software string.
      */
     public function metadataEditingSoftware(): ?string

--- a/src/Model/Exif/ExifDocument.php
+++ b/src/Model/Exif/ExifDocument.php
@@ -1315,6 +1315,21 @@ final readonly class ExifDocument
     }
 
     /**
+     * Returns the image editing software version string when legacy tags are provided.
+     *
+     * EXIF 3.0 reassigned the identifier to IMAGE_EDITING_SOFTWARE, so only legacy
+     * metadata produces a value.
+     */
+    public function imageEditingSoftwareVersion(): ?string
+    {
+        if ($this->exifThreeOrNewer) {
+            return null;
+        }
+
+        return $this->str($this->exifIfd, ExifTag::IMAGE_EDITING_SOFTWARE_VERSION_LEGACY);
+    }
+
+    /**
      * Returns the metadata editing software string.
      */
     public function metadataEditingSoftware(): ?string

--- a/tests/Curate/Resolver/ExifTagResolverTest.php
+++ b/tests/Curate/Resolver/ExifTagResolverTest.php
@@ -447,6 +447,7 @@ final class ExifTagResolverTest extends TestCase
         $exifIfd = new Ifd([
             ExifTag::CAMERA_FIRMWARE_VERSION_LEGACY           => new IfdEntry(ExifTag::CAMERA_FIRMWARE_VERSION_LEGACY, 2, 1, 'FW 3.1.0'),
             ExifTag::RAW_DEVELOPING_SOFTWARE_VERSION_LEGACY   => new IfdEntry(ExifTag::RAW_DEVELOPING_SOFTWARE_VERSION_LEGACY, 2, 1, 'RawLab 5.2.1'),
+            ExifTag::IMAGE_EDITING_SOFTWARE_VERSION_LEGACY    => new IfdEntry(ExifTag::IMAGE_EDITING_SOFTWARE_VERSION_LEGACY, 2, 1, 'ImageLab 2.3'),
             ExifTag::METADATA_EDITING_SOFTWARE_VERSION_LEGACY => new IfdEntry(ExifTag::METADATA_EDITING_SOFTWARE_VERSION_LEGACY, 2, 1, 'MetaLab 1.0.0'),
         ]);
 
@@ -454,6 +455,7 @@ final class ExifTagResolverTest extends TestCase
 
         self::assertSame('FW 3.1.0', $resolver->cameraFirmwareVersion());
         self::assertSame('RawLab 5.2.1', $resolver->rawDevelopingSoftwareVersion());
+        self::assertSame('ImageLab 2.3', $resolver->imageEditingSoftwareVersion());
         self::assertSame('MetaLab 1.0.0', $resolver->metadataEditingSoftwareVersion());
     }
 

--- a/tests/Model/Exif/ExifDocumentTest.php
+++ b/tests/Model/Exif/ExifDocumentTest.php
@@ -996,6 +996,7 @@ final class ExifDocumentTest extends TestCase
         $exifIfd = new Ifd([
             ExifTag::CAMERA_FIRMWARE_VERSION_LEGACY           => new IfdEntry(ExifTag::CAMERA_FIRMWARE_VERSION_LEGACY, 2, 1, 'FW 3.1.0'),
             ExifTag::RAW_DEVELOPING_SOFTWARE_VERSION_LEGACY   => new IfdEntry(ExifTag::RAW_DEVELOPING_SOFTWARE_VERSION_LEGACY, 2, 1, 'RawLab 5.2.1'),
+            ExifTag::IMAGE_EDITING_SOFTWARE_VERSION_LEGACY    => new IfdEntry(ExifTag::IMAGE_EDITING_SOFTWARE_VERSION_LEGACY, 2, 1, 'ImageLab 2.3'),
             ExifTag::METADATA_EDITING_SOFTWARE_VERSION_LEGACY => new IfdEntry(ExifTag::METADATA_EDITING_SOFTWARE_VERSION_LEGACY, 2, 1, 'MetaLab 1.0.0'),
         ]);
 
@@ -1003,6 +1004,7 @@ final class ExifDocumentTest extends TestCase
 
         self::assertSame('FW 3.1.0', $doc->cameraFirmwareVersion());
         self::assertSame('RawLab 5.2.1', $doc->rawDevelopingSoftwareVersion());
+        self::assertSame('ImageLab 2.3', $doc->imageEditingSoftwareVersion());
         self::assertSame('MetaLab 1.0.0', $doc->metadataEditingSoftwareVersion());
     }
 
@@ -1083,6 +1085,7 @@ final class ExifDocumentTest extends TestCase
         self::assertSame('Raw Developer X', $doc->rawDevelopingSoftware());
         self::assertNull($doc->rawDevelopingSoftwareVersion());
         self::assertSame('Image Editor Y', $doc->imageEditingSoftware());
+        self::assertNull($doc->imageEditingSoftwareVersion());
         self::assertSame('Metadata Tool Z', $doc->metadataEditingSoftware());
         self::assertNull($doc->metadataEditingSoftwareVersion());
     }


### PR DESCRIPTION
## Summary
- add an EXIF document accessor for legacy image editing software versions that is disabled for EXIF 3 payloads
- expose the new accessor via the tag resolver for structured consumers
- extend EXIF document and resolver tests to cover legacy image editing software version data

## Testing
- composer ci:test:php:unit *(fails: TruthComparisonTest fixture expectations and unsupported HEIC containers in the current environment)*

------
https://chatgpt.com/codex/tasks/task_e_68fe3da18ce483239532aadf8a53d45f