### PR TITLE
feat(exif): support camera serial number tag

### DIFF
--- a/src/Curate/Resolver/CameraResolver.php
+++ b/src/Curate/Resolver/CameraResolver.php
@@ -36,7 +36,7 @@ final readonly class CameraResolver
         $make     = $exifDocument?->cameraMake() ?? $this->xmpString($xmpDocument, self::NS_TIFF, 'Make');
         $model    = $exifDocument?->cameraModel() ?? $this->xmpString($xmpDocument, self::NS_TIFF, 'Model');
         $owner    = $exifDocument?->ownerName() ?? $this->xmpString($xmpDocument, self::NS_AUX, 'OwnerName');
-        $serial   = $exifDocument?->bodySerialNumber() ?? $this->xmpString($xmpDocument, self::NS_AUX, 'SerialNumber');
+        $serial   = $exifDocument?->cameraSerialNumber() ?? $this->xmpString($xmpDocument, self::NS_AUX, 'SerialNumber');
         $firmware = $this->xmpString($xmpDocument, self::NS_XMP, 'CreatorTool');
 
         if ($make === null && $model === null && $owner === null && $serial === null && $firmware === null) {

--- a/src/Curate/Resolver/ExifTagResolver.php
+++ b/src/Curate/Resolver/ExifTagResolver.php
@@ -277,6 +277,14 @@ final readonly class ExifTagResolver
     }
 
     /**
+     * Returns the preferred camera serial number across EXIF versions.
+     */
+    public function cameraSerialNumber(): ?string
+    {
+        return $this->document?->cameraSerialNumber();
+    }
+
+    /**
      * Returns the processing software string when recorded.
      */
     public function processingSoftware(): ?string

--- a/src/Curate/StructuredMetadataBuilder.php
+++ b/src/Curate/StructuredMetadataBuilder.php
@@ -659,7 +659,7 @@ final class StructuredMetadataBuilder
             make: $exif->cameraMake(),
             model: $exif->cameraModel(),
             ownerName: $exif->ownerName(),
-            serialNumber: $exif->bodySerialNumber(),
+            serialNumber: $exif->cameraSerialNumber(),
             firmware: CompositeResolver::first($firmwareCandidates),
             fileSource: $exif->fileSource(),
             sensingMethod: $exif->sensingMethod(),

--- a/src/Model/Exif/ExifDocument.php
+++ b/src/Model/Exif/ExifDocument.php
@@ -198,6 +198,20 @@ final readonly class ExifDocument
     }
 
     /**
+     * Returns the camera serial number, preferring the EXIF 3.0 tag when available.
+     */
+    public function cameraSerialNumber(): ?string
+    {
+        $serial = $this->str($this->exifIfd, ExifTag::CAMERA_SERIAL_NUMBER);
+
+        if ($serial !== null) {
+            return $serial;
+        }
+
+        return $this->bodySerialNumber();
+    }
+
+    /**
      * Returns the lens serial number if present.
      *
      * @return string|null

--- a/src/Model/Exif/ExifTag.php
+++ b/src/Model/Exif/ExifTag.php
@@ -307,6 +307,8 @@ final readonly class ExifTag
 
     public const int BODY_SERIAL_NUMBER = 0xA431;
 
+    public const int CAMERA_SERIAL_NUMBER = 0xC62F;
+
     public const int LENS_SPECIFICATION = 0xA432;
 
     public const int LENS_MAKE = 0xA433;

--- a/tests/Curate/Resolver/ExifTagResolverTest.php
+++ b/tests/Curate/Resolver/ExifTagResolverTest.php
@@ -458,6 +458,32 @@ final class ExifTagResolverTest extends TestCase
     }
 
     #[Test]
+    public function cameraSerialNumberPrefersNewTag(): void
+    {
+        $exifIfd = new Ifd([
+            ExifTag::CAMERA_SERIAL_NUMBER => new IfdEntry(ExifTag::CAMERA_SERIAL_NUMBER, 2, 1, 'NEW-SERIAL'),
+            ExifTag::BODY_SERIAL_NUMBER   => new IfdEntry(ExifTag::BODY_SERIAL_NUMBER, 2, 1, 'LEGACY-SERIAL'),
+        ]);
+
+        $resolver = new ExifTagResolver(new ExifDocument(new Ifd([]), $exifIfd, null, null, null));
+
+        self::assertSame('NEW-SERIAL', $resolver->cameraSerialNumber());
+        self::assertSame('LEGACY-SERIAL', $resolver->bodySerialNumber());
+    }
+
+    #[Test]
+    public function cameraSerialNumberFallsBackToLegacyTag(): void
+    {
+        $exifIfd = new Ifd([
+            ExifTag::BODY_SERIAL_NUMBER => new IfdEntry(ExifTag::BODY_SERIAL_NUMBER, 2, 1, 'LEGACY-ONLY'),
+        ]);
+
+        $resolver = new ExifTagResolver(new ExifDocument(new Ifd([]), $exifIfd, null, null, null));
+
+        self::assertSame('LEGACY-ONLY', $resolver->cameraSerialNumber());
+    }
+
+    #[Test]
     public function resolvesMakerNoteSafetyFlag(): void
     {
         $safeIfd = new Ifd([

--- a/tests/Model/Exif/ExifDocumentTest.php
+++ b/tests/Model/Exif/ExifDocumentTest.php
@@ -709,6 +709,32 @@ final class ExifDocumentTest extends TestCase
     }
 
     #[Test]
+    public function cameraSerialNumberPrefersNewTag(): void
+    {
+        $exifIfd = new Ifd([
+            ExifTag::CAMERA_SERIAL_NUMBER => new IfdEntry(ExifTag::CAMERA_SERIAL_NUMBER, 2, 1, "CAMERA-0001\0"),
+            ExifTag::BODY_SERIAL_NUMBER   => new IfdEntry(ExifTag::BODY_SERIAL_NUMBER, 2, 1, 'BODY-LEGACY'),
+        ]);
+
+        $doc = new ExifDocument(new Ifd([]), $exifIfd, null, null, null);
+
+        self::assertSame('CAMERA-0001', $doc->cameraSerialNumber());
+        self::assertSame('BODY-LEGACY', $doc->bodySerialNumber());
+    }
+
+    #[Test]
+    public function cameraSerialNumberFallsBackToBodyTag(): void
+    {
+        $exifIfd = new Ifd([
+            ExifTag::BODY_SERIAL_NUMBER => new IfdEntry(ExifTag::BODY_SERIAL_NUMBER, 2, 1, 'BODY-ONLY'),
+        ]);
+
+        $doc = new ExifDocument(new Ifd([]), $exifIfd, null, null, null);
+
+        self::assertSame('BODY-ONLY', $doc->cameraSerialNumber());
+    }
+
+    #[Test]
     public function makerNoteSafetyMapsNumericValues(): void
     {
         $safeExifIfd = new Ifd([

--- a/tests/Model/Exif/ExifTagTest.php
+++ b/tests/Model/Exif/ExifTagTest.php
@@ -195,6 +195,7 @@ final class ExifTagTest extends TestCase
             'IMAGE_UNIQUE_ID'                          => 0xA420,
             'CAMERA_OWNER_NAME'                        => 0xA430,
             'BODY_SERIAL_NUMBER'                       => 0xA431,
+            'CAMERA_SERIAL_NUMBER'                     => 0xC62F,
             'LENS_SPECIFICATION'                       => 0xA432,
             'LENS_MAKE'                                => 0xA433,
             'LENS_MODEL'                               => 0xA434,


### PR DESCRIPTION
## Summary
- add the CAMERA_SERIAL_NUMBER constant and expose a cameraSerialNumber accessor that falls back to BODY_SERIAL_NUMBER
- wire the new accessor through the EXIF resolver and structured metadata builder so camera metadata can read the newer tag
- extend the EXIF document, resolver, and tag constant tests to cover both modern and legacy serial number payloads

## Testing
- .build/bin/phpunit --configuration .build/phpunit.xml tests/Model/Exif/ExifTagTest.php tests/Model/Exif/ExifDocumentTest.php tests/Curate/Resolver/ExifTagResolverTest.php

------
https://chatgpt.com/codex/tasks/task_e_68fe3dba6044832392703cf484aff9d6