### PR TITLE
feat(curate): add EXIF acceleration fallback

### DIFF
--- a/src/Curate/StructuredMetadataBuilder.php
+++ b/src/Curate/StructuredMetadataBuilder.php
@@ -261,7 +261,7 @@ final class StructuredMetadataBuilder
 
         $device = $this->buildDevice($exifResolver, $quickTimeResolver, $xmpResolver);
 
-        $apple = $this->buildApple($appleMakerNotes, $quickTimeResolver, $metadata->quickTime);
+        $apple = $this->buildApple($appleMakerNotes, $quickTimeResolver, $metadata->quickTime, $exifResolver);
         $xmp   = $xmpResolver->value();
 
         $file = new File(
@@ -853,6 +853,7 @@ final class StructuredMetadataBuilder
      * @param AppleMakerNotes|null $makerNotes        Parsed Apple maker note payload.
      * @param QuickTimeResolver    $quickTimeResolver Resolver exposing QuickTime metadata entries.
      * @param QuickTimeMeta|null   $quickTimeMeta     QuickTime metadata container used for content identifiers.
+     * @param ExifTagResolver      $exifResolver      Resolver exposing EXIF fallback values.
      *
      * @return Apple Apple metadata value object with normalised fields.
      */
@@ -860,6 +861,7 @@ final class StructuredMetadataBuilder
         ?AppleMakerNotes $makerNotes,
         QuickTimeResolver $quickTimeResolver,
         ?QuickTimeMeta $quickTimeMeta,
+        ExifTagResolver $exifResolver,
     ): Apple {
         $contentIdentifier = $makerNotes?->contentIdentifier;
         if ($contentIdentifier === null) {
@@ -938,6 +940,10 @@ final class StructuredMetadataBuilder
         $accelerationVector = $makerNotes?->accelerationVector;
         if ($accelerationVector === null) {
             $accelerationVector = $this->quickTimeFloatList($quickTimeResolver, 'AccelerationVector');
+        }
+
+        if ($accelerationVector === null) {
+            $accelerationVector = $exifResolver->accelerationVector();
         }
 
         $flags          = $makerNotes instanceof AppleMakerNotes ? $makerNotes->flags : [];

--- a/tests/Curate/StructuredMetadataBuilderTest.php
+++ b/tests/Curate/StructuredMetadataBuilderTest.php
@@ -870,6 +870,42 @@ final class StructuredMetadataBuilderTest extends TestCase
         self::assertEqualsWithDelta(0.56, $structured->motion->accelZ, 1e-12);
     }
 
+    /**
+     * Ensures EXIF acceleration vector data is used when maker notes and QuickTime values are absent.
+     */
+    #[Test]
+    public function usesExifAccelerationVectorWhenOtherSourcesMissing(): void
+    {
+        $exifIfd = new Ifd([
+            ExifTag::ACCELERATION => new IfdEntry(
+                ExifTag::ACCELERATION,
+                10,
+                3,
+                new ExifRationalList([
+                    new ExifRational(1, 5),
+                    new ExifRational(-3, 10),
+                    new ExifRational(7, 20),
+                ]),
+            ),
+        ]);
+
+        $exifDocument = new ExifDocument(new Ifd([]), $exifIfd, null, null, null);
+
+        $metadata   = new Metadata(['primary'], null, $exifDocument, []);
+        $structured = (new StructuredMetadataBuilder())->build($metadata);
+
+        $vector = $structured->apple->accelerationVector;
+        self::assertNotNull($vector);
+        self::assertCount(3, $vector);
+        self::assertEqualsWithDelta(0.2, $vector[0], 1e-12);
+        self::assertEqualsWithDelta(-0.3, $vector[1], 1e-12);
+        self::assertEqualsWithDelta(0.35, $vector[2], 1e-12);
+
+        self::assertEqualsWithDelta(0.2, $structured->motion->accelX, 1e-12);
+        self::assertEqualsWithDelta(-0.3, $structured->motion->accelY, 1e-12);
+        self::assertEqualsWithDelta(0.35, $structured->motion->accelZ, 1e-12);
+    }
+
     #[Test]
     public function usesQuickTimeEnumeratedValuesWhenMakerNotesMissing(): void
     {


### PR DESCRIPTION
## Summary
- add an ExifTagResolver fallback when building Apple acceleration vectors if maker notes and QuickTime metadata are empty
- extend StructuredMetadataBuilder tests to cover EXIF-only acceleration data and propagation into motion metadata

## Testing
- composer ci:test:php:unit *(fails: existing TruthComparison fixtures report unsupported containers and mismatches)*
- composer ci:test:php:phpstan *(fails: existing baseline issues in AppleDecoder, ExifDocument, and test suite)*

------
https://chatgpt.com/codex/tasks/task_e_68fe64387fb483239aa655084dfe9de8