### PR TITLE
feat: expose camera profile metadata

### DIFF
--- a/src/Curate/Resolver/ExifTagResolver.php
+++ b/src/Curate/Resolver/ExifTagResolver.php
@@ -613,6 +613,102 @@ final readonly class ExifTagResolver
     }
 
     /**
+     * Returns the camera calibration signature from the EXIF payload.
+     */
+    public function cameraCalibrationSignature(): ?string
+    {
+        return $this->document?->cameraCalibrationSignature();
+    }
+
+    /**
+     * Returns the profile calibration signature from the EXIF payload.
+     */
+    public function profileCalibrationSignature(): ?string
+    {
+        return $this->document?->profileCalibrationSignature();
+    }
+
+    /**
+     * Returns the ProfileHueSatMap dimensions.
+     *
+     * @return list<int>|null
+     */
+    public function profileHueSatMapDims(): ?array
+    {
+        return $this->document?->profileHueSatMapDims();
+    }
+
+    /**
+     * Returns the ProfileHueSatMapData1 coefficients.
+     *
+     * @return list<float>|null
+     */
+    public function profileHueSatMapData1(): ?array
+    {
+        return $this->document?->profileHueSatMapData1();
+    }
+
+    /**
+     * Returns the ProfileHueSatMapData2 coefficients.
+     *
+     * @return list<float>|null
+     */
+    public function profileHueSatMapData2(): ?array
+    {
+        return $this->document?->profileHueSatMapData2();
+    }
+
+    /**
+     * Returns the ProfileHueSatMapData3 coefficients.
+     *
+     * @return list<float>|null
+     */
+    public function profileHueSatMapData3(): ?array
+    {
+        return $this->document?->profileHueSatMapData3();
+    }
+
+    /**
+     * Returns the ProfileLookTable dimensions.
+     *
+     * @return list<int>|null
+     */
+    public function profileLookTableDims(): ?array
+    {
+        return $this->document?->profileLookTableDims();
+    }
+
+    /**
+     * Returns the ProfileLookTableData coefficients.
+     *
+     * @return list<float>|null
+     */
+    public function profileLookTableData(): ?array
+    {
+        return $this->document?->profileLookTableData();
+    }
+
+    /**
+     * Returns the ProfileToneCurve values.
+     *
+     * @return list<float>|null
+     */
+    public function profileToneCurve(): ?array
+    {
+        return $this->document?->profileToneCurve();
+    }
+
+    /**
+     * Returns the ProfileGainTableMap values.
+     *
+     * @return list<float>|null
+     */
+    public function profileGainTableMap(): ?array
+    {
+        return $this->document?->profileGainTableMap();
+    }
+
+    /**
      * Returns the opto-electronic conversion function data.
      *
      * @return array{payload:string, matrix:(array{columns:int, rows:int, labels:array{columns:list<string>, rows:list<string>}, values:list<list<float|null>>}|null)}|null

--- a/src/Model/Exif/ExifDocument.php
+++ b/src/Model/Exif/ExifDocument.php
@@ -728,6 +728,102 @@ final readonly class ExifDocument
     }
 
     /**
+     * Returns the camera calibration signature recorded by the camera profile.
+     */
+    public function cameraCalibrationSignature(): ?string
+    {
+        return $this->str($this->exifIfd, ExifTag::CAMERA_CALIBRATION_SIGNATURE);
+    }
+
+    /**
+     * Returns the profile calibration signature recorded by the color profile.
+     */
+    public function profileCalibrationSignature(): ?string
+    {
+        return $this->str($this->exifIfd, ExifTag::PROFILE_CALIBRATION_SIGNATURE);
+    }
+
+    /**
+     * Returns the ProfileHueSatMap dimensions declared in the EXIF payload.
+     *
+     * @return list<int>|null
+     */
+    public function profileHueSatMapDims(): ?array
+    {
+        return $this->numericList($this->exifIfd, ExifTag::PROFILE_HUE_SAT_MAP_DIMS);
+    }
+
+    /**
+     * Returns the ProfileHueSatMapData1 coefficients as floating point values.
+     *
+     * @return list<float>|null
+     */
+    public function profileHueSatMapData1(): ?array
+    {
+        return $this->rationalList($this->exifIfd, ExifTag::PROFILE_HUE_SAT_MAP_DATA1);
+    }
+
+    /**
+     * Returns the ProfileHueSatMapData2 coefficients as floating point values.
+     *
+     * @return list<float>|null
+     */
+    public function profileHueSatMapData2(): ?array
+    {
+        return $this->rationalList($this->exifIfd, ExifTag::PROFILE_HUE_SAT_MAP_DATA2);
+    }
+
+    /**
+     * Returns the ProfileHueSatMapData3 coefficients as floating point values.
+     *
+     * @return list<float>|null
+     */
+    public function profileHueSatMapData3(): ?array
+    {
+        return $this->rationalList($this->exifIfd, ExifTag::PROFILE_HUE_SAT_MAP_DATA3);
+    }
+
+    /**
+     * Returns the ProfileLookTable dimensions declared in the EXIF payload.
+     *
+     * @return list<int>|null
+     */
+    public function profileLookTableDims(): ?array
+    {
+        return $this->numericList($this->exifIfd, ExifTag::PROFILE_LOOK_TABLE_DIMS);
+    }
+
+    /**
+     * Returns the ProfileLookTableData coefficients as floating point values.
+     *
+     * @return list<float>|null
+     */
+    public function profileLookTableData(): ?array
+    {
+        return $this->rationalList($this->exifIfd, ExifTag::PROFILE_LOOK_TABLE_DATA);
+    }
+
+    /**
+     * Returns the ProfileToneCurve as a floating point list.
+     *
+     * @return list<float>|null
+     */
+    public function profileToneCurve(): ?array
+    {
+        return $this->rationalList($this->exifIfd, ExifTag::PROFILE_TONE_CURVE);
+    }
+
+    /**
+     * Returns the ProfileGainTableMap as a floating point list.
+     *
+     * @return list<float>|null
+     */
+    public function profileGainTableMap(): ?array
+    {
+        return $this->rationalList($this->exifIfd, ExifTag::PROFILE_GAIN_TABLE_MAP);
+    }
+
+    /**
      * Returns the opto-electronic conversion function data.
      *
      * @return array{payload:string, matrix:(array{columns:int, rows:int, labels:array{columns:list<string>, rows:list<string>}, values:list<list<float|null>>}|null)}|null

--- a/src/Model/Exif/ExifTag.php
+++ b/src/Model/Exif/ExifTag.php
@@ -392,6 +392,27 @@ final readonly class ExifTag
 
     public const int DEVICE_SETTING_DESCRIPTION = 0xA40B;
 
+    // Camera profile (EXIF 2.3/3.0)
+    public const int PROFILE_HUE_SAT_MAP_DIMS = 0xC6B0;
+
+    public const int PROFILE_HUE_SAT_MAP_DATA1 = 0xC6B1;
+
+    public const int PROFILE_HUE_SAT_MAP_DATA2 = 0xC6B2;
+
+    public const int PROFILE_HUE_SAT_MAP_DATA3 = 0xC6B3;
+
+    public const int PROFILE_LOOK_TABLE_DIMS = 0xC6B4;
+
+    public const int PROFILE_LOOK_TABLE_DATA = 0xC6B5;
+
+    public const int PROFILE_TONE_CURVE = 0xC6B6;
+
+    public const int PROFILE_GAIN_TABLE_MAP = 0xC6B7;
+
+    public const int CAMERA_CALIBRATION_SIGNATURE = 0xC6F3;
+
+    public const int PROFILE_CALIBRATION_SIGNATURE = 0xC6F4;
+
     // GPS sub IFD (Table 66 – EXIF 3.0)
     public const int GPS_VERSION_ID = 0x0000;
 

--- a/tests/Model/Exif/ExifTagTest.php
+++ b/tests/Model/Exif/ExifTagTest.php
@@ -213,6 +213,18 @@ final class ExifTagTest extends TestCase
             'SOURCE_EXPOSURE_TIMES_OF_COMPOSITE_IMAGE' => 0xA462,
             'GAMMA'                                    => 0xA500,
 
+            // Camera color profile
+            'PROFILE_HUE_SAT_MAP_DIMS'                  => 0xC6B0,
+            'PROFILE_HUE_SAT_MAP_DATA1'                 => 0xC6B1,
+            'PROFILE_HUE_SAT_MAP_DATA2'                 => 0xC6B2,
+            'PROFILE_HUE_SAT_MAP_DATA3'                 => 0xC6B3,
+            'PROFILE_LOOK_TABLE_DIMS'                   => 0xC6B4,
+            'PROFILE_LOOK_TABLE_DATA'                   => 0xC6B5,
+            'PROFILE_TONE_CURVE'                        => 0xC6B6,
+            'PROFILE_GAIN_TABLE_MAP'                    => 0xC6B7,
+            'CAMERA_CALIBRATION_SIGNATURE'              => 0xC6F3,
+            'PROFILE_CALIBRATION_SIGNATURE'             => 0xC6F4,
+
             // Environmental sensing and processing notes
             'TEMPERATURE'                      => 0x9400,
             'HUMIDITY'                         => 0x9401,

--- a/tests/Parse/Tiff/TiffExifReaderTest.php
+++ b/tests/Parse/Tiff/TiffExifReaderTest.php
@@ -150,6 +150,39 @@ final class TiffExifReaderTest extends TestCase
     }
 
     /**
+     * Ensures camera profile related EXIF tags are surfaced through the document and resolver.
+     */
+    #[Test]
+    public function surfacesColorProfileTags(): void
+    {
+        $blob      = self::buildClassicColorProfileBlob();
+        $document = (new TiffExifReader())->parseFromBlob($blob);
+        $resolver = new ExifTagResolver($document);
+
+        self::assertSame('ImageMeta Camera', $document->cameraCalibrationSignature());
+        self::assertSame('Profile Signature', $document->profileCalibrationSignature());
+        self::assertSame([6, 4, 2], $document->profileHueSatMapDims());
+        self::assertSame([1.0, 2.0, 3.0], $document->profileHueSatMapData1());
+        self::assertSame([4.0, 5.0, 6.0], $document->profileHueSatMapData2());
+        self::assertSame([7.0, 8.0, 9.0], $document->profileHueSatMapData3());
+        self::assertSame([5, 3, 1], $document->profileLookTableDims());
+        self::assertSame([10.0, 11.0, 12.0], $document->profileLookTableData());
+        self::assertSame([0.0, 0.5, 1.0, 1.5], $document->profileToneCurve());
+        self::assertSame([2.0, 3.0, 4.0], $document->profileGainTableMap());
+
+        self::assertSame('ImageMeta Camera', $resolver->cameraCalibrationSignature());
+        self::assertSame('Profile Signature', $resolver->profileCalibrationSignature());
+        self::assertSame([6, 4, 2], $resolver->profileHueSatMapDims());
+        self::assertSame([1.0, 2.0, 3.0], $resolver->profileHueSatMapData1());
+        self::assertSame([4.0, 5.0, 6.0], $resolver->profileHueSatMapData2());
+        self::assertSame([7.0, 8.0, 9.0], $resolver->profileHueSatMapData3());
+        self::assertSame([5, 3, 1], $resolver->profileLookTableDims());
+        self::assertSame([10.0, 11.0, 12.0], $resolver->profileLookTableData());
+        self::assertSame([0.0, 0.5, 1.0, 1.5], $resolver->profileToneCurve());
+        self::assertSame([2.0, 3.0, 4.0], $resolver->profileGainTableMap());
+    }
+
+    /**
      * Ensures the DocumentName tag is surfaced even when newer aliases are absent.
      */
     #[Test]
