### PR TITLE
fix: default FlashPix fallback when tag missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ used directly without consulting tag identifiers.
 | `Interop` | `index`, `version` | `InteropIndex`, `InteropVersion` | Hex fallback for binary data |
 | `TiffData` | `compression`, `photometric`, `ycbcrSubSampling`, `primaryChromaticities` | `Compression`, `PhotometricInterpretation`, `YCbCrSubSampling`, `PrimaryChromaticities` | `Compression`, `Photometric`, `ValueConverters::toPrimaryChromaticities()` |
 | `CompositeImageInfo` | `type`, `counts`, `exposureTimesTotal` | `CompositeImage`, `SourceImageNumberOfCompositeImage`, `SourceExposureTimesOfCompositeImage` | `CompositeImage`, rational to float |
-| `Standards` | `exifVersion`, `flashpixVersion` | `ExifVersion`, `FlashpixVersion` | `ValueConverters::toExifVersion()` |
+| `Standards` | `exifVersion`, `flashpixVersion` | `ExifVersion`, `FlashpixVersion` | `ValueConverters::toExifVersion()` (defaults FlashPix to `1.00` when missing) |
 | `Lens` | `lensSpecification`, `maxApertureFNumber` | `LensSpecification`, `MaxApertureValue` | `ValueConverters::apexToFNumber()` |
 | `Exposure` | `exposureBiasEv`, `gainControl`, `contrast` | `ExposureBiasValue`, `GainControl`, `Contrast` | `GainControl` enum |
 | `Scene` | `subjectDistanceRange` | `SubjectDistanceRange` | `SubjectDistanceRange` enum |

--- a/src/Curate/Resolver/ExifTagResolver.php
+++ b/src/Curate/Resolver/ExifTagResolver.php
@@ -1230,11 +1230,35 @@ final readonly class ExifTagResolver
     }
 
     /**
-     * Returns the FlashPix version string if present.
+     * Returns the FlashPix version string, defaulting to '1.00' when missing or padded.
      */
     public function flashpixVersion(): ?string
     {
-        return $this->document?->flashpixVersion();
+        if (!$this->document instanceof ExifDocument) {
+            return null;
+        }
+
+        $version = $this->document->flashpixVersion();
+        if ($version !== null) {
+            return $version;
+        }
+
+        $entry = $this->getEntry($this->document->exifIfd, ExifTag::FLASHPIX_VERSION);
+        if (!$entry instanceof IfdEntry) {
+            return '1.00';
+        }
+
+        $value = $entry->value;
+        if (!is_string($value)) {
+            return '1.00';
+        }
+
+        $trimmed = trim($value, "\0 ");
+        if ($trimmed === '') {
+            return '1.00';
+        }
+
+        return null;
     }
 
     /**

--- a/tests/Parse/Tiff/TiffExifReaderTest.php
+++ b/tests/Parse/Tiff/TiffExifReaderTest.php
@@ -324,6 +324,20 @@ final class TiffExifReaderTest extends TestCase
     }
 
     /**
+     * Ensures FlashPix version defaults to 1.00 when the tag is absent.
+     */
+    #[Test]
+    public function defaultsFlashpixVersionWhenTagMissing(): void
+    {
+        $blob     = $this->buildClassicVersionBlobWithoutFlashpix();
+        $document = (new TiffExifReader())->parseFromBlob($blob);
+        $resolver = new ExifTagResolver($document);
+
+        self::assertNull($document->flashpixVersion());
+        self::assertSame('1.00', $resolver->flashpixVersion());
+    }
+
+    /**
      * Ensures PrintIM payloads preserve their binary data and are decoded into structured output.
      */
     #[Test]
@@ -1171,6 +1185,29 @@ final class TiffExifReaderTest extends TestCase
             . pack('V', 0);
 
         return $header . $ifd0 . $ifd1 . $ifd2;
+    }
+
+    /**
+     * Builds a Classic TIFF blob with an EXIF version entry but no FlashPix version tag.
+     */
+    private function buildClassicVersionBlobWithoutFlashpix(): string
+    {
+        $header = 'II' . pack('v', 0x002A) . pack('V', 8);
+
+        $exifIfdOffset = 8 + 2 + 12 + 4;
+
+        $ifd0Entries = [
+            self::packClassicEntry(ExifTag::EXIF_IFD_POINTER, 4, 1, $exifIfdOffset),
+        ];
+        $ifd0 = pack('v', count($ifd0Entries)) . implode('', $ifd0Entries) . pack('V', 0);
+
+        $exifEntries = [
+            self::packClassicEntry(ExifTag::EXIF_VERSION, 7, 4, self::inlineAsciiToInt('0232', 4)),
+        ];
+
+        $exifIfd = pack('v', count($exifEntries)) . implode('', $exifEntries) . pack('V', 0);
+
+        return $header . $ifd0 . $exifIfd;
     }
 
     /**


### PR DESCRIPTION
## Summary
- default the FlashPix resolver to report version 1.00 when the EXIF tag is missing or padded
- add TIFF reader coverage for the missing FlashPix tag scenario
- document the FlashPix fallback in the README for structured metadata

## Testing
- ./.build/bin/phpunit tests/Parse/Tiff/TiffExifReaderTest.php

------
https://chatgpt.com/codex/tasks/task_e_68fe67c276dc832382652cf23717d0cc