### PR TITLE
Add 16-byte BigTIFF offset handling

### DIFF
--- a/src/Parse/Tiff/TiffExifReader.php
+++ b/src/Parse/Tiff/TiffExifReader.php
@@ -28,6 +28,7 @@ use MagicSunday\ImageMeta\Model\Exif\ExifTag;
 use MagicSunday\ImageMeta\Model\Exif\Ifd;
 use MagicSunday\ImageMeta\Model\Exif\IfdEntry;
 
+use function array_slice;
 use function chr;
 use function function_exists;
 use function iconv;
@@ -37,6 +38,7 @@ use function is_float;
 use function is_int;
 use function is_string;
 use function intdiv;
+use function ltrim;
 use function mb_convert_encoding;
 use function ord;
 use function pack;
@@ -44,6 +46,7 @@ use function rtrim;
 use function sha1;
 use function sprintf;
 use function strlen;
+use function strspn;
 use function strncmp;
 use function substr;
 
@@ -134,6 +137,8 @@ final class TiffExifReader
 
     private bool $bigTiff = false;
 
+    private int $bigTiffOffsetSize = 8;
+
     private UInt64 $blobSize;
 
     private ?string $makerNoteRaw = null;
@@ -162,9 +167,10 @@ final class TiffExifReader
         $this->buf->seek(0);
         $this->blobSize = UInt64::fromInt($this->buf->size());
 
-        $this->makerNoteRaw = null;
-        $this->subIfds      = [];
-        $this->ifdCache     = [];
+        $this->makerNoteRaw      = null;
+        $this->subIfds           = [];
+        $this->ifdCache          = [];
+        $this->bigTiffOffsetSize = 8;
 
         // byte order
         $boSig    = $this->buf->read(2);
@@ -178,7 +184,7 @@ final class TiffExifReader
         if ($magic === self::TIFF_MAGIC_BIG) {
             $this->bigTiff = true;
             $this->parseBigTiffHeader();
-            $firstIfd = $this->readU64();
+            $firstIfd = $this->readBigTiffOffsetValue();
             $ifd0     = $this->readIfd($firstIfd);
         } elseif ($magic === self::TIFF_MAGIC_CLASSIC) {
             $this->bigTiff = false;
@@ -255,37 +261,49 @@ final class TiffExifReader
      */
     private function parseBigTiffHeader(): void
     {
-        // BigTIFF header after magic: 2 bytes: offset size (should be 8), 2 bytes: zero/reserved, then 8‑byte first IFD offset
+        // BigTIFF header after magic: 2 bytes offset size (8 or 16), 2 bytes reserved, then the first IFD offset
         $offSize  = $this->readU16();
         $reserved = $this->readU16();
 
-        if ($offSize !== 8) {
-            throw new ParseError('Unsupported BigTIFF offset size (expected 8)');
+        if ($offSize !== 8 && $offSize !== 16) {
+            throw new ParseError('Unsupported BigTIFF offset size (expected 8 or 16)');
         }
 
         if ($reserved !== 0) {
             throw new ParseError('Bad BigTIFF header (reserved != 0)');
         }
+
+        $this->bigTiffOffsetSize = $offSize;
     }
 
     /**
      * Parses an image file directory starting at the given byte offset.
      *
-     * @param int|UInt64 $offset Zero-based byte offset to the IFD structure.
+     * @param int|UInt64|string $offset Zero-based byte offset to the IFD structure.
      *
      * @return Ifd
      */
-    private function readIfd(int|UInt64 $offset): Ifd
+    private function readIfd(int|UInt64|string $offset): Ifd
     {
         if ($offset instanceof UInt64) {
             if ($offset->isZero()) {
                 return new Ifd([]);
             }
-        } elseif ($offset <= 0) {
-            return new Ifd([]);
-        }
 
-        $offsetInt = $this->ensureOffset($offset, 'IFD offset');
+            $offsetInt = $this->ensureOffset($offset, 'IFD offset');
+        } elseif (is_int($offset)) {
+            if ($offset <= 0) {
+                return new Ifd([]);
+            }
+
+            $offsetInt = $this->ensureOffset($offset, 'IFD offset');
+        } else {
+            if ($this->decimalStringIsZero($offset)) {
+                return new Ifd([]);
+            }
+
+            $offsetInt = $this->ensureOffset($offset, 'IFD offset');
+        }
 
         if (isset($this->ifdCache[$offsetInt])) {
             return $this->ifdCache[$offsetInt];
@@ -298,7 +316,14 @@ final class TiffExifReader
             $entries += $this->readDirEntry();
         }
 
-        $next = $this->bigTiff ? $this->normaliseOptionalOffset($this->readU64(), 'IFD next offset') : $this->readU32();
+        if ($this->bigTiff) {
+            $next = $this->normaliseBigTiffOptionalOffset(
+                $this->readBigTiffOffsetValue(),
+                'IFD next offset',
+            );
+        } else {
+            $next = $this->readU32();
+        }
         $ifd  = new Ifd($entries, $next > 0 ? $next : null);
 
         $this->ifdCache[$offsetInt] = $ifd;
@@ -862,7 +887,7 @@ final class TiffExifReader
         }
 
         $componentSize    = $this->bytesPerComponent($type);
-        $inlineThreshold  = 8;
+        $inlineThreshold  = $this->bigTiffOffsetSize;
         $inlineValueBytes = $componentSize * $count;
 
         if ($inlineValueBytes <= $inlineThreshold) {
@@ -874,14 +899,18 @@ final class TiffExifReader
             return [$inlineBytes, $inlineBytes];
         }
 
-        return [$this->readU64(), null];
+        return [$this->readBigTiffOffsetValue(), null];
     }
 
     /**
      * Ensures that an offset lies within the TIFF blob and returns it as an integer.
      */
