### PR TITLE
fix: use EXIF acceleration vector when Apple data is missing

### DIFF
--- a/src/Curate/StructuredMetadataBuilder.php
+++ b/src/Curate/StructuredMetadataBuilder.php
@@ -1062,6 +1062,10 @@ final class StructuredMetadataBuilder
 
         $vector = $apple->accelerationVector;
 
+        if (!is_array($vector)) {
+            $vector = $exif->accelerationVector();
+        }
+
         $accelX = null;
         $accelY = null;
         $accelZ = null;

--- a/tests/Curate/StructuredMetadataBuilderTest.php
+++ b/tests/Curate/StructuredMetadataBuilderTest.php
@@ -847,6 +847,38 @@ final class StructuredMetadataBuilderTest extends TestCase
     }
 
     /**
+     * Ensures EXIF acceleration vectors populate motion when Apple data is absent.
+     */
+    #[Test]
+    public function usesExifAccelerationVectorWhenAppleDataMissing(): void
+    {
+        $ifd0 = new Ifd([]);
+
+        $exifIfd = new Ifd([
+            ExifTag::ACCELERATION => new IfdEntry(
+                ExifTag::ACCELERATION,
+                10,
+                3,
+                new ExifRationalList([
+                    new ExifRational(-3, 1),
+                    new ExifRational(4, 1),
+                    new ExifRational(1, 2),
+                ]),
+            ),
+        ]);
+
+        $exifDocument = new ExifDocument($ifd0, $exifIfd, null, null, null);
+
+        $metadata   = new Metadata(['primary'], null, $exifDocument, []);
+        $structured = (new StructuredMetadataBuilder())->build($metadata);
+
+        self::assertNull($structured->apple->accelerationVector);
+        self::assertEqualsWithDelta(-3.0, $structured->motion->accelX, 1e-12);
+        self::assertEqualsWithDelta(4.0, $structured->motion->accelY, 1e-12);
+        self::assertEqualsWithDelta(0.5, $structured->motion->accelZ, 1e-12);
+    }
+
+    /**
      * Ensures QuickTime metadata provides an acceleration vector when maker notes are absent.
      */
     #[Test]


### PR DESCRIPTION
## Summary
- fall back to the EXIF acceleration vector when Apple metadata does not supply one
- extend the structured metadata builder tests to cover the EXIF acceleration fallback

## Testing
- composer ci:test:php:unit *(fails: fixture HEIC samples and truth data are unavailable in the container)*
- ./.build/bin/phpunit --configuration .build/phpunit.xml tests/Curate/StructuredMetadataBuilderTest.php

------
https://chatgpt.com/codex/tasks/task_e_68fe643b31988323a367f216a1c57b93