### PR TITLE
Fix BigTIFF inline payload handling

### DIFF
--- a/src/Parse/Tiff/TiffExifReader.php
+++ b/src/Parse/Tiff/TiffExifReader.php
@@ -316,9 +316,14 @@ final class TiffExifReader
         $tag      = $this->readU16();
         $type     = $this->readU16();
         $cnt      = $this->bigTiff ? $this->readU64()->toInt('directory entry value count') : $this->readU32();
-        $valOrOff = $this->bigTiff ? $this->readValueOrOffset($type, $cnt) : $this->readU32();
+        if ($this->bigTiff) {
+            [$valOrOff, $inlineBytes] = $this->readValueOrOffset($type, $cnt);
+        } else {
+            $valOrOff    = $this->readU32();
+            $inlineBytes = null;
+        }
 
-        [$rawBytes] = $this->valueBytes($type, $cnt, $valOrOff);
+        [$rawBytes] = $this->valueBytes($type, $cnt, $valOrOff, $inlineBytes);
         $value      = $this->decodeBytes($type, $cnt, $rawBytes);
         $value      = $this->convertUInt64Values($tag, $type, $cnt, $rawBytes, $value);
 
@@ -848,12 +853,12 @@ final class TiffExifReader
      * @param int $type  TIFF field type code.
      * @param int $count Number of values represented.
      *
-     * @return int|UInt64|string
+     * @return array{0:int|UInt64|string,1:string|null}
      */
-    private function readValueOrOffset(int $type, int $count): int|UInt64|string
+    private function readValueOrOffset(int $type, int $count): array
     {
         if (!$this->bigTiff) {
-            return $this->readU32();
+            return [$this->readU32(), null];
         }
 
         $componentSize    = $this->bytesPerComponent($type);
@@ -861,16 +866,15 @@ final class TiffExifReader
         $inlineValueBytes = $componentSize * $count;
 
         if ($inlineValueBytes <= $inlineThreshold) {
-            $bytes = $this->buf->read($inlineThreshold);
+            $rawField    = $this->buf->read($inlineThreshold);
+            $inlineBytes = $inlineValueBytes === $inlineThreshold
+                ? $rawField
+                : substr($rawField, 0, $inlineValueBytes);
 
-            if ($inlineValueBytes === $inlineThreshold) {
-                return $bytes;
-            }
-
-            return substr($bytes, 0, $inlineValueBytes);
+            return [$inlineBytes, $inlineBytes];
         }
 
-        return $this->readU64();
+        return [$this->readU64(), null];
     }
 
     /**
@@ -925,14 +929,30 @@ final class TiffExifReader
      * @param int        $type          TIFF field type code.
      * @param int        $count         Number of values represented.
      * @param int|UInt64|string $valueOrOffset Inline value bytes or an offset into the blob.
+     * @param string|null       $inlineBytes   Raw bytes captured from the value/offset field.
      *
      * @return array{0: string, 1: int|null}
      */
-    private function valueBytes(int $type, int $count, int|UInt64|string $valueOrOffset): array
+    private function valueBytes(int $type, int $count, int|UInt64|string $valueOrOffset, ?string $inlineBytes = null): array
     {
         $unitSize        = $this->bytesPerComponent($type);
         $dataSize        = $unitSize * $count;
         $inlineThreshold = $this->bigTiff ? 8 : 4;
+
+        if ($inlineBytes !== null) {
+            if (strlen($inlineBytes) < $dataSize) {
+                throw new ParseError(
+                    sprintf(
+                        'Inline value for TIFF type %d truncated (expected %d bytes, got %d)',
+                        $type,
+                        $dataSize,
+                        strlen($inlineBytes),
+                    ),
+                );
+            }
+
+            return [substr($inlineBytes, 0, $dataSize), null];
+        }
 
         if ($dataSize <= $inlineThreshold) {
             if (is_string($valueOrOffset)) {
@@ -947,7 +967,7 @@ final class TiffExifReader
                     );
                 }
 
-                return [$valueOrOffset, null];
+                return [substr($valueOrOffset, 0, $dataSize), null];
             }
 
             $raw = $this->uXToBytes($valueOrOffset, $inlineThreshold);

--- a/tests/Parse/Tiff/TiffExifReaderTest.php
+++ b/tests/Parse/Tiff/TiffExifReaderTest.php
@@ -914,6 +914,20 @@ final class TiffExifReaderTest extends TestCase
         self::assertSame(0x80, ord($value[7]));
     }
 
+    #[Test]
+    public function decodesBigTiffInlineNegativeDouble(): void
+    {
+        $reader   = new TiffExifReader();
+        $document = $reader->parseFromBlob(self::buildBigTiffInlineNegativeDoubleBlob());
+
+        $entry = $document->ifd0->get(ExifTag::CAMERA_YAW_DEGREE);
+        self::assertNotNull($entry);
+
+        $value = $entry->value;
+        self::assertIsFloat($value);
+        self::assertSame(-5.0, $value);
+    }
+
     /**
      * Builds a Classic TIFF little-endian EXIF payload with nested IFDs.
      */
@@ -1571,6 +1585,32 @@ final class TiffExifReaderTest extends TestCase
     }
 
     /**
+     * Builds a minimal BigTIFF payload containing an inline DOUBLE value.
+     */
+    private static function buildBigTiffInlineNegativeDoubleBlob(): string
+    {
+        $header = 'II'
+            . pack('v', 0x002B)
+            . pack('v', 8)
+            . pack('v', 0)
+            . pack('V', 16)
+            . pack('V', 0);
+
+        $components = self::inlineDoubleComponents(-5.0);
+
+        $entry = self::packBigTiffEntry(
+            ExifTag::CAMERA_YAW_DEGREE,
+            12,
+            1,
+            $components,
+        );
+
+        $ifd0 = pack('V', 1) . pack('V', 0) . $entry . pack('V', 0) . pack('V', 0);
+
+        return $header . $ifd0;
+    }
+
+    /**
      * Builds a BigTIFF payload exercising LONG8/SLONG8/IFD8 field types with offsets beyond 4 GB.
      */
     private static function buildBigTiffLong8OffsetsBlob(): string
@@ -1823,6 +1863,24 @@ final class TiffExifReaderTest extends TestCase
         $bytes = str_pad($ascii, $width, "\0");
 
         return self::toLittleEndianInteger($bytes);
+    }
+
+    /**
+     * Splits a little-endian DOUBLE value into inline low/high 32-bit components.
+     *
+     * @return array{0:int,1:int}
+     */
+    private static function inlineDoubleComponents(float $value): array
+    {
+        $parts = unpack('V2', pack('e', $value));
+        if ($parts === false) {
+            throw new RuntimeException('Unable to split inline DOUBLE components.');
+        }
+
+        return [
+            (int) ($parts[1] & 0xFFFFFFFF),
+            (int) ($parts[2] & 0xFFFFFFFF),
+        ];
     }
 
     /**


### PR DESCRIPTION
## Summary
- capture BigTIFF inline value fields as raw bytes so 8-byte payloads avoid unsigned conversion
- update valueBytes to pass through captured inline bytes for downstream decoding helpers
- add a BigTIFF regression test covering an inline negative DOUBLE directory entry

## Testing
- composer ci:test:php:unit -- tests/Parse/Tiff/TiffExifReaderTest.php

------
https://chatgpt.com/codex/tasks/task_e_68fe67cae4588323941624a25c0c4f89