### PR TITLE
feat(exif): expose TIFF/EP identifier string

### DIFF
--- a/src/Curate/Resolver/ExifTagResolver.php
+++ b/src/Curate/Resolver/ExifTagResolver.php
@@ -142,6 +142,7 @@ final readonly class ExifTagResolver
             'interopindex'        => $this->interopIndex(),
             'interopversion'      => $this->interopVersion(),
             'relatedimagefileformat' => $this->relatedImageFileFormat(),
+            'tiffepstandardid'       => $this->tiffEpStandardIdString(),
             'processingsoftware'  => $this->processingSoftware(),
             'hostcomputer'        => $this->hostComputer(),
             default               => null,
@@ -419,6 +420,14 @@ final readonly class ExifTagResolver
     public function tiffEpStandardId(): ?array
     {
         return $this->document?->tiffEpStandardId();
+    }
+
+    /**
+     * Returns the TIFF/EP standard identifier string when available.
+     */
+    public function tiffEpStandardIdString(): ?string
+    {
+        return $this->document?->tiffEpStandardIdString();
     }
 
     /**

--- a/src/Curate/StructuredMetadataBuilder.php
+++ b/src/Curate/StructuredMetadataBuilder.php
@@ -211,6 +211,7 @@ final class StructuredMetadataBuilder
             profile: $profile,
             flashpixVersion: $exifResolver->flashpixVersion(),
             tiffEpStandardId: $exifResolver->tiffEpStandardId(),
+            tiffEpStandardString: $exifResolver->tiffEpStandardIdString(),
         );
 
         $flashPix = new FlashPix($metadata->flashPixStreams);

--- a/src/Model/Exif/ExifDocument.php
+++ b/src/Model/Exif/ExifDocument.php
@@ -56,6 +56,13 @@ final readonly class ExifDocument
     private bool $exifThreeOrNewer;
 
     /**
+     * @var list<int>|null
+     */
+    private ?array $tiffEpStandardId;
+
+    private ?string $tiffEpStandardIdString;
+
+    /**
      * @param Ifd                     $ifd0            Root IFD of the TIFF structure.
      * @param Ifd|null                $exifIfd         Sub IFD containing EXIF-specific tags.
      * @param Ifd|null                $gpsIfd          Sub IFD containing GPS-related tags.
@@ -80,6 +87,11 @@ final readonly class ExifDocument
         $this->exifVersion               = CoreValueConverters::toExifVersion($rawVersion);
         $this->exifProfile               = ExifCapabilities::fromVersion($this->exifVersion);
         $this->exifThreeOrNewer          = (float) $this->exifProfile >= 3.0;
+
+        $tiffEpBytes    = $this->numericList($this->exifIfd, ExifTag::TIFF_EP_STANDARD_ID);
+        $tiffEpStandard = ValueConverters::tiffEpStandardId($tiffEpBytes);
+        $this->tiffEpStandardId       = $tiffEpStandard['bytes'] ?? null;
+        $this->tiffEpStandardIdString = $tiffEpStandard['string'] ?? null;
     }
 
     /**
@@ -736,9 +748,15 @@ final readonly class ExifDocument
      */
     public function tiffEpStandardId(): ?array
     {
-        $values = $this->numericList($this->exifIfd, ExifTag::TIFF_EP_STANDARD_ID);
+        return $this->tiffEpStandardId;
+    }
 