-    private function ensureOffset(int|UInt64 $offset, string $context, int $length = 0): int
+    private function ensureOffset(int|UInt64|string $offset, string $context, int $length = 0): int
     {
+        if (is_string($offset)) {
+            return $this->ensureDecimalOffset($offset, $context, $length);
+        }
+
         $offset64 = $offset instanceof UInt64 ? $offset : UInt64::fromInt($offset);
 
         $this->assertOffsetRange($offset64, $length, $context);
@@ -895,6 +924,30 @@ final class TiffExifReader
     private function normaliseOptionalOffset(UInt64 $offset, string $context): int
     {
         if ($offset->isZero()) {
+            return 0;
+        }
+
+        return $this->ensureOffset($offset, $context);
+    }
+
+    /**
+     * Normalises a BigTIFF optional offset according to the configured field width.
+     */
+    private function normaliseBigTiffOptionalOffset(int|UInt64|string $offset, string $context): int
+    {
+        if ($offset instanceof UInt64) {
+            return $this->normaliseOptionalOffset($offset, $context);
+        }
+
+        if (is_int($offset)) {
+            if ($offset <= 0) {
+                return 0;
+            }
+
+            return $this->ensureOffset($offset, $context);
+        }
+
+        if ($this->decimalStringIsZero($offset)) {
             return 0;
         }
 
@@ -1392,6 +1445,10 @@ final class TiffExifReader
                 return $this->ensureOffset($first, sprintf('IFD pointer tag 0x%04X', $entry->tag));
             }
 
+            if (is_string($first)) {
+                return $this->ensureOffset($first, sprintf('IFD pointer tag 0x%04X', $entry->tag));
+            }
+
             if (is_float($first)) {
                 return $this->pointerOffsetFromFloat($first, $entry->tag);
             }
@@ -1436,5 +1493,224 @@ final class TiffExifReader
         }
 
         return $this->ensureOffset((int) $value, sprintf('IFD pointer tag 0x%04X', $tag));
