### PR TITLE
feat: expose TIFF subfile type tags

### DIFF
--- a/src/Curate/Resolver/ExifTagResolver.php
+++ b/src/Curate/Resolver/ExifTagResolver.php
@@ -92,6 +92,8 @@ final readonly class ExifTagResolver
             'standardoutputsensitivity' => $this->numericValue($this->document?->exifIfd, ExifTag::STANDARD_OUTPUT_SENSITIVITY),
             'recommendedexposureindex'  => $this->numericValue($this->document?->exifIfd, ExifTag::RECOMMENDED_EXPOSURE_INDEX),
             'exifimagewidth'            => $this->numericValue($this->document?->exifIfd, ExifTag::PIXEL_X_DIMENSION),
+            'newsubfiletype'            => $this->numericValue($this->document?->ifd0, ExifTag::NEW_SUBFILE_TYPE),
+            'subfiletype'               => $this->numericValue($this->document?->ifd0, ExifTag::SUBFILE_TYPE),
             'imagewidth'                => $this->numericValue($this->document?->ifd0, ExifTag::IMAGE_WIDTH),
             'exifimageheight'           => $this->numericValue($this->document?->exifIfd, ExifTag::PIXEL_Y_DIMENSION),
             'imagelength'               => $this->numericValue($this->document?->ifd0, ExifTag::IMAGE_HEIGHT),
@@ -488,6 +490,22 @@ final readonly class ExifTagResolver
         }
 
         return CoreValueConverters::apexToFNumber($apex);
+    }
+
+    /**
+     * Returns the TIFF 6.0 NewSubfileType bitfield.
+     */
+    public function newSubfileType(): ?int
+    {
+        return $this->numericValue($this->document?->ifd0, ExifTag::NEW_SUBFILE_TYPE);
+    }
+
+    /**
+     * Returns the legacy TIFF 5.0 SubfileType value.
+     */
+    public function subfileType(): ?int
+    {
+        return $this->numericValue($this->document?->ifd0, ExifTag::SUBFILE_TYPE);
     }
 
     /**

--- a/src/Model/Exif/ExifTag.php
+++ b/src/Model/Exif/ExifTag.php
@@ -18,6 +18,16 @@ final readonly class ExifTag
 {
     // Image file directory (IFD0)
     /**
+     * TIFF 6.0 subfile type bitfield describing the purpose of the image data.
+     */
+    public const int NEW_SUBFILE_TYPE = 0x00FE;
+
+    /**
+     * Legacy TIFF 5.0 subfile type value describing the image purpose.
+     */
+    public const int SUBFILE_TYPE = 0x00FF;
+
+    /**
      * EXIF 3.0 tag recording the software responsible for final image processing.
      */
     public const int PROCESSING_SOFTWARE = 0x000B;

--- a/tests/Curate/Resolver/ExifTagResolverTest.php
+++ b/tests/Curate/Resolver/ExifTagResolverTest.php
@@ -441,6 +441,22 @@ final class ExifTagResolverTest extends TestCase
     }
 
     #[Test]
+    public function resolvesSubfileTypeTags(): void
+    {
+        $ifd0 = new Ifd([
+            ExifTag::NEW_SUBFILE_TYPE => new IfdEntry(ExifTag::NEW_SUBFILE_TYPE, 4, 1, 2),
+            ExifTag::SUBFILE_TYPE     => new IfdEntry(ExifTag::SUBFILE_TYPE, 3, 1, 1),
+        ]);
+
+        $resolver = new ExifTagResolver(new ExifDocument($ifd0, null, null, null, null));
+
+        self::assertSame(2, $resolver->newSubfileType());
+        self::assertSame(1, $resolver->subfileType());
+        self::assertSame(2, $resolver->int('newsubfiletype'));
+        self::assertSame(1, $resolver->int('subfiletype'));
+    }
+
+    #[Test]
     public function resolvesXpStringFallbacks(): void
     {
         $ifd0 = new Ifd([

--- a/tests/Model/Exif/ExifTagTest.php
+++ b/tests/Model/Exif/ExifTagTest.php
@@ -63,6 +63,8 @@ final class ExifTagTest extends TestCase
             'GPS_H_POSITIONING_ERROR' => 0x001F,
 
             // Image file directory (IFD0)
+            'NEW_SUBFILE_TYPE'             => 0x00FE,
+            'SUBFILE_TYPE'                 => 0x00FF,
             'PROCESSING_SOFTWARE'           => 0x000B,
             'IMAGE_WIDTH'                    => 0x0100,
             'IMAGE_HEIGHT'                   => 0x0101,
@@ -283,6 +285,15 @@ final class ExifTagTest extends TestCase
     public function testHostComputerConstantIsRetained(): void
     {
         self::assertSame(0x013C, ExifTag::HOST_COMPUTER);
+    }
+
+    /**
+     * Ensures the TIFF subfile type identifiers match the registry values.
+     */
+    public function testSubfileTypeConstantsMatchSpecification(): void
+    {
+        self::assertSame(0x00FE, ExifTag::NEW_SUBFILE_TYPE);
+        self::assertSame(0x00FF, ExifTag::SUBFILE_TYPE);
     }
 
     /**


### PR DESCRIPTION
## Summary
- add NEW_SUBFILE_TYPE and SUBFILE_TYPE constants to the EXIF tag registry
- expose TIFF subfile type values through ExifTagResolver with coverage
- extend existing model tests to assert the documented tag identifiers

## Testing
- composer ci:test:php:unit *(fails: TruthComparisonTest depends on unavailable HEIC fixtures in this environment)*
- composer ci:test:php:phpstan *(fails: pre-existing MakerNotes\AppleDecoder and TruthComparison issues surfaced in baseline)*

------
https://chatgpt.com/codex/tasks/task_e_68fe63ceca608323be40c165a83f3c64