### PR TITLE
feat(exif): expose acceleration vectors

### DIFF
--- a/docs/fields.md
+++ b/docs/fields.md
@@ -17,8 +17,8 @@ circle of confusion (CoC) model used by the derived metrics helper.
   * `Capture::cameraElevationAngleDeg`
   * `Gps::track`, `Gps::imageDirection`, `Gps::destinationBearing`
 * **Metres per second squared (m/s²)**
-  * `Capture::accelerationMs2`
-  * `Motion::accelX`, `Motion::accelY`, `Motion::accelZ`
+  * `Capture::accelerationMs2`, `Capture::accelerationVectorMs2`
+  * `Motion::accelX`, `Motion::accelY`, `Motion::accelZ`, `Motion::accelerationVectorMs2`
 
 Unless stated otherwise, temperatures recorded via EXIF tags (for example `Capture::temperatureC`) remain in Celsius.
 Time zone offsets in `Temporal` are expressed as raw EXIF strings and minutes (`timeZoneOffsetMinutes`). GPS speed values

--- a/src/Curate/Resolver/CaptureResolver.php
+++ b/src/Curate/Resolver/CaptureResolver.php
@@ -52,6 +52,7 @@ final readonly class CaptureResolver
             batteryLevelPercent: $exifDocument?->batteryLevelPercent(),
             waterDepthM: null,
             accelerationMs2: null,
+            accelerationVectorMs2: null,
             cameraElevationAngleDeg: null,
             selfTimerModeSeconds: $exifDocument?->selfTimerModeSeconds(),
         );

--- a/src/Curate/Resolver/ExifTagResolver.php
+++ b/src/Curate/Resolver/ExifTagResolver.php
@@ -1802,6 +1802,16 @@ final readonly class ExifTagResolver
     }
 
     /**
+     * Returns the camera acceleration vector in m/s².
+     *
+     * @return list<float>|null
+     */
+    public function accelerationVectorMs2(): ?array
+    {
+        return $this->document?->accelerationVectorMs2();
+    }
+
+    /**
      * Returns the camera elevation angle in degrees.
      */
     public function cameraElevationAngleDeg(): ?float

--- a/src/Curate/StructuredMetadataBuilder.php
+++ b/src/Curate/StructuredMetadataBuilder.php
@@ -248,6 +248,7 @@ final class StructuredMetadataBuilder
             batteryLevelPercent: $exifResolver->batteryLevelPercent(),
             waterDepthM: $exifResolver->waterDepthMeters(),
             accelerationMs2: $exifResolver->accelerationMs2(),
+            accelerationVectorMs2: $exifResolver->accelerationVectorMs2(),
             cameraElevationAngleDeg: $exifResolver->cameraElevationAngleDeg(),
             selfTimerModeSeconds: $exifResolver->selfTimerModeSeconds(),
         );
@@ -1049,19 +1050,32 @@ final class StructuredMetadataBuilder
         $pitchDeg = $exif->cameraPitchDeg();
         $yawDeg   = $exif->cameraYawDeg();
 
-        $vector = $apple->accelerationVector;
+        $appleVector = is_array($apple->accelerationVector) ? $apple->accelerationVector : null;
+        $exifVector  = $exif->accelerationVectorMs2();
 
         $accelX = null;
         $accelY = null;
         $accelZ = null;
 
-        if (is_array($vector)) {
-            $accelX = $vector[0] ?? null;
-            $accelY = $vector[1] ?? null;
-            $accelZ = $vector[2] ?? null;
+        if (is_array($appleVector)) {
+            $accelX = $appleVector[0] ?? null;
+            $accelY = $appleVector[1] ?? null;
+            $accelZ = $appleVector[2] ?? null;
         }
 
-        return new Motion($rollDeg, $pitchDeg, $yawDeg, $accelX, $accelY, $accelZ, null, null, null);
+        if ($accelX === null && is_array($exifVector)) {
+            $accelX = $exifVector[0] ?? null;
+        }
+
+        if ($accelY === null && is_array($exifVector)) {
+            $accelY = $exifVector[1] ?? null;
+        }
+
+        if ($accelZ === null && is_array($exifVector)) {
+            $accelZ = $exifVector[2] ?? null;
+        }
+
+        return new Motion($rollDeg, $pitchDeg, $yawDeg, $accelX, $accelY, $accelZ, null, null, null, $exifVector);
     }
 
     private function buildUav(ExifTagResolver $exif, QuickTimeResolver $quickTime): Uav