+    }
+
+    /**
+     * Reads a BigTIFF offset using the configured field width.
+     */
+    private function readBigTiffOffsetValue(): int|UInt64|string
+    {
+        if ($this->bigTiffOffsetSize === 8) {
+            return $this->readU64();
+        }
+
+        if ($this->bigTiffOffsetSize !== 16) {
+            throw new ParseError('Unsupported BigTIFF offset size.');
+        }
+
+        $raw    = $this->buf->read(16);
+        $little = $this->bo === Endian::Little;
+
+        $lowBytes  = $little ? substr($raw, 0, 8) : substr($raw, 8, 8);
+        $highBytes = $little ? substr($raw, 8, 8) : substr($raw, 0, 8);
+
+        $low  = Unpack::uint64($lowBytes, $little, 'BigTIFF offset (low)');
+        $high = Unpack::uint64($highBytes, $little, 'BigTIFF offset (high)');
+
+        if (!$high->isZero()) {
+            return $this->uint128ToDecimal($high, $low);
+        }
+
+        if ($low->fitsSignedInt()) {
+            return $low->toInt('BigTIFF offset');
+        }
+
+        return $this->uint64ToDecimal($low);
+    }
+
+    /**
+     * Converts an unsigned 64-bit integer into its decimal string representation.
+     */
+    private function uint64ToDecimal(UInt64 $value): string
+    {
+        return $this->wordsToDecimal([
+            $value->high(),
+            $value->low(),
+        ]);
+    }
+
+    /**
+     * Converts a 128-bit unsigned integer into a decimal string.
+     */
+    private function uint128ToDecimal(UInt64 $high, UInt64 $low): string
+    {
+        return $this->wordsToDecimal([
+            $high->high(),
+            $high->low(),
+            $low->high(),
+            $low->low(),
+        ]);
+    }
+
+    /**
+     * Converts an array of base-2^32 words (most significant first) into a decimal string.
+     *
+     * @param array<int> $words
+     */
+    private function wordsToDecimal(array $words): string
+    {
+        $words = $this->trimLeadingZeroWords($words);
+
+        if ($words === []) {
+            return '0';
+        }
+
+        $digits = '';
+
+        while ($words !== []) {
+            [$words, $remainder] = $this->divModWordsBy10($words);
+            $digits             = (string) $remainder . $digits;
+            $words              = $this->trimLeadingZeroWords($words);
+        }
+
+        return $digits;
+    }
+
+    /**
+     * Divides a base-2^32 big integer by 10.
+     *
+     * @param array<int> $words
+     *
+     * @return array{0: array<int>, 1: int}
+     */
+    private function divModWordsBy10(array $words): array
+    {
+        $quotient = [];
+        $carry    = 0;
+
+        foreach ($words as $word) {
+            $value = ($carry << 32) + $word;
+            $q     = intdiv($value, 10);
+            $r     = (int) ($value - ($q * 10));
+
+            if ($quotient !== [] || $q !== 0) {
+                $quotient[] = $q;
+            }
+
+            $carry = $r;
+        }
+
+        return [$quotient, $carry];
+    }
+
+    /**
+     * Removes leading zero words from a base-2^32 representation.
+     *
+     * @param array<int> $words
+     *
+     * @return array<int>
+     */
+    private function trimLeadingZeroWords(array $words): array
+    {
+        $index = 0;
+        $count = count($words);
+
+        while ($index < $count && $words[$index] === 0) {
+            ++$index;
+        }
+
+        if ($index === 0) {
+            return $words;
+        }
+
+        if ($index >= $count) {
+            return [];
+        }
+
+        return array_slice($words, $index);
+    }
+
+    /**
+     * Ensures that a decimal offset lies within the TIFF blob and returns it as an integer.
+     */
+    private function ensureDecimalOffset(string $offset, string $context, int $length): int
+    {
+        $normalised = $this->normaliseDecimalString($offset);
+        $size       = $this->buf->size();
+
+        if ($this->compareDecimalStringToInt($normalised, $size) > 0) {
+            throw new BoundsError(sprintf('%s exceeds TIFF data length.', $context));
+        }
+
+        if ($length > $size) {
+            throw new BoundsError(sprintf('%s length %d exceeds TIFF data length.', $context, $length));
+        }
+
+        if ($length > 0) {
+            $limit = $size - $length;
+            if ($this->compareDecimalStringToInt($normalised, $limit) > 0) {
+                throw new BoundsError(sprintf('%s exceeds TIFF data length.', $context));
+            }
+        }
+
+        return (int) $normalised;
+    }
+
+    /**
+     * Normalises a decimal string by validating its characters and removing leading zeros.
+     */
+    private function normaliseDecimalString(string $value): string
+    {
+        if ($value === '') {
+            throw new ParseError('Decimal offset must not be empty.');
+        }
+
+        if (strspn($value, '0123456789') !== strlen($value)) {
+            throw new ParseError('Decimal offset contains invalid characters.');
+        }
+
+        $trimmed = ltrim($value, '0');
+
+        return $trimmed === '' ? '0' : $trimmed;
+    }
+
+    /**
+     * Compares a decimal string against a non-negative integer.
+     */
+    private function compareDecimalStringToInt(string $decimal, int $int): int
+    {
+        if ($int < 0) {
+            return 1;
+        }
+
+        $intString = $int === 0 ? '0' : ltrim((string) $int, '0');
+        $decLen    = strlen($decimal);
+        $intLen    = strlen($intString);
+
+        if ($decLen !== $intLen) {
+            return $decLen <=> $intLen;
+        }
+
+        if ($decimal === $intString) {
+            return 0;
+        }
+
+        return $decimal < $intString ? -1 : 1;
+    }
+
+    /**
+     * Determines whether a decimal string represents zero.
+     */
+    private function decimalStringIsZero(string $value): bool
+    {
+        $length = strlen($value);
+
+        for ($i = 0; $i < $length; ++$i) {
+            if ($value[$i] !== '0') {
+                return false;
+            }
+        }
+
+        return true;
     }
 }

