### PR TITLE
fix: normalize uncalibrated R98 color space

### DIFF
--- a/src/Curate/StructuredMetadataBuilder.php
+++ b/src/Curate/StructuredMetadataBuilder.php
@@ -1469,8 +1469,15 @@ final class StructuredMetadataBuilder
 
         if ($colorSpace === ColorSpace::UNCALIBRATED) {
             $interopIndex = $resolver->string('InteropIndex');
-            if ($interopIndex !== null && strtoupper($interopIndex) === 'R03') {
-                return ColorSpace::ADOBE_RGB;
+            if ($interopIndex !== null) {
+                $normalizedInteropIndex = strtoupper($interopIndex);
+                if ($normalizedInteropIndex === 'R03') {
+                    return ColorSpace::ADOBE_RGB;
+                }
+
+                if ($normalizedInteropIndex === 'R98') {
+                    return ColorSpace::SRGB;
+                }
             }
         }
 

--- a/tests/Curate/StructuredMetadataBuilderTest.php
+++ b/tests/Curate/StructuredMetadataBuilderTest.php
@@ -1614,6 +1614,33 @@ final class StructuredMetadataBuilderTest extends TestCase
     }
 
     /**
+     * Ensures an uncalibrated color space is normalized to sRGB when interoperability index R98 is present.
+     */
+    #[Test]
+    public function normalizesUncalibratedColorSpaceViaInteropR98(): void
+    {
+        $ifd0 = new Ifd([
+            ExifTag::IMAGE_WIDTH  => new IfdEntry(ExifTag::IMAGE_WIDTH, 4, 1, 1024),
+            ExifTag::IMAGE_HEIGHT => new IfdEntry(ExifTag::IMAGE_HEIGHT, 4, 1, 768),
+        ]);
+
+        $exifIfd = new Ifd([
+            ExifTag::COLOR_SPACE => new IfdEntry(ExifTag::COLOR_SPACE, 3, 1, ColorSpace::UNCALIBRATED->value),
+        ]);
+
+        $interopIfd = new Ifd([
+            ExifTag::INTEROPERABILITY_INDEX => new IfdEntry(ExifTag::INTEROPERABILITY_INDEX, 2, 3, 'R98'),
+        ]);
+
+        $exifDocument = new ExifDocument($ifd0, $exifIfd, null, $interopIfd, null);
+        $metadata     = new Metadata(['primary'], null, $exifDocument);
+
+        $structured = (new StructuredMetadataBuilder())->build($metadata);
+
+        self::assertSame(ColorSpace::SRGB, $structured->image->colorSpace);
+    }
+
+    /**
      * Confirms that lenses providing only MAX_APERTURE_VALUE still expose the derived f-number.
      */
     #[Test]


### PR DESCRIPTION
## Summary
- map interoperability index R98 to sRGB when EXIF colour space is uncalibrated
- cover the R98 interoperability override in the StructuredMetadataBuilder unit tests

## Testing
- composer ci:test:php:unit *(fails: existing TruthComparison fixtures unavailable in container)*
- .build/bin/phpunit --configuration .build/phpunit.xml --filter normalizesUncalibratedColorSpaceViaInteropR98

------
https://chatgpt.com/codex/tasks/task_e_68fe3dd0990c8323b6f8cfc1528397dc