### PR TITLE
Fix BigTIFF UInt64 pointer normalization

### DIFF
--- a/src/Core/MemoryBuffer.php
+++ b/src/Core/MemoryBuffer.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace MagicSunday\ImageMeta\Core;
 
+use MagicSunday\ImageMeta\Core\Util\UInt64;
 use MagicSunday\ImageMeta\Core\Util\Unpack;
 
 use function ord;
@@ -58,17 +59,14 @@ final class MemoryBuffer
     /**
      * Moves the read cursor to an absolute offset within the buffer.
      *
-     * @param int $offset absolute position in bytes
+     * @param int|UInt64 $offset absolute position in bytes
      *
      * @throws BoundsError when the requested offset is outside the buffer
      */
-    public function seek(int $offset): void
+    public function seek(int|UInt64 $offset): void
     {
-        if ($offset < 0 || $offset > $this->size()) {
-            throw new BoundsError('MemoryBuffer seek out of range: ' . $offset);
-        }
-
-        $this->pos = $offset;
+        $offsetInt   = $this->normaliseOffset($offset, 0, 'MemoryBuffer seek out of range');
+        $this->pos   = $offsetInt;
     }
 
     /**
@@ -76,26 +74,28 @@ final class MemoryBuffer
      *
      * The cursor advances by the number of requested bytes.
      *
-     * @param int $length number of bytes to consume
+     * @param int|UInt64 $length number of bytes to consume
      *
      * @return string raw binary data with the requested length
      *
      * @throws BoundsError when the requested length exceeds the buffer
      * @throws ParseError  when the read returns fewer bytes than requested
      */
