### PR TITLE
feat: support SRATIONAL timezone offsets

### DIFF
--- a/src/Model/Exif/ExifDocument.php
+++ b/src/Model/Exif/ExifDocument.php
@@ -26,6 +26,7 @@ use MagicSunday\ImageMeta\Value\Enum\Saturation;
 use MagicSunday\ImageMeta\Value\Enum\SceneType;
 use MagicSunday\ImageMeta\Value\Enum\Sharpness;
 
+use function abs;
 use function array_key_exists;
 use function array_map;
 use function array_values;
@@ -38,6 +39,7 @@ use function ord;
 use function preg_replace;
 use function preg_split;
 use function rtrim;
+use function sprintf;
 use function sqrt;
 use function str_pad;
 use function str_replace;
@@ -45,6 +47,7 @@ use function strlen;
 use function strtoupper;
 use function substr;
 use function trim;
+use function intdiv;
 
 /**
  * Represents a parsed EXIF payload and exposes convenience accessors.
@@ -1746,25 +1749,71 @@ final readonly class ExifDocument
      */
     public function timeZoneOffsetMinutes(): ?array
     {
-        $values = $this->numericList($this->exifIfd, ExifTag::TIME_ZONE_OFFSET);
+        $value = $this->value($this->exifIfd, ExifTag::TIME_ZONE_OFFSET);
 
-        if ($values === null || $values === []) {
+        if ($value === null) {
             return null;
         }
 
-        $minutes = [];
-
-        foreach ($values as $value) {
-            $converted = ValueConverters::offsetToMinutes($value);
-
-            if ($converted === null) {
+        if ($value instanceof ExifRationalList) {
+            if ($value->values === []) {
                 return null;
             }
 
-            $minutes[] = $converted;
+            $minutes = [];
+
+            foreach ($value->values as $component) {
+                $converted = ValueConverters::offsetToMinutes($component);
+                if ($converted === null) {
+                    return null;
+                }
+
+                $minutes[] = $converted;
+            }
+
+            return $minutes;
         }
 
-        return $minutes;
+        if ($value instanceof ExifNumericList) {
+            if ($value->values === []) {
+                return null;
+            }
+
+            $minutes = [];
+
+            foreach ($value->values as $component) {
+                if ($component instanceof UInt64) {
+                    $component = $component->toInt('EXIF numeric list component');
+                }
+
+                if (!is_int($component) && !is_float($component)) {
+                    return null;
+                }
+
+                $converted = ValueConverters::offsetToMinutes($component);
+                if ($converted === null) {
+                    return null;
+                }
+
+                $minutes[] = $converted;
+            }
+
+            return $minutes;
+        }
+
+        if ($value instanceof ExifRational) {
+            $converted = ValueConverters::offsetToMinutes($value);
+
+            return $converted === null ? null : [$converted];
+        }
+
+        if (is_int($value) || is_float($value) || is_string($value)) {
+            $converted = ValueConverters::offsetToMinutes($value);
+
+            return $converted === null ? null : [$converted];
+        }
+
+        return null;
     }
 
     /**
@@ -2428,13 +2477,19 @@ final readonly class ExifDocument
      */
     private function derivedOffsetFromTimeZoneOffset(int $component = 0): ?string
     {
-        $values = $this->numericList($this->exifIfd, ExifTag::TIME_ZONE_OFFSET);
+        $values = $this->timeZoneOffsetMinutes();
 
         if ($values === null || !array_key_exists($component, $values)) {
             return null;
         }
 
-        return ValueConverters::parseOffsetString($values[$component]);
+        $minutes = $values[$component];
+        $sign    = $minutes < 0 ? '-' : '+';
+        $absolute = abs($minutes);
+        $hours    = intdiv($absolute, 60);
+        $remainingMinutes = $absolute % 60;
+
+        return sprintf('%s%02d:%02d', $sign, $hours, $remainingMinutes);
     }
 
     /**

--- a/src/Model/Exif/ValueConverters.php
+++ b/src/Model/Exif/ValueConverters.php
@@ -697,9 +697,9 @@ final readonly class ValueConverters
     /**
      * Normalises EXIF offset time values to a canonical "+HH:MM" representation.
      *
-     * @param int|float|string|null $value The raw offset value.
+     * @param int|float|string|ExifRational|ExifRationalList|null $value The raw offset value.
      */
-    public static function parseOffsetString(int|float|string|null $value): ?string
+    public static function parseOffsetString(int|float|string|ExifRational|ExifRationalList|null $value): ?string
     {
         $components = self::parseOffsetComponents($value);
 
@@ -717,7 +717,7 @@ final readonly class ValueConverters
      *
      * @param int|float|string|null $value The raw offset value.
      */
-    public static function offsetToMinutes(int|float|string|null $value): ?int
+    public static function offsetToMinutes(int|float|string|ExifRational|ExifRationalList|null $value): ?int
     {
         $components = self::parseOffsetComponents($value);
 
@@ -1391,14 +1391,32 @@ final readonly class ValueConverters
     /**
      * Parses numeric and textual offset encodings into sign, hour and minute components.
      *
-     * @param int|float|string|null $value The raw value to parse.
+     * @param int|float|string|ExifRational|ExifRationalList|null $value The raw value to parse.
      *
      * @return array{sign:int, hours:int, minutes:int}|null
      */
-    private static function parseOffsetComponents(int|float|string|null $value): ?array
+    private static function parseOffsetComponents(int|float|string|ExifRational|ExifRationalList|null $value): ?array
     {
         if ($value === null) {
             return null;
+        }
+
+        if ($value instanceof ExifRationalList) {
+            $first = $value->values[0] ?? null;
+
+            if ($first instanceof ExifRational) {
+                return self::parseOffsetComponents($first);
+            }
+
+            return null;
+        }
+
+        if ($value instanceof ExifRational) {
+            if ($value->denominator === 0) {
+                return null;
+            }
+
+            $value = (float) $value->numerator / (float) $value->denominator;
         }
 
         $raw = is_string($value) ? trim($value) : (string) $value;

--- a/tests/Curate/StructuredMetadataBuilderTest.php
+++ b/tests/Curate/StructuredMetadataBuilderTest.php
@@ -1376,6 +1376,35 @@ final class StructuredMetadataBuilderTest extends TestCase
         self::assertSame('-02:00', $structured->temporal->original?->format('P'));
     }
 
+    #[Test]
+    public function buildsTemporalFromSrationalTimeZoneOffset(): void
+    {
+        $ifd0 = new Ifd([
+            ExifTag::DATETIME_ORIGINAL => new IfdEntry(ExifTag::DATETIME_ORIGINAL, 2, 1, '2024:06:15 09:30:00'),
+        ]);
+
+        $exifIfd = new Ifd([
+            ExifTag::DATETIME_ORIGINAL => new IfdEntry(ExifTag::DATETIME_ORIGINAL, 2, 1, '2024:06:15 09:30:00'),
+            ExifTag::TIME_ZONE_OFFSET  => new IfdEntry(
+                ExifTag::TIME_ZONE_OFFSET,
+                10,
+                1,
+                new ExifRationalList([
+                    new ExifRational(11, 2),
+                ]),
+            ),
+        ]);
+
+        $exifDocument = new ExifDocument($ifd0, $exifIfd, null, null, null);
+        $metadata     = new Metadata(['primary'], null, $exifDocument);
+
+        $structured = (new StructuredMetadataBuilder())->build($metadata);
+
+        self::assertSame('TimeZoneOffset', $structured->temporal->tzSource);
+        self::assertSame('+05:30', $structured->temporal->original?->format('P'));
+        self::assertSame([330], $structured->temporal->timeZoneOffsetMinutes);
+    }
+
     /**
      * Ensures DateTimeOriginal does not leak the PHP default timezone when offset metadata is missing.
      */

--- a/tests/Model/Exif/ExifDocumentTest.php
+++ b/tests/Model/Exif/ExifDocumentTest.php
@@ -296,6 +296,35 @@ final class ExifDocumentTest extends TestCase
     }
 
     #[Test]
+    public function normalisesSrationalTimeZoneOffsetValues(): void
+    {
+        $ifd0 = new Ifd([
+            ExifTag::DATETIME_ORIGINAL => new IfdEntry(ExifTag::DATETIME_ORIGINAL, 2, 1, '2024:03:01 06:07:08'),
+        ]);
+
+        $exifIfd = new Ifd([
+            ExifTag::DATETIME_ORIGINAL => new IfdEntry(ExifTag::DATETIME_ORIGINAL, 2, 1, '2024:03:01 06:07:08'),
+            ExifTag::TIME_ZONE_OFFSET  => new IfdEntry(
+                ExifTag::TIME_ZONE_OFFSET,
+                10,
+                2,
+                new ExifRationalList([
+                    new ExifRational(11, 2),
+                    new ExifRational(-23, 4),
+                ]),
+            ),
+        ]);
+
+        $document = new ExifDocument($ifd0, $exifIfd, null, null, null);
+
+        self::assertSame([330, -345], $document->timeZoneOffsetMinutes());
+
+        $capture = $document->captureDateTime();
+        self::assertNotNull($capture);
+        self::assertSame('2024-03-01T06:07:08.000+05:30', $capture->format(self::ISO_8601_MILLISECONDS));
+    }
+
+    #[Test]
     public function decodesPrintImageMatchingPayload(): void
     {
         $payload = $this->buildPrintImPayload();

--- a/tests/Model/Exif/ValueConvertersTest.php
+++ b/tests/Model/Exif/ValueConvertersTest.php
@@ -304,6 +304,13 @@ final class ValueConvertersTest extends TestCase
         yield 'positive offset' => ['+01:30', 90];
         yield 'negative compact' => ['-0330', -210];
         yield 'decimal hours' => ['2.25', 135];
+        yield 'srational positive' => [new ExifRational(11, 2), 330];
+        yield 'srational list negative' => [
+            new ExifRationalList([
+                new ExifRational(-11, 2),
+            ]),
+            -330,
+        ];
         yield 'invalid input' => ['invalid', null];
     }
 


### PR DESCRIPTION
## Summary
- normalise EXIF SRATIONAL TimeZoneOffset entries to minutes in ExifDocument and legacy offset fallback logic
- extend ValueConverters offset helpers to accept ExifRational and ExifRationalList inputs
- add PHPUnit coverage for fractional offsets in the document, value converters, and structured metadata builder

## Testing
- composer exec phpunit -- tests/Model/Exif/ValueConvertersTest.php tests/Model/Exif/ExifDocumentTest.php tests/Curate/StructuredMetadataBuilderTest.php

------
https://chatgpt.com/codex/tasks/task_e_68fe63ecbd68832384625563ecdaff99