### PR TITLE
chore: remove unused composite resolver helpers

### DIFF
--- a/docs/phpstan-follow-up.md
+++ b/docs/phpstan-follow-up.md
@@ -19,9 +19,6 @@ PHPUNIT
 - [x] `function.alreadyNarrowedType`: Call to function `is_numeric()` with `float|int` will always evaluate to true at lines 196, 209, and 228.
 - [x] `booleanOr.alwaysFalse`: Result of `||` is always false at lines 196, 209, and 228.
 
-### Curate/Resolver/CompositeResolver.php
-- [x] `argument.type`: Parameter `$candidates` of `CompositeResolver::firstInt()` expects `list<(Closure(): int)|float|int|string|null>`; lists of nullable closures reported at lines 77, 92, and 97.
-
 ### Curate/Resolver/RegionsResolver.php
 - [x] `arrayValues.list`: `array_values()` called on an array that is already a list at lines 127 and 188.
 

--- a/src/Curate/Resolver/CompositeResolver.php
+++ b/src/Curate/Resolver/CompositeResolver.php
@@ -20,9 +20,7 @@ use MagicSunday\ImageMeta\Model\Exif\ExifDocument;
 use function abs;
 use function intdiv;
 use function is_array;
-use function is_float;
 use function is_int;
-use function is_numeric;
 use function is_string;
 use function sprintf;
 
@@ -49,51 +47,6 @@ final readonly class CompositeResolver
         }
 
         return null;
-    }
-
-    /**
-     * Selects the first integer value from the candidate list applying numeric normalisation.
-     *
-     * @param array<int, (Closure(): (int|null))|float|int|string|null> $candidates
-     */
-    public static function firstInt(array $candidates): ?int
-    {
-        foreach ($candidates as $candidate) {
-            $value      = $candidate instanceof Closure ? $candidate() : $candidate;
-            $normalized = self::normalizeInteger($value);
-
-            if ($normalized !== null) {
-                return $normalized;
-            }
-        }
-
-        return null;
-    }
-
-    /**
-     * Resolves the ISO sensitivity using EXIF fallbacks.
-     */
-    public static function intISO(?ExifDocument $document): ?int
-    {
-        if (!$document instanceof ExifDocument) {
-            return null;
-        }
-
-        return $document->iso();
-    }
-
-    /**
-     * Resolves the image dimensions using EXIF fallbacks.
-     *
-     * @return array{0:?int,1:?int}
-     */
-    public static function dimensions(?ExifDocument $document): array
-    {
-        if (!$document instanceof ExifDocument) {
-            return [null, null];
-        }
-
-        return [$document->imageWidth(), $document->imageHeight()];
     }
 
     /**
@@ -143,23 +96,4 @@ final readonly class CompositeResolver
         ];
     }
 
-    /**
-     * Normalizes integer candidates coming from various metadata sources.
-     */
-    private static function normalizeInteger(int|float|string|null $value): ?int
-    {
-        if (is_int($value)) {
-            return $value;
-        }
-
-        if (is_float($value)) {
-            return (int) $value;
-        }
-
-        if (is_string($value) && $value !== '' && is_numeric($value)) {
-            return (int) $value;
-        }
-
-        return null;
-    }
 }


### PR DESCRIPTION
## Summary
- remove unused helper methods from `CompositeResolver` and the related dead imports
- update the PHPStan follow-up checklist to reflect the removed helpers

## Testing
- composer ci:test:php:unit
- composer ci:test:php:phpstan *(fails: existing 342 baseline issues)*

------
https://chatgpt.com/codex/tasks/task_e_68ff360024dc8323925a3269dfaa15d1