@@ -857,7 +890,90 @@ final class TiffExifReaderTest extends TestCase
     }
 
     /**
+     * Builds a Classic TIFF blob that embeds camera profile tags within the EXIF IFD.
+     */
+    private static function buildClassicColorProfileBlob(): string
+    {
+        $header = 'II' . pack('v', 0x002A) . pack('V', 8);
+
+        $ifd0EntryCount = 1;
+        $ifd0Length     = 2 + ($ifd0EntryCount * 12) + 4;
+        $exifIfdOffset  = strlen($header) + $ifd0Length;
+
+        $ifd0Entries = [
+            self::packClassicEntry(ExifTag::EXIF_IFD_POINTER, 4, 1, $exifIfdOffset),
+        ];
+
+        $blob = $header;
+        $blob .= pack('v', $ifd0EntryCount) . implode('', $ifd0Entries) . pack('V', 0);
+
+        $cameraSignature  = "ImageMeta Camera\0";
+        $profileSignature = "Profile Signature\0";
+        $hueSatDims       = pack('v*', 6, 4, 2);
+        $lookDims         = pack('v*', 5, 3, 1);
+        $hueSatData1      = self::packFloatArrayLE([1.0, 2.0, 3.0]);
+        $hueSatData2      = self::packFloatArrayLE([4.0, 5.0, 6.0]);
+        $hueSatData3      = self::packFloatArrayLE([7.0, 8.0, 9.0]);
+        $lookData         = self::packFloatArrayLE([10.0, 11.0, 12.0]);
+        $toneCurve        = self::packFloatArrayLE([0.0, 0.5, 1.0, 1.5]);
+        $gainTableMap     = self::packFloatArrayLE([2.0, 3.0, 4.0]);
+
+        $exifEntryCount = 10;
+        $exifIfdLength  = 2 + ($exifEntryCount * 12) + 4;
+        $dataOffset     = $exifIfdOffset + $exifIfdLength;
+
+        $cameraSignatureOffset  = $dataOffset;
+        $dataOffset            += strlen($cameraSignature);
+        $profileSignatureOffset = $dataOffset;
+        $dataOffset            += strlen($profileSignature);
+        $hueSatDimsOffset       = $dataOffset;
+        $dataOffset            += strlen($hueSatDims);
+        $hueSatData1Offset      = $dataOffset;
+        $dataOffset            += strlen($hueSatData1);
+        $hueSatData2Offset      = $dataOffset;
+        $dataOffset            += strlen($hueSatData2);
+        $hueSatData3Offset      = $dataOffset;
+        $dataOffset            += strlen($hueSatData3);
+        $lookDimsOffset         = $dataOffset;
+        $dataOffset            += strlen($lookDims);
+        $lookDataOffset         = $dataOffset;
+        $dataOffset            += strlen($lookData);
+        $toneCurveOffset        = $dataOffset;
+        $dataOffset            += strlen($toneCurve);
+        $gainTableOffset        = $dataOffset;
+        $dataOffset            += strlen($gainTableMap);
+
+        $exifEntries = [
+            self::packClassicEntry(ExifTag::CAMERA_CALIBRATION_SIGNATURE, 2, strlen($cameraSignature), $cameraSignatureOffset),
+            self::packClassicEntry(ExifTag::PROFILE_CALIBRATION_SIGNATURE, 2, strlen($profileSignature), $profileSignatureOffset),
+            self::packClassicEntry(ExifTag::PROFILE_HUE_SAT_MAP_DIMS, 3, 3, $hueSatDimsOffset),
+            self::packClassicEntry(ExifTag::PROFILE_HUE_SAT_MAP_DATA1, 11, 3, $hueSatData1Offset),
+            self::packClassicEntry(ExifTag::PROFILE_HUE_SAT_MAP_DATA2, 11, 3, $hueSatData2Offset),
+            self::packClassicEntry(ExifTag::PROFILE_HUE_SAT_MAP_DATA3, 11, 3, $hueSatData3Offset),
+            self::packClassicEntry(ExifTag::PROFILE_LOOK_TABLE_DIMS, 3, 3, $lookDimsOffset),
+            self::packClassicEntry(ExifTag::PROFILE_LOOK_TABLE_DATA, 11, 3, $lookDataOffset),
+            self::packClassicEntry(ExifTag::PROFILE_TONE_CURVE, 11, 4, $toneCurveOffset),
+            self::packClassicEntry(ExifTag::PROFILE_GAIN_TABLE_MAP, 11, 3, $gainTableOffset),
+        ];
+
+        $blob .= pack('v', $exifEntryCount) . implode('', $exifEntries) . pack('V', 0);
+        $blob .= $cameraSignature;
+        $blob .= $profileSignature;
+        $blob .= $hueSatDims;
+        $blob .= $hueSatData1;
+        $blob .= $hueSatData2;
+        $blob .= $hueSatData3;
+        $blob .= $lookDims;
+        $blob .= $lookData;
+        $blob .= $toneCurve;
+        $blob .= $gainTableMap;
+
+        return $blob;
+    }
+
+    /**
      * Builds a Classic TIFF blob that only exposes the legacy DocumentName tag.
+
      */
     private static function buildClassicDocumentNameBlob(): string
     {
@@ -1464,6 +1580,16 @@ final class TiffExifReaderTest extends TestCase
     private static function packRationalLE(int $numerator, int $denominator): string
     {
         return pack('V', $numerator) . pack('V', $denominator);
+    }
+
+    /**
+     * Packs single precision floating point values using little-endian byte order.
+     *
+     * @param list<float> $values
+     */
+    private static function packFloatArrayLE(array $values): string
+    {
+        return pack('g*', ...$values);
     }
 
     /**


### PR DESCRIPTION
## Summary
- add EXIF 2.3/3.0 camera profile tag constants and expose them through ExifDocument
- extend ExifTagResolver with helpers for HueSat maps, look tables, tone curves, and signatures
- cover the new tags with synthetic TIFF fixtures and update constant assertions

## Testing
- composer ci:test:php:unit *(fails: truth comparison suite depends on unavailable fixtures and unsupported HEIC containers in the sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68fe538d5074832389c7c6e900e00feb