### PR TITLE
feat: add enums for ICC rendering intents and DNG gain tables

### DIFF
--- a/src/Curate/StructuredMetadataBuilder.php
+++ b/src/Curate/StructuredMetadataBuilder.php
@@ -41,6 +41,7 @@ use MagicSunday\ImageMeta\Value\Container;
 use MagicSunday\ImageMeta\Value\Derived;
 use MagicSunday\ImageMeta\Value\Device;
 use MagicSunday\ImageMeta\Value\Enum\ColorSpace;
+use MagicSunday\ImageMeta\Value\Enum\DngProfileGainTableTag;
 use MagicSunday\ImageMeta\Value\Enum\ExposureProgram;
 use MagicSunday\ImageMeta\Value\Enum\MeteringMode;
 use MagicSunday\ImageMeta\Value\Enum\Orientation;
@@ -410,7 +411,7 @@ final class StructuredMetadataBuilder
         $gainMap = null;
         $gainMapData = $exifDocument?->profileGainTableMap();
         if (is_array($gainMapData) && $gainMapData !== []) {
-            $gainMap = new ColorProfileGainMap($gainMapData);
+            $gainMap = new ColorProfileGainMap(DngProfileGainTableTag::GAIN_TABLE_MAP, $gainMapData);
         }
 
         $colorProfile = new ColorProfile(

--- a/src/Model/Exif/ExifDocument.php
+++ b/src/Model/Exif/ExifDocument.php
@@ -32,6 +32,7 @@ use MagicSunday\ImageMeta\Value\Enum\YCbCrPositioning;
 use MagicSunday\ImageMeta\Value\Enum\CompositeImage;
 use MagicSunday\ImageMeta\Value\Enum\Contrast;
 use MagicSunday\ImageMeta\Value\Enum\CustomRendered;
+use MagicSunday\ImageMeta\Value\Enum\DngProfileGainTableTag;
 use MagicSunday\ImageMeta\Value\Enum\Saturation;
 use MagicSunday\ImageMeta\Value\Enum\SceneCaptureType;
 use MagicSunday\ImageMeta\Value\Enum\SceneType;
@@ -1406,8 +1407,10 @@ final readonly class ExifDocument
      */
     public function profileGainTableMap(): ?array
     {
+        $gainTableTag = DngProfileGainTableTag::GAIN_TABLE_MAP;
+
         foreach ($this->profileIfds() as $ifd) {
-            $values = $this->rationalList($ifd, ExifTag::PROFILE_GAIN_TABLE_MAP);
+            $values = $this->rationalList($ifd, $gainTableTag->value);
             if ($values === null || $values === []) {
                 continue;
             }
@@ -2366,11 +2369,13 @@ final readonly class ExifDocument
     {
         $candidates = [];
 
+        $gainTableTag = DngProfileGainTableTag::GAIN_TABLE_MAP;
+
         foreach ($this->profileSourceIfds() as $ifd) {
             if ($ifd->get(ExifTag::PROFILE_HUE_SAT_MAP_DIMS) instanceof IfdEntry
                 || $ifd->get(ExifTag::PROFILE_LOOK_TABLE_DIMS) instanceof IfdEntry
                 || $ifd->get(ExifTag::PROFILE_TONE_CURVE) instanceof IfdEntry
-                || $ifd->get(ExifTag::PROFILE_GAIN_TABLE_MAP) instanceof IfdEntry) {
+                || $ifd->get($gainTableTag->value) instanceof IfdEntry) {
                 $candidates[] = $ifd;
             }
         }

--- a/src/Model/Exif/ExifTag.php
+++ b/src/Model/Exif/ExifTag.php
@@ -477,11 +477,6 @@ final readonly class ExifTag
      */
     public const int PROFILE_TONE_CURVE = 0xC6FC;
 
-    /**
-     * Optional profile gain table map encoded as IEEE-754 floats.
-     */
-    public const int PROFILE_GAIN_TABLE_MAP = 0xC7A4;
-
     // GPS sub IFD (Table 66 – EXIF 3.0)
     public const int GPS_VERSION_ID = 0x0000;
 

--- a/src/Parse/Icc/IccDecoder.php
+++ b/src/Parse/Icc/IccDecoder.php
@@ -14,6 +14,7 @@ namespace MagicSunday\ImageMeta\Parse\Icc;
 use Imagick;
 use ImagickPixel;
 use MagicSunday\ImageMeta\Core\ParseError;
+use MagicSunday\ImageMeta\Value\Enum\IccRenderingIntent;
 use Throwable;
 
 use function array_key_exists;
@@ -45,16 +46,6 @@ final class IccDecoder
     private const int TAG_RECORD_LENGTH = 12;
 
     private const string ICC_SIGNATURE = 'ICC_PROFILE\0';
-
-    /**
-     * Mapping of ICC rendering intent enumerations to descriptive strings.
-     */
-    private const array RENDERING_INTENT_MAP = [
-        0 => 'Perceptual',
-        1 => 'Media-Relative Colorimetric',
-        2 => 'Saturation',
-        3 => 'ICC-Absolute Colorimetric',
-    ];
 
     /**
      * Decodes the ICC profile payload by extracting header fields and well known tags.
@@ -215,7 +206,7 @@ final class IccDecoder
     {
         $intent = $this->uInt32Be(substr($data, 64, 4));
 
-        return self::RENDERING_INTENT_MAP[$intent] ?? null;
+        return IccRenderingIntent::fromProfileHeaderValue($intent)?->label();
     }
 
     /**

--- a/src/Value/ColorProfileGainMap.php
+++ b/src/Value/ColorProfileGainMap.php
@@ -11,15 +11,28 @@ declare(strict_types=1);
 
 namespace MagicSunday\ImageMeta\Value;
 
+use MagicSunday\ImageMeta\Value\Enum\DngProfileGainTableTag;
+
 /**
  * Encapsulates the optional DNG profile gain table map payload.
  */
 final readonly class ColorProfileGainMap
 {
     /**
-     * @param list<float> $values Normalised per-pixel gain factors stored in scan-line order.
+     * @param DngProfileGainTableTag $tag    Enumerated gain table tag represented by this payload.
+     * @param list<float>            $values Normalised per-pixel gain factors stored in scan-line order.
      */
-    public function __construct(public array $values)
+    public function __construct(
+        public DngProfileGainTableTag $tag,
+        public array $values,
+    ) {
+    }
+
+    /**
+     * Returns the human readable gain table label.
+     */
+    public function label(): string
     {
+        return $this->tag->label();
     }
 }

--- a/src/Value/Enum/DngProfileGainTableTag.php
+++ b/src/Value/Enum/DngProfileGainTableTag.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\ImageMeta\Value\Enum;
+
+/**
+ * Enumerates the DNG profile gain table related tags.
+ */
+enum DngProfileGainTableTag: int
+{
+    case GAIN_TABLE_MAP = 0xC7A4;
+
+    /**
+     * Creates an enum from the provided EXIF tag identifier when available.
+     */
+    public static function fromTagId(?int $tag): ?self
+    {
+        if ($tag === null) {
+            return null;
+        }
+
+        return self::tryFrom($tag);
+    }
+
+    /**
+     * Returns the human readable tag label.
+     */
+    public function label(): string
+    {
+        return match ($this) {
+            self::GAIN_TABLE_MAP => 'ProfileGainTableMap',
+        };
+    }
+}

--- a/src/Value/Enum/IccRenderingIntent.php
+++ b/src/Value/Enum/IccRenderingIntent.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\ImageMeta\Value\Enum;
+
+/**
+ * Enumerates the rendering intents defined by the ICC specification.
+ */
+enum IccRenderingIntent: int
+{
+    case PERCEPTUAL                     = 0;
+    case MEDIA_RELATIVE_COLORIMETRIC    = 1;
+    case SATURATION                     = 2;
+    case ICC_ABSOLUTE_COLORIMETRIC      = 3;
+
+    /**
+     * Creates an enum instance from the raw ICC header field.
+     */
+    public static function fromProfileHeaderValue(?int $value): ?self
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        return self::tryFrom($value);
+    }
+
+    /**
+     * Returns the human readable rendering intent label.
+     */
+    public function label(): string
+    {
+        return match ($this) {
+            self::PERCEPTUAL                  => 'Perceptual',
+            self::MEDIA_RELATIVE_COLORIMETRIC => 'Media-Relative Colorimetric',
+            self::SATURATION                  => 'Saturation',
+            self::ICC_ABSOLUTE_COLORIMETRIC   => 'ICC-Absolute Colorimetric',
+        };
+    }
+}

--- a/tests/Curate/StructuredMetadataBuilderTest.php
+++ b/tests/Curate/StructuredMetadataBuilderTest.php
@@ -39,6 +39,7 @@ use MagicSunday\ImageMeta\Value\Enum\Compression;
 use MagicSunday\ImageMeta\Value\Enum\Contrast;
 use MagicSunday\ImageMeta\Value\Enum\ExposureMode;
 use MagicSunday\ImageMeta\Value\Enum\ExposureProgram;
+use MagicSunday\ImageMeta\Value\Enum\DngProfileGainTableTag;
 use MagicSunday\ImageMeta\Value\Enum\FileSource;
 use MagicSunday\ImageMeta\Value\Enum\GainControl;
 use MagicSunday\ImageMeta\Value\Enum\LightSource;
@@ -1850,6 +1851,8 @@ final class StructuredMetadataBuilderTest extends TestCase
     #[Test]
     public function populatesColorProfileCalibrationFromExif(): void
     {
+        $gainTableTag = DngProfileGainTableTag::GAIN_TABLE_MAP;
+
         $profileIfd = new Ifd([
             ExifTag::PROFILE_HUE_SAT_MAP_DIMS    => new IfdEntry(ExifTag::PROFILE_HUE_SAT_MAP_DIMS, 4, 3, new ExifNumericList([6, 3, 2])),
             ExifTag::PROFILE_HUE_SAT_MAP_DATA_1 => new IfdEntry(ExifTag::PROFILE_HUE_SAT_MAP_DATA_1, 11, 12, new ExifNumericList([
@@ -1878,7 +1881,7 @@ final class StructuredMetadataBuilderTest extends TestCase
                 0.1,
             ])),
             ExifTag::PROFILE_TONE_CURVE          => new IfdEntry(ExifTag::PROFILE_TONE_CURVE, 11, 4, new ExifNumericList([0.0, 0.0, 0.5, 0.6])),
-            ExifTag::PROFILE_GAIN_TABLE_MAP      => new IfdEntry(ExifTag::PROFILE_GAIN_TABLE_MAP, 11, 4, new ExifNumericList([1.0, 1.05, 0.95, 1.1])),
+            $gainTableTag->value                 => new IfdEntry($gainTableTag->value, 11, 4, new ExifNumericList([1.0, 1.05, 0.95, 1.1])),
         ]);
 
         $exifIfd = new Ifd([
@@ -1913,6 +1916,8 @@ final class StructuredMetadataBuilderTest extends TestCase
         self::assertNotNull($profile->toneCurve);
         self::assertSame([[0.0, 0.0], [0.5, 0.6]], $profile->toneCurve->points);
         self::assertNotNull($profile->gainMap);
+        self::assertSame($gainTableTag, $profile->gainMap->tag);
+        self::assertSame('ProfileGainTableMap', $profile->gainMap->label());
         self::assertSame([1.0, 1.05, 0.95, 1.1], $profile->gainMap->values);
     }
 

--- a/tests/Model/Exif/ExifTagTest.php
+++ b/tests/Model/Exif/ExifTagTest.php
@@ -182,7 +182,6 @@ final class ExifTagTest extends TestCase
             'PROFILE_LOOK_TABLE_DIMS'                  => 0xC6FA,
             'PROFILE_LOOK_TABLE_DATA'                  => 0xC6FB,
             'PROFILE_TONE_CURVE'                       => 0xC6FC,
-            'PROFILE_GAIN_TABLE_MAP'                   => 0xC7A4,
             'PROFILE_CALIBRATION_SIGNATURE'            => 0xC6F4,
             'USER_COMMENT'                             => 0x9286,
             'SUB_SEC_TIME'                             => 0x9290,

--- a/tests/Parse/Tiff/TiffExifReaderTest.php
+++ b/tests/Parse/Tiff/TiffExifReaderTest.php
@@ -24,6 +24,7 @@ use MagicSunday\ImageMeta\Model\Exif\ExifRationalList;
 use MagicSunday\ImageMeta\Model\Exif\ExifTag;
 use MagicSunday\ImageMeta\Model\Exif\Ifd;
 use MagicSunday\ImageMeta\Parse\Tiff\TiffExifReader;
+use MagicSunday\ImageMeta\Value\Enum\DngProfileGainTableTag;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -1148,7 +1149,7 @@ final class TiffExifReaderTest extends TestCase
             self::packClassicEntry(ExifTag::PROFILE_LOOK_TABLE_DIMS, 3, count($lookDims), $lookDimsOffset),
             self::packClassicEntry(ExifTag::PROFILE_LOOK_TABLE_DATA, 11, count($lookData), $lookDataOffset),
             self::packClassicEntry(ExifTag::PROFILE_TONE_CURVE, 11, count($toneCurve), $toneCurveOffset),
-            self::packClassicEntry(ExifTag::PROFILE_GAIN_TABLE_MAP, 11, count($gainMap), $gainMapOffset),
+            self::packClassicEntry(DngProfileGainTableTag::GAIN_TABLE_MAP->value, 11, count($gainMap), $gainMapOffset),
         ];
 
         $blob .= pack('v', $subIfdEntryCount) . implode('', $subIfdEntries) . pack('V', 0);

--- a/tests/Value/Enum/DngProfileGainTableTagTest.php
+++ b/tests/Value/Enum/DngProfileGainTableTagTest.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\ImageMeta\Tests\Value\Enum;
+
+use MagicSunday\ImageMeta\Value\Enum\DngProfileGainTableTag;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \MagicSunday\ImageMeta\Value\Enum\DngProfileGainTableTag
+ */
+#[CoversClass(DngProfileGainTableTag::class)]
+final class DngProfileGainTableTagTest extends TestCase
+{
+    #[Test]
+    public function exposesLabelForGainTableMap(): void
+    {
+        $tag = DngProfileGainTableTag::fromTagId(0xC7A4);
+
+        self::assertNotNull($tag);
+        self::assertSame('ProfileGainTableMap', $tag->label());
+    }
+
+    #[Test]
+    public function returnsNullForUnknownTag(): void
+    {
+        self::assertNull(DngProfileGainTableTag::fromTagId(0xC7A5));
+    }
+}

--- a/tests/Value/Enum/IccRenderingIntentTest.php
+++ b/tests/Value/Enum/IccRenderingIntentTest.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\ImageMeta\Tests\Value\Enum;
+
+use MagicSunday\ImageMeta\Value\Enum\IccRenderingIntent;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \MagicSunday\ImageMeta\Value\Enum\IccRenderingIntent
+ */
+#[CoversClass(IccRenderingIntent::class)]
+final class IccRenderingIntentTest extends TestCase
+{
+    #[Test]
+    public function mapsKnownRenderingIntents(): void
+    {
+        self::assertSame('Perceptual', IccRenderingIntent::fromProfileHeaderValue(0)?->label());
+        self::assertSame('Media-Relative Colorimetric', IccRenderingIntent::fromProfileHeaderValue(1)?->label());
+        self::assertSame('Saturation', IccRenderingIntent::fromProfileHeaderValue(2)?->label());
+        self::assertSame('ICC-Absolute Colorimetric', IccRenderingIntent::fromProfileHeaderValue(3)?->label());
+    }
+
+    #[Test]
+    public function returnsNullForUnknownIntent(): void
+    {
+        self::assertNull(IccRenderingIntent::fromProfileHeaderValue(4));
+    }
+}


### PR DESCRIPTION
## Summary
- add shared enums for ICC rendering intents and DNG profile gain table tags
- refactor ICC and EXIF handling to consume the new enums and propagate gain table labels
- extend unit coverage for the new helpers and updated metadata pipeline

## Testing
- composer ci:test:php:unit

------
https://chatgpt.com/codex/tasks/task_e_68ff15a417d08323aa824c64b37293fc