### PR TITLE
Fix Apple acceleration vector fallback

### DIFF
--- a/src/Curate/StructuredMetadataBuilder.php
+++ b/src/Curate/StructuredMetadataBuilder.php
@@ -947,10 +947,6 @@ final class StructuredMetadataBuilder
             $accelerationVector = $this->quickTimeFloatList($quickTimeResolver, 'AccelerationVector');
         }
 
-        if ($accelerationVector === null) {
-            $accelerationVector = $exifResolver->accelerationVector();
-        }
-
         $flags          = $makerNotes instanceof AppleMakerNotes ? $makerNotes->flags : [];
         $quickTimeFlags = $this->quickTimeFlags($quickTimeResolver);
         foreach ($quickTimeFlags as $key => $value) {

--- a/tests/Curate/StructuredMetadataBuilderTest.php
+++ b/tests/Curate/StructuredMetadataBuilderTest.php
@@ -946,12 +946,7 @@ final class StructuredMetadataBuilderTest extends TestCase
         $metadata   = new Metadata(['primary'], null, $exifDocument, []);
         $structured = (new StructuredMetadataBuilder())->build($metadata);
 
-        $vector = $structured->apple->accelerationVector;
-        self::assertNotNull($vector);
-        self::assertCount(3, $vector);
-        self::assertEqualsWithDelta(0.2, $vector[0], 1e-12);
-        self::assertEqualsWithDelta(-0.3, $vector[1], 1e-12);
-        self::assertEqualsWithDelta(0.35, $vector[2], 1e-12);
+        self::assertNull($structured->apple->accelerationVector);
 
         self::assertEqualsWithDelta(0.2, $structured->motion->accelX, 1e-12);
         self::assertEqualsWithDelta(-0.3, $structured->motion->accelY, 1e-12);


### PR DESCRIPTION
## Summary
- prevent the Apple metadata aggregate from reusing EXIF acceleration vectors when maker notes and QuickTime data are absent
- adjust the structured metadata tests to expect motion data to derive from EXIF while Apple acceleration metadata remains null

## Testing
- composer ci:test:php:unit

------
https://chatgpt.com/codex/tasks/task_e_68fe841fc67483239fe782c9c7337185