### PR TITLE
refactor: consolidate Apple metadata VO usage

### DIFF
--- a/src/Curate/Resolver/AppleResolver.php
+++ b/src/Curate/Resolver/AppleResolver.php
@@ -11,8 +11,8 @@ declare(strict_types=1);
 
 namespace MagicSunday\ImageMeta\Curate\Resolver;
 
+use MagicSunday\ImageMeta\MakerNotes\Apple\AppleMakerNotes;
 use MagicSunday\ImageMeta\Model\QuickTimeMeta;
-use MagicSunday\ImageMeta\Value\Apple;
 
 use function is_numeric;
 use function preg_split;
@@ -68,9 +68,9 @@ final readonly class AppleResolver
     ];
 
     /**
-     * Builds an Apple value object from available metadata.
+     * Builds an Apple maker note value object from available metadata.
      */
-    public function resolve(?QuickTimeMeta $quickTimeMeta): ?Apple
+    public function resolve(?QuickTimeMeta $quickTimeMeta): ?AppleMakerNotes
     {
         if (!$quickTimeMeta instanceof QuickTimeMeta) {
             return null;
@@ -132,32 +132,42 @@ final readonly class AppleResolver
             return null;
         }
 
-        return new Apple(
-            $identifier,
-            $cameraType,
-            $hdrHeadroom,
-            $hdrGain,
-            $snr,
-            $focusPosition,
-            $livePhotoIndex,
-            null,
-            $colorTemperature,
-            $semanticPreset,
-            $semanticWarmth,
-            $semanticTone,
-            $flags,
-            $accelerationVector,
-            null,
-            $makerNoteVersion,
-            $hdrImageType,
-            $burstUuid,
-            $focusDistanceRange,
-            $oisMode,
-            $imageCaptureType,
-            $imageUniqueId,
-            $photoIdentifier,
-            $afMeasuredDepth,
-            $afConfidence,
+        return new AppleMakerNotes(
+            contentIdentifier: $identifier,
+            cameraType: $cameraType,
+            hdrHeadroom: $hdrHeadroom,
+            hdrGain: $hdrGain,
+            snr: $snr,
+            aeStable: null,
+            aeTarget: null,
+            aeAverage: null,
+            afStable: null,
+            afPerformance: null,
+            signalToNoiseRatioType: null,
+            luminanceNoiseAmplitude: null,
+            focusPosition: $focusPosition,
+            livePhotoIndex: $livePhotoIndex,
+            colorTemperature: $colorTemperature,
+            semanticStylePreset: $semanticPreset,
+            semanticStyleWarmth: $semanticWarmth,
+            semanticStyleTone: $semanticTone,
+            flags: $flags,
+            accelerationVector: $accelerationVector,
+            imageCaptureRequestId: null,
+            qualityHint: null,
+            colorCorrectionMatrix: null,
+            livePhotoTime: null,
+            runTime: null,
+            makerNoteVersion: $makerNoteVersion,
+            hdrImageType: $hdrImageType,
+            burstUuid: $burstUuid,
+            focusDistanceRange: $focusDistanceRange,
+            oisMode: $oisMode,
+            imageCaptureType: $imageCaptureType,
+            imageUniqueId: $imageUniqueId,
+            photoIdentifier: $photoIdentifier,
+            afMeasuredDepth: $afMeasuredDepth,
+            afConfidence: $afConfidence,
         );
     }
 

--- a/src/Curate/StructuredMetadata.php
+++ b/src/Curate/StructuredMetadata.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
 
 namespace MagicSunday\ImageMeta\Curate;
 
-use MagicSunday\ImageMeta\Value\Apple;
+use MagicSunday\ImageMeta\MakerNotes\Apple\AppleMakerNotes;
 use MagicSunday\ImageMeta\Value\Audio;
 use MagicSunday\ImageMeta\Value\AudioClips;
 use MagicSunday\ImageMeta\Value\Author;
@@ -70,7 +70,7 @@ final readonly class StructuredMetadata
      * @param Capture             $capture             Environmental capture metadata.
      * @param Gps                 $gps                 Geographic positioning information.
      * @param Device              $device              Host device information.
-     * @param Apple               $apple               Apple-specific metadata aggregate.
+     * @param AppleMakerNotes     $apple               Apple-specific metadata aggregate.
      * @param Xmp                 $xmp                 Parsed XMP document wrapper.
      * @param File                $file                File level metadata and characteristics.
      * @param Container           $container           Container format metadata.
@@ -109,7 +109,7 @@ final readonly class StructuredMetadata
         public Capture $capture,
         public Gps $gps,
         public Device $device,
-        public Apple $apple,
+        public AppleMakerNotes $apple,
         public Xmp $xmp,
         public File $file,
         public Container $container,

--- a/src/Curate/StructuredMetadataBuilder.php
+++ b/src/Curate/StructuredMetadataBuilder.php
@@ -26,7 +26,6 @@ use MagicSunday\ImageMeta\MakerNotes\Apple\AppleMakerNotes;
 use MagicSunday\ImageMeta\Model\Metadata;
 use MagicSunday\ImageMeta\Model\QuickTimeMeta;
 use MagicSunday\ImageMeta\Parse\Icc\IccDecoder;
-use MagicSunday\ImageMeta\Value\Apple;
 use MagicSunday\ImageMeta\Value\AudioClips;
 use MagicSunday\ImageMeta\Value\Audio;
 use MagicSunday\ImageMeta\Value\Author;
@@ -774,7 +773,7 @@ final class StructuredMetadataBuilder
      *
      * @param ExifTagResolver   $exif      Resolver exposing EXIF scene metadata.
      * @param QuickTimeResolver $quickTime Resolver providing QuickTime scene hints.
-     * @param Apple             $apple     Aggregated Apple maker note metadata.
+     * @param AppleMakerNotes   $apple     Aggregated Apple maker note metadata.
      * @param int|null          $faceCount Number of detected face regions.
      *
      * @return Scene Scene metadata value object.
@@ -782,7 +781,7 @@ final class StructuredMetadataBuilder
     private function buildScene(
         ExifTagResolver $exif,
         QuickTimeResolver $quickTime,
-        Apple $apple,
+        AppleMakerNotes $apple,
         ?int $faceCount,
     ): Scene {
         $flags = $apple->flags;
@@ -859,14 +858,14 @@ final class StructuredMetadataBuilder
      * @param QuickTimeMeta|null   $quickTimeMeta     QuickTime metadata container used for content identifiers.
      * @param ExifTagResolver      $exifResolver      Resolver exposing EXIF fallback values.
      *
-     * @return Apple Apple metadata value object with normalised fields.
+     * @return AppleMakerNotes Apple metadata value object with normalised fields.
      */
     private function buildApple(
         ?AppleMakerNotes $makerNotes,
         QuickTimeResolver $quickTimeResolver,
         ?QuickTimeMeta $quickTimeMeta,
         ExifTagResolver $exifResolver,
-    ): Apple {
+    ): AppleMakerNotes {
         $contentIdentifier = $makerNotes?->contentIdentifier;
         if ($contentIdentifier === null) {
             $contentIdentifier = $quickTimeMeta?->contentIdentifier();
@@ -956,6 +955,29 @@ final class StructuredMetadataBuilder
 
         $runTime = $this->appleRunTime($makerNotes?->runTime);
 
+        $aeStable              = $makerNotes?->aeStable;
+        $aeTarget              = $makerNotes?->aeTarget;
+        $aeAverage             = $makerNotes?->aeAverage;
+        $afStable              = $makerNotes?->afStable;
+        $afPerformance         = $makerNotes?->afPerformance;
+        $signalToNoiseRatioType = $makerNotes?->signalToNoiseRatioType;
+        $luminanceNoiseAmplitude = $makerNotes?->luminanceNoiseAmplitude;
+
+        $imageCaptureRequestId = $makerNotes?->imageCaptureRequestId;
+        if ($imageCaptureRequestId === null) {
+            $imageCaptureRequestId = $this->quickTimeString($quickTimeResolver, 'ImageCaptureRequestID');
+        }
+
+        $qualityHint = $makerNotes?->qualityHint;
+        if ($qualityHint === null) {
+            $qualityHint = $this->quickTimeStringOrNumeric($quickTimeResolver, 'QualityHint');
+        }
+
+        $colorCorrectionMatrix = $makerNotes?->colorCorrectionMatrix;
+        if ($colorCorrectionMatrix === null) {
+            $colorCorrectionMatrix = $this->quickTimeFloatList($quickTimeResolver, 'ColorCorrectionMatrix');
+        }
+
         $makerNoteVersion = $makerNotes?->makerNoteVersion;
         if ($makerNoteVersion === null) {
             $makerNoteVersion = $this->quickTimeString($quickTimeResolver, 'MakerNoteVersion');
@@ -1006,32 +1028,42 @@ final class StructuredMetadataBuilder
             $afConfidence = $this->quickTimeFloat($quickTimeResolver, 'AFConfidence');
         }
 
-        return new Apple(
-            $contentIdentifier,
-            $cameraType,
-            $hdrHeadroom,
-            $hdrGain,
-            $snr,
-            $focusPosition,
-            $livePhotoIndex,
-            $livePhotoTime,
-            $colorTemperature,
-            $semanticPreset,
-            $semanticWarmth,
-            $semanticTone,
-            $flags,
-            $accelerationVector,
-            $runTime,
-            $makerNoteVersion,
-            $hdrImageType,
-            $burstUuid,
-            $focusDistanceRange,
-            $oisMode,
-            $imageCaptureType,
-            $imageUniqueId,
-            $photoIdentifier,
-            $afMeasuredDepth,
-            $afConfidence,
+        return new AppleMakerNotes(
+            contentIdentifier: $contentIdentifier,
+            cameraType: $cameraType,
+            hdrHeadroom: $hdrHeadroom,
+            hdrGain: $hdrGain,
+            snr: $snr,
+            aeStable: $aeStable,
+            aeTarget: $aeTarget,
+            aeAverage: $aeAverage,
+            afStable: $afStable,
+            afPerformance: $afPerformance,
+            signalToNoiseRatioType: $signalToNoiseRatioType,
+            luminanceNoiseAmplitude: $luminanceNoiseAmplitude,
+            focusPosition: $focusPosition,
+            livePhotoIndex: $livePhotoIndex,
+            colorTemperature: $colorTemperature,
+            semanticStylePreset: $semanticPreset,
+            semanticStyleWarmth: $semanticWarmth,
+            semanticStyleTone: $semanticTone,
+            flags: $flags,
+            accelerationVector: $accelerationVector,
+            imageCaptureRequestId: $imageCaptureRequestId,
+            qualityHint: $qualityHint,
+            colorCorrectionMatrix: $colorCorrectionMatrix,
+            livePhotoTime: $livePhotoTime,
+            runTime: $runTime,
+            makerNoteVersion: $makerNoteVersion,
+            hdrImageType: $hdrImageType,
+            burstUuid: $burstUuid,
+            focusDistanceRange: $focusDistanceRange,
+            oisMode: $oisMode,
+            imageCaptureType: $imageCaptureType,
+            imageUniqueId: $imageUniqueId,
+            photoIdentifier: $photoIdentifier,
+            afMeasuredDepth: $afMeasuredDepth,
+            afConfidence: $afConfidence,
         );
     }
 
@@ -1047,11 +1079,11 @@ final class StructuredMetadataBuilder
      * Builds the motion metadata aggregate from EXIF and Apple motion sources.
      *
      * @param ExifTagResolver $exif  Resolver exposing EXIF camera orientation measurements.
-     * @param Apple           $apple Aggregated Apple metadata composed from maker notes and QuickTime sources.
+     * @param AppleMakerNotes $apple Aggregated Apple metadata composed from maker notes and QuickTime sources.
      *
      * @return Motion Motion metadata aggregate with camera orientation and per-axis acceleration.
      */
-    private function buildMotion(ExifTagResolver $exif, Apple $apple): Motion
+    private function buildMotion(ExifTagResolver $exif, AppleMakerNotes $apple): Motion
     {
         $rollDeg  = $exif->cameraRollDeg();
         $pitchDeg = $exif->cameraPitchDeg();

--- a/src/Value/Apple.php
+++ b/src/Value/Apple.php
@@ -11,64 +11,11 @@ declare(strict_types=1);
 
 namespace MagicSunday\ImageMeta\Value;
 
+use MagicSunday\ImageMeta\MakerNotes\Apple\AppleMakerNotes;
+
 /**
- * Holds Apple specific metadata aggregated from maker notes and QuickTime sources.
+ * @deprecated Use {@see AppleMakerNotes} instead.
  */
-final readonly class Apple
-{
-    /**
-     * @param string|null         $contentIdentifier   Unique content identifier assigned by Apple platforms.
-     * @param string|int|null     $cameraType          Reported hardware camera type (e.g. "Wide", "Tele").
-     * @param float|null          $hdrHeadroom         HDR headroom value reported by the capture pipeline.
-     * @param list<float>|null    $hdrGain             HDR gain values per colour channel.
-     * @param float|null          $snr                 Signal-to-noise ratio setting applied during capture.
-     * @param float|null          $focusPosition       Focus position within the device specific range.
-     * @param int|null            $livePhotoIndex      Index of the still frame for Live Photo sequences.
-     * @param float|null          $livePhotoTime       Normalised Live Photo timestamp in seconds.
-     * @param int|null            $colorTemperature    White balance colour temperature in Kelvin.
-     * @param string|null         $semanticStylePreset Semantic style preset name.
-     * @param float|null          $semanticStyleWarmth Semantic style warmth value.
-     * @param float|null          $semanticStyleTone   Semantic style tone value.
-     * @param array<string, bool> $flags               Boolean flags derived from maker notes or QuickTime metadata.
-     * @param list<float>|null    $accelerationVector  Acceleration vector recorded during capture.
-     * @param RunTime|null        $runTime             Capture runtime metadata describing the CMTime payload.
-     * @param string|null         $makerNoteVersion    Maker note version string reported by the device.
-     * @param string|null         $hdrImageType        HDR image classification (e.g. "HDR").
-     * @param string|null         $burstUuid           Identifier referencing the originating burst sequence.
-     * @param list<float>|null    $focusDistanceRange  Near and far focus distance bounds in meters.
-     * @param string|null         $oisMode             Optical image stabilisation mode.
-     * @param string|null         $imageCaptureType    Capture type enumeration label.
-     * @param string|null         $imageUniqueId       Unique image identifier distinct from EXIF/ImageUniqueID.
-     * @param string|null         $photoIdentifier     Photos framework identifier for the asset.
-     * @param float|null          $afMeasuredDepth     Autofocus measured depth value in meters.
-     * @param float|null          $afConfidence        Autofocus confidence score between 0.0 and 1.0.
-     */
-    public function __construct(
-        public ?string $contentIdentifier,
-        public string|int|null $cameraType,
-        public ?float $hdrHeadroom,
-        public ?array $hdrGain,
-        public ?float $snr,
-        public ?float $focusPosition,
-        public ?int $livePhotoIndex,
-        public ?float $livePhotoTime,
-        public ?int $colorTemperature,
-        public ?string $semanticStylePreset,
-        public ?float $semanticStyleWarmth,
-        public ?float $semanticStyleTone,
-        public array $flags,
-        public ?array $accelerationVector,
-        public ?RunTime $runTime,
-        public ?string $makerNoteVersion,
-        public ?string $hdrImageType,
-        public ?string $burstUuid,
-        public ?array $focusDistanceRange,
-        public ?string $oisMode,
-        public ?string $imageCaptureType,
-        public ?string $imageUniqueId,
-        public ?string $photoIdentifier,
-        public ?float $afMeasuredDepth,
-        public ?float $afConfidence,
-    ) {
-    }
+if (!class_exists(__NAMESPACE__ . '\\Apple', false)) {
+    class_alias(AppleMakerNotes::class, __NAMESPACE__ . '\\Apple');
 }

--- a/tests/Curate/Resolver/AppleResolverTest.php
+++ b/tests/Curate/Resolver/AppleResolverTest.php
@@ -12,8 +12,8 @@ declare(strict_types=1);
 namespace MagicSunday\ImageMeta\Tests\Curate\Resolver;
 
 use MagicSunday\ImageMeta\Curate\Resolver\AppleResolver;
+use MagicSunday\ImageMeta\MakerNotes\Apple\AppleMakerNotes;
 use MagicSunday\ImageMeta\Model\QuickTimeMeta;
-use MagicSunday\ImageMeta\Value\Apple;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
@@ -50,7 +50,7 @@ final class AppleResolverTest extends TestCase
 
         $apple = $resolver->resolve($quickTime);
 
-        self::assertInstanceOf(Apple::class, $apple);
+        self::assertInstanceOf(AppleMakerNotes::class, $apple);
         self::assertSame('qt-content', $apple->contentIdentifier);
         self::assertSame('Wide', $apple->cameraType);
         self::assertSame([1.1, 1.2, 1.3], $apple->hdrGain);

--- a/tests/Curate/StructuredMetadataBuilderTest.php
+++ b/tests/Curate/StructuredMetadataBuilderTest.php
@@ -718,23 +718,26 @@ final class StructuredMetadataBuilderTest extends TestCase
             hdrHeadroom: 3.0,
             hdrGain: [2.1, 2.2, 2.3],
             snr: 18.5,
-            aeStable: null,
-            aeTarget: null,
-            aeAverage: null,
-            afStable: null,
-            afPerformance: null,
-            signalToNoiseRatioType: null,
-            luminanceNoiseAmplitude: null,
+            aeStable: true,
+            aeTarget: 0.92,
+            aeAverage: 0.78,
+            afStable: false,
+            afPerformance: 0.44,
+            signalToNoiseRatioType: 'focus',
+            luminanceNoiseAmplitude: 1.25,
             focusPosition: 0.5,
             livePhotoIndex: 4,
-            livePhotoTime: 0.2,
             colorTemperature: 4300,
             semanticStylePreset: 'MakerPreset',
             semanticStyleWarmth: 0.3,
             semanticStyleTone: -0.2,
-            runTime: new RunTime(epoch: 7, timescale: 20, value: 100, flags: 9),
             flags: ['livePhotoAuto' => false, 'nightMode' => true],
             accelerationVector: [0.05, 0.1, -0.1],
+            imageCaptureRequestId: 'req-42',
+            qualityHint: 'High',
+            colorCorrectionMatrix: [1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0],
+            livePhotoTime: 0.2,
+            runTime: new RunTime(epoch: 7, timescale: 20, value: 100, flags: 9),
             makerNoteVersion: '2.0',
             hdrImageType: 'HDR',
             burstUuid: 'maker-burst',
@@ -776,6 +779,13 @@ final class StructuredMetadataBuilderTest extends TestCase
         self::assertSame([2.1, 2.2, 2.3], $structured->apple->hdrGain);
         self::assertEqualsWithDelta(3.0, $structured->apple->hdrHeadroom, 1e-12);
         self::assertEqualsWithDelta(18.5, $structured->apple->snr, 1e-12);
+        self::assertTrue($structured->apple->aeStable);
+        self::assertEqualsWithDelta(0.92, $structured->apple->aeTarget, 1e-12);
+        self::assertEqualsWithDelta(0.78, $structured->apple->aeAverage, 1e-12);
+        self::assertFalse($structured->apple->afStable);
+        self::assertEqualsWithDelta(0.44, $structured->apple->afPerformance, 1e-12);
+        self::assertSame('focus', $structured->apple->signalToNoiseRatioType);
+        self::assertEqualsWithDelta(1.25, $structured->apple->luminanceNoiseAmplitude, 1e-12);
         self::assertEqualsWithDelta(0.5, $structured->apple->focusPosition, 1e-12);
         self::assertSame(4, $structured->apple->livePhotoIndex);
         self::assertEqualsWithDelta(0.2, $structured->apple->livePhotoTime, 1e-12);
@@ -786,6 +796,9 @@ final class StructuredMetadataBuilderTest extends TestCase
         self::assertFalse($structured->apple->flags['livePhotoAuto']);
         self::assertTrue($structured->apple->flags['nightMode']);
         self::assertSame([0.05, 0.1, -0.1], $structured->apple->accelerationVector);
+        self::assertSame('req-42', $structured->apple->imageCaptureRequestId);
+        self::assertSame('High', $structured->apple->qualityHint);
+        self::assertSame([1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0], $structured->apple->colorCorrectionMatrix);
         self::assertSame('2.0', $structured->apple->makerNoteVersion);
         self::assertSame('HDR', $structured->apple->hdrImageType);
         self::assertSame('maker-burst', $structured->apple->burstUuid);


### PR DESCRIPTION
## Summary
- reuse MagicSunday\\ImageMeta\\MakerNotes\\Apple\\AppleMakerNotes as the sole Apple metadata value object across the resolver and structured aggregate
- expand structured metadata builder coverage to include maker-note specific properties and QuickTime fallbacks
- deprecate MagicSunday\\ImageMeta\\Value\\Apple via class_alias for backwards compatibility

## Testing
- composer ci:test:php:unit -- tests/Curate/Resolver/AppleResolverTest.php tests/Curate/StructuredMetadataBuilderTest.php

------
https://chatgpt.com/codex/tasks/task_e_68fea037f4e48323bb690a6e3e5c5f35