-    public function read(int $length): string
+    public function read(int|UInt64 $length): string
     {
-        if ($length === 0) {
+        $len = $this->normaliseLength($length);
+
+        if ($len === 0) {
             return '';
         }
 
-        $end = $this->pos + $length;
-        if ($length < 0 || $end > $this->size()) {
-            throw new BoundsError('MemoryBuffer read out of range: ' . $this->pos . '+' . $length);
+        $end = $this->pos + $len;
+        if ($end > $this->size()) {
+            throw new BoundsError('MemoryBuffer read out of range: ' . $this->pos . '+' . $len);
         }
 
-        $chunk = substr($this->data, $this->pos, $length);
-        if (strlen($chunk) !== $length) {
+        $chunk = substr($this->data, $this->pos, $len);
+        if (strlen($chunk) !== $len) {
             throw new ParseError('MemoryBuffer short read');
         }
 
@@ -157,9 +157,9 @@ final class MemoryBuffer
     /**
      * Reads an unsigned 64-bit integer using little-endian byte order.
      *
-     * @return int unsigned 64-bit integer
+     * @return UInt64 unsigned 64-bit integer
      */
-    public function readU64LE(): int
+    public function readU64LE(): UInt64
     {
         $lo = $this->readU32LE();
         $hi = $this->readU32LE();
@@ -170,9 +170,9 @@ final class MemoryBuffer
     /**
      * Reads an unsigned 64-bit integer using big-endian byte order.
      *
-     * @return int unsigned 64-bit integer
+     * @return UInt64 unsigned 64-bit integer
      */
-    public function readU64BE(): int
+    public function readU64BE(): UInt64
     {
         $hi = $this->readU32BE();
         $lo = $this->readU32BE();
@@ -193,5 +193,52 @@ final class MemoryBuffer
         $bytes = $this->read($length);
 
         return Unpack::int($format, $bytes, 'integer from buffer');
+    }
+
+    private function normaliseOffset(int|UInt64 $offset, int $length, string $message): int
+    {
+        if ($offset instanceof UInt64) {
+            $offsetInt = $this->normaliseUInt64($offset, $length, $message);
+
+            return $offsetInt;
+        }
+
+        if ($offset < 0) {
+            throw new BoundsError($message . ': ' . $offset);
+        }
+
+        if ($offset > $this->size() - $length) {
+            throw new BoundsError($message . ': ' . $offset);
+        }
+
+        return $offset;
+    }
+
+    private function normaliseLength(int|UInt64 $length): int
+    {
+        if ($length instanceof UInt64) {
+            return $this->normaliseUInt64($length, 0, 'MemoryBuffer read length out of range');
+        }
+
+        if ($length < 0) {
+            throw new BoundsError('MemoryBuffer read length out of range: ' . $length);
+        }
+
+        return $length;
+    }
+
+    private function normaliseUInt64(UInt64 $value, int $padding, string $message): int
+    {
+        if ($value->compareInt($this->size()) > 0) {
+            throw new BoundsError($message . ': ' . $value->toHex());
+        }
+
+        $intValue = $value->toInt($message);
+
+        if ($intValue > $this->size() - $padding) {
+            throw new BoundsError($message . ': ' . $value->toHex());
+        }
+
+        return $intValue;
     }
 }

--- a/src/Core/Stream.php
+++ b/src/Core/Stream.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace MagicSunday\ImageMeta\Core;
 
+use MagicSunday\ImageMeta\Core\Util\UInt64;
 use MagicSunday\ImageMeta\Core\Util\Unpack;
 
 use function fopen;
@@ -164,9 +165,9 @@ final class Stream
     /**
      * Reads an unsigned 64-bit big-endian integer from the stream.
      *
-     * @return int
+     * @return UInt64
      */
-    public function readU64BE(): int
+    public function readU64BE(): UInt64
     {
         $hi = $this->readU32BE();
         $lo = $this->readU32BE();

--- a/src/Core/StreamWindow.php
+++ b/src/Core/StreamWindow.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace MagicSunday\ImageMeta\Core;
 
+use MagicSunday\ImageMeta\Core\Util\UInt64;
 use MagicSunday\ImageMeta\Core\Util\Unpack;
 
 use function ord;
@@ -127,9 +128,9 @@ final class StreamWindow
     /**
      * Reads an unsigned 64-bit big-endian integer from the window.
      *
-     * @return int
+     * @return UInt64
      */
-    public function readU64BE(): int
+    public function readU64BE(): UInt64
     {
         $hi = $this->readU32BE();
         $lo = $this->readU32BE();

--- a/src/Core/Util/UInt64.php
+++ b/src/Core/Util/UInt64.php
@@ -1,0 +1,138 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\ImageMeta\Core\Util;
+
+use MagicSunday\ImageMeta\Core\ParseError;
+
+use function intdiv;
+use function sprintf;
+
+/**
+ * Represents an unsigned 64-bit integer composed of two 32-bit halves.
+ */
+final class UInt64
+{
+    private const int UINT32_MASK = 0xFFFFFFFF;
+
+    private const int UINT32_BASE = 4_294_967_296;
+
+    public function __construct(
+        private readonly int $hi,
+        private readonly int $lo,
+    ) {
+        $this->assertUint32($this->hi);
+        $this->assertUint32($this->lo);
+    }
+
+    /**
+     * Creates an instance from two unsigned 32-bit components.
+     */
+    public static function fromUInt32(int $hi, int $lo): self
+    {
+        return new self($hi & self::UINT32_MASK, $lo & self::UINT32_MASK);
+    }
+
+    /**
+     * Creates an instance from a non-negative integer value.
+     */
+    public static function fromInt(int $value): self
+    {
+        if ($value < 0) {
+            throw new ParseError('Cannot create UInt64 from a negative integer.');
+        }
+
+        $hi = (int) intdiv($value, self::UINT32_BASE);
+        $lo = $value & self::UINT32_MASK;
+
+        return new self($hi, $lo);
+    }
+
+    public function high(): int
+    {
+        return $this->hi;
+    }
+
+    public function low(): int
+    {
+        return $this->lo;
+    }
+
+    public function isZero(): bool
+    {
+        return $this->hi === 0 && $this->lo === 0;
+    }
+
+    public function compare(self $other): int
+    {
+        if ($this->hi !== $other->hi) {
+            return $this->hi <=> $other->hi;
+        }
+
+        return $this->lo <=> $other->lo;
+    }
+
+    public function compareInt(int $value): int
+    {
+        if ($value < 0) {
+            return 1;
+        }
+
+        return $this->compare(self::fromInt($value));
+    }
+
+    public function addSmall(int $value): self
+    {
+        if ($value < 0) {
+            throw new ParseError('Cannot add a negative value to UInt64.');
+        }
+
+        $lo = $this->lo + $value;
+        $hi = $this->hi;
+
+        if ($lo > self::UINT32_MASK) {
+            $lo -= self::UINT32_BASE;
+            ++$hi;
+        }
+
+        return self::fromUInt32($hi, $lo);
+    }
+
+    public function fitsSignedInt(): bool
+    {
+        if (PHP_INT_SIZE >= 8) {
+            return $this->hi <= 0x7FFFFFFF;
+        }
+
+        return $this->hi === 0 && $this->lo <= 0x7FFFFFFF;
+    }
+
+    public function toInt(string $context): int
+    {
+        if (!$this->fitsSignedInt()) {
+            throw new ParseError(sprintf('%s exceeds supported integer range.', $context));
+        }
+
+        return (int) (($this->hi * self::UINT32_BASE) + $this->lo);
+    }
+
+    public function toHex(): string
+    {
+        return sprintf('%08X%08X', $this->hi, $this->lo);
+    }
+
+    private function assertUint32(int $value): void
+    {
+        if ($value < 0 || $value > self::UINT32_MASK) {
+            throw new ParseError('UInt64 components must be unsigned 32-bit integers.');
+        }
+    }
+}

--- a/src/Core/Util/Unpack.php
+++ b/src/Core/Util/Unpack.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 namespace MagicSunday\ImageMeta\Core\Util;
 
 use MagicSunday\ImageMeta\Core\ParseError;
+use MagicSunday\ImageMeta\Core\Util\UInt64;
 
 use function is_float;
 use function is_int;
@@ -56,35 +57,11 @@ final class Unpack
      * @param int $hi High-order 32 bits.
      * @param int $lo Low-order 32 bits.
      *
-     * @return int
+     * @return UInt64
      */
-    public static function combineUint32(int $hi, int $lo): int
+    public static function combineUint32(int $hi, int $lo): UInt64
     {
-        if (PHP_INT_SIZE < 8) {
-            throw new ParseError('64-bit integers are not supported on this platform.');
-        }
-
-        $hiUnsigned = $hi & 0xFFFFFFFF;
-        $loUnsigned = $lo & 0xFFFFFFFF;
-
-        $isNegative = ($hiUnsigned & 0x80000000) !== 0;
-
-        if ($isNegative) {
-            $hiComplement = (~$hiUnsigned) & 0xFFFFFFFF;
-            $loComplement = (~$loUnsigned) & 0xFFFFFFFF;
-            $magnitude    = ($hiComplement << 32) | $loComplement;
-
-            return -1 - $magnitude;
-        }
-
-        $maxHi = PHP_INT_MAX >> 32;
-        $maxLo = PHP_INT_MAX & 0xFFFFFFFF;
-
-        if ($hiUnsigned > $maxHi || ($hiUnsigned === $maxHi && $loUnsigned > $maxLo)) {
-            throw new ParseError('64-bit unsigned value exceeds PHP_INT_MAX.');
-        }
-
-        return ($hiUnsigned << 32) | $loUnsigned;
+        return UInt64::fromUInt32($hi, $lo);
     }
 
     /**

--- a/src/Model/Exif/ExifDocument.php
+++ b/src/Model/Exif/ExifDocument.php
@@ -15,6 +15,7 @@ use DateTimeImmutable;
 use DateTimeZone;
 use Exception;
 use MagicSunday\ImageMeta\Core\ExifCapabilities;
+use MagicSunday\ImageMeta\Core\Util\UInt64;
 use MagicSunday\ImageMeta\Core\ValueConverters as CoreValueConverters;
 use MagicSunday\ImageMeta\MakerNotes\MakerNotesMetadata;
 use MagicSunday\ImageMeta\Value\Enum\CfaPatternColor;
@@ -579,50 +580,6 @@ final readonly class ExifDocument
         $counts = $this->numericList($this->ifd0, ExifTag::STRIP_BYTE_COUNTS);
 
         return $counts ?? $this->numericList($this->ifd1, ExifTag::STRIP_BYTE_COUNTS);
-    }
-
-    /**
-     * Returns the tile width defined for the primary or thumbnail image data.
-     */
-    public function tileWidth(): ?int
-    {
-        $width = $this->int($this->ifd0, ExifTag::TILE_WIDTH);
-
-        return $width ?? $this->int($this->ifd1, ExifTag::TILE_WIDTH);
-    }
-
-    /**
-     * Returns the tile length defined for the primary or thumbnail image data.
-     */
-    public function tileLength(): ?int
-    {
-        $length = $this->int($this->ifd0, ExifTag::TILE_LENGTH);
-
-        return $length ?? $this->int($this->ifd1, ExifTag::TILE_LENGTH);
-    }
-
-    /**
-     * Returns the tile offsets defined for the primary or thumbnail image data.
-     *
-     * @return list<int>|null
-     */
-    public function tileOffsets(): ?array
-    {
-        $offsets = $this->numericList($this->ifd0, ExifTag::TILE_OFFSETS);
-
-        return $offsets ?? $this->numericList($this->ifd1, ExifTag::TILE_OFFSETS);
-    }
-
-    /**
-     * Returns the tile byte counts defined for the primary or thumbnail image data.
-     *
-     * @return list<int>|null
-     */
-    public function tileByteCounts(): ?array
-    {
-        $counts = $this->numericList($this->ifd0, ExifTag::TILE_BYTE_COUNTS);
-
-        return $counts ?? $this->numericList($this->ifd1, ExifTag::TILE_BYTE_COUNTS);
     }
 
     /**
@@ -2080,7 +2037,16 @@ final readonly class ExifDocument
         $value = $this->value($ifd, $tag);
 
         if ($value instanceof ExifNumericList) {
-            return array_map(static fn (int|float $v): int => (int) $v, $value->values);
+            return array_map(
+                static function (int|float|UInt64 $component): int {
+                    if ($component instanceof UInt64) {
+                        return $component->toInt('EXIF numeric list component');
+                    }
+
+                    return (int) $component;
+                },
+                $value->values,
+            );
         }
 
         if (is_int($value)) {

--- a/src/Model/Exif/ExifNumericList.php
+++ b/src/Model/Exif/ExifNumericList.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 namespace MagicSunday\ImageMeta\Model\Exif;
 
 use InvalidArgumentException;
+use MagicSunday\ImageMeta\Core\Util\UInt64;
 
 use function array_is_list;
 use function is_float;
@@ -23,7 +24,7 @@ use function is_int;
 final readonly class ExifNumericList
 {
     /**
-     * @var list<int|float>
+     * @var list<int|float|UInt64>
      */
     public array $values;
 
@@ -37,18 +38,14 @@ final readonly class ExifNumericList
         }
 
         foreach ($values as $value) {
-            if (is_int($value)) {
+            if (is_int($value) || is_float($value) || $value instanceof UInt64) {
                 continue;
             }
 
-            if (is_float($value)) {
-                continue;
-            }
-
-            throw new InvalidArgumentException('Numeric EXIF lists may only contain integers or floats.');
+            throw new InvalidArgumentException('Numeric EXIF lists may only contain integers, floats, or UInt64 values.');
         }
 
-        /** @var list<int|float> $values */
+        /** @var list<int|float|UInt64> $values */
         $this->values = $values;
     }
 

--- a/src/Model/Exif/ExifTag.php
+++ b/src/Model/Exif/ExifTag.php
@@ -153,14 +153,6 @@ final readonly class ExifTag
 
     public const int PRIMARY_CHROMATICITIES = 0x013F;
 
-    public const int TILE_WIDTH = 0x0142;
-
-    public const int TILE_LENGTH = 0x0143;
-
-    public const int TILE_OFFSETS = 0x0144;
-
-    public const int TILE_BYTE_COUNTS = 0x0145;
-
     public const int JPEG_INTERCHANGE_FORMAT = 0x0201;
 
     public const int JPEG_INTERCHANGE_FORMAT_LENGTH = 0x0202;

--- a/src/Parse/IsoBmff/IsoBmffExtractor.php
+++ b/src/Parse/IsoBmff/IsoBmffExtractor.php
@@ -1387,7 +1387,7 @@ final readonly class IsoBmffExtractor
             2       => $window->readU16BE(),
             3       => Unpack::int('N', "\0" . $window->read(3), '24-bit integer value'),
             4       => $window->readU32BE(),
-            8       => $window->readU64BE(),
+            8       => $window->readU64BE()->toInt('64-bit integer value'),
             default => throw new ParseError('unsupported integer size ' . $bytes),
         };
     }
@@ -1490,7 +1490,7 @@ final readonly class IsoBmffExtractor
         if ($size32 === 0) {
             $size = $limit - $offset;
         } elseif ($size32 === 1) {
-            $size = $this->stream->readU64BE();
+            $size = $this->stream->readU64BE()->toInt('extended box size');
             $headerSize += 8;
         }
 

--- a/src/Parse/Tiff/TiffExifReader.php
+++ b/src/Parse/Tiff/TiffExifReader.php
@@ -11,9 +11,11 @@ declare(strict_types=1);
 
 namespace MagicSunday\ImageMeta\Parse\Tiff;
 
+use MagicSunday\ImageMeta\Core\BoundsError;
 use MagicSunday\ImageMeta\Core\Endian;
 use MagicSunday\ImageMeta\Core\MemoryBuffer;
 use MagicSunday\ImageMeta\Core\ParseError;
+use MagicSunday\ImageMeta\Core\Util\UInt64;
 use MagicSunday\ImageMeta\Core\Util\Unpack;
 use MagicSunday\ImageMeta\MakerNotes\MakerNotesDecoderInterface;
 use MagicSunday\ImageMeta\MakerNotes\MakerNotesMetadata;
@@ -34,6 +36,7 @@ use function is_finite;
 use function is_float;
 use function is_int;
 use function is_string;
+use function intdiv;
 use function mb_convert_encoding;
 use function ord;
 use function pack;
@@ -110,6 +113,19 @@ final class TiffExifReader
         ExifTag::TILE_BYTE_COUNTS,
     ];
 
+    /**
+     * Tags whose values encode offsets within the TIFF blob.
+     *
+     * @var list<int>
+     */
+    private const array POINTER_TAGS = [
+        ExifTag::EXIF_IFD_POINTER,
+        ExifTag::GPS_IFD_POINTER,
+        ExifTag::INTEROPERABILITY_IFD_POINTER,
+        ExifTag::SUB_IFDS,
+        ExifTag::JPEG_INTERCHANGE_FORMAT,
+    ];
+
     private const string UNICODE_REPLACEMENT = "\u{FFFD}";
 
     private MemoryBuffer $buf;
@@ -117,6 +133,8 @@ final class TiffExifReader
     private Endian $bo;
 
     private bool $bigTiff = false;
+
+    private UInt64 $blobSize;
 
     private ?string $makerNoteRaw = null;
 
@@ -142,6 +160,7 @@ final class TiffExifReader
     {
         $this->buf = new MemoryBuffer($tiffBlob);
         $this->buf->seek(0);
+        $this->blobSize = UInt64::fromInt($this->buf->size());
 
         $this->makerNoteRaw = null;
         $this->subIfds      = [];
@@ -252,31 +271,37 @@ final class TiffExifReader
     /**
      * Parses an image file directory starting at the given byte offset.
      *
-     * @param int $offset Zero-based byte offset to the IFD structure.
+     * @param int|UInt64 $offset Zero-based byte offset to the IFD structure.
      *
      * @return Ifd
      */
-    private function readIfd(int $offset): Ifd
+    private function readIfd(int|UInt64 $offset): Ifd
     {
-        if ($offset <= 0) {
+        if ($offset instanceof UInt64) {
+            if ($offset->isZero()) {
+                return new Ifd([]);
+            }
+        } elseif ($offset <= 0) {
             return new Ifd([]);
         }
 
-        if (isset($this->ifdCache[$offset])) {
-            return $this->ifdCache[$offset];
+        $offsetInt = $this->ensureOffset($offset, 'IFD offset');
+
+        if (isset($this->ifdCache[$offsetInt])) {
+            return $this->ifdCache[$offsetInt];
         }
 
-        $this->buf->seek($offset);
-        $entryCount = $this->bigTiff ? $this->readU64() : $this->readU16();
+        $this->buf->seek($offsetInt);
+        $entryCount = $this->bigTiff ? $this->readU64()->toInt('IFD entry count') : $this->readU16();
         $entries    = [];
         for ($i = 0; $i < $entryCount; ++$i) {
             $entries += $this->readDirEntry();
         }
 
-        $next = $this->bigTiff ? $this->readU64() : $this->readU32();
+        $next = $this->bigTiff ? $this->normaliseOptionalOffset($this->readU64(), 'IFD next offset') : $this->readU32();
         $ifd  = new Ifd($entries, $next > 0 ? $next : null);
 
-        $this->ifdCache[$offset] = $ifd;
+        $this->ifdCache[$offsetInt] = $ifd;
 
         return $ifd;
     }
@@ -290,11 +315,12 @@ final class TiffExifReader
     {
         $tag      = $this->readU16();
         $type     = $this->readU16();
-        $cnt      = $this->bigTiff ? $this->readU64() : $this->readU32();
+        $cnt      = $this->bigTiff ? $this->readU64()->toInt('directory entry value count') : $this->readU32();
         $valOrOff = $this->bigTiff ? $this->readValueOrOffset($type, $cnt) : $this->readU32();
 
         [$rawBytes] = $this->valueBytes($type, $cnt, $valOrOff);
         $value      = $this->decodeBytes($type, $cnt, $rawBytes);
+        $value      = $this->convertUInt64Values($tag, $type, $cnt, $rawBytes, $value);
 
         if (in_array($tag, self::UTF16LE_STRING_TAGS, true)) {
             $value = $this->decodeUtf16LeString($rawBytes);
@@ -305,7 +331,7 @@ final class TiffExifReader
         }
 
         if (in_array($tag, self::COUNTED_IMAGE_DATA_TAGS, true)) {
-            $value = $this->normaliseCountedImageDataField($type, $cnt, $rawBytes, $value);
+            $value = $this->normaliseCountedImageDataField($tag, $type, $cnt, $rawBytes, $value);
         }
 
         $entry = new IfdEntry($tag, $type, $cnt, $value);
@@ -328,6 +354,7 @@ final class TiffExifReader
      * @return int|ExifNumericList
      */
     private function normaliseCountedImageDataField(
+        int $tag,
         int $type,
         int $count,
         string $rawBytes,
@@ -336,6 +363,9 @@ final class TiffExifReader
         if ($count <= 0) {
             return new ExifNumericList([]);
         }
+
+        $isOffsetTag = $tag === ExifTag::STRIP_OFFSETS || $tag === ExifTag::TILE_OFFSETS;
+        $context     = sprintf('IFD tag 0x%04X', $tag);
 
         if ($count === 1) {
             if ($value instanceof ExifNumericList) {
@@ -358,7 +388,7 @@ final class TiffExifReader
                 return (int) $value;
             }
 
-            $components = $this->decodeCountedComponents($type, $rawBytes, $count);
+            $components = $this->decodeCountedComponents($tag, $type, $rawBytes, $count);
 
             return $components[0] ?? 0;
         }
@@ -380,7 +410,7 @@ final class TiffExifReader
             return new ExifNumericList($normalised);
         }
 
-        $components = $this->decodeCountedComponents($type, $rawBytes, $count);
+        $components = $this->decodeCountedComponents($tag, $type, $rawBytes, $count);
 
         return new ExifNumericList($components);
     }
@@ -388,13 +418,14 @@ final class TiffExifReader
     /**
      * Decodes numeric components for counted strip/tile entries into integers.
      *
+     * @param int    $tag      TIFF tag identifier used to determine bounds checks.
      * @param int    $type     TIFF field type code.
      * @param string $rawBytes Raw bytes representing the values.
      * @param int    $count    Number of values represented.
      *
      * @return list<int>
      */
-    private function decodeCountedComponents(int $type, string $rawBytes, int $count): array
+    private function decodeCountedComponents(int $tag, int $type, string $rawBytes, int $count): array
     {
         $componentSize   = $this->bytesPerComponent($type);
         $expectedLength  = $componentSize * $count;
@@ -409,7 +440,7 @@ final class TiffExifReader
         for ($i = 0; $i < $count; ++$i) {
             $chunk = substr($rawBytes, $i * $componentSize, $componentSize);
 
-            $components[] = match ($type) {
+            $value = match ($type) {
                 self::TYPE_SHORT => $this->unpackU16($chunk),
                 self::TYPE_SSHORT => $this->unpackS16($chunk),
                 self::TYPE_LONG,
@@ -420,9 +451,74 @@ final class TiffExifReader
                 self::TYPE_SLONG8 => $this->unpackS64($chunk),
                 default => throw new ParseError('Unsupported numeric type for strip/tile field: ' . $type),
             };
+
+            if ($value instanceof UInt64) {
+                $value = ($tag === ExifTag::STRIP_OFFSETS || $tag === ExifTag::TILE_OFFSETS)
+                    ? $this->ensureOffset($value, sprintf('IFD tag 0x%04X', $tag))
+                    : $value->toInt(sprintf('IFD tag 0x%04X', $tag));
+            }
+
+            $components[] = $value;
         }
 
         return $components;
+    }
+
+    /**
+     * Converts decoded UInt64 values into integers to keep downstream models scalar.
+     *
+     * @param string $rawBytes Raw bytes backing the decoded value.
+     */
+    private function convertUInt64Values(
+        int $tag,
+        int $type,
+        int $count,
+        string $rawBytes,
+        int|float|string|ExifRational|ExifRationalList|ExifNumericList|UInt64 $value,
+    ): int|float|string|ExifRational|ExifRationalList|ExifNumericList {
+        if ($value instanceof UInt64) {
+            return $this->normaliseScalarUInt64($tag, $value);
+        }
+
+        if ($value instanceof ExifNumericList) {
+            $converted       = [];
+            $needsConversion = false;
+            foreach ($value->values as $component) {
+                if ($component instanceof UInt64) {
+                    $converted[] = $this->normaliseScalarUInt64($tag, $component);
+                    $needsConversion = true;
+                } elseif (is_int($component) || is_float($component)) {
+                    $converted[] = $component;
+                }
+            }
+
+            if ($needsConversion) {
+                return new ExifNumericList($converted);
+            }
+        }
+
+        return $value;
+    }
+
+    /**
+     * Normalises a UInt64 scalar into an integer, applying bounds checks for offsets.
+     */
+    private function normaliseScalarUInt64(int $tag, UInt64 $value): int
+    {
+        if ($this->isPointerTag($tag)) {
+            if (!$value->fitsSignedInt()) {
+                throw new BoundsError(sprintf('IFD tag 0x%04X exceeds supported integer range.', $tag));
+            }
+
+            return $value->toInt(sprintf('IFD tag 0x%04X', $tag));
+        }
+
+        return $value->toInt(sprintf('IFD tag 0x%04X value', $tag));
+    }
+
+    private function isPointerTag(int $tag): bool
+    {
+        return in_array($tag, self::POINTER_TAGS, true);
     }
 
     /**
@@ -473,7 +569,7 @@ final class TiffExifReader
         if ($value instanceof ExifNumericList) {
             $offsets = [];
             foreach ($value->values as $component) {
-                if (!is_int($component) && !is_float($component)) {
+                if (!is_int($component) && !is_float($component) && !$component instanceof UInt64) {
                     continue;
                 }
 
@@ -498,9 +594,9 @@ final class TiffExifReader
      * @param int    $count Number of values represented.
      * @param string $bytes Raw value bytes read from the blob.
      *
-     * @return int|float|string|ExifRational|ExifRationalList|ExifNumericList
+     * @return int|float|string|ExifRational|ExifRationalList|ExifNumericList|UInt64
      */
-    private function decodeBytes(int $type, int $count, string $bytes): int|float|string|ExifRational|ExifRationalList|ExifNumericList
+    private function decodeBytes(int $type, int $count, string $bytes): int|float|string|ExifRational|ExifRationalList|ExifNumericList|UInt64
     {
         $componentSize = $this->bytesPerComponent($type);
         $bytesLength   = strlen($bytes);
@@ -750,9 +846,9 @@ final class TiffExifReader
      * @param int $type  TIFF field type code.
      * @param int $count Number of values represented.
      *
-     * @return int
+     * @return int|UInt64
      */
-    private function readValueOrOffset(int $type, int $count): int
+    private function readValueOrOffset(int $type, int $count): int|UInt64
     {
         if (!$this->bigTiff) {
             return $this->readU32();
@@ -772,15 +868,61 @@ final class TiffExifReader
     }
 
     /**
+     * Ensures that an offset lies within the TIFF blob and returns it as an integer.
+     */
+    private function ensureOffset(int|UInt64 $offset, string $context, int $length = 0): int
+    {
+        $offset64 = $offset instanceof UInt64 ? $offset : UInt64::fromInt($offset);
+
+        $this->assertOffsetRange($offset64, $length, $context);
+
+        return $offset64->toInt($context);
+    }
+
+    /**
+     * Normalises an optional offset that may be zero.
+     */
+    private function normaliseOptionalOffset(UInt64 $offset, string $context): int
+    {
+        if ($offset->isZero()) {
+            return 0;
+        }
+
+        return $this->ensureOffset($offset, $context);
+    }
+
+    /**
+     * Verifies that an offset and optional length are contained within the TIFF blob.
+     */
+    private function assertOffsetRange(UInt64 $offset, int $length, string $context): void
+    {
+        if ($offset->compare($this->blobSize) > 0) {
+            throw new BoundsError(sprintf('%s exceeds TIFF data length.', $context));
+        }
+
+        $size = $this->buf->size();
+
+        if ($length > $size) {
+            throw new BoundsError(sprintf('%s length %d exceeds TIFF data length.', $context, $length));
+        }
+
+        $offsetInt = $offset->toInt($context);
+
+        if ($length > 0 && $offsetInt > $size - $length) {
+            throw new BoundsError(sprintf('%s exceeds TIFF data length.', $context));
+        }
+    }
+
+    /**
      * Extracts the raw bytes addressed by a directory entry.
      *
-     * @param int $type          TIFF field type code.
-     * @param int $count         Number of values represented.
-     * @param int $valueOrOffset Inline value bytes or an offset into the blob.
+     * @param int        $type          TIFF field type code.
+     * @param int        $count         Number of values represented.
+     * @param int|UInt64 $valueOrOffset Inline value bytes or an offset into the blob.
      *
      * @return array{0: string, 1: int|null}
      */
-    private function valueBytes(int $type, int $count, int $valueOrOffset): array
+    private function valueBytes(int $type, int $count, int|UInt64 $valueOrOffset): array
     {
         $unitSize        = $this->bytesPerComponent($type);
         $dataSize        = $unitSize * $count;
@@ -792,7 +934,7 @@ final class TiffExifReader
             return [substr($raw, 0, $dataSize), null];
         }
 
-        $offset  = $valueOrOffset;
+        $offset  = $this->ensureOffset($valueOrOffset, sprintf('Value offset for TIFF type %d', $type), $dataSize);
         $current = $this->buf->tell();
         $this->buf->seek($offset);
         $bytes = $this->buf->read($dataSize);
@@ -979,45 +1121,47 @@ final class TiffExifReader
     /**
      * Reads an unsigned 64-bit integer using the file byte order.
      *
-     * @return int
+     * @return UInt64
      */
-    private function readU64(): int
+    private function readU64(): UInt64
     {
-        $value = $this->bo === Endian::Little ? $this->buf->readU64LE() : $this->buf->readU64BE();
-
-        if ($value < 0) {
-            throw new ParseError('64-bit unsigned value exceeds PHP_INT_MAX.');
-        }
-
-        return $value;
+        return $this->bo === Endian::Little ? $this->buf->readU64LE() : $this->buf->readU64BE();
     }
 
     /**
      * Converts an integer into a byte string respecting the configured endianness.
      *
-     * @param int $v     Integer value to convert.
+     * @param int|UInt64 $v     Integer value to convert.
      * @param int $bytes Number of bytes to output.
      *
      * @return string
      */
-    private function uXToBytes(int $v, int $bytes): string
+    private function uXToBytes(int|UInt64 $v, int $bytes): string
     {
         // Convert integer to a byte string of specific length using current endianness
         if ($bytes === 4) {
-            return $this->bo === Endian::Little ? pack('V', $v) : pack('N', $v);
+            $value = $v instanceof UInt64 ? $v->toInt('Inline 32-bit value') : $v;
+
+            return $this->bo === Endian::Little ? pack('V', $value) : pack('N', $value);
         }
 
         if ($bytes === 8) {
-            $hi = ($v >> 32) & 0xFFFFFFFF;
-            $lo = $v & 0xFFFFFFFF;
+            if ($v instanceof UInt64) {
+                $hi = $v->high();
+                $lo = $v->low();
+            } else {
+                $lo = $v & 0xFFFFFFFF;
+                $hi = (int) intdiv($v, 0x100000000);
+            }
 
             return $this->bo === Endian::Little ? pack('V2', $lo, $hi) : pack('N2', $hi, $lo);
         }
 
         // fallback (shouldn't happen here)
         $bin = '';
+        $value = $v instanceof UInt64 ? $v->toInt('Inline value') : $v;
         for ($i = 0; $i < $bytes; ++$i) {
-            $bin = chr(($v >> ($this->bo === Endian::Little ? ($i * 8) : (($bytes - 1 - $i) * 8))) & 0xFF) . $bin;
+            $bin = chr(($value >> ($this->bo === Endian::Little ? ($i * 8) : (($bytes - 1 - $i) * 8))) & 0xFF) . $bin;
         }
 
         return $bin;
@@ -1128,9 +1272,9 @@ final class TiffExifReader
      *
      * @param string $b Source bytes.
      *
-     * @return int
+     * @return UInt64
      */
-    private function unpackU64(string $b): int
+    private function unpackU64(string $b): UInt64
     {
         [$hi, $lo] = $this->unpackU64Parts($b);
 
@@ -1149,12 +1293,12 @@ final class TiffExifReader
         [$hi, $lo] = $this->unpackU64Parts($b);
 
         if (($hi & 0x80000000) === 0) {
-            return Unpack::combineUint32($hi, $lo);
+            return Unpack::combineUint32($hi, $lo)->toInt('Signed 64-bit integer');
         }
 
         $hiComplement = (~$hi) & 0xFFFFFFFF;
         $loComplement = (~$lo) & 0xFFFFFFFF;
-        $magnitude    = Unpack::combineUint32($hiComplement, $loComplement) + 1;
+        $magnitude    = Unpack::combineUint32($hiComplement, $loComplement)->addSmall(1)->toInt('Signed 64-bit integer magnitude');
 
         return -$magnitude;
     }
@@ -1209,6 +1353,10 @@ final class TiffExifReader
             return $this->validatePointerOffset($value, $entry->tag);
         }
 
+        if ($value instanceof UInt64) {
+            return $this->ensureOffset($value, sprintf('IFD pointer tag 0x%04X', $entry->tag));
+        }
+
         if (is_float($value)) {
             return $this->pointerOffsetFromFloat($value, $entry->tag);
         }
@@ -1217,6 +1365,10 @@ final class TiffExifReader
             $first = $value->values[0] ?? null;
             if (is_int($first)) {
                 return $this->validatePointerOffset($first, $entry->tag);
+            }
+
+            if ($first instanceof UInt64) {
+                return $this->ensureOffset($first, sprintf('IFD pointer tag 0x%04X', $entry->tag));
             }
 
             if (is_float($first)) {
@@ -1241,11 +1393,7 @@ final class TiffExifReader
             throw new ParseError(sprintf('IFD pointer tag 0x%04X must not be negative.', $tag));
         }
 
-        if ($offset > PHP_INT_MAX) {
-            throw new ParseError(sprintf('IFD pointer tag 0x%04X is out of range.', $tag));
-        }
-
-        return $offset;
+        return $this->ensureOffset($offset, sprintf('IFD pointer tag 0x%04X', $tag));
     }
 
     /**
@@ -1262,10 +1410,10 @@ final class TiffExifReader
             throw new ParseError(sprintf('IFD pointer tag 0x%04X must contain an integer offset.', $tag));
         }
 
-        if ($value < 0.0 || $value > PHP_INT_MAX) {
-            throw new ParseError(sprintf('IFD pointer tag 0x%04X is out of range.', $tag));
+        if ($value < 0.0) {
+            throw new ParseError(sprintf('IFD pointer tag 0x%04X must not be negative.', $tag));
         }
 
-        return $this->validatePointerOffset((int) $value, $tag);
+        return $this->ensureOffset((int) $value, sprintf('IFD pointer tag 0x%04X', $tag));
     }
 }

--- a/tests/Core/MemoryBuffer/MemoryBufferTest.php
+++ b/tests/Core/MemoryBuffer/MemoryBufferTest.php
@@ -166,8 +166,8 @@ namespace MagicSunday\ImageMeta\Tests\Core\MemoryBuffer {
             self::assertSame(0x1234, $buffer->readU16BE());
             self::assertSame(0x78563412, $buffer->readU32LE());
             self::assertSame(0x12345678, $buffer->readU32BE());
-            self::assertSame(0x0123456789ABCDEF, $buffer->readU64LE());
-            self::assertSame(0x0123456789ABCDEF, $buffer->readU64BE());
+            self::assertSame(0x0123456789ABCDEF, $buffer->readU64LE()->toInt('test value'));
+            self::assertSame(0x0123456789ABCDEF, $buffer->readU64BE()->toInt('test value'));
             self::assertSame($buffer->size(), $buffer->tell());
         }
     }

--- a/tests/Core/Stream/StreamTest.php
+++ b/tests/Core/Stream/StreamTest.php
@@ -48,7 +48,7 @@ final class StreamTest extends TestCase
         self::assertSame(2, $stream->tell());
         self::assertSame(0x10203040, $stream->readU32BE());
         self::assertSame(6, $stream->tell());
-        self::assertSame(0x0123456789ABCDEF, $stream->readU64BE());
+        self::assertSame(0x0123456789ABCDEF, $stream->readU64BE()->toInt('test value'));
         self::assertSame(14, $stream->tell());
     }
 

--- a/tests/Core/StreamWindow/StreamWindowTest.php
+++ b/tests/Core/StreamWindow/StreamWindowTest.php
@@ -109,7 +109,7 @@ final class StreamWindowTest extends TestCase
         self::assertSame(0xAA, $window->readU8());
         self::assertSame(0xBEEF, $window->readU16BE());
         self::assertSame(0x01020304, $window->readU32BE());
-        self::assertSame(0x0123456789ABCDEF, $window->readU64BE());
+        self::assertSame(0x0123456789ABCDEF, $window->readU64BE()->toInt('test value'));
         self::assertSame(strlen($payload), $window->tell());
     }
 

--- a/tests/Parse/Tiff/TiffExifReaderTest.php
+++ b/tests/Parse/Tiff/TiffExifReaderTest.php
@@ -321,8 +321,8 @@ final class TiffExifReaderTest extends TestCase
             . pack('V', 0x00000000)
             . pack('V', 0x80000000);
 
-        $this->expectException(ParseError::class);
-        $this->expectExceptionMessage('exceeds PHP_INT_MAX');
+        $this->expectException(BoundsError::class);
+        $this->expectExceptionMessage('IFD offset exceeds TIFF data length.');
 
         (new TiffExifReader())->parseFromBlob($blob);
     }
@@ -339,6 +339,19 @@ final class TiffExifReaderTest extends TestCase
         $ifd0    = pack('v', 1) . $entries . pack('V', 0);
 
         $blob = $header . $ifd0;
+
+        $this->expectException(BoundsError::class);
+
+        (new TiffExifReader())->parseFromBlob($blob);
+    }
+
+    /**
+     * Ensures BigTIFF pointer offsets beyond the signed 63-bit range are rejected with a bounds error.
+     */
+    #[Test]
+    public function failsOnOutOfRangeBigTiffPointer(): void
+    {
+        $blob = self::buildBigTiffOutOfRangeOffsetBlob();
 
         $this->expectException(BoundsError::class);
 
@@ -803,10 +816,10 @@ final class TiffExifReaderTest extends TestCase
         $pointerMethod = $refClass->getMethod('pointerOffset');
         $pointerMethod->setAccessible(true);
 
-        self::assertSame(
-            self::BIG_TIFF_LONG8_JPEG_OFFSET,
-            $pointerMethod->invoke($reader, $jpegEntry),
-        );
+        $this->expectException(BoundsError::class);
+        $this->expectExceptionMessage('IFD pointer tag 0x0201 exceeds TIFF data length.');
+
+        $pointerMethod->invoke($reader, $jpegEntry);
     }
 
     /**
@@ -1385,6 +1398,31 @@ final class TiffExifReaderTest extends TestCase
     }
 
     /**
+     * Builds a BigTIFF payload where an IFD pointer exceeds the signed 63-bit range.
+     */
+    private static function buildBigTiffOutOfRangeOffsetBlob(): string
+    {
+        $header = 'II'
+            . pack('v', 0x002B)
+            . pack('v', 8)
+            . pack('v', 0)
+            . pack('V', 16)
+            . pack('V', 0);
+
+        $entries = [
+            self::packBigTiffEntry(ExifTag::GPS_IFD_POINTER, 18, 1, [0x00000001, 0x80000000]),
+        ];
+
+        $ifd0 = pack('V', count($entries))
+            . pack('V', 0)
+            . implode('', $entries)
+            . pack('V', 0)
+            . pack('V', 0);
+
+        return $header . $ifd0;
+    }
+
+    /**
      * Builds a minimal Classic TIFF payload containing scene and software tags inline.
      */
     private function buildClassicSceneSoftwareBlob(): string
@@ -1552,10 +1590,10 @@ final class TiffExifReaderTest extends TestCase
      * @param int $count         Number of values represented.
      * @param int $valueOrOffset Inline value or data offset.
      */
-    private static function packBigTiffEntry(int $tag, int $type, int $count, int $valueOrOffset): string
+    private static function packBigTiffEntry(int $tag, int $type, int $count, int|array $valueOrOffset): string
     {
         [$countLo, $countHi] = self::splitUInt64($count);
-        [$valueLo, $valueHi] = self::splitUInt64($valueOrOffset);
+        [$valueLo, $valueHi] = self::splitUInt64Components($valueOrOffset);
 
         return pack('v', $tag)
             . pack('v', $type)
@@ -1711,10 +1749,26 @@ final class TiffExifReaderTest extends TestCase
      *
      * @param int $value 64-bit integer value to encode.
      */
-    private static function packUInt64LE(int $value): string
+    private static function packUInt64LE(int|array $value): string
     {
-        [$lo, $hi] = self::splitUInt64($value);
+        [$lo, $hi] = self::splitUInt64Components($value);
 
         return pack('V', $lo) . pack('V', $hi);
+    }
+
+    /**
+     * Normalises an unsigned 64-bit representation into low/high components.
+     *
+     * @param int|array{0:int,1:int} $value Unsigned integer or explicit low/high pair.
+     *
+     * @return array{0:int,1:int}
+     */
+    private static function splitUInt64Components(int|array $value): array
+    {
+        if (is_array($value)) {
+            return [$value[0] & 0xFFFFFFFF, $value[1] & 0xFFFFFFFF];
+        }
+
+        return self::splitUInt64($value);
     }
 }


### PR DESCRIPTION
## Summary
- allow `ExifNumericList` entries to carry `UInt64` values and normalise them when exposing numeric lists through `ExifDocument`
- remove duplicate TIFF tile tag constants and import the UInt64 helper where required
- tighten BigTIFF pointer handling to throw `BoundsError` for out-of-range 64-bit offsets and update the TIFF parser tests accordingly

## Testing
- `.build/bin/phpunit --configuration .build/phpunit.xml tests/Parse/Tiff/TiffExifReaderTest.php`
- `composer ci:test:php:unit` *(fails: truth-comparison fixtures and unsupported container formats in the test suite)*
- `composer ci:test:php:phpstan` *(fails: existing maker-note/normaliser type issues already present in the codebase)*

------
https://chatgpt.com/codex/tasks/task_e_68fe5ab155d88323892f4b8c329c4d64