### PR TITLE
Default GPS version when EXIF tag is missing

### DIFF
--- a/docs/fields.md
+++ b/docs/fields.md
@@ -24,6 +24,8 @@ Unless stated otherwise, temperatures recorded via EXIF tags (for example `Captu
 Time zone offsets in `Temporal` are expressed as raw EXIF strings and minutes (`timeZoneOffsetMinutes`). GPS speed values
 (`Gps::speedMs`) are normalised to metres per second.
 
+When the EXIF GPS IFD omits `GPSVersionID` or only includes null padding, `Gps::version` resolves to the EXIF default `2.0.0.0`.
+
 ## Circle of confusion model
 
 `ValueConverters::calcCircleOfConfusionMm()` assumes a full-frame reference circle of confusion of 0.030&nbsp;mm. When a crop

--- a/src/Curate/Resolver/ExifTagResolver.php
+++ b/src/Curate/Resolver/ExifTagResolver.php
@@ -1585,6 +1585,8 @@ final readonly class ExifTagResolver
 
     /**
      * Returns the GPS version identifier string.
+     *
+     * Falls back to the EXIF default (2.0.0.0) when the IFD omits the tag or only reports padding.
      */
     public function gpsVersion(): ?string
     {

--- a/src/Curate/Resolver/GpsResolver.php
+++ b/src/Curate/Resolver/GpsResolver.php
@@ -43,6 +43,8 @@ final readonly class GpsResolver
 
     /**
      * Builds a GPS value object from the available metadata.
+     *
+     * The GPS version defaults to 2.0.0.0 whenever EXIF omits the tag or only exposes padding bytes.
      */
     public function resolve(?ExifDocument $exifDocument, ?XmpDocument $xmpDocument): ?Gps
     {

--- a/src/Model/Exif/ValueConverters.php
+++ b/src/Model/Exif/ValueConverters.php
@@ -101,6 +101,7 @@ final readonly class ValueConverters
     private const MAX_PRINT_IMAGE_MATCHING_PARAMETERS = 512;
     private const PRINTABLE_ASCII_MIN = 0x20;
     private const PRINTABLE_ASCII_MAX = 0x7E;
+    private const DEFAULT_GPS_VERSION = '2.0.0.0';
 
     /**
      * Converts a TIFF RATIONAL or scalar value into a floating point value.
@@ -1107,6 +1108,9 @@ final readonly class ValueConverters
             $components = array_map(static fn (int|float $component): int => (int) $component, $value->values);
 
             $normalized = implode('.', $components);
+            if ($normalized === '') {
+                $normalized = self::DEFAULT_GPS_VERSION;
+            }
 
             return [
                 'normalized' => $normalized,
@@ -1118,10 +1122,15 @@ final readonly class ValueConverters
             $clean = trim(str_replace("\0", '', $value));
             if ($clean !== '') {
                 $normalized = $clean;
+
+                return [
+                    'normalized' => $normalized,
+                    'raw' => $raw,
+                ];
             }
 
             return [
-                'normalized' => $normalized,
+                'normalized' => self::DEFAULT_GPS_VERSION,
                 'raw' => $raw,
             ];
         }
@@ -1145,7 +1154,7 @@ final readonly class ValueConverters
         }
 
         return [
-            'normalized' => null,
+            'normalized' => self::DEFAULT_GPS_VERSION,
             'raw' => $raw,
         ];
     }

--- a/src/Value/Gps.php
+++ b/src/Value/Gps.php
@@ -25,7 +25,7 @@ final readonly class Gps
      * @param string|null            $longitudeRef               Longitude hemisphere reference (E/W).
      * @param float|null             $altitude                   Altitude in metres relative to sea level.
      * @param int|null               $altitudeRef                Altitude reference (0 = above, 1 = below sea level).
-     * @param string|null            $version                    GPS metadata version string.
+     * @param string|null            $version                    GPS metadata version string (defaults to 2.0.0.0 when omitted).
      * @param string|null            $versionRaw                 Raw GPS version payload without normalisation.
      * @param string|null            $satellites                 Satellites used for measurement.
      * @param string|null            $status                     Receiver status at capture time.

--- a/tests/Curate/Resolver/GpsResolverTest.php
+++ b/tests/Curate/Resolver/GpsResolverTest.php
@@ -183,4 +183,42 @@ final class GpsResolverTest extends TestCase
         self::assertEqualsWithDelta(1.5, $gps->destinationDistanceOriginal ?? 0.0, 1e-6);
         self::assertSame('2024-05-06T10:34:56+00:00', $gps->timestamp?->format(DATE_ATOM));
     }
+
+    #[Test]
+    public function defaultsGpsVersionWhenExifTagMissing(): void
+    {
+        $gpsIfd = new Ifd([
+            ExifTag::GPS_LATITUDE_REF => new IfdEntry(ExifTag::GPS_LATITUDE_REF, 2, 2, 'N'),
+            ExifTag::GPS_LATITUDE     => new IfdEntry(
+                ExifTag::GPS_LATITUDE,
+                5,
+                3,
+                new ExifRationalList([
+                    new ExifRational(40, 1),
+                    new ExifRational(0, 1),
+                    new ExifRational(0, 1),
+                ]),
+            ),
+            ExifTag::GPS_LONGITUDE_REF => new IfdEntry(ExifTag::GPS_LONGITUDE_REF, 2, 2, 'E'),
+            ExifTag::GPS_LONGITUDE     => new IfdEntry(
+                ExifTag::GPS_LONGITUDE,
+                5,
+                3,
+                new ExifRationalList([
+                    new ExifRational(8, 1),
+                    new ExifRational(0, 1),
+                    new ExifRational(0, 1),
+                ]),
+            ),
+        ]);
+
+        $exifDocument = new ExifDocument(new Ifd([]), null, $gpsIfd, null, null);
+
+        $resolver = new GpsResolver();
+        $gps      = $resolver->resolve($exifDocument, null);
+
+        self::assertInstanceOf(Gps::class, $gps);
+        self::assertSame('2.0.0.0', $gps->version);
+        self::assertNull($gps->versionRaw);
+    }
 }

--- a/tests/Model/Exif/ExifDocumentTest.php
+++ b/tests/Model/Exif/ExifDocumentTest.php
@@ -149,6 +149,9 @@ final class ExifDocumentTest extends TestCase
         self::assertEqualsWithDelta(40.441666, $gps['lat'], 0.000001);
         self::assertEqualsWithDelta(79.983333, $gps['lon'], 0.000001);
         self::assertEquals(123.0, $gps['alt']);
+        self::assertSame('2.0.0.0', $gps['version']);
+        self::assertArrayHasKey('version_raw', $gps);
+        self::assertNull($gps['version_raw']);
     }
 
     #[Test]

--- a/tests/Model/Exif/ValueConvertersTest.php
+++ b/tests/Model/Exif/ValueConvertersTest.php
@@ -626,6 +626,30 @@ final class ValueConvertersTest extends TestCase
     }
 
     #[Test]
+    public function defaultsGpsVersionWhenEntryMissing(): void
+    {
+        $gps = new Ifd([]);
+
+        $result = ValueConverters::gpsFromIfd($gps);
+
+        self::assertSame('2.0.0.0', $result['version']);
+        self::assertNull($result['version_raw']);
+    }
+
+    #[Test]
+    public function defaultsGpsVersionWhenStringPayloadEmpty(): void
+    {
+        $gps = new Ifd([
+            ExifTag::GPS_VERSION_ID => new IfdEntry(ExifTag::GPS_VERSION_ID, 2, 4, "\0\0\0\0"),
+        ]);
+
+        $result = ValueConverters::gpsFromIfd($gps);
+
+        self::assertSame('2.0.0.0', $result['version']);
+        self::assertSame("\0\0\0\0", $result['version_raw']);
+    }
+
+    #[Test]
     public function decodeSpatialFrequencyResponseReturnsLabels(): void
     {
         $payload = pack('n', 1) . pack('n', 1);


### PR DESCRIPTION
## Summary
- default the GPS version to 2.0.0.0 when GPSVersionID is absent or contains only padding
- add unit coverage ensuring ExifDocument and the GPS resolver expose the default version
- document the default version behaviour in the GPS value object, resolver comments, and field reference

## Testing
- composer ci:test:php:unit *(fails: integration fixtures such as HEIC samples are unavailable in the container)*
- .build/bin/phpunit tests/Model/Exif/ValueConvertersTest.php tests/Model/Exif/ExifDocumentTest.php tests/Curate/Resolver/GpsResolverTest.php


------
https://chatgpt.com/codex/tasks/task_e_68fe642cb5448323b48c2369c6e7f8d3