### PR TITLE
fix: honor legacy software tag when EXIF <3.0

### DIFF
--- a/src/Curate/Resolver/ExifTagResolver.php
+++ b/src/Curate/Resolver/ExifTagResolver.php
@@ -305,18 +305,11 @@ final readonly class ExifTagResolver
     }
 
     /**
-     * Returns the software tag value.
+     * Returns the software tag value while mirroring the document fallback.
      */
     public function software(): ?string
     {
-        $processingSoftware = $this->processingSoftware();
-        if ($processingSoftware !== null) {
-            return $processingSoftware;
-        }
-
-        $ifd0 = $this->document?->ifd0;
-
-        return $this->stringValue($ifd0, ExifTag::SOFTWARE);
+        return $this->document?->processingSoftware();
     }
 
     /**

--- a/src/Model/Exif/ExifDocument.php
+++ b/src/Model/Exif/ExifDocument.php
@@ -389,11 +389,22 @@ final readonly class ExifDocument
     }
 
     /**
-     * Returns the processing software string recorded during final image adjustments.
+     * Returns the processing software string recorded during final image adjustments,
+     * falling back to the legacy software tag for EXIF 2.x payloads.
      */
     public function processingSoftware(): ?string
     {
-        return $this->str($this->ifd0, ExifTag::PROCESSING_SOFTWARE);
+        $value = null;
+
+        if ($this->exifThreeOrNewer) {
+            $value = $this->str($this->ifd0, ExifTag::PROCESSING_SOFTWARE);
+        }
+
+        if ($value !== null) {
+            return $value;
+        }
+
+        return $this->str($this->ifd0, ExifTag::SOFTWARE);
     }
 
     /**

--- a/tests/Curate/Resolver/ExifTagResolverTest.php
+++ b/tests/Curate/Resolver/ExifTagResolverTest.php
@@ -262,6 +262,7 @@ final class ExifTagResolverTest extends TestCase
     public function exposesTemporalMetadata(): void
     {
         $exifIfd = new Ifd([
+            ExifTag::EXIF_VERSION               => new IfdEntry(ExifTag::EXIF_VERSION, 7, 4, '0300'),
             ExifTag::SUB_SEC_TIME           => new IfdEntry(ExifTag::SUB_SEC_TIME, 2, 3, '987'),
             ExifTag::SUB_SEC_TIME_ORIGINAL  => new IfdEntry(ExifTag::SUB_SEC_TIME_ORIGINAL, 2, 3, '123'),
             ExifTag::SUB_SEC_TIME_DIGITIZED => new IfdEntry(ExifTag::SUB_SEC_TIME_DIGITIZED, 2, 3, '456'),
@@ -326,6 +327,7 @@ final class ExifTagResolverTest extends TestCase
         ]);
 
         $exifIfd = new Ifd([
+            ExifTag::EXIF_VERSION               => new IfdEntry(ExifTag::EXIF_VERSION, 7, 4, '0300'),
             ExifTag::COMPONENTS_CONFIGURATION  => new IfdEntry(ExifTag::COMPONENTS_CONFIGURATION, 7, 4, new ExifNumericList([1, 2, 3, 0])),
             ExifTag::SCENE_TYPE                => new IfdEntry(ExifTag::SCENE_TYPE, 7, 1, chr(1)),
             ExifTag::CFA_REPEAT_PATTERN_DIM    => new IfdEntry(ExifTag::CFA_REPEAT_PATTERN_DIM, 3, 2, new ExifNumericList([6, 4])),
@@ -373,7 +375,11 @@ final class ExifTagResolverTest extends TestCase
             ExifTag::SOFTWARE => new IfdEntry(ExifTag::SOFTWARE, 2, 1, 'Legacy Writer'),
         ]);
 
-        $resolver = new ExifTagResolver(new ExifDocument($ifd0, null, null, null, null));
+        $exifIfd = new Ifd([
+            ExifTag::EXIF_VERSION => new IfdEntry(ExifTag::EXIF_VERSION, 7, 4, '0221'),
+        ]);
+
+        $resolver = new ExifTagResolver(new ExifDocument($ifd0, $exifIfd, null, null, null));
 
         self::assertSame('Legacy Writer', $resolver->software());
     }

--- a/tests/Curate/StructuredMetadataBuilderTest.php
+++ b/tests/Curate/StructuredMetadataBuilderTest.php
@@ -646,7 +646,11 @@ final class StructuredMetadataBuilderTest extends TestCase
             ExifTag::SOFTWARE            => new IfdEntry(ExifTag::SOFTWARE, 2, 1, 'Legacy Writer'),
         ]);
 
-        $exifDocument = new ExifDocument($ifd0, null, null, null, null);
+        $exifIfd = new Ifd([
+            ExifTag::EXIF_VERSION => new IfdEntry(ExifTag::EXIF_VERSION, 7, 4, '0300'),
+        ]);
+
+        $exifDocument = new ExifDocument($ifd0, $exifIfd, null, null, null);
 
         $metadata = new Metadata(
             ['primary'],

--- a/tests/Model/Exif/ExifDocumentTest.php
+++ b/tests/Model/Exif/ExifDocumentTest.php
@@ -1090,9 +1090,29 @@ final class ExifDocumentTest extends TestCase
             ExifTag::PROCESSING_SOFTWARE => new IfdEntry(ExifTag::PROCESSING_SOFTWARE, 2, 1, "PixelLab\0\0"),
         ]);
 
-        $doc = new ExifDocument($ifd0, null, null, null, null);
+        $exifIfd = new Ifd([
+            ExifTag::EXIF_VERSION => new IfdEntry(ExifTag::EXIF_VERSION, 7, 4, '0300'),
+        ]);
+
+        $doc = new ExifDocument($ifd0, $exifIfd, null, null, null);
 
         self::assertSame('PixelLab', $doc->processingSoftware());
+    }
+
+    #[Test]
+    public function processingSoftwareFallsBackToLegacyForExifTwo(): void
+    {
+        $ifd0 = new Ifd([
+            ExifTag::SOFTWARE => new IfdEntry(ExifTag::SOFTWARE, 2, 1, 'Legacy Editor'),
+        ]);
+
+        $exifIfd = new Ifd([
+            ExifTag::EXIF_VERSION => new IfdEntry(ExifTag::EXIF_VERSION, 7, 4, '0221'),
+        ]);
+
+        $doc = new ExifDocument($ifd0, $exifIfd, null, null, null);
+
+        self::assertSame('Legacy Editor', $doc->processingSoftware());
     }
 
     #[Test]


### PR DESCRIPTION
## Summary
- ensure the EXIF processing software accessor falls back to the legacy Software tag for EXIF 2.x payloads or when the new tag is absent
- let the EXIF resolver reuse the document accessor so structured metadata inherits the unified fallback
- extend EXIF document, resolver, and structured metadata tests with EXIF 2.x fixtures covering the fallback

## Testing
- composer ci:test:php:unit *(fails: known TruthComparison fixtures are unavailable in the sandbox environment)*
- composer exec -- phpunit --configuration .build/phpunit.xml tests/Model/Exif/ExifDocumentTest.php tests/Curate/Resolver/ExifTagResolverTest.php tests/Curate/StructuredMetadataBuilderTest.php


------
https://chatgpt.com/codex/tasks/task_e_68fe63af3b048323a2d8bcaf4ee5140f