### PR TITLE
fix: handle BigTIFF offsets beyond signed range

### DIFF
--- a/src/Core/Util/Unpack.php
+++ b/src/Core/Util/Unpack.php
@@ -65,6 +65,42 @@ final class Unpack
     }
 
     /**
+     * Unpacks an unsigned 64-bit integer into a {@see UInt64} instance.
+     *
+     * @param string $bytes        Raw bytes to unpack.
+     * @param bool   $littleEndian Whether the bytes use little-endian order.
+     * @param string $context      Human-readable description used in error messages.
+     *
+     * @return UInt64
+     */
+    public static function uint64(string $bytes, bool $littleEndian, string $context): UInt64
+    {
+        $format = $littleEndian ? 'V2' : 'N2';
+        $parts  = unpack($format, $bytes);
+
+        if ($parts === false || !isset($parts[1], $parts[2])) {
+            throw new ParseError('Failed to unpack ' . $context . '.');
+        }
+
+        $first  = $parts[1];
+        $second = $parts[2];
+
+        if ((!is_int($first) && !is_float($first)) || (!is_int($second) && !is_float($second))) {
+            throw new ParseError('Unpacked ' . $context . ' is not numeric.');
+        }
+
+        if ($littleEndian) {
+            $lo = (int) $first;
+            $hi = (int) $second;
+        } else {
+            $hi = (int) $first;
+            $lo = (int) $second;
+        }
+
+        return self::combineUint32($hi, $lo);
+    }
+
+    /**
      * Unpacks a numeric value using {@see unpack} while validating the result.
      *
      * @param string $format  Format accepted by {@see unpack}.

--- a/src/Model/Exif/IfdEntry.php
+++ b/src/Model/Exif/IfdEntry.php
@@ -11,6 +11,8 @@ declare(strict_types=1);
 
 namespace MagicSunday\ImageMeta\Model\Exif;
 
+use MagicSunday\ImageMeta\Core\Util\UInt64;
+
 use function array_values;
 use function count;
 use function is_array;
@@ -20,7 +22,7 @@ use function is_int;
 /**
  * Represents a single entry within an image file directory (IFD).
  *
- * @phpstan-type ExifScalarValue int|float|string|ExifRational|ExifRationalList|ExifNumericList
+ * @phpstan-type ExifScalarValue int|float|string|ExifRational|ExifRationalList|ExifNumericList|UInt64
  * @phpstan-type ExifInputValue ExifScalarValue|array<int|string, int|float|array<int|string, int|float>>
  */
 final readonly class IfdEntry
@@ -31,7 +33,7 @@ final readonly class IfdEntry
 
     public int $count;
 
-    public int|float|string|ExifRational|ExifRationalList|ExifNumericList $value;
+    public int|float|string|ExifRational|ExifRationalList|ExifNumericList|UInt64 $value;
 
     /**
      * Normalises raw decoded values so callers may provide convenient array representations.
@@ -45,7 +47,7 @@ final readonly class IfdEntry
         int $tag,
         int $type,
         int $count,
-        int|float|string|ExifRational|ExifRationalList|ExifNumericList|array $value,
+        int|float|string|ExifRational|ExifRationalList|ExifNumericList|UInt64|array $value,
     ) {
         $this->tag   = $tag;
         $this->type  = $type;
@@ -65,8 +67,8 @@ final readonly class IfdEntry
     private function normaliseValue(
         int $type,
         int $count,
-        int|float|string|ExifRational|ExifRationalList|ExifNumericList|array $value,
-    ): int|float|string|ExifRational|ExifRationalList|ExifNumericList {
+        int|float|string|ExifRational|ExifRationalList|ExifNumericList|UInt64|array $value,
+    ): int|float|string|ExifRational|ExifRationalList|ExifNumericList|UInt64 {
         if (!is_array($value)) {
             return $value;
         }

--- a/src/Parse/Tiff/TiffExifReader.php
+++ b/src/Parse/Tiff/TiffExifReader.php
@@ -465,7 +465,7 @@ final class TiffExifReader
     }
 
     /**
-     * Converts decoded UInt64 values into integers to keep downstream models scalar.
+     * Converts decoded UInt64 values into integers when possible, preserving oversize pointer offsets.
      *
      * @param string $rawBytes Raw bytes backing the decoded value.
      */
@@ -475,7 +475,7 @@ final class TiffExifReader
         int $count,
         string $rawBytes,
         int|float|string|ExifRational|ExifRationalList|ExifNumericList|UInt64 $value,
-    ): int|float|string|ExifRational|ExifRationalList|ExifNumericList {
+    ): int|float|string|ExifRational|ExifRationalList|ExifNumericList|UInt64 {
         if ($value instanceof UInt64) {
             return $this->normaliseScalarUInt64($tag, $value);
         }
@@ -501,16 +501,18 @@ final class TiffExifReader
     }
 
     /**
-     * Normalises a UInt64 scalar into an integer, applying bounds checks for offsets.
+     * Normalises a UInt64 scalar into an integer when possible, preserving oversized pointer values.
+     *
+     * @return int|UInt64
      */
-    private function normaliseScalarUInt64(int $tag, UInt64 $value): int
+    private function normaliseScalarUInt64(int $tag, UInt64 $value): int|UInt64
     {
         if ($this->isPointerTag($tag)) {
-            if (!$value->fitsSignedInt()) {
-                throw new BoundsError(sprintf('IFD tag 0x%04X exceeds supported integer range.', $tag));
+            if ($value->fitsSignedInt()) {
+                return $value->toInt(sprintf('IFD pointer tag 0x%04X', $tag));
             }
 
-            return $value->toInt(sprintf('IFD tag 0x%04X', $tag));
+            return $value;
         }
 
         return $value->toInt(sprintf('IFD tag 0x%04X value', $tag));
@@ -1276,9 +1278,7 @@ final class TiffExifReader
      */
     private function unpackU64(string $b): UInt64
     {
-        [$hi, $lo] = $this->unpackU64Parts($b);
-
-        return Unpack::combineUint32($hi, $lo);
+        return Unpack::uint64($b, $this->bo === Endian::Little, '64-bit value from TIFF bytes');
     }
 
     /**
@@ -1290,10 +1290,12 @@ final class TiffExifReader
      */
     private function unpackS64(string $b): int
     {
-        [$hi, $lo] = $this->unpackU64Parts($b);
+        $unsigned = $this->unpackU64($b);
+        $hi       = $unsigned->high();
+        $lo       = $unsigned->low();
 
         if (($hi & 0x80000000) === 0) {
-            return Unpack::combineUint32($hi, $lo)->toInt('Signed 64-bit integer');
+            return $unsigned->toInt('Signed 64-bit integer');
         }
 
         $hiComplement = (~$hi) & 0xFFFFFFFF;
@@ -1301,26 +1303,6 @@ final class TiffExifReader
         $magnitude    = Unpack::combineUint32($hiComplement, $loComplement)->addSmall(1)->toInt('Signed 64-bit integer magnitude');
 
         return -$magnitude;
-    }
-
-    /**
-     * Reads the high and low 32-bit components of a 64-bit value according to the current endianness.
-     *
-     * @param string $b Source bytes.
-     *
-     * @return array{0:int,1:int}
-     */
-    private function unpackU64Parts(string $b): array
-    {
-        if ($this->bo === Endian::Little) {
-            $lo = $this->unpackU32(substr($b, 0, 4));
-            $hi = $this->unpackU32(substr($b, 4, 4));
-        } else {
-            $hi = $this->unpackU32(substr($b, 0, 4));
-            $lo = $this->unpackU32(substr($b, 4, 4));
-        }
-
-        return [$hi, $lo];
     }
 
     /**

--- a/tests/Parse/Tiff/TiffExifReaderTest.php
+++ b/tests/Parse/Tiff/TiffExifReaderTest.php
@@ -426,6 +426,7 @@ final class TiffExifReaderTest extends TestCase
         $blob = self::buildBigTiffOutOfRangeOffsetBlob();
 
         $this->expectException(BoundsError::class);
+        $this->expectExceptionMessage('IFD pointer tag 0x8825 exceeds TIFF data length.');
 
         (new TiffExifReader())->parseFromBlob($blob);
     }


### PR DESCRIPTION
## Summary
- add an unsigned 64-bit unpack helper and use it when decoding BigTIFF values
- allow TIFF pointer fields to retain UInt64 values when they exceed the native integer range
- extend the EXIF IFD model and tests to cover out-of-range BigTIFF pointer validation

## Testing
- `composer ci:test:php:unit -- tests/Parse/Tiff/TiffExifReaderTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68fe644d8ff083238fb4686db6d57db9