### PR TITLE
fix: remove duplicate tile accessors in ExifDocument

### DIFF
--- a/src/Model/Exif/ExifDocument.php
+++ b/src/Model/Exif/ExifDocument.php
@@ -585,50 +585,6 @@ final readonly class ExifDocument
     }
 
     /**
-     * Returns the tile width defined for the primary or thumbnail image data.
-     */
-    public function tileWidth(): ?int
-    {
-        $width = $this->int($this->ifd0, ExifTag::TILE_WIDTH);
-
-        return $width ?? $this->int($this->ifd1, ExifTag::TILE_WIDTH);
-    }
-
-    /**
-     * Returns the tile length defined for the primary or thumbnail image data.
-     */
-    public function tileLength(): ?int
-    {
-        $length = $this->int($this->ifd0, ExifTag::TILE_LENGTH);
-
-        return $length ?? $this->int($this->ifd1, ExifTag::TILE_LENGTH);
-    }
-
-    /**
-     * Returns the tile offsets defined for the primary or thumbnail image data.
-     *
-     * @return list<int>|null
-     */
-    public function tileOffsets(): ?array
-    {
-        $offsets = $this->numericList($this->ifd0, ExifTag::TILE_OFFSETS);
-
-        return $offsets ?? $this->numericList($this->ifd1, ExifTag::TILE_OFFSETS);
-    }
-
-    /**
-     * Returns the tile byte counts defined for the primary or thumbnail image data.
-     *
-     * @return list<int>|null
-     */
-    public function tileByteCounts(): ?array
-    {
-        $counts = $this->numericList($this->ifd0, ExifTag::TILE_BYTE_COUNTS);
-
-        return $counts ?? $this->numericList($this->ifd1, ExifTag::TILE_BYTE_COUNTS);
-    }
-
-    /**
      * Returns the transfer function lookup table when available.
      *
      * @return list<int>|null


### PR DESCRIPTION
## Summary
- remove the duplicated tile accessor methods from `ExifDocument`
- ensure only a single implementation of each tile helper remains to avoid fatal redeclaration errors

## Testing
- composer ci:test:php:unit *(fails: existing TruthComparisonTest fixture expectations and unsupported container errors)*

------
https://chatgpt.com/codex/tasks/task_e_68fe5d2be5c08323b30a2e99b0b693fc