### PR TITLE
feat: add flashpix version accessor to ExifDocument

### DIFF
--- a/src/Curate/Resolver/ExifTagResolver.php
+++ b/src/Curate/Resolver/ExifTagResolver.php
@@ -1149,18 +1149,7 @@ final readonly class ExifTagResolver
      */
     public function flashpixVersion(): ?string
     {
-        $value = $this->stringValue($this->document?->exifIfd, ExifTag::FLASHPIX_VERSION);
-
-        if ($value === null) {
-            return null;
-        }
-
-        $trimmed = trim($value, "\0");
-        if ($trimmed === '') {
-            return null;
-        }
-
-        return CoreValueConverters::toExifVersion($trimmed);
+        return $this->document?->flashpixVersion();
     }
 
     /**

--- a/src/Model/Exif/ExifDocument.php
+++ b/src/Model/Exif/ExifDocument.php
@@ -311,6 +311,26 @@ final readonly class ExifDocument
     }
 
     /**
+     * Returns the normalised FlashPix version string when present.
+     */
+    public function flashpixVersion(): ?string
+    {
+        $value = $this->rawString($this->exifIfd, ExifTag::FLASHPIX_VERSION);
+
+        if ($value === null) {
+            return null;
+        }
+
+        $trimmed = trim($value, "\0 ");
+
+        if ($trimmed === '') {
+            return null;
+        }
+
+        return CoreValueConverters::toExifVersion($trimmed);
+    }
+
+    /**
      * Returns the derived EXIF capability profile identifier.
      */
     public function exifProfile(): string

--- a/tests/Model/Exif/ExifDocumentTest.php
+++ b/tests/Model/Exif/ExifDocumentTest.php
@@ -152,6 +152,25 @@ final class ExifDocumentTest extends TestCase
     }
 
     #[Test]
+    public function normalisesFlashpixVersionFromPaddedNumericString(): void
+    {
+        $ifd0 = new Ifd([]);
+
+        $exifIfd = new Ifd([
+            ExifTag::FLASHPIX_VERSION => new IfdEntry(
+                ExifTag::FLASHPIX_VERSION,
+                2,
+                1,
+                pack('A8', '0300'),
+            ),
+        ]);
+
+        $doc = new ExifDocument($ifd0, $exifIfd, null, null, null);
+
+        self::assertSame('3.00', $doc->flashpixVersion());
+    }
+
+    #[Test]
     public function exposesCompositeImageMetadata(): void
     {
         $ifd0 = new Ifd([]);


### PR DESCRIPTION
## Summary
- add an ExifDocument accessor that trims and normalises FlashPix version strings
- delegate the resolver logic to the document-level helper
- cover padded FlashPix version bytes via a unit test fixture

## Testing
- composer ci:test:php:unit *(fails: existing TruthComparison fixture expectations and unsupported HEIC samples)*

------
https://chatgpt.com/codex/tasks/task_e_68fe63af78948323a85ba02da00bb537