### PR TITLE
feat: handle BigTIFF 16-byte offsets

### DIFF
--- a/src/Parse/Tiff/TiffExifReader.php
+++ b/src/Parse/Tiff/TiffExifReader.php
@@ -44,6 +44,7 @@ use function rtrim;
 use function sha1;
 use function sprintf;
 use function strlen;
+use function str_pad;
 use function strncmp;
 use function substr;
 
@@ -134,6 +135,8 @@ final class TiffExifReader
 
     private bool $bigTiff = false;
 
+    private int $bigTiffOffsetSize = 8;
+
     private UInt64 $blobSize;
 
     private ?string $makerNoteRaw = null;
@@ -162,9 +165,10 @@ final class TiffExifReader
         $this->buf->seek(0);
         $this->blobSize = UInt64::fromInt($this->buf->size());
 
-        $this->makerNoteRaw = null;
-        $this->subIfds      = [];
-        $this->ifdCache     = [];
+        $this->makerNoteRaw      = null;
+        $this->subIfds           = [];
+        $this->ifdCache          = [];
+        $this->bigTiffOffsetSize = 8;
 
         // byte order
         $boSig    = $this->buf->read(2);
@@ -178,7 +182,7 @@ final class TiffExifReader
         if ($magic === self::TIFF_MAGIC_BIG) {
             $this->bigTiff = true;
             $this->parseBigTiffHeader();
-            $firstIfd = $this->readU64();
+            $firstIfd = $this->readBigTiffOffset();
             $ifd0     = $this->readIfd($firstIfd);
         } elseif ($magic === self::TIFF_MAGIC_CLASSIC) {
             $this->bigTiff = false;
@@ -255,17 +259,19 @@ final class TiffExifReader
      */
     private function parseBigTiffHeader(): void
     {
-        // BigTIFF header after magic: 2 bytes: offset size (should be 8), 2 bytes: zero/reserved, then 8‑byte first IFD offset
+        // BigTIFF header after magic: 2 bytes offset size, 2 bytes reserved
         $offSize  = $this->readU16();
         $reserved = $this->readU16();
 
-        if ($offSize !== 8) {
-            throw new ParseError('Unsupported BigTIFF offset size (expected 8)');
+        if ($offSize !== 8 && $offSize !== 16) {
+            throw new ParseError('Unsupported BigTIFF offset size (expected 8 or 16)');
         }
 
         if ($reserved !== 0) {
             throw new ParseError('Bad BigTIFF header (reserved != 0)');
         }
+
+        $this->bigTiffOffsetSize = $offSize;
     }
 
     /**
@@ -275,7 +281,7 @@ final class TiffExifReader
      *
      * @return Ifd
      */
-    private function readIfd(int|UInt64 $offset): Ifd
+    private function readIfd(int|UInt64|string $offset): Ifd
     {
         if ($offset instanceof UInt64) {
             if ($offset->isZero()) {
@@ -298,7 +304,7 @@ final class TiffExifReader
             $entries += $this->readDirEntry();
         }
 
-        $next = $this->bigTiff ? $this->normaliseOptionalOffset($this->readU64(), 'IFD next offset') : $this->readU32();
+        $next = $this->bigTiff ? $this->normaliseOptionalOffset($this->readBigTiffOffset(), 'IFD next offset') : $this->readU32();
         $ifd  = new Ifd($entries, $next > 0 ? $next : null);
 
         $this->ifdCache[$offsetInt] = $ifd;
@@ -313,12 +319,19 @@ final class TiffExifReader
      */
     private function readDirEntry(): array
     {
-        $tag      = $this->readU16();
-        $type     = $this->readU16();
-        $cnt      = $this->bigTiff ? $this->readU64()->toInt('directory entry value count') : $this->readU32();
-        $valOrOff = $this->bigTiff ? $this->readValueOrOffset($type, $cnt) : $this->readU32();
+        $tag  = $this->readU16();
+        $type = $this->readU16();
 
-        [$rawBytes] = $this->valueBytes($type, $cnt, $valOrOff);
+        if ($this->bigTiff) {
+            $cnt = $this->readU64()->toInt('directory entry value count');
+            [$valOrOff, $inlineBytes] = $this->readValueOrOffset($type, $cnt);
+        } else {
+            $cnt        = $this->readU32();
+            $valOrOff   = $this->readU32();
+            $inlineBytes = null;
+        }
+
+        [$rawBytes] = $this->valueBytes($type, $cnt, $valOrOff, $inlineBytes);
         $value      = $this->decodeBytes($type, $cnt, $rawBytes);
         $value      = $this->convertUInt64Values($tag, $type, $cnt, $rawBytes, $value);
 
@@ -846,32 +859,110 @@ final class TiffExifReader
      * @param int $type  TIFF field type code.
      * @param int $count Number of values represented.
      *
-     * @return int|UInt64
+     * @return array{0:int|UInt64|string,1:?string}
      */
-    private function readValueOrOffset(int $type, int $count): int|UInt64
+    private function readValueOrOffset(int $type, int $count): array
     {
         if (!$this->bigTiff) {
-            return $this->readU32();
+            return [$this->readU32(), null];
         }
 
         $componentSize    = $this->bytesPerComponent($type);
-        $inlineThreshold  = 8;
+        $inlineThreshold  = $this->bigTiffOffsetSize;
         $inlineValueBytes = $componentSize * $count;
 
-        if ($inlineValueBytes <= $inlineThreshold && $type === self::TYPE_SLONG8) {
-            $bytes = $this->buf->read($inlineThreshold);
+        $fieldBytes = $this->buf->read($this->bigTiffOffsetSize);
 
-            return $this->unpackS64($bytes);
+        if ($inlineValueBytes <= $inlineThreshold) {
+            return [0, $fieldBytes];
         }
 
-        return $this->readU64();
+        return [$this->decodeOffsetField($fieldBytes), null];
+    }
+
+    /**
+     * Reads a BigTIFF offset value honouring the configured offset size.
+     */
+    private function readBigTiffOffset(): int|UInt64|string
+    {
+        $bytes = $this->buf->read($this->bigTiffOffsetSize);
+
+        return $this->decodeOffsetField($bytes);
+    }
+
+    /**
+     * Converts a raw BigTIFF offset field into a PHP representation.
+     *
+     * @param string $bytes Raw bytes of length {@see $bigTiffOffsetSize}.
+     *
+     * @return int|UInt64|string
+     */
+    private function decodeOffsetField(string $bytes): int|UInt64|string
+    {
+        if (strlen($bytes) !== $this->bigTiffOffsetSize) {
+            throw new ParseError('Truncated BigTIFF offset field.');
+        }
+
+        if ($this->bigTiffOffsetSize === 8) {
+            return $this->unpackU64($bytes);
+        }
+
+        if ($this->bigTiffOffsetSize !== 16) {
+            throw new ParseError('Unsupported BigTIFF offset size: ' . $this->bigTiffOffsetSize);
+        }
+
+        if ($this->bo === Endian::Little) {
+            $lowBytes  = substr($bytes, 0, 8);
+            $highBytes = substr($bytes, 8, 8);
+        } else {
+            $highBytes = substr($bytes, 0, 8);
+            $lowBytes  = substr($bytes, 8, 8);
+        }
+
+        $low  = $this->unpackU64($lowBytes);
+        $high = $this->unpackU64($highBytes);
+
+        if ($high->isZero()) {
+            if ($low->fitsSignedInt()) {
+                return $low->toInt('BigTIFF offset');
+            }
+
+            return $this->formatOffsetString(null, $low);
+        }
+
+        return $this->formatOffsetString($high, $low);
+    }
+
+    /**
+     * Formats UInt64 components into a hexadecimal offset string.
+     */
+    private function formatOffsetString(?UInt64 $high, UInt64 $low): string
+    {
+        if ($high === null || $high->isZero()) {
+            $hex = ltrim($low->toHex(), '0');
+
+            return '0x' . ($hex === '' ? '0' : $hex);
+        }
+
+        $hexHigh = ltrim($high->toHex(), '0');
+        if ($hexHigh === '') {
+            $hexHigh = '0';
+        }
+
+        $hexLow = $low->toHex();
+
+        return '0x' . $hexHigh . str_pad($hexLow, 16, '0', STR_PAD_LEFT);
     }
 
     /**
      * Ensures that an offset lies within the TIFF blob and returns it as an integer.
      */
-    private function ensureOffset(int|UInt64 $offset, string $context, int $length = 0): int
+    private function ensureOffset(int|UInt64|string $offset, string $context, int $length = 0): int
     {
+        if (is_string($offset)) {
+            throw new BoundsError(sprintf('%s exceeds supported integer range (%s).', $context, $offset));
+        }
+
         $offset64 = $offset instanceof UInt64 ? $offset : UInt64::fromInt($offset);
 
         $this->assertOffsetRange($offset64, $length, $context);
@@ -882,9 +973,25 @@ final class TiffExifReader
     /**
      * Normalises an optional offset that may be zero.
      */
-    private function normaliseOptionalOffset(UInt64 $offset, string $context): int
+    private function normaliseOptionalOffset(int|UInt64|string $offset, string $context): int
     {
-        if ($offset->isZero()) {
+        if (is_int($offset)) {
+            if ($offset <= 0) {
+                return 0;
+            }
+
+            return $this->ensureOffset($offset, $context);
+        }
+
+        if ($offset instanceof UInt64) {
+            if ($offset->isZero()) {
+                return 0;
+            }
+
+            return $this->ensureOffset($offset, $context);
+        }
+
+        if ($offset === '0x0') {
             return 0;
         }
 
@@ -916,17 +1023,26 @@ final class TiffExifReader
     /**
      * Extracts the raw bytes addressed by a directory entry.
      *
-     * @param int        $type          TIFF field type code.
-     * @param int        $count         Number of values represented.
-     * @param int|UInt64 $valueOrOffset Inline value bytes or an offset into the blob.
+     * @param int                      $type          TIFF field type code.
+     * @param int                      $count         Number of values represented.
+     * @param int|UInt64|string        $valueOrOffset Inline value bytes or an offset into the blob.
+     * @param string|null              $inlineBytes   Raw inline value bytes for BigTIFF entries.
      *
      * @return array{0: string, 1: int|null}
      */
-    private function valueBytes(int $type, int $count, int|UInt64 $valueOrOffset): array
+    private function valueBytes(int $type, int $count, int|UInt64|string $valueOrOffset, ?string $inlineBytes = null): array
     {
         $unitSize        = $this->bytesPerComponent($type);
         $dataSize        = $unitSize * $count;
-        $inlineThreshold = $this->bigTiff ? 8 : 4;
+        $inlineThreshold = $this->bigTiff ? $this->bigTiffOffsetSize : 4;
+
+        if ($inlineBytes !== null) {
+            if (strlen($inlineBytes) < $dataSize) {
+                throw new ParseError('Truncated inline value for BigTIFF directory entry.');
+            }
+
+            return [substr($inlineBytes, 0, $dataSize), null];
+        }
 
         if ($dataSize <= $inlineThreshold) {
             $raw = $this->uXToBytes($valueOrOffset, $inlineThreshold);

--- a/tests/Parse/Tiff/TiffExifReaderTest.php
+++ b/tests/Parse/Tiff/TiffExifReaderTest.php
@@ -116,6 +116,46 @@ final class TiffExifReaderTest extends TestCase
         0x0000000100000400,
     ];
 
+    private const int BIG_TIFF_OFFSET16_TILE_WIDTH = 4096;
+
+    private const int BIG_TIFF_OFFSET16_TILE_LENGTH = 2048;
+
+    /**
+     * @var array<int>
+     */
+    private const array BIG_TIFF_OFFSET16_STRIP_OFFSETS = [
+        0x0000000300000100,
+        0x0000000300000200,
+        0x0000000300000300,
+    ];
+
+    /**
+     * @var array<int>
+     */
+    private const array BIG_TIFF_OFFSET16_STRIP_BYTE_COUNTS = [
+        0x0000000000002000,
+        0x0000000000001000,
+        0x0000000000000800,
+    ];
+
+    /**
+     * @var array<int>
+     */
+    private const array BIG_TIFF_OFFSET16_TILE_OFFSETS = [
+        0x0000000400000100,
+        0x0000000400000200,
+        0x0000000400000300,
+    ];
+
+    /**
+     * @var array<int>
+     */
+    private const array BIG_TIFF_OFFSET16_TILE_BYTE_COUNTS = [
+        0x0000000000004000,
+        0x0000000000002000,
+        0x0000000000001000,
+    ];
+
     /**
      * Provides representative Classic TIFF and BigTIFF payloads.
      *
@@ -131,6 +171,11 @@ final class TiffExifReaderTest extends TestCase
         yield 'big_tiff' => [
             self::buildBigTiffBlob(),
             'assertBigTiffDocument',
+        ];
+
+        yield 'big_tiff_offset16' => [
+            self::buildBigTiffOffset16Blob(),
+            'assertBigTiffOffset16Document',
         ];
     }
 
@@ -854,6 +899,56 @@ final class TiffExifReaderTest extends TestCase
     }
 
     /**
+     * Asserts the decoded values of the BigTIFF payload using 16-byte offsets.
+     */
+    private static function assertBigTiffOffset16Document(ExifDocument $doc): void
+    {
+        self::assertSame(self::BIG_TIFF_OFFSET16_TILE_WIDTH, $doc->ifd0->get(ExifTag::TILE_WIDTH)?->value);
+        self::assertSame(self::BIG_TIFF_OFFSET16_TILE_LENGTH, $doc->ifd0->get(ExifTag::TILE_LENGTH)?->value);
+
+        $stripOffsetsEntry = $doc->ifd0->get(ExifTag::STRIP_OFFSETS);
+        self::assertNotNull($stripOffsetsEntry);
+        $stripOffsets = $stripOffsetsEntry->value;
+        self::assertInstanceOf(ExifNumericList::class, $stripOffsets);
+        self::assertSame(self::BIG_TIFF_OFFSET16_STRIP_OFFSETS, $stripOffsets->values);
+
+        $stripByteCountsEntry = $doc->ifd0->get(ExifTag::STRIP_BYTE_COUNTS);
+        self::assertNotNull($stripByteCountsEntry);
+        $stripByteCounts = $stripByteCountsEntry->value;
+        self::assertInstanceOf(ExifNumericList::class, $stripByteCounts);
+        self::assertSame(self::BIG_TIFF_OFFSET16_STRIP_BYTE_COUNTS, $stripByteCounts->values);
+
+        $tileOffsetsEntry = $doc->ifd0->get(ExifTag::TILE_OFFSETS);
+        self::assertNotNull($tileOffsetsEntry);
+        $tileOffsets = $tileOffsetsEntry->value;
+        self::assertInstanceOf(ExifNumericList::class, $tileOffsets);
+        self::assertSame(self::BIG_TIFF_OFFSET16_TILE_OFFSETS, $tileOffsets->values);
+
+        $tileByteCountsEntry = $doc->ifd0->get(ExifTag::TILE_BYTE_COUNTS);
+        self::assertNotNull($tileByteCountsEntry);
+        $tileByteCounts = $tileByteCountsEntry->value;
+        self::assertInstanceOf(ExifNumericList::class, $tileByteCounts);
+        self::assertSame(self::BIG_TIFF_OFFSET16_TILE_BYTE_COUNTS, $tileByteCounts->values);
+
+        self::assertSame(
+            self::BIG_TIFF_OFFSET16_STRIP_OFFSETS,
+            $doc->stripOffsets(),
+        );
+        self::assertSame(
+            self::BIG_TIFF_OFFSET16_STRIP_BYTE_COUNTS,
+            $doc->stripByteCounts(),
+        );
+        self::assertSame(
+            self::BIG_TIFF_OFFSET16_TILE_OFFSETS,
+            $doc->tileOffsets(),
+        );
+        self::assertSame(
+            self::BIG_TIFF_OFFSET16_TILE_BYTE_COUNTS,
+            $doc->tileByteCounts(),
+        );
+    }
+
+    /**
      * Ensures BigTIFF LONG8/SLONG8/IFD8 entries are decoded exactly like ExifTool.
      */
     #[Test]
@@ -1527,6 +1622,75 @@ final class TiffExifReaderTest extends TestCase
     }
 
     /**
+     * Builds a BigTIFF payload using 16-byte offsets for directory fields.
+     */
+    private static function buildBigTiffOffset16Blob(): string
+    {
+        $offsetSize     = 16;
+        $firstIfdOffset = 256;
+
+        $header = 'II'
+            . pack('v', 0x002B)
+            . pack('v', $offsetSize)
+            . pack('v', 0)
+            . self::packBigTiffOffsetValue($firstIfdOffset, $offsetSize);
+
+        $entryCount = 6;
+        $entrySize  = 2 + 2 + 8 + $offsetSize;
+        $ifdLength  = 8 + ($entryCount * $entrySize) + $offsetSize;
+
+        $baseOffset = $firstIfdOffset + $ifdLength;
+        $cursor     = self::alignOffset($baseOffset, $offsetSize);
+
+        $stripOffsetsData = implode('', array_map([self::class, 'packUInt64LE'], self::BIG_TIFF_OFFSET16_STRIP_OFFSETS));
+        $stripOffsetsOffset = $cursor;
+        $cursor = self::alignOffset($cursor + strlen($stripOffsetsData), $offsetSize);
+
+        $stripByteCountsData = implode('', array_map([self::class, 'packUInt64LE'], self::BIG_TIFF_OFFSET16_STRIP_BYTE_COUNTS));
+        $stripByteCountsOffset = $cursor;
+        $cursor = self::alignOffset($cursor + strlen($stripByteCountsData), $offsetSize);
+
+        $tileOffsetsData = implode('', array_map([self::class, 'packUInt64LE'], self::BIG_TIFF_OFFSET16_TILE_OFFSETS));
+        $tileOffsetsOffset = $cursor;
+        $cursor = self::alignOffset($cursor + strlen($tileOffsetsData), $offsetSize);
+
+        $tileByteCountsData = implode('', array_map([self::class, 'packUInt64LE'], self::BIG_TIFF_OFFSET16_TILE_BYTE_COUNTS));
+        $tileByteCountsOffset = $cursor;
+
+        $ifd0Entries = [
+            self::packBigTiffEntry(ExifTag::TILE_WIDTH, 4, 1, self::BIG_TIFF_OFFSET16_TILE_WIDTH, $offsetSize),
+            self::packBigTiffEntry(ExifTag::TILE_LENGTH, 4, 1, self::BIG_TIFF_OFFSET16_TILE_LENGTH, $offsetSize),
+            self::packBigTiffEntry(ExifTag::STRIP_OFFSETS, 16, count(self::BIG_TIFF_OFFSET16_STRIP_OFFSETS), $stripOffsetsOffset, $offsetSize),
+            self::packBigTiffEntry(ExifTag::STRIP_BYTE_COUNTS, 16, count(self::BIG_TIFF_OFFSET16_STRIP_BYTE_COUNTS), $stripByteCountsOffset, $offsetSize),
+            self::packBigTiffEntry(ExifTag::TILE_OFFSETS, 16, count(self::BIG_TIFF_OFFSET16_TILE_OFFSETS), $tileOffsetsOffset, $offsetSize),
+            self::packBigTiffEntry(ExifTag::TILE_BYTE_COUNTS, 16, count(self::BIG_TIFF_OFFSET16_TILE_BYTE_COUNTS), $tileByteCountsOffset, $offsetSize),
+        ];
+
+        $ifd0 = pack('V', count($ifd0Entries))
+            . pack('V', 0)
+            . implode('', $ifd0Entries)
+            . self::packBigTiffOffsetValue(0, $offsetSize);
+
+        $blob = $header;
+        self::padBufferTo($blob, $firstIfdOffset);
+        $blob .= $ifd0;
+
+        self::padBufferTo($blob, $stripOffsetsOffset);
+        $blob .= $stripOffsetsData;
+
+        self::padBufferTo($blob, $stripByteCountsOffset);
+        $blob .= $stripByteCountsData;
+
+        self::padBufferTo($blob, $tileOffsetsOffset);
+        $blob .= $tileOffsetsData;
+
+        self::padBufferTo($blob, $tileByteCountsOffset);
+        $blob .= $tileByteCountsData;
+
+        return $blob;
+    }
+
+    /**
      * Builds a BigTIFF payload exercising LONG8/SLONG8/IFD8 field types with offsets beyond 4 GB.
      */
     private static function buildBigTiffLong8OffsetsBlob(): string
@@ -1755,17 +1919,60 @@ final class TiffExifReaderTest extends TestCase
      * @param int $count         Number of values represented.
      * @param int $valueOrOffset Inline value or data offset.
      */
-    private static function packBigTiffEntry(int $tag, int $type, int $count, int|array $valueOrOffset): string
+    private static function packBigTiffEntry(int $tag, int $type, int $count, int|array $valueOrOffset, int $offsetSize = 8): string
     {
         [$countLo, $countHi] = self::splitUInt64($count);
-        [$valueLo, $valueHi] = self::splitUInt64Components($valueOrOffset);
+        $valueBytes           = self::packBigTiffFieldValue($valueOrOffset, $offsetSize);
 
         return pack('v', $tag)
             . pack('v', $type)
             . pack('V', $countLo)
             . pack('V', $countHi)
-            . pack('V', $valueLo)
-            . pack('V', $valueHi);
+            . $valueBytes;
+    }
+
+    /**
+     * Packs the value/offset field for a BigTIFF entry respecting the offset size.
+     *
+     * @param int|array<int> $valueOrOffset Inline value or referenced offset.
+     */
+    private static function packBigTiffFieldValue(int|array $valueOrOffset, int $offsetSize): string
+    {
+        if ($offsetSize === 8) {
+            [$valueLo, $valueHi] = self::splitUInt64Components($valueOrOffset);
+
+            return pack('V', $valueLo) . pack('V', $valueHi);
+        }
+
+        if ($offsetSize === 16) {
+            if (is_array($valueOrOffset)) {
+                $low  = $valueOrOffset[0] ?? 0;
+                $high = $valueOrOffset[1] ?? 0;
+            } else {
+                $low  = $valueOrOffset;
+                $high = 0;
+            }
+
+            return self::packUInt64LE($low) . self::packUInt64LE($high);
+        }
+
+        throw new RuntimeException('Unsupported BigTIFF offset size: ' . $offsetSize);
+    }
+
+    /**
+     * Packs a BigTIFF offset value with the configured offset size.
+     */
+    private static function packBigTiffOffsetValue(int $value, int $offsetSize): string
+    {
+        if ($offsetSize === 8) {
+            return self::packUInt64LE($value);
+        }
+
+        if ($offsetSize === 16) {
+            return self::packUInt64LE($value) . self::packUInt64LE(0);
+        }
+
+        throw new RuntimeException('Unsupported BigTIFF offset size: ' . $offsetSize);
     }
 
     /**


### PR DESCRIPTION
## Summary
- allow BigTIFF offset size 16 and propagate the width through offset parsing and value extraction
- guard pointer validation against offsets beyond the PHP integer range and format 128-bit values for diagnostics
- add a synthetic BigTIFF payload exercising 16-byte strip and tile fields

## Testing
- composer ci:test:php:unit *(fails: missing HEIC/fixture assets in this environment)*
- .build/bin/phpunit tests/Parse/Tiff/TiffExifReaderTest.php

------
https://chatgpt.com/codex/tasks/task_e_68fe6407e12883239213b8aa92b1da74