### PR TITLE
Fix rights and author metadata to use EXIF sources

### DIFF
--- a/src/Curate/StructuredMetadataBuilder.php
+++ b/src/Curate/StructuredMetadataBuilder.php
@@ -453,10 +453,7 @@ final class StructuredMetadataBuilder
         );
 
         $rights = new Rights(
-            copyright: CompositeResolver::first([
-                fn (): ?string => $xmpDocument?->string('http://purl.org/dc/elements/1.1/', 'rights'),
-                fn (): ?string => $exifDocument?->artist(),
-            ]),
+            copyright: $exifDocument?->copyright(),
             usageTerms: $xmpDocument?->string('http://ns.adobe.com/xap/1.0/rights/', 'UsageTerms'),
             licenseUrl: $xmpDocument?->string('http://ns.adobe.com/xap/1.0/rights/', 'WebStatement'),
             creditLine: $xmpDocument?->string('http://ns.adobe.com/photoshop/1.0/', 'Credit'),
@@ -465,13 +462,8 @@ final class StructuredMetadataBuilder
 
         $author = new Author(
             artist: $exifDocument?->artist(),
-            ownerName: CompositeResolver::first([
-                fn (): ?string => $exifDocument?->ownerName(),
-                fn (): ?string => $xmpDocument?->string('http://ns.adobe.com/xap/1.0/aux/', 'OwnerName'),
-            ]),
-            creator: CompositeResolver::first([
-                fn (): ?string => $this->firstListValue($xmpDocument?->stringList('http://purl.org/dc/elements/1.1/', 'creator') ?? []),
-            ]),
+            ownerName: $exifDocument?->ownerName(),
+            creator: $this->firstListValue($xmpDocument?->stringList('http://purl.org/dc/elements/1.1/', 'creator') ?? []),
             creatorEmail: $xmpDocument?->string('http://iptc.org/std/Iptc4xmpCore/1.0/xmlns/', 'CreatorContactInfo/Iptc4xmpCore:CiEmailWork'),
             photographer: $exifDocument?->photographer(),
             imageEditor: $exifDocument?->imageEditor(),

--- a/tests/Curate/StructuredMetadataBuilderTest.php
+++ b/tests/Curate/StructuredMetadataBuilderTest.php
@@ -117,6 +117,7 @@ final class StructuredMetadataBuilderTest extends TestCase
 
         $exifIfd = new Ifd([
             ExifTag::IMAGE_TITLE                 => new IfdEntry(ExifTag::IMAGE_TITLE, 2, 12, 'Sunset Title'),
+            ExifTag::CAMERA_OWNER_NAME           => new IfdEntry(ExifTag::CAMERA_OWNER_NAME, 2, 10, 'Jane Owner'),
             ExifTag::PHOTOGRAPHER                => new IfdEntry(ExifTag::PHOTOGRAPHER, 2, 22, 'Jane D. Photographer'),
             ExifTag::IMAGE_EDITOR                => new IfdEntry(ExifTag::IMAGE_EDITOR, 2, 12, 'John Editor'),
             ExifTag::EXIF_VERSION                => new IfdEntry(ExifTag::EXIF_VERSION, 7, 4, '0300'),
@@ -232,10 +233,12 @@ final class StructuredMetadataBuilderTest extends TestCase
 
         $xmpDocument = new XmpDocument([
             '{http://purl.org/dc/elements/1.1/}creator'                                                => ['Jane Doe'],
+            '{http://purl.org/dc/elements/1.1/}rights'                                                 => 'XMP Rights Statement',
             '{http://iptc.org/std/Iptc4xmpCore/1.0/xmlns/}CreatorContactInfo/Iptc4xmpCore:CiEmailWork' => 'jane@example.com',
             '{http://ns.adobe.com/tiff/1.0/}Make'                                                      => 'Canon',
             '{http://ns.adobe.com/tiff/1.0/}Model'                                                     => 'EOS R6 II',
             '{http://ns.adobe.com/tiff/1.0/}DocumentName'                                              => 'IMG_5123.CR3',
+            '{http://ns.adobe.com/xap/1.0/aux/}OwnerName'                                              => 'XMP Owner Name',
         ]);
 
         $quickTime = new QuickTimeMeta([
@@ -281,6 +284,8 @@ final class StructuredMetadataBuilderTest extends TestCase
         self::assertSame('Canon', $structured->camera->make);
         self::assertSame('EOS R6 II', $structured->camera->model);
         self::assertSame('Jane Doe', $structured->author->artist);
+        self::assertSame('Jane Owner', $structured->author->ownerName);
+        self::assertSame('Jane Doe 2024', $structured->rights->copyright);
         self::assertSame('Restricted', $structured->rights->securityClassification);
         self::assertSame('1.2.3', $structured->camera->firmware);
         self::assertSame(FileSource::DIGITAL_CAMERA, $structured->camera->fileSource);
@@ -433,6 +438,30 @@ final class StructuredMetadataBuilderTest extends TestCase
         self::assertSame('+01:30', $structured->temporal->offsetTimeDigitized);
         self::assertSame([-120, -60], $structured->temporal->timeZoneOffsetMinutes);
         self::assertSame('OffsetTimeOriginal', $structured->temporal->tzSource);
+    }
+
+    #[Test]
+    public function doesNotFallbackToXmpForRightsOrOwnerName(): void
+    {
+        $xmpDocument = new XmpDocument([
+            '{http://purl.org/dc/elements/1.1/}rights'    => 'XMP Rights Statement',
+            '{http://ns.adobe.com/xap/1.0/aux/}OwnerName' => 'XMP Owner Name',
+            '{http://purl.org/dc/elements/1.1/}creator'   => ['XMP Creator'],
+        ]);
+
+        $metadata = new Metadata(
+            ['primary'],
+            null,
+            new ExifDocument(new Ifd([]), new Ifd([]), null, null, null),
+            ['<xmp/>'],
+            $xmpDocument,
+        );
+
+        $structured = (new StructuredMetadataBuilder())->build($metadata);
+
+        self::assertNull($structured->rights->copyright);
+        self::assertNull($structured->author->ownerName);
+        self::assertSame('XMP Creator', $structured->author->creator);
     }
 
     #[Test]


### PR DESCRIPTION
## Summary
- ensure the structured rights and author aggregates read EXIF tags directly instead of falling back to XMP values
- extend the structured metadata builder tests to cover EXIF-only population and absence of XMP overrides for copyright and owner name

## Testing
- composer ci:test:php:unit

------
https://chatgpt.com/codex/tasks/task_e_68ff361e7b1c83238e664eb97757bb85