-        return $values;
+    /**
+     * Returns the TIFF/EP standard identifier as a normalised string representation.
+     */
+    public function tiffEpStandardIdString(): ?string
+    {
+        return $this->tiffEpStandardIdString;
     }
 
     /**

--- a/src/Model/Exif/ValueConverters.php
+++ b/src/Model/Exif/ValueConverters.php
@@ -17,6 +17,7 @@ use MagicSunday\ImageMeta\Value\Enum\CfaPatternColor;
 use MagicSunday\ImageMeta\Value\FlashInfo;
 
 use function abs;
+use function chr;
 use function array_map;
 use function count;
 use function ctype_digit;
@@ -98,6 +99,8 @@ final readonly class ValueConverters
     private const MAX_SRATIONAL_MATRIX_LABEL_LENGTH = 255;
     private const SRATIONAL_VALUE_SIZE = 8;
     private const MAX_PRINT_IMAGE_MATCHING_PARAMETERS = 512;
+    private const PRINTABLE_ASCII_MIN = 0x20;
+    private const PRINTABLE_ASCII_MAX = 0x7E;
 
     /**
      * Converts a TIFF RATIONAL or scalar value into a floating point value.
@@ -218,6 +221,82 @@ final readonly class ValueConverters
         }
 
         return null;
+    }
+
+    /**
+     * Normalises the TIFF/EP standard identifier to both byte and string representations.
+     *
+     * @param list<int>|null $bytes Raw TIFF/EP identifier bytes.
+     *
+     * @return array{bytes:list<int>, string:?string}|null
+     */
+    public static function tiffEpStandardId(?array $bytes): ?array
+    {
+        if ($bytes === null) {
+            return null;
+        }
+
+        if ($bytes === []) {
+            return null;
+        }
+
+        $normalised = [];
+        foreach ($bytes as $byte) {
+            if (!is_int($byte)) {
+                return null;
+            }
+
+            if ($byte < 0 || $byte > 0xFF) {
+                return null;
+            }
+
+            $normalised[] = $byte;
+        }
+
+        if ($normalised === []) {
+            return null;
+        }
+
+        return [
+            'bytes'  => $normalised,
+            'string' => self::formatTiffEpStandardIdString($normalised),
+        ];
+    }
+
+    /**
+     * Formats the TIFF/EP identifier bytes into a readable representation.
+     *
+     * @param list<int> $bytes
+     */
+    private static function formatTiffEpStandardIdString(array $bytes): ?string
+    {
+        $hasPrintable = true;
+
+        foreach ($bytes as $byte) {
+            if ($byte === 0) {
+                break;
+            }
+
+            if ($byte < self::PRINTABLE_ASCII_MIN || $byte > self::PRINTABLE_ASCII_MAX) {
+                $hasPrintable = false;
+                break;
+            }
+        }
+
+        if ($hasPrintable) {
+            $string = '';
+            foreach ($bytes as $byte) {
+                if ($byte === 0) {
+                    break;
+                }
+
+                $string .= chr($byte);
+            }
+
+            return $string === '' ? null : $string;
+        }
+
+        return implode('.', array_map(static fn (int $component): string => (string) $component, $bytes));
     }
 
     /**

--- a/src/Value/Standards.php
+++ b/src/Value/Standards.php
@@ -17,16 +17,18 @@ namespace MagicSunday\ImageMeta\Value;
 final readonly class Standards
 {
     /**
-     * @param string|null    $exifVersion      Normalised EXIF specification version (e.g. "3.00").
-     * @param string|null    $profile          Derived EXIF capability profile (e.g. "3.0").
-     * @param string|null    $flashpixVersion  FlashPix specification version string.
-     * @param list<int>|null $tiffEpStandardId TIFF/EP identifier bytes.
+     * @param string|null    $exifVersion          Normalised EXIF specification version (e.g. "3.00").
+     * @param string|null    $profile              Derived EXIF capability profile (e.g. "3.0").
+     * @param string|null    $flashpixVersion      FlashPix specification version string.
+     * @param list<int>|null $tiffEpStandardId     TIFF/EP identifier bytes.
+     * @param string|null    $tiffEpStandardString Human readable TIFF/EP identifier.
      */
     public function __construct(
         public ?string $exifVersion,
         public ?string $profile,
         public ?string $flashpixVersion,
         public ?array $tiffEpStandardId,
+        public ?string $tiffEpStandardString,
     ) {
     }
 }

--- a/tests/Curate/StructuredMetadataBuilderTest.php
+++ b/tests/Curate/StructuredMetadataBuilderTest.php
@@ -330,6 +330,7 @@ final class StructuredMetadataBuilderTest extends TestCase
         self::assertSame('3.0', $structured->standards->profile);
         self::assertSame('1.00', $structured->standards->flashpixVersion);
         self::assertSame([1, 0, 0, 0], $structured->standards->tiffEpStandardId);
+        self::assertSame('1.0.0.0', $structured->standards->tiffEpStandardString);
 
         self::assertEqualsWithDelta(1.9965, $structured->lens->maxApertureFNumber, 0.001);
 

--- a/tests/Model/Exif/ExifDocumentTest.php
+++ b/tests/Model/Exif/ExifDocumentTest.php
@@ -945,6 +945,7 @@ final class ExifDocumentTest extends TestCase
         self::assertEqualsWithDelta(79.0, $doc->focalPlaneYResolution() ?? 0.0, 0.0001);
         self::assertSame(2, $doc->focalPlaneResolutionUnit());
         self::assertSame([2, 0, 0, 0], $doc->tiffEpStandardId());
+        self::assertSame('2.0.0.0', $doc->tiffEpStandardIdString());
         self::assertSame([1024, 768], $doc->subjectLocation());
         self::assertSame(320.0, $doc->exposureIndex());
         self::assertSame(SceneType::DIRECTLY_PHOTOGRAPHED_IMAGE, $doc->sceneType());
@@ -964,6 +965,26 @@ final class ExifDocumentTest extends TestCase
         self::assertSame('RawLab', $doc->rawDevelopingSoftware());
         self::assertSame('EditLab', $doc->imageEditingSoftware());
         self::assertSame('MetaLab', $doc->metadataEditingSoftware());
+    }
+
+    #[Test]
+    public function decodesPrintableTiffEpStandardIdBytes(): void
+    {
+        $ifd0 = new Ifd([]);
+
+        $exifIfd = new Ifd([
+            ExifTag::TIFF_EP_STANDARD_ID => new IfdEntry(
+                ExifTag::TIFF_EP_STANDARD_ID,
+                1,
+                5,
+                new ExifNumericList([0x30, 0x31, 0x30, 0x30, 0]),
+            ),
+        ]);
+
+        $doc = new ExifDocument($ifd0, $exifIfd, null, null, null);
+
+        self::assertSame([48, 49, 48, 48, 0], $doc->tiffEpStandardId());
+        self::assertSame('0100', $doc->tiffEpStandardIdString());
     }
 
     #[Test]


### PR DESCRIPTION
## Summary
- normalise the TIFF/EP standard identifier into bytes and a human-readable string
- expose the decoded identifier on the EXIF document, resolver and structured metadata aggregate
- extend the standards value object and PHPUnit suite to cover the new string accessor

## Testing
- composer ci:test:php:unit *(fails: Fatal error: Cannot redefine class constant MagicSunday\\ImageMeta\\Model\\Exif\\ExifTag::TILE_WIDTH)*

------
https://chatgpt.com/codex/tasks/task_e_68fe5aa92fb48323aacf1e56cbb61b65