### PR TITLE
Fix BigTIFF inline payload decoding

### DIFF
--- a/src/Parse/Tiff/TiffExifReader.php
+++ b/src/Parse/Tiff/TiffExifReader.php
@@ -313,12 +313,19 @@ final class TiffExifReader
      */
     private function readDirEntry(): array
     {
-        $tag      = $this->readU16();
-        $type     = $this->readU16();
-        $cnt      = $this->bigTiff ? $this->readU64()->toInt('directory entry value count') : $this->readU32();
-        $valOrOff = $this->bigTiff ? $this->readValueOrOffset($type, $cnt) : $this->readU32();
+        $tag  = $this->readU16();
+        $type = $this->readU16();
 
-        [$rawBytes] = $this->valueBytes($type, $cnt, $valOrOff);
+        if ($this->bigTiff) {
+            $cnt = $this->readU64()->toInt('directory entry value count');
+            [$valOrOff, $inlineValueBytes] = $this->readValueOrOffset($type, $cnt);
+        } else {
+            $cnt              = $this->readU32();
+            $valOrOff         = $this->readU32();
+            $inlineValueBytes = null;
+        }
+
+        [$rawBytes] = $this->valueBytes($type, $cnt, $valOrOff, $inlineValueBytes);
         $value      = $this->decodeBytes($type, $cnt, $rawBytes);
         $value      = $this->convertUInt64Values($tag, $type, $cnt, $rawBytes, $value);
 
@@ -846,25 +853,21 @@ final class TiffExifReader
      * @param int $type  TIFF field type code.
      * @param int $count Number of values represented.
      *
-     * @return int|UInt64
+     * @return array{0: int|UInt64, 1: string|null}
      */
-    private function readValueOrOffset(int $type, int $count): int|UInt64
+    private function readValueOrOffset(int $type, int $count): array
     {
-        if (!$this->bigTiff) {
-            return $this->readU32();
-        }
-
         $componentSize    = $this->bytesPerComponent($type);
         $inlineThreshold  = 8;
         $inlineValueBytes = $componentSize * $count;
 
-        if ($inlineValueBytes <= $inlineThreshold && $type === self::TYPE_SLONG8) {
+        if ($inlineValueBytes <= $inlineThreshold) {
             $bytes = $this->buf->read($inlineThreshold);
 
-            return $this->unpackS64($bytes);
+            return [0, $bytes];
         }
 
-        return $this->readU64();
+        return [$this->readU64(), null];
     }
 
     /**
@@ -916,20 +919,26 @@ final class TiffExifReader
     /**
      * Extracts the raw bytes addressed by a directory entry.
      *
-     * @param int        $type          TIFF field type code.
-     * @param int        $count         Number of values represented.
-     * @param int|UInt64 $valueOrOffset Inline value bytes or an offset into the blob.
+     * @param int         $type             TIFF field type code.
+     * @param int         $count            Number of values represented.
+     * @param int|UInt64  $valueOrOffset    Inline value bytes or an offset into the blob.
+     * @param string|null $inlineValueBytes Raw inline value bytes captured from the directory entry.
      *
      * @return array{0: string, 1: int|null}
      */
-    private function valueBytes(int $type, int $count, int|UInt64 $valueOrOffset): array
+    private function valueBytes(
+        int $type,
+        int $count,
+        int|UInt64 $valueOrOffset,
+        ?string $inlineValueBytes = null
+    ): array
     {
         $unitSize        = $this->bytesPerComponent($type);
         $dataSize        = $unitSize * $count;
         $inlineThreshold = $this->bigTiff ? 8 : 4;
 
         if ($dataSize <= $inlineThreshold) {
-            $raw = $this->uXToBytes($valueOrOffset, $inlineThreshold);
+            $raw = $inlineValueBytes ?? $this->uXToBytes($valueOrOffset, $inlineThreshold);
 
             return [substr($raw, 0, $dataSize), null];
         }

--- a/tests/Parse/Tiff/TiffExifReaderTest.php
+++ b/tests/Parse/Tiff/TiffExifReaderTest.php
@@ -894,6 +894,16 @@ final class TiffExifReaderTest extends TestCase
         $pointerMethod->invoke($reader, $jpegEntry);
     }
 
+    #[Test]
+    public function decodesInlineBigTiffDouble(): void
+    {
+        $document = (new TiffExifReader())->parseFromBlob(self::buildBigTiffInlineDoubleBlob());
+
+        $entry = $document->ifd0->get(ExifTag::CAMERA_YAW_DEGREE);
+        self::assertNotNull($entry);
+        self::assertSame(-5.0, $entry->value);
+    }
+
     /**
      * Builds a Classic TIFF little-endian EXIF payload with nested IFDs.
      */
@@ -1524,6 +1534,32 @@ final class TiffExifReaderTest extends TestCase
         $blob .= $tileByteCountsData;
 
         return $blob;
+    }
+
+    /**
+     * Builds a minimal BigTIFF payload containing an inline DOUBLE value.
+     */
+    private static function buildBigTiffInlineDoubleBlob(): string
+    {
+        $header = 'II'
+            . pack('v', 0x002B)
+            . pack('v', 8)
+            . pack('v', 0)
+            . pack('V', 16)
+            . pack('V', 0);
+
+        $yawBytes = pack('e', -5.0);
+        /** @var array{1:int,2:int} $components */
+        $components = unpack('V2', $yawBytes);
+        $entryValue = [$components[1], $components[2]];
+
+        $entries = [
+            self::packBigTiffEntry(ExifTag::CAMERA_YAW_DEGREE, 12, 1, $entryValue),
+        ];
+
+        $ifd0 = pack('V', count($entries)) . pack('V', 0) . implode('', $entries) . pack('V', 0) . pack('V', 0);
+
+        return $header . $ifd0;
     }
 
     /**


### PR DESCRIPTION
## Summary
- capture inline BigTIFF directory entry payloads as raw bytes before decoding
- thread inline bytes through value extraction so 64-bit types and doubles preserve their bit patterns
- cover inline negative DOUBLE handling with a synthetic BigTIFF regression test

## Testing
- composer ci:test:php:unit *(fails: expected TruthComparison fixtures are unavailable in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68fe644c8e688323a5c6c151c577b923