### PR TITLE
Support 16-byte BigTIFF offsets

### DIFF
--- a/src/Parse/Tiff/TiffExifReader.php
+++ b/src/Parse/Tiff/TiffExifReader.php
@@ -29,6 +29,7 @@ use MagicSunday\ImageMeta\Model\Exif\Ifd;
 use MagicSunday\ImageMeta\Model\Exif\IfdEntry;
 
 use function chr;
+use function ctype_digit;
 use function function_exists;
 use function iconv;
 use function in_array;
@@ -45,6 +46,7 @@ use function sha1;
 use function sprintf;
 use function strlen;
 use function strncmp;
+use function strrev;
 use function substr;
 
 /**
@@ -134,6 +136,8 @@ final class TiffExifReader
 
     private bool $bigTiff = false;
 
+    private int $bigTiffOffsetSize = 8;
+
     private UInt64 $blobSize;
 
     private ?string $makerNoteRaw = null;
@@ -177,9 +181,8 @@ final class TiffExifReader
         $magic = $this->readU16();
         if ($magic === self::TIFF_MAGIC_BIG) {
             $this->bigTiff = true;
-            $this->parseBigTiffHeader();
-            $firstIfd = $this->readU64();
-            $ifd0     = $this->readIfd($firstIfd);
+            $firstIfd      = $this->parseBigTiffHeader();
+            $ifd0          = $this->readIfd($firstIfd);
         } elseif ($magic === self::TIFF_MAGIC_CLASSIC) {
             $this->bigTiff = false;
             $firstIfd      = $this->readU32();
@@ -253,19 +256,23 @@ final class TiffExifReader
     /**
      * Validates the BigTIFF header following the magic identifier.
      */
-    private function parseBigTiffHeader(): void
+    private function parseBigTiffHeader(): int|UInt64|string
     {
-        // BigTIFF header after magic: 2 bytes: offset size (should be 8), 2 bytes: zero/reserved, then 8‑byte first IFD offset
+        // BigTIFF header after magic: 2 bytes: offset size, 2 bytes: zero/reserved, followed by the first IFD offset
         $offSize  = $this->readU16();
         $reserved = $this->readU16();
 
-        if ($offSize !== 8) {
-            throw new ParseError('Unsupported BigTIFF offset size (expected 8)');
+        if ($offSize !== 8 && $offSize !== 16) {
+            throw new ParseError('Unsupported BigTIFF offset size (expected 8 or 16)');
         }
+
+        $this->bigTiffOffsetSize = $offSize;
 
         if ($reserved !== 0) {
             throw new ParseError('Bad BigTIFF header (reserved != 0)');
         }
+
+        return $this->readBigTiffOffsetValue('BigTIFF first IFD offset');
     }
 
     /**
@@ -275,10 +282,14 @@ final class TiffExifReader
      *
      * @return Ifd
      */
-    private function readIfd(int|UInt64 $offset): Ifd
+    private function readIfd(int|UInt64|string $offset): Ifd
     {
         if ($offset instanceof UInt64) {
             if ($offset->isZero()) {
+                return new Ifd([]);
+            }
+        } elseif (is_string($offset)) {
+            if ($this->isDecimalZero($offset)) {
                 return new Ifd([]);
             }
         } elseif ($offset <= 0) {
@@ -298,8 +309,13 @@ final class TiffExifReader
             $entries += $this->readDirEntry();
         }
 
-        $next = $this->bigTiff ? $this->normaliseOptionalOffset($this->readU64(), 'IFD next offset') : $this->readU32();
-        $ifd  = new Ifd($entries, $next > 0 ? $next : null);
+        if ($this->bigTiff) {
+            $nextValue = $this->readBigTiffOffsetValue('IFD next offset');
+            $next      = $this->normaliseOptionalOffset($nextValue, 'IFD next offset');
+        } else {
+            $next = $this->readU32();
+        }
+        $ifd = new Ifd($entries, $next > 0 ? $next : null);
 
         $this->ifdCache[$offsetInt] = $ifd;
 
@@ -857,7 +873,7 @@ final class TiffExifReader
         }
 
         $componentSize    = $this->bytesPerComponent($type);
-        $inlineThreshold  = 8;
+        $inlineThreshold  = $this->bigTiffOffsetSize;
         $inlineValueBytes = $componentSize * $count;
 
         if ($inlineValueBytes <= $inlineThreshold) {
@@ -870,14 +886,53 @@ final class TiffExifReader
             return substr($bytes, 0, $inlineValueBytes);
         }
 
-        return $this->readU64();
+        $context = sprintf('TIFF type %d offset', $type);
+
+        return $this->readBigTiffOffsetValue($context);
+    }
+
+    /**
+     * Reads a BigTIFF offset field according to the configured offset size.
+     *
+     * @param string $context Human-readable description used in error messages.
+     *
+     * @return int|UInt64|string
+     */
+    private function readBigTiffOffsetValue(string $context): int|UInt64|string
+    {
+        if ($this->bigTiffOffsetSize === 8) {
+            return $this->readU64();
+        }
+
+        $bytes = $this->buf->read($this->bigTiffOffsetSize);
+
+        if ($this->bo === Endian::Little) {
+            $bytes = strrev($bytes);
+        }
+
+        $decimal    = $this->bytesToDecimalString($bytes);
+        $normalised = ltrim($decimal, '0');
+
+        if ($normalised === '') {
+            return 0;
+        }
+
+        if ($this->decimalExceedsPhpInt($normalised)) {
+            return $normalised;
+        }
+
+        return $this->decimalStringToInt($normalised, $context);
     }
 
     /**
      * Ensures that an offset lies within the TIFF blob and returns it as an integer.
      */