--- a/tests/Parse/Tiff/TiffExifReaderTest.php
+++ b/tests/Parse/Tiff/TiffExifReaderTest.php
@@ -121,6 +121,42 @@ final class TiffExifReaderTest extends TestCase
     ];
 
     /**
+     * @var array<int>
+     */
+    private const array BIG_TIFF_OFFSET16_STRIP_OFFSETS = [
+        0x0000000000000100,
+        0x0000000000000200,
+        0x0000000000000300,
+    ];
+
+    /**
+     * @var array<int>
+     */
+    private const array BIG_TIFF_OFFSET16_STRIP_BYTE_COUNTS = [
+        0x0000000000000080,
+        0x0000000000000100,
+        0x0000000000000180,
+    ];
+
+    /**
+     * @var array<int>
+     */
+    private const array BIG_TIFF_OFFSET16_TILE_OFFSETS = [
+        0x0000000000000400,
+        0x0000000000000500,
+        0x0000000000000600,
+    ];
+
+    /**
+     * @var array<int>
+     */
+    private const array BIG_TIFF_OFFSET16_TILE_BYTE_COUNTS = [
+        0x0000000000000200,
+        0x0000000000000280,
+        0x0000000000000300,
+    ];
+
+    /**
      * Provides representative Classic TIFF and BigTIFF payloads.
      *
      * @return iterable<string, array{0:string,1:string}>
@@ -135,6 +171,11 @@ final class TiffExifReaderTest extends TestCase
         yield 'big_tiff' => [
             self::buildBigTiffBlob(),
             'assertBigTiffDocument',
+        ];
+
+        yield 'big_tiff_offset16' => [
+            self::buildBigTiffOffset16Blob(),
+            'assertBigTiffOffset16Document',
         ];
     }
 
@@ -870,6 +911,41 @@ final class TiffExifReaderTest extends TestCase
         self::assertSame(self::BIG_TIFF_TILE_LENGTH, $doc->tileLength());
         self::assertSame(self::BIG_TIFF_TILE_OFFSETS, $doc->tileOffsets());
         self::assertSame(self::BIG_TIFF_TILE_BYTE_COUNTS, $doc->tileByteCounts());
+    }
+
+    /**
+     * Asserts the decoded values of the synthetic 16-byte BigTIFF payload.
+     */
+    private static function assertBigTiffOffset16Document(ExifDocument $doc): void
+    {
+        $stripOffsetsEntry = $doc->ifd0->get(ExifTag::STRIP_OFFSETS);
+        self::assertNotNull($stripOffsetsEntry);
+        $stripOffsets = $stripOffsetsEntry->value;
+        self::assertInstanceOf(ExifNumericList::class, $stripOffsets);
+        self::assertSame(self::BIG_TIFF_OFFSET16_STRIP_OFFSETS, $stripOffsets->values);
+
+        $stripCountsEntry = $doc->ifd0->get(ExifTag::STRIP_BYTE_COUNTS);
+        self::assertNotNull($stripCountsEntry);
+        $stripByteCounts = $stripCountsEntry->value;
+        self::assertInstanceOf(ExifNumericList::class, $stripByteCounts);
+        self::assertSame(self::BIG_TIFF_OFFSET16_STRIP_BYTE_COUNTS, $stripByteCounts->values);
+
+        $tileOffsetsEntry = $doc->ifd0->get(ExifTag::TILE_OFFSETS);
+        self::assertNotNull($tileOffsetsEntry);
+        $tileOffsets = $tileOffsetsEntry->value;
+        self::assertInstanceOf(ExifNumericList::class, $tileOffsets);
+        self::assertSame(self::BIG_TIFF_OFFSET16_TILE_OFFSETS, $tileOffsets->values);
+
+        $tileCountsEntry = $doc->ifd0->get(ExifTag::TILE_BYTE_COUNTS);
+        self::assertNotNull($tileCountsEntry);
+        $tileByteCounts = $tileCountsEntry->value;
+        self::assertInstanceOf(ExifNumericList::class, $tileByteCounts);
+        self::assertSame(self::BIG_TIFF_OFFSET16_TILE_BYTE_COUNTS, $tileByteCounts->values);
+
+        self::assertSame(self::BIG_TIFF_OFFSET16_STRIP_OFFSETS, $doc->stripOffsets());
+        self::assertSame(self::BIG_TIFF_OFFSET16_STRIP_BYTE_COUNTS, $doc->stripByteCounts());
+        self::assertSame(self::BIG_TIFF_OFFSET16_TILE_OFFSETS, $doc->tileOffsets());
+        self::assertSame(self::BIG_TIFF_OFFSET16_TILE_BYTE_COUNTS, $doc->tileByteCounts());
     }
 
     /**
@@ -1684,6 +1760,96 @@ final class TiffExifReaderTest extends TestCase
     }
 
     /**
+     * Builds a BigTIFF payload that uses 16-byte offsets for strips and tiles.
+     */
+    private static function buildBigTiffOffset16Blob(): string
+    {
+        $offsetSize = 16;
+        $header     = 'II'
+            . pack('v', 0x002B)
+            . pack('v', $offsetSize)
+            . pack('v', 0)
+            . self::encodeBigTiffValueField(24, $offsetSize);
+
+        $entryCount = 4;
+        $entrySize  = 12 + $offsetSize;
+        $ifdLength  = 8 + ($entryCount * $entrySize) + $offsetSize;
+        $baseOffset = strlen($header) + $ifdLength;
+
+        $stripOffsetsData    = implode('', array_map([self::class, 'packUInt64LE'], self::BIG_TIFF_OFFSET16_STRIP_OFFSETS));
+        $stripByteCountsData = implode('', array_map([self::class, 'packUInt64LE'], self::BIG_TIFF_OFFSET16_STRIP_BYTE_COUNTS));
+        $tileOffsetsData     = implode('', array_map([self::class, 'packUInt64LE'], self::BIG_TIFF_OFFSET16_TILE_OFFSETS));
+        $tileByteCountsData  = implode('', array_map([self::class, 'packUInt64LE'], self::BIG_TIFF_OFFSET16_TILE_BYTE_COUNTS));
+
+        $cursor = $baseOffset;
+
+        $cursor             = self::alignOffset($cursor, 16);
+        $stripOffsetsOffset = $cursor;
+        $cursor            += strlen($stripOffsetsData);
+
+        $cursor                 = self::alignOffset($cursor, 16);
+        $stripByteCountsOffset  = $cursor;
+        $cursor                += strlen($stripByteCountsData);
+
+        $cursor            = self::alignOffset($cursor, 16);
+        $tileOffsetsOffset = $cursor;
+        $cursor           += strlen($tileOffsetsData);
+
+        $cursor                = self::alignOffset($cursor, 16);
+        $tileByteCountsOffset  = $cursor;
+        $cursor               += strlen($tileByteCountsData);
+
+        $entries = [
+            self::packBigTiffEntry(
+                ExifTag::STRIP_OFFSETS,
+                16,
+                count(self::BIG_TIFF_OFFSET16_STRIP_OFFSETS),
+                $stripOffsetsOffset,
+                $offsetSize,
+            ),
+            self::packBigTiffEntry(
+                ExifTag::STRIP_BYTE_COUNTS,
+                16,
+                count(self::BIG_TIFF_OFFSET16_STRIP_BYTE_COUNTS),
+                $stripByteCountsOffset,
+                $offsetSize,
+            ),
+            self::packBigTiffEntry(
+                ExifTag::TILE_OFFSETS,
+                18,
+                count(self::BIG_TIFF_OFFSET16_TILE_OFFSETS),
+                $tileOffsetsOffset,
+                $offsetSize,
+            ),
+            self::packBigTiffEntry(
+                ExifTag::TILE_BYTE_COUNTS,
+                16,
+                count(self::BIG_TIFF_OFFSET16_TILE_BYTE_COUNTS),
+                $tileByteCountsOffset,
+                $offsetSize,
+            ),
+        ];
+
+        $ifd0 = self::packBigTiffIfd($entries, $offsetSize);
+
+        $blob = $header . $ifd0;
+
+        self::padBufferTo($blob, $stripOffsetsOffset);
+        $blob .= $stripOffsetsData;
+
+        self::padBufferTo($blob, $stripByteCountsOffset);
+        $blob .= $stripByteCountsData;
+
+        self::padBufferTo($blob, $tileOffsetsOffset);
+        $blob .= $tileOffsetsData;
+
+        self::padBufferTo($blob, $tileByteCountsOffset);
+        $blob .= $tileByteCountsData;
+
+        return $blob;
+    }
+
+    /**
      * Builds a BigTIFF payload where an IFD pointer exceeds the signed 63-bit range.
      */
     private static function buildBigTiffOutOfRangeOffsetBlob(): string
