### PR TITLE
fix: enforce 8 kHz sample rate for JPEG μ-law audio segments

### DIFF
--- a/src/Parse/Jpeg/JpegExtractor.php
+++ b/src/Parse/Jpeg/JpegExtractor.php
@@ -643,6 +643,10 @@ final class JpegExtractor
             throw new ParseError(sprintf('Audio segment at offset %d uses unsupported sample rate %d', $offset, $sampleRate));
         }
 
+        if ($format === self::AUDIO_FORMAT_MU_LAW && $sampleRate !== 8_000) {
+            throw new ParseError(sprintf('Audio segment at offset %d uses unsupported μ-law sample rate %d', $offset, $sampleRate));
+        }
+
         $formatName = match ($format) {
             self::AUDIO_FORMAT_PCM       => 'PCM',
             self::AUDIO_FORMAT_MU_LAW    => 'MU_LAW_PCM',

--- a/tests/Parse/Jpeg/JpegExtractorTest.php
+++ b/tests/Parse/Jpeg/JpegExtractorTest.php
@@ -272,6 +272,22 @@ final class JpegExtractorTest extends TestCase
     }
 
     /**
+     * Ensures μ-law APP2 segments only accept 8 kHz sampling rate.
+     */
+    #[Test]
+    public function testMuLawAudioSegmentWithNonEightKilohertzSampleRateThrows(): void
+    {
+        $payload = self::segment(self::MARKER_APP2, self::audioPayload(1, 1, 11_025, 8, str_repeat("\x00", 8)));
+        $jpeg    = $this->jpeg($payload);
+
+        $extractor = $this->createExtractor($jpeg);
+
+        $this->expectException(ParseError::class);
+
+        $extractor->getAudioStreams();
+    }
+
+    /**
      * Ensures MPF APP2 payloads are buffered across segments and decoded.
      */
     #[Test]


### PR DESCRIPTION
## Summary
- require μ-law EXIF audio segments to advertise an 8 kHz sample rate before accepting them
- extend the JPEG extractor tests to cover the new μ-law guard alongside the existing passing fixture

## Testing
- .build/bin/phpunit --configuration .build/phpunit.xml tests/Parse/Jpeg

------
https://chatgpt.com/codex/tasks/task_e_68fe3dd5fa988323bcd975d13df90836