--- a/src/Model/Exif/ExifDocument.php
+++ b/src/Model/Exif/ExifDocument.php
@@ -32,6 +32,7 @@ use function ord;
 use function preg_replace;
 use function preg_split;
 use function rtrim;
+use function sqrt;
 use function str_pad;
 use function str_replace;
 use function strlen;
@@ -1166,10 +1167,28 @@ final readonly class ExifDocument
     }
 
     /**
-     * Returns the camera acceleration in metres per second squared.
+     * Returns the camera acceleration vector in metres per second squared.
+     *
+     * @return list<float>|null
+     */
+    public function accelerationVectorMs2(): ?array
+    {
+        $value = $this->value($this->exifIfd, ExifTag::ACCELERATION);
+
+        return ValueConverters::accelerationVector($value);
+    }
+
+    /**
+     * Returns the camera acceleration magnitude in metres per second squared.
      */
     public function accelerationMs2(): ?float
     {
+        $vector = $this->accelerationVectorMs2();
+
+        if (is_array($vector)) {
+            return sqrt(($vector[0] ** 2) + ($vector[1] ** 2) + ($vector[2] ** 2));
+        }
+
         return $this->rational($this->exifIfd, ExifTag::ACCELERATION);
     }
 

--- a/src/Model/Exif/ValueConverters.php
+++ b/src/Model/Exif/ValueConverters.php
@@ -198,6 +198,45 @@ final readonly class ValueConverters
     }
 
     /**
+     * Normalises the EXIF acceleration vector to a list of floats.
+     *
+     * @param int|float|string|ExifRational|ExifRationalList|ExifNumericList|null $value Raw acceleration value.
+     *
+     * @return list<float>|null
+     */
+    public static function accelerationVector(
+        int|float|string|ExifRational|ExifRationalList|ExifNumericList|null $value,
+    ): ?array {
+        if ($value instanceof ExifRationalList) {
+            if (count($value->values) !== 3) {
+                return null;
+            }
+
+            $vector = [];
+            foreach ($value->values as $component) {
+                $float = self::rationalToFloat($component);
+                if ($float === null) {
+                    return null;
+                }
+
+                $vector[] = $float;
+            }
+
+            return $vector;
+        }
+
+        if ($value instanceof ExifNumericList) {
+            if (count($value->values) !== 3) {
+                return null;
+            }
+
+            return array_map(static fn (int|float $component): float => (float) $component, $value->values);
+        }
+
+        return null;
+    }
+
+    /**
      * Scales ratios to percentages when battery readings are encoded as fractions.
      */
     private static function normaliseBatteryPercent(float $value): float

--- a/src/Value/Capture.php
+++ b/src/Value/Capture.php
@@ -25,7 +25,8 @@ final readonly class Capture
      * @param float|null             $pressureHPa             Ambient pressure in hPa.
      * @param float|null             $batteryLevelPercent      Battery level percentage.
      * @param float|null             $waterDepthM             Water depth in metres.
-     * @param float|null             $accelerationMs2         Camera acceleration in metres per second squared.
+     * @param float|null             $accelerationMs2         Camera acceleration magnitude in metres per second squared.
+     * @param list<float>|null       $accelerationVectorMs2   Camera acceleration vector in metres per second squared.
      * @param float|null             $cameraElevationAngleDeg Camera elevation angle in degrees.
      * @param int|null               $selfTimerModeSeconds    Configured self timer delay in seconds.
      */