@@ -1871,22 +2037,88 @@ final class TiffExifReaderTest extends TestCase
     /**
      * Packs a BigTIFF directory entry in little-endian order.
      *
-     * @param int $tag           TIFF tag identifier.
-     * @param int $type          TIFF field type code.
-     * @param int $count         Number of values represented.
-     * @param int $valueOrOffset Inline value or data offset.
+     * @param int                 $tag           TIFF tag identifier.
+     * @param int                 $type          TIFF field type code.
+     * @param int                 $count         Number of values represented.
+     * @param int|array|string    $valueOrOffset Inline value or data offset.
+     * @param int                 $fieldWidth    Size of the value/offset field.
      */
-    private static function packBigTiffEntry(int $tag, int $type, int $count, int|array $valueOrOffset): string
+    private static function packBigTiffEntry(
+        int $tag,
+        int $type,
+        int $count,
+        int|array|string $valueOrOffset,
+        int $fieldWidth = 8,
+    ): string
     {
         [$countLo, $countHi] = self::splitUInt64($count);
-        [$valueLo, $valueHi] = self::splitUInt64Components($valueOrOffset);
 
         return pack('v', $tag)
             . pack('v', $type)
             . pack('V', $countLo)
             . pack('V', $countHi)
-            . pack('V', $valueLo)
-            . pack('V', $valueHi);
+            . self::encodeBigTiffValueField($valueOrOffset, $fieldWidth);
+    }
+
+    /**
+     * Packs a BigTIFF IFD body with the provided entries and next-offset value.
+     *
+     * @param list<string> $entries
+     */
+    private static function packBigTiffIfd(array $entries, int $fieldWidth, int $nextOffset = 0): string
+    {
+        return pack('V', count($entries))
+            . pack('V', 0)
+            . implode('', $entries)
+            . self::encodeBigTiffValueField($nextOffset, $fieldWidth);
+    }
+
+    /**
+     * Encodes a value for storage in the BigTIFF value/offset field.
+     *
+     * @param int|array<int>|string $valueOrOffset
+     */
+    private static function encodeBigTiffValueField(int|array|string $valueOrOffset, int $fieldWidth): string
+    {
+        if ($fieldWidth % 4 !== 0) {
+            throw new RuntimeException('BigTIFF field width must be a multiple of four bytes.');
+        }
+
+        if (is_string($valueOrOffset)) {
+            if (strlen($valueOrOffset) > $fieldWidth) {
+                throw new RuntimeException('Inline value exceeds BigTIFF field width.');
+            }
+
+            return str_pad($valueOrOffset, $fieldWidth, "\0");
+        }
+
+        $wordCount = (int) ($fieldWidth / 4);
+        $words     = [];
+
+        if (is_array($valueOrOffset)) {
+            foreach ($valueOrOffset as $word) {
+                $words[] = $word & 0xFFFFFFFF;
+            }
+        } else {
+            [$valueLo, $valueHi] = self::splitUInt64Components($valueOrOffset);
+            $words[]             = $valueLo;
+            $words[]             = $valueHi;
+        }
+
+        if (count($words) > $wordCount) {
+            throw new RuntimeException('Too many components for BigTIFF value field.');
+        }
+
+        while (count($words) < $wordCount) {
+            $words[] = 0;
+        }
+
+        $bytes = '';
+        foreach ($words as $word) {
+            $bytes .= pack('V', $word);
+        }
+
+        return $bytes;
     }
 
     /**


### PR DESCRIPTION
## Summary
- accept 16-byte offset fields in the BigTIFF header and propagate the configured width through value/offset handling
- normalise large offsets via decimal conversion so pointer validation can guard against out-of-range references
- add a synthetic BigTIFF fixture with 16-byte offsets that exercises strip and tile fields

## Testing
- composer ci:test:php:unit *(fails: missing EXIF/HEIC fixtures and known truth-comparison expectations)*
- .build/bin/phpunit --configuration .build/phpunit.xml tests/Parse/Tiff/TiffExifReaderTest.php
- composer ci:test:php:phpstan *(fails: baseline project issues reported before this change)*

------
https://chatgpt.com/codex/tasks/task_e_68fe6d7636708323a8638390c2e91b19