### PR TITLE
Preserve BigTIFF inline raw values

### DIFF
--- a/src/Parse/Tiff/TiffExifReader.php
+++ b/src/Parse/Tiff/TiffExifReader.php
@@ -846,9 +846,9 @@ final class TiffExifReader
      * @param int $type  TIFF field type code.
      * @param int $count Number of values represented.
      *
-     * @return int|UInt64
+     * @return int|UInt64|string
      */
-    private function readValueOrOffset(int $type, int $count): int|UInt64
+    private function readValueOrOffset(int $type, int $count): int|UInt64|string
     {
         if (!$this->bigTiff) {
             return $this->readU32();
@@ -858,10 +858,14 @@ final class TiffExifReader
         $inlineThreshold  = 8;
         $inlineValueBytes = $componentSize * $count;
 
-        if ($inlineValueBytes <= $inlineThreshold && $type === self::TYPE_SLONG8) {
+        if ($inlineValueBytes <= $inlineThreshold) {
             $bytes = $this->buf->read($inlineThreshold);
 
-            return $this->unpackS64($bytes);
+            if ($inlineValueBytes === $inlineThreshold) {
+                return $bytes;
+            }
+
+            return substr($bytes, 0, $inlineValueBytes);
         }
 
         return $this->readU64();
@@ -918,17 +922,32 @@ final class TiffExifReader
      *
      * @param int        $type          TIFF field type code.
      * @param int        $count         Number of values represented.
-     * @param int|UInt64 $valueOrOffset Inline value bytes or an offset into the blob.
+     * @param int|UInt64|string $valueOrOffset Inline value bytes or an offset into the blob.
      *
      * @return array{0: string, 1: int|null}
      */
-    private function valueBytes(int $type, int $count, int|UInt64 $valueOrOffset): array
+    private function valueBytes(int $type, int $count, int|UInt64|string $valueOrOffset): array
     {
         $unitSize        = $this->bytesPerComponent($type);
         $dataSize        = $unitSize * $count;
         $inlineThreshold = $this->bigTiff ? 8 : 4;
 
         if ($dataSize <= $inlineThreshold) {
+            if (is_string($valueOrOffset)) {
+                if (strlen($valueOrOffset) < $dataSize) {
+                    throw new ParseError(
+                        sprintf(
+                            'Inline value for TIFF type %d truncated (expected %d bytes, got %d)',
+                            $type,
+                            $dataSize,
+                            strlen($valueOrOffset),
+                        ),
+                    );
+                }
+
+                return [$valueOrOffset, null];
+            }
+
             $raw = $this->uXToBytes($valueOrOffset, $inlineThreshold);
 
             return [substr($raw, 0, $dataSize), null];

--- a/tests/Parse/Tiff/TiffExifReaderTest.php
+++ b/tests/Parse/Tiff/TiffExifReaderTest.php
@@ -56,6 +56,10 @@ final class TiffExifReaderTest extends TestCase
 {
     private const int CUSTOM_SIGNED_LONG8_TAG = 0xC7A1;
 
+    private const int BIG_TIFF_INLINE_UNDEFINED_TAG = 0xC7A2;
+
+    private const string BIG_TIFF_INLINE_UNDEFINED_BYTES = "\x01\x00\x00\x00\x00\x00\x00\x80";
+
     /**
      * Expected StripOffsets values captured from ExifTool parsing the synthetic BigTIFF LONG8 fixture.
      *
@@ -894,6 +898,21 @@ final class TiffExifReaderTest extends TestCase
         $pointerMethod->invoke($reader, $jpegEntry);
     }
 
+    #[Test]
+    public function preservesBigTiffInlineUndefinedHighBit(): void
+    {
+        $reader   = new TiffExifReader();
+        $document = $reader->parseFromBlob(self::buildBigTiffInlineUndefinedHighBitBlob());
+
+        $entry = $document->ifd0->get(self::BIG_TIFF_INLINE_UNDEFINED_TAG);
+        self::assertNotNull($entry);
+
+        $value = $entry->value;
+        self::assertIsString($value);
+        self::assertSame(self::BIG_TIFF_INLINE_UNDEFINED_BYTES, $value);
+        self::assertSame(0x80, ord($value[7]));
+    }
+
     /**
      * Builds a Classic TIFF little-endian EXIF payload with nested IFDs.
      */
@@ -1524,6 +1543,30 @@ final class TiffExifReaderTest extends TestCase
         $blob .= $tileByteCountsData;
 
         return $blob;
+    }
+
+    /**
+     * Builds a minimal BigTIFF payload containing an inline UNDEFINED value with the high bit set.
+     */
+    private static function buildBigTiffInlineUndefinedHighBitBlob(): string
+    {
+        $header = 'II'
+            . pack('v', 0x002B)
+            . pack('v', 8)
+            . pack('v', 0)
+            . pack('V', 16)
+            . pack('V', 0);
+
+        $entry = self::packBigTiffEntry(
+            self::BIG_TIFF_INLINE_UNDEFINED_TAG,
+            7,
+            strlen(self::BIG_TIFF_INLINE_UNDEFINED_BYTES),
+            [0x00000001, 0x80000000],
+        );
+
+        $ifd0 = pack('V', 1) . pack('V', 0) . $entry . pack('V', 0) . pack('V', 0);
+
+        return $header . $ifd0;
     }
 
     /**


### PR DESCRIPTION
## Summary
- stop coercing inline BigTIFF directory values into integers and keep their raw bytes
- allow valueBytes() to accept already-read byte strings and validate their length
- add a regression test covering a BigTIFF inline UNDEFINED value with the high bit set

## Testing
- composer ci:test:php:unit *(fails: TruthComparisonTest fixtures are unavailable in this environment)*
- .build/bin/phpunit tests/Parse/Tiff/TiffExifReaderTest.php

------
https://chatgpt.com/codex/tasks/task_e_68fe63c2c24c8323bba1cb9f10c50167