@@ -37,6 +38,7 @@ final readonly class Capture
         public ?float $batteryLevelPercent,
         public ?float $waterDepthM,
         public ?float $accelerationMs2,
+        public ?array $accelerationVectorMs2,
         public ?float $cameraElevationAngleDeg,
         public ?int $selfTimerModeSeconds,
     ) {

--- a/src/Value/Motion.php
+++ b/src/Value/Motion.php
@@ -26,6 +26,7 @@ final readonly class Motion
      * @param float|null $gyroX    Gyroscope reading around the X axis.
      * @param float|null $gyroY    Gyroscope reading around the Y axis.
      * @param float|null $gyroZ    Gyroscope reading around the Z axis.
+     * @param list<float>|null $accelerationVectorMs2 Acceleration vector sourced from EXIF measurements.
      */
     public function __construct(
         public ?float $rollDeg,
@@ -37,6 +38,7 @@ final readonly class Motion
         public ?float $gyroX,
         public ?float $gyroY,
         public ?float $gyroZ,
+        public ?array $accelerationVectorMs2,
     ) {
     }
 }

--- a/tests/Curate/StructuredMetadataBuilderTest.php
+++ b/tests/Curate/StructuredMetadataBuilderTest.php
@@ -164,7 +164,16 @@ final class StructuredMetadataBuilderTest extends TestCase
             ExifTag::PRESSURE                    => new IfdEntry(ExifTag::PRESSURE, 10, 1, new ExifRational(101325, 100)),
             ExifTag::BATTERY_LEVEL               => new IfdEntry(ExifTag::BATTERY_LEVEL, 5, 1, new ExifRational(82, 100)),
             ExifTag::WATER_DEPTH                 => new IfdEntry(ExifTag::WATER_DEPTH, 10, 1, new ExifRational(150, 10)),
-            ExifTag::ACCELERATION                => new IfdEntry(ExifTag::ACCELERATION, 10, 1, new ExifRational(98, 10)),
+            ExifTag::ACCELERATION                => new IfdEntry(
+                ExifTag::ACCELERATION,
+                10,
+                3,
+                new ExifRationalList([
+                    new ExifRational(98, 10),
+                    new ExifRational(0, 1),
+                    new ExifRational(0, 1),
+                ]),
+            ),
             ExifTag::CAMERA_ELEVATION_ANGLE      => new IfdEntry(ExifTag::CAMERA_ELEVATION_ANGLE, 10, 1, new ExifRational(150, 10)),
             ExifTag::AIRCRAFT_MAKE               => new IfdEntry(ExifTag::AIRCRAFT_MAKE, 2, 3, 'DJI'),
             ExifTag::AIRCRAFT_MODEL              => new IfdEntry(ExifTag::AIRCRAFT_MODEL, 2, 6, 'Mavic 3'),
@@ -331,6 +340,7 @@ final class StructuredMetadataBuilderTest extends TestCase
         self::assertEqualsWithDelta(1013.25, $structured->capture->pressureHPa, 0.001);
         self::assertEqualsWithDelta(15.0, $structured->capture->waterDepthM, 0.001);
         self::assertEqualsWithDelta(9.8, $structured->capture->accelerationMs2, 0.001);
+        self::assertSame([9.8, 0.0, 0.0], $structured->capture->accelerationVectorMs2);
         self::assertEqualsWithDelta(15.0, $structured->capture->cameraElevationAngleDeg, 0.001);
         self::assertSame(10, $structured->capture->selfTimerModeSeconds);
         self::assertSame('DJI', $structured->uav->manufacturer);
@@ -350,6 +360,10 @@ final class StructuredMetadataBuilderTest extends TestCase
         self::assertEqualsWithDelta(2.0, $motionRoll, 0.0001);
         self::assertEqualsWithDelta(-3.5, $motionPitch, 0.0001);
         self::assertEqualsWithDelta(12.3, $motionYaw, 0.0001);
+        self::assertSame([9.8, 0.0, 0.0], $structured->motion->accelerationVectorMs2);
+        self::assertEqualsWithDelta(9.8, $structured->motion->accelX ?? 0.0, 0.0001);
+        self::assertEqualsWithDelta(0.0, $structured->motion->accelY ?? 0.0, 0.0001);
+        self::assertEqualsWithDelta(0.0, $structured->motion->accelZ ?? 0.0, 0.0001);
 
         self::assertSame('sound.wav', $structured->related->relatedSoundFile);
 
@@ -853,6 +867,7 @@ final class StructuredMetadataBuilderTest extends TestCase
         self::assertEqualsWithDelta(0.12, $structured->motion->accelX, 1e-12);
         self::assertEqualsWithDelta(-0.34, $structured->motion->accelY, 1e-12);
         self::assertEqualsWithDelta(0.56, $structured->motion->accelZ, 1e-12);
+        self::assertNull($structured->motion->accelerationVectorMs2);
     }
 
     #[Test]

--- a/tests/Model/Exif/ExifDocumentTest.php
+++ b/tests/Model/Exif/ExifDocumentTest.php
@@ -785,7 +785,16 @@ final class ExifDocumentTest extends TestCase
             ExifTag::PRESSURE                    => new IfdEntry(ExifTag::PRESSURE, 10, 1, new ExifRational(100000, 100)),
             ExifTag::BATTERY_LEVEL               => new IfdEntry(ExifTag::BATTERY_LEVEL, 5, 1, new ExifRational(3, 4)),
             ExifTag::WATER_DEPTH                 => new IfdEntry(ExifTag::WATER_DEPTH, 10, 1, new ExifRational(30, 10)),
-            ExifTag::ACCELERATION                => new IfdEntry(ExifTag::ACCELERATION, 10, 1, new ExifRational(10, 1)),
+            ExifTag::ACCELERATION                => new IfdEntry(
+                ExifTag::ACCELERATION,
+                10,
+                3,
+                new ExifRationalList([
+                    new ExifRational(6, 1),
+                    new ExifRational(8, 1),
+                    new ExifRational(0, 1),
+                ]),
+            ),
             ExifTag::CAMERA_ELEVATION_ANGLE      => new IfdEntry(ExifTag::CAMERA_ELEVATION_ANGLE, 10, 1, new ExifRational(50, 10)),
             ExifTag::RELATED_SOUND_FILE          => new IfdEntry(ExifTag::RELATED_SOUND_FILE, 2, 1, 'clip.wav'),
             ExifTag::FLASH_ENERGY                => new IfdEntry(ExifTag::FLASH_ENERGY, 5, 1, new ExifRational(150, 10)),
@@ -838,6 +847,11 @@ final class ExifDocumentTest extends TestCase
         self::assertEqualsWithDelta(55.0, $doc->humidityPercent(), 0.0001);
         self::assertEqualsWithDelta(1000.0, $doc->pressureHPa(), 0.0001);
         self::assertEqualsWithDelta(3.0, $doc->waterDepthMeters(), 0.0001);
+        $accelerationVector = $doc->accelerationVectorMs2();
+        self::assertNotNull($accelerationVector);
+        self::assertEqualsWithDelta(6.0, $accelerationVector[0] ?? 0.0, 0.0001);
+        self::assertEqualsWithDelta(8.0, $accelerationVector[1] ?? 0.0, 0.0001);
+        self::assertEqualsWithDelta(0.0, $accelerationVector[2] ?? 0.0, 0.0001);
         self::assertEqualsWithDelta(10.0, $doc->accelerationMs2(), 0.0001);
         self::assertEqualsWithDelta(5.0, $doc->cameraElevationAngleDeg(), 0.0001);
         self::assertSame('clip.wav', $doc->relatedSoundFile());

--- a/tests/Parse/Tiff/TiffExifReaderTest.php
+++ b/tests/Parse/Tiff/TiffExifReaderTest.php
@@ -150,6 +150,27 @@ final class TiffExifReaderTest extends TestCase
     }
 
     #[Test]
+    public function normalisesAccelerationVector(): void
+    {
+        $blob      = self::buildClassicAccelerationVectorBlob();
+        $document = (new TiffExifReader())->parseFromBlob($blob);
+
+        $vector = $document->accelerationVectorMs2();
+        self::assertNotNull($vector);
+        self::assertEqualsWithDelta(0.1, $vector[0] ?? 0.0, 1e-12);
+        self::assertEqualsWithDelta(0.2, $vector[1] ?? 0.0, 1e-12);
+        self::assertEqualsWithDelta(-0.3, $vector[2] ?? 0.0, 1e-12);
+        self::assertEqualsWithDelta(0.3741657387, $document->accelerationMs2() ?? 0.0, 1e-10);
+
+        $resolver = new ExifTagResolver($document);
+        $resolvedVector = $resolver->accelerationVectorMs2();
+        self::assertNotNull($resolvedVector);
+        self::assertEqualsWithDelta(0.1, $resolvedVector[0] ?? 0.0, 1e-12);
+        self::assertEqualsWithDelta(0.2, $resolvedVector[1] ?? 0.0, 1e-12);
+        self::assertEqualsWithDelta(-0.3, $resolvedVector[2] ?? 0.0, 1e-12);
+    }
+
+    #[Test]
     public function parsesLinkedIfdChain(): void
     {
         $blob      = $this->buildClassicLinkedIfdBlob();
@@ -876,6 +897,34 @@ final class TiffExifReaderTest extends TestCase
     }
 
     /**
+     * Builds a Classic TIFF blob that encodes a three-component acceleration vector.
+     */
+    private static function buildClassicAccelerationVectorBlob(): string
+    {
+        $header = 'II' . pack('v', 0x002A) . pack('V', 8);
+
+        $exifIfdOffset = 8 + 2 + 12 + 4;
+        $vectorOffset  = $exifIfdOffset + 2 + 12 + 4;
+
+        $ifd0Entries = [
+            self::packClassicEntry(ExifTag::EXIF_IFD_POINTER, 4, 1, $exifIfdOffset),
+        ];
+
+        $vector = self::packSignedRationalLE(1, 10)
+            . self::packSignedRationalLE(2, 10)
+            . self::packSignedRationalLE(-3, 10);
+
+        $exifEntries = [
+            self::packClassicEntry(ExifTag::ACCELERATION, 10, 3, $vectorOffset),
+        ];
+
+        $ifd0    = pack('v', count($ifd0Entries)) . implode('', $ifd0Entries) . pack('V', 0);
+        $exifIfd = pack('v', count($exifEntries)) . implode('', $exifEntries) . pack('V', 0);
+
+        return $header . $ifd0 . $exifIfd . $vector;
+    }
+
+    /**
      * Builds a Classic TIFF blob containing a PrintIM payload.
      *
      * @return array{0: string, 1: string}
@@ -1413,6 +1462,14 @@ final class TiffExifReaderTest extends TestCase
     private static function packRationalLE(int $numerator, int $denominator): string
     {
         return pack('V', $numerator) . pack('V', $denominator);
+    }
+
+    /**
+     * Packs a signed rational number using little-endian byte order.
+     */
+    private static function packSignedRationalLE(int $numerator, int $denominator): string
+    {
+        return pack('l', $numerator) . pack('l', $denominator);
     }
 
     /**


### PR DESCRIPTION
## Summary
- add a ValueConverters helper and ExifDocument accessors to normalise EXIF acceleration vectors
- surface per-axis acceleration through Capture and Motion values and merge EXIF/Apple data in StructuredMetadataBuilder
- extend TIFF/curation tests with synthetic acceleration fixtures and document the new vector outputs

## Testing
- `composer ci:test:php:unit` *(fails: TruthComparison fixtures unavailable in the execution environment)*
- `.build/bin/phpunit tests/Parse/Tiff/TiffExifReaderTest.php tests/Model/Exif/ExifDocumentTest.php tests/Curate/StructuredMetadataBuilderTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68fe3dc7d7c083239ee9cffc18fb129a