-    private function ensureOffset(int|UInt64 $offset, string $context, int $length = 0): int
+    private function ensureOffset(int|UInt64|string $offset, string $context, int $length = 0): int
     {
+        if (is_string($offset)) {
+            $offset = $this->decimalStringToInt($offset, $context);
+        }
+
         $offset64 = $offset instanceof UInt64 ? $offset : UInt64::fromInt($offset);
 
         $this->assertOffsetRange($offset64, $length, $context);
@@ -888,9 +943,17 @@ final class TiffExifReader
     /**
      * Normalises an optional offset that may be zero.
      */
-    private function normaliseOptionalOffset(UInt64 $offset, string $context): int
+    private function normaliseOptionalOffset(int|UInt64|string $offset, string $context): int
     {
-        if ($offset->isZero()) {
+        if ($offset instanceof UInt64) {
+            if ($offset->isZero()) {
+                return 0;
+            }
+        } elseif (is_string($offset)) {
+            if ($this->isDecimalZero($offset)) {
+                return 0;
+            }
+        } elseif ($offset <= 0) {
             return 0;
         }
 
@@ -920,6 +983,147 @@ final class TiffExifReader
     }
 
     /**
+     * Converts a big-endian byte string into a decimal representation.
+     *
+     * @param string $bytes Unsigned integer bytes in big-endian order.
+     */
+    private function bytesToDecimalString(string $bytes): string
+    {
+        $value  = '0';
+        $length = strlen($bytes);
+
+        for ($i = 0; $i < $length; ++$i) {
+            $value = $this->decimalMultiplySmall($value, 256);
+            $value = $this->decimalAddSmall($value, ord($bytes[$i]));
+        }
+
+        return $value;
+    }
+
+    /**
+     * Multiplies a decimal string with a small integer factor.
+     *
+     * @param string $value  Decimal string to multiply.
+     * @param int    $factor Factor to apply.
+     */
+    private function decimalMultiplySmall(string $value, int $factor): string
+    {
+        if ($value === '0' || $factor === 0) {
+            return '0';
+        }
+
+        $carry  = 0;
+        $result = '';
+
+        for ($i = strlen($value) - 1; $i >= 0; --$i) {
+            $digit   = ord($value[$i]) - 48;
+            $product = ($digit * $factor) + $carry;
+            $result  = chr(($product % 10) + 48) . $result;
+            $carry   = intdiv($product, 10);
+        }
+
+        while ($carry > 0) {
+            $result = chr(($carry % 10) + 48) . $result;
+            $carry  = intdiv($carry, 10);
+        }
+
+        return ltrim($result, '0') ?: '0';
+    }
+
+    /**
+     * Adds a small integer value to a decimal string.
+     *
+     * @param string $value  Decimal string augend.
+     * @param int    $addend Non-negative integer addend.
+     */
+    private function decimalAddSmall(string $value, int $addend): string
+    {
+        if ($addend === 0) {
+            return $value;
+        }
+
+        $result = '';
+        $carry  = $addend;
+
+        for ($i = strlen($value) - 1; $i >= 0; --$i) {
+            $digit = ord($value[$i]) - 48;
+            $sum   = $digit + ($carry % 10);
+            $carry = intdiv($carry, 10);
+
+            if ($sum >= 10) {
+                $sum -= 10;
+                ++$carry;
+            }
+
+            $result = chr($sum + 48) . $result;
+        }
+
+        while ($carry > 0) {
+            $digit = $carry % 10;
+            $carry = intdiv($carry, 10);
+            $result = chr($digit + 48) . $result;
+        }
+
+        return ltrim($result, '0') ?: '0';
+    }
+
+    /**
+     * Determines whether a decimal string exceeds PHP's integer range.
+     */
+    private function decimalExceedsPhpInt(string $value): bool
+    {
+        $phpMax   = (string) PHP_INT_MAX;
+        $length   = strlen($value);
+        $maxLength = strlen($phpMax);
+
+        if ($length !== $maxLength) {
+            return $length > $maxLength;
+        }
+
+        return $value > $phpMax;
+    }
+
+    /**
+     * Converts a decimal string into an integer while validating its range.
+     *
+     * @param string $value   Decimal representation to convert.
+     * @param string $context Human-readable context for error messages.
+     */
+    private function decimalStringToInt(string $value, string $context): int
+    {
+        if (!ctype_digit($value)) {
+            throw new ParseError(sprintf('%s must contain a non-negative decimal value.', $context));
+        }
+
+        $normalised = ltrim($value, '0');
+        if ($normalised === '') {
+            return 0;
+        }
+
+        if ($this->decimalExceedsPhpInt($normalised)) {
+            throw new ParseError(sprintf('%s exceeds supported integer range.', $context));
+        }
+
+        $result = 0;
+        $length = strlen($normalised);
+
+        for ($i = 0; $i < $length; ++$i) {
+            $digit  = ord($normalised[$i]) - 48;
+            $result = ($result * 10) + $digit;
+        }
+
+        return $result;
+    }
+
+    /**
+     * Checks whether the provided decimal string represents zero.
+     */
+    private function isDecimalZero(string $value): bool
+    {
+        return ctype_digit($value) && ltrim($value, '0') === '';
+    }
+
+    /**
      * Extracts the raw bytes addressed by a directory entry.
      *
      * @param int        $type          TIFF field type code.
@@ -932,7 +1136,7 @@ final class TiffExifReader
     {
         $unitSize        = $this->bytesPerComponent($type);
         $dataSize        = $unitSize * $count;
-        $inlineThreshold = $this->bigTiff ? 8 : 4;
+        $inlineThreshold = $this->bigTiff ? $this->bigTiffOffsetSize : 4;
 
         if ($dataSize <= $inlineThreshold) {
             if (is_string($valueOrOffset)) {
@@ -1358,6 +1562,10 @@ final class TiffExifReader
             return $this->ensureOffset($value, sprintf('IFD pointer tag 0x%04X', $entry->tag));
         }
 
+        if (is_string($value)) {
+            return $this->pointerOffsetFromString($value, $entry->tag);
+        }
+
         if (is_float($value)) {
             return $this->pointerOffsetFromFloat($value, $entry->tag);
         }
@@ -1370,6 +1578,10 @@ final class TiffExifReader
 
             if ($first instanceof UInt64) {
                 return $this->ensureOffset($first, sprintf('IFD pointer tag 0x%04X', $entry->tag));
+            }
+
+            if (is_string($first)) {
+                return $this->pointerOffsetFromString($first, $entry->tag);
             }
 
             if (is_float($first)) {
@@ -1395,6 +1607,21 @@ final class TiffExifReader
         }
 
         return $this->ensureOffset($offset, sprintf('IFD pointer tag 0x%04X', $tag));
+    }
+
+    /**
+     * Normalises a string offset representation to a validated integer.
+     *
+     * @param string $value Decimal offset string.
+     * @param int    $tag   Tag identifier emitting the offset.
+     */
+    private function pointerOffsetFromString(string $value, int $tag): int
+    {
+        if (!ctype_digit($value)) {
+            throw new ParseError(sprintf('IFD pointer tag 0x%04X must contain a numeric offset.', $tag));
+        }
+
+        return $this->ensureOffset($value, sprintf('IFD pointer tag 0x%04X', $tag));
     }
 
     /**

--- a/tests/Parse/Tiff/TiffExifReaderTest.php
+++ b/tests/Parse/Tiff/TiffExifReaderTest.php
@@ -121,6 +121,42 @@ final class TiffExifReaderTest extends TestCase
     ];
 
     /**
+     * @var array<int>
+     */
+    private const array BIG_TIFF_WIDE_STRIP_OFFSETS = [
+        0x0000000000000100,
+        0x0000000000000200,
+        0x0000000000000300,
+    ];
+
+    /**
+     * @var array<int>
+     */
+    private const array BIG_TIFF_WIDE_STRIP_BYTE_COUNTS = [
+        0x0000000000000080,
+        0x0000000000000400,
+        0x0000000000000200,
+    ];
+
+    /**
+     * @var array<int>
+     */
+    private const array BIG_TIFF_WIDE_TILE_OFFSETS = [
+        0x0000000000000300,
+        0x0000000000000400,
+        0x0000000000000500,
+    ];
+
+    /**
+     * @var array<int>
+     */
+    private const array BIG_TIFF_WIDE_TILE_BYTE_COUNTS = [
+        0x0000000000000200,
+        0x0000000000000200,
+        0x0000000000000100,
+    ];
+
+    /**
      * Provides representative Classic TIFF and BigTIFF payloads.
      *
      * @return iterable<string, array{0:string,1:string}>
@@ -135,6 +171,11 @@ final class TiffExifReaderTest extends TestCase
         yield 'big_tiff' => [
             self::buildBigTiffBlob(),
             'assertBigTiffDocument',
+        ];
+
+        yield 'big_tiff_wide_offsets' => [
+            self::buildBigTiffWideOffsetBlob(),
+            'assertBigTiffWideOffsetDocument',
         ];
     }
 
@@ -859,6 +900,46 @@ final class TiffExifReaderTest extends TestCase
     }
 
     /**
+     * Asserts the decoded values of the synthetic BigTIFF payload using 16-byte offsets.
+     *
+     * @param ExifDocument $doc Parsed document returned by the TIFF reader.
+     */
+    private static function assertBigTiffWideOffsetDocument(ExifDocument $doc): void
+    {
+        $ifd0 = $doc->ifd0;
+
+        $stripOffsetsEntry = $ifd0->get(ExifTag::STRIP_OFFSETS);
+        self::assertNotNull($stripOffsetsEntry);
+        $stripOffsets = $stripOffsetsEntry->value;
+        self::assertInstanceOf(ExifNumericList::class, $stripOffsets);
+        self::assertSame(self::BIG_TIFF_WIDE_STRIP_OFFSETS, $stripOffsets->values);
+
+        $stripByteCountsEntry = $ifd0->get(ExifTag::STRIP_BYTE_COUNTS);
+        self::assertNotNull($stripByteCountsEntry);
+        $stripByteCounts = $stripByteCountsEntry->value;
+        self::assertInstanceOf(ExifNumericList::class, $stripByteCounts);
+        self::assertSame(self::BIG_TIFF_WIDE_STRIP_BYTE_COUNTS, $stripByteCounts->values);
+
+        $tileOffsetsEntry = $ifd0->get(ExifTag::TILE_OFFSETS);
+        self::assertNotNull($tileOffsetsEntry);
+        $tileOffsets = $tileOffsetsEntry->value;
+        self::assertInstanceOf(ExifNumericList::class, $tileOffsets);
+        self::assertSame(self::BIG_TIFF_WIDE_TILE_OFFSETS, $tileOffsets->values);
+
+        $tileByteCountsEntry = $ifd0->get(ExifTag::TILE_BYTE_COUNTS);
+        self::assertNotNull($tileByteCountsEntry);
+        $tileByteCounts = $tileByteCountsEntry->value;
+        self::assertInstanceOf(ExifNumericList::class, $tileByteCounts);
+        self::assertSame(self::BIG_TIFF_WIDE_TILE_BYTE_COUNTS, $tileByteCounts->values);
+
+        self::assertSame(self::BIG_TIFF_WIDE_STRIP_OFFSETS, $doc->stripOffsets());
+        self::assertSame(self::BIG_TIFF_WIDE_STRIP_BYTE_COUNTS, $doc->stripByteCounts());
+        self::assertSame(self::BIG_TIFF_WIDE_TILE_OFFSETS, $doc->tileOffsets());
+        self::assertSame(self::BIG_TIFF_WIDE_TILE_BYTE_COUNTS, $doc->tileByteCounts());
+    }
+
+
+    /**
      * Ensures BigTIFF LONG8/SLONG8/IFD8 entries are decoded exactly like ExifTool.
      */
     #[Test]
@@ -1547,6 +1628,81 @@ final class TiffExifReaderTest extends TestCase
     }
 
     /**
+     * Builds a BigTIFF payload using 16-byte offsets for counted image data fields.
+     */
+    private static function buildBigTiffWideOffsetBlob(): string
+    {
+        $stripOffsetsValues    = self::BIG_TIFF_WIDE_STRIP_OFFSETS;
+        $stripByteCountsValues = self::BIG_TIFF_WIDE_STRIP_BYTE_COUNTS;
+        $tileOffsetsValues     = self::BIG_TIFF_WIDE_TILE_OFFSETS;
+        $tileByteCountsValues  = self::BIG_TIFF_WIDE_TILE_BYTE_COUNTS;
+
+        $stripOffsetsData    = implode('', array_map([self::class, 'packUInt64LE'], $stripOffsetsValues));
+        $stripByteCountsData = implode('', array_map([self::class, 'packUInt64LE'], $stripByteCountsValues));
+        $tileOffsetsData     = implode('', array_map([self::class, 'packUInt64LE'], $tileOffsetsValues));
+        $tileByteCountsData  = implode('', array_map([self::class, 'packUInt64LE'], $tileByteCountsValues));
+
+        $entryCount   = 4;
+        $headerLength = 24;
+        $entrySize    = 2 + 2 + 8 + 16;
+        $ifdLength    = 8 + ($entryCount * $entrySize) + 16;
+        $baseOffset   = $headerLength + $ifdLength;
+
+        $cursor = $baseOffset;
+
+        $stripOffsetsOffset = $cursor;
+        $cursor += strlen($stripOffsetsData);
+        $cursor = self::alignOffset($cursor, 16);
+
+        $stripByteCountsOffset = $cursor;
+        $cursor += strlen($stripByteCountsData);
+        $cursor = self::alignOffset($cursor, 16);
+
+        $tileOffsetsOffset = $cursor;
+        $cursor += strlen($tileOffsetsData);
+        $cursor = self::alignOffset($cursor, 16);
+
+        $tileByteCountsOffset = $cursor;
+        $cursor += strlen($tileByteCountsData);
+
+        $header = 'II'
+            . pack('v', 0x002B)
+            . pack('v', 16)
+            . pack('v', 0)
+            . self::packUInt64LE($headerLength)
+            . str_repeat("\0", 8);
+
+        $ifdEntries = [
+            self::packBigTiffEntryWithWidth(ExifTag::STRIP_OFFSETS, 16, count($stripOffsetsValues), $stripOffsetsOffset, 16),
+            self::packBigTiffEntryWithWidth(ExifTag::STRIP_BYTE_COUNTS, 16, count($stripByteCountsValues), $stripByteCountsOffset, 16),
+            self::packBigTiffEntryWithWidth(ExifTag::TILE_OFFSETS, 16, count($tileOffsetsValues), $tileOffsetsOffset, 16),
+            self::packBigTiffEntryWithWidth(ExifTag::TILE_BYTE_COUNTS, 16, count($tileByteCountsValues), $tileByteCountsOffset, 16),
+        ];
+
+        $ifd0 = pack('V', count($ifdEntries))
+            . pack('V', 0)
+            . implode('', $ifdEntries)
+            . str_repeat("\0", 16);
+
+        $blob = $header . $ifd0;
+
+        self::padBufferTo($blob, $stripOffsetsOffset);
+        $blob .= $stripOffsetsData;
+
+        self::padBufferTo($blob, $stripByteCountsOffset);
+        $blob .= $stripByteCountsData;
+
+        self::padBufferTo($blob, $tileOffsetsOffset);
+        $blob .= $tileOffsetsData;
+
+        self::padBufferTo($blob, $tileByteCountsOffset);
+        $blob .= $tileByteCountsData;
+
+        return $blob;
+    }
+
+
+    /**
      * Builds a minimal BigTIFF payload containing an inline UNDEFINED value with the high bit set.
      */
     private static function buildBigTiffInlineUndefinedHighBitBlob(): string
@@ -1801,15 +1957,46 @@ final class TiffExifReaderTest extends TestCase
      */
     private static function packBigTiffEntry(int $tag, int $type, int $count, int|array $valueOrOffset): string
     {
-        [$countLo, $countHi] = self::splitUInt64($count);
-        [$valueLo, $valueHi] = self::splitUInt64Components($valueOrOffset);
+        return self::packBigTiffEntryWithWidth($tag, $type, $count, $valueOrOffset, 8);
+    }
 
-        return pack('v', $tag)
+    /**
+     * Packs a BigTIFF directory entry with a configurable value field width.
+     *
+     * @param int                          $tag           TIFF tag identifier.
+     * @param int                          $type          TIFF field type code.
+     * @param int                          $count         Number of values represented.
+     * @param int|array|string             $valueOrOffset Inline value or data offset.
+     * @param int                          $valueWidth    Size of the value/offset field in bytes.
+     */
+    private static function packBigTiffEntryWithWidth(int $tag, int $type, int $count, int|array|string $valueOrOffset, int $valueWidth): string
+    {
+        [$countLo, $countHi] = self::splitUInt64($count);
+
+        $entry = pack('v', $tag)
             . pack('v', $type)
             . pack('V', $countLo)
-            . pack('V', $countHi)
-            . pack('V', $valueLo)
-            . pack('V', $valueHi);
+            . pack('V', $countHi);
+
+        if ($valueWidth === 8) {
+            [$valueLo, $valueHi] = self::splitUInt64Components($valueOrOffset);
+
+            return $entry
+                . pack('V', $valueLo)
+                . pack('V', $valueHi);
+        }
+
+        if ($valueWidth === 16) {
+            if (is_string($valueOrOffset)) {
+                $raw = str_pad($valueOrOffset, 16, "\0");
+            } else {
+                $raw = self::packUInt64LE($valueOrOffset) . str_repeat("\0", 8);
+            }
+
+            return $entry . $raw;
+        }
+
+        throw new RuntimeException('Unsupported BigTIFF value width: ' . $valueWidth);
     }
 
     /**


### PR DESCRIPTION
## Summary
- allow the TIFF reader to accept 16-byte BigTIFF offset sizes and handle large offsets safely
- add decimal helpers and pointer validation to normalise 128-bit offsets before seeking data
- extend the BigTIFF unit tests with a synthetic fixture that exercises strip and tile fields using 16-byte offsets

## Testing
- composer exec phpunit -- tests/Parse/Tiff/TiffExifReaderTest.php

------
https://chatgpt.com/codex/tasks/task_e_68fe67d27f588323ada7da2b5610b97c