### PR TITLE
fix: default FlashPix version fallback

### DIFF
--- a/src/Curate/Resolver/ExifTagResolver.php
+++ b/src/Curate/Resolver/ExifTagResolver.php
@@ -1146,18 +1146,20 @@ final readonly class ExifTagResolver
 
     /**
      * Returns the FlashPix version string if present.
+     *
+     * Defaults to '1.00' when the tag is missing or contains only padding.
      */
     public function flashpixVersion(): ?string
     {
         $value = $this->stringValue($this->document?->exifIfd, ExifTag::FLASHPIX_VERSION);
 
         if ($value === null) {
-            return null;
+            return '1.00';
         }
 
         $trimmed = trim($value, "\0");
         if ($trimmed === '') {
-            return null;
+            return '1.00';
         }
 
         return CoreValueConverters::toExifVersion($trimmed);

--- a/tests/Curate/StructuredMetadataBuilderTest.php
+++ b/tests/Curate/StructuredMetadataBuilderTest.php
@@ -1966,6 +1966,11 @@ final class StructuredMetadataBuilderTest extends TestCase
                     continue;
                 }
 
+                if ($name === 'standards' && $field === 'flashpixVersion') {
+                    self::assertSame('1.00', $fieldValue, 'standards::flashpixVersion should fall back to the FlashPix 1.00 default');
+                    continue;
+                }
+
                 if (is_array($fieldValue)) {
                     self::assertSame([], $fieldValue, sprintf('%s::%s should be an empty array when metadata is missing', $name, $field));
                     continue;

--- a/tests/Parse/Tiff/TiffExifReaderTest.php
+++ b/tests/Parse/Tiff/TiffExifReaderTest.php
@@ -320,6 +320,41 @@ final class TiffExifReaderTest extends TestCase
     }
 
     /**
+     * Ensures FlashPix defaults to version 1.00 when the tag is absent.
+     */
+    #[Test]
+    public function defaultsFlashpixVersionWhenTagMissing(): void
+    {
+        $blob     = $this->buildClassicVersionBlobWithoutFlashpixTag();
+        $document = (new TiffExifReader())->parseFromBlob($blob);
+
+        $exifIfd = $document->exifIfd;
+        self::assertNotNull($exifIfd);
+        self::assertNull($exifIfd->get(ExifTag::FLASHPIX_VERSION));
+
+        $resolver = new ExifTagResolver($document);
+
+        self::assertSame('1.00', $resolver->flashpixVersion());
+    }
+
+    /**
+     * Ensures FlashPix padding values are normalised to the default version.
+     */
+    #[Test]
+    public function defaultsFlashpixVersionWhenTagContainsOnlyPadding(): void
+    {
+        $blob     = $this->buildClassicFlashpixPaddingBlob();
+        $document = (new TiffExifReader())->parseFromBlob($blob);
+
+        $exifIfd = $document->exifIfd;
+        self::assertNotNull($exifIfd);
+
+        $resolver = new ExifTagResolver($document);
+
+        self::assertSame('1.00', $resolver->flashpixVersion());
+    }
+
+    /**
      * Ensures PrintIM payloads preserve their binary data and are decoded into structured output.
      */
     #[Test]
@@ -1170,6 +1205,53 @@ final class TiffExifReaderTest extends TestCase
         $exifEntries = [
             self::packClassicEntry(ExifTag::EXIF_VERSION, 7, 4, self::inlineAsciiToInt('0232', 4)),
             self::packClassicEntry(ExifTag::FLASHPIX_VERSION, 7, 4, self::inlineAsciiToInt('0100', 4)),
+        ];
+
+        $exifIfd = pack('v', count($exifEntries)) . implode('', $exifEntries) . pack('V', 0);
+
+        return $header . $ifd0 . $exifIfd;
+    }
+
+    /**
+     * Builds a Classic TIFF blob without a FlashPix version tag.
+     */
+    private function buildClassicVersionBlobWithoutFlashpixTag(): string
+    {
+        $header = 'II' . pack('v', 0x002A) . pack('V', 8);
+
+        $exifIfdOffset = 8 + 2 + 12 + 4;
+
+        $ifd0Entries = [
+            self::packClassicEntry(ExifTag::EXIF_IFD_POINTER, 4, 1, $exifIfdOffset),
+        ];
+        $ifd0 = pack('v', count($ifd0Entries)) . implode('', $ifd0Entries) . pack('V', 0);
+
+        $exifEntries = [
+            self::packClassicEntry(ExifTag::EXIF_VERSION, 7, 4, self::inlineAsciiToInt('0232', 4)),
+        ];
+
+        $exifIfd = pack('v', count($exifEntries)) . implode('', $exifEntries) . pack('V', 0);
+
+        return $header . $ifd0 . $exifIfd;
+    }
+
+    /**
+     * Builds a Classic TIFF blob with a padded FlashPix version tag.
+     */
+    private function buildClassicFlashpixPaddingBlob(): string
+    {
+        $header = 'II' . pack('v', 0x002A) . pack('V', 8);
+
+        $exifIfdOffset = 8 + 2 + 12 + 4;
+
+        $ifd0Entries = [
+            self::packClassicEntry(ExifTag::EXIF_IFD_POINTER, 4, 1, $exifIfdOffset),
+        ];
+        $ifd0 = pack('v', count($ifd0Entries)) . implode('', $ifd0Entries) . pack('V', 0);
+
+        $exifEntries = [
+            self::packClassicEntry(ExifTag::EXIF_VERSION, 7, 4, self::inlineAsciiToInt('0232', 4)),
+            self::packClassicEntry(ExifTag::FLASHPIX_VERSION, 7, 4, self::inlineAsciiToInt('', 4)),
         ];
 
         $exifIfd = pack('v', count($exifEntries)) . implode('', $exifEntries) . pack('V', 0);


### PR DESCRIPTION
## Summary
- default the FlashPix version resolver to 1.00 when the EXIF tag is missing or padded
- extend TIFF EXIF reader coverage for missing and padded FlashPix entries
- adjust structured metadata defaults to expect the FlashPix 1.00 fallback

## Testing
- composer ci:test:php:unit *(fails: known fixture-dependent TruthComparison tests in this environment)*
- .build/bin/phpunit tests/Parse/Tiff/TiffExifReaderTest.php
- .build/bin/phpunit tests/Curate/StructuredMetadataBuilderTest.php

------
https://chatgpt.com/codex/tasks/task_e_68fe642bfcf883238d44f0e351a2b2f3