### PR TITLE
fix: ensure device software uses EXIF metadata

### DIFF
--- a/src/Curate/StructuredMetadataBuilder.php
+++ b/src/Curate/StructuredMetadataBuilder.php
@@ -600,14 +600,11 @@ final class StructuredMetadataBuilder
      */
     private function buildDevice(?ExifDocument $exif, ?QuickTimeMeta $quickTime, ?XmpDocument $xmpDocument): Device
     {
-        $softwareCandidates = [
-            fn (): ?string => $this->quickTimeString($quickTime, 'com.apple.quicktime.software'),
-            fn (): ?string => $xmpDocument?->string('http://ns.adobe.com/xap/1.0/', 'CreatorTool'),
-        ];
+        $softwareCandidates = [];
 
         if ($exif instanceof ExifDocument) {
-            $softwareCandidates[] = fn (): ?string => $exif->software();
-            $softwareCandidates[] = fn (): ?string => $exif->hostComputer();
+            $softwareCandidates[] = static fn (): ?string => $exif->software();
+            $softwareCandidates[] = static fn (): ?string => $exif->hostComputer();
         }
 
         return new Device(

--- a/tests/Curate/StructuredMetadataBuilderTest.php
+++ b/tests/Curate/StructuredMetadataBuilderTest.php
@@ -597,11 +597,12 @@ final class StructuredMetadataBuilderTest extends TestCase
     public function buildsStructuredAggregateForHeif(): void
     {
         $ifd0 = new Ifd([
-            ExifTag::IMAGE_WIDTH  => new IfdEntry(ExifTag::IMAGE_WIDTH, 4, 1, 4032),
-            ExifTag::IMAGE_HEIGHT => new IfdEntry(ExifTag::IMAGE_HEIGHT, 4, 1, 3024),
-            ExifTag::MAKE         => new IfdEntry(ExifTag::MAKE, 2, 5, 'Apple'),
-            ExifTag::MODEL        => new IfdEntry(ExifTag::MODEL, 2, 9, 'iPhone 15'),
-            ExifTag::ORIENTATION  => new IfdEntry(ExifTag::ORIENTATION, 3, 1, Orientation::TOP_LEFT->value),
+            ExifTag::IMAGE_WIDTH           => new IfdEntry(ExifTag::IMAGE_WIDTH, 4, 1, 4032),
+            ExifTag::IMAGE_HEIGHT          => new IfdEntry(ExifTag::IMAGE_HEIGHT, 4, 1, 3024),
+            ExifTag::MAKE                  => new IfdEntry(ExifTag::MAKE, 2, 5, 'Apple'),
+            ExifTag::MODEL                 => new IfdEntry(ExifTag::MODEL, 2, 9, 'iPhone 15'),
+            ExifTag::ORIENTATION           => new IfdEntry(ExifTag::ORIENTATION, 3, 1, Orientation::TOP_LEFT->value),
+            ExifTag::PROCESSING_SOFTWARE   => new IfdEntry(ExifTag::PROCESSING_SOFTWARE, 2, 8, 'iOS 17.3'),
         ]);
 
         $exifIfd = new Ifd([
@@ -642,7 +643,7 @@ final class StructuredMetadataBuilderTest extends TestCase
             self::assertEqualsWithDelta($expected, $structured->composite->exposureTimesTotal[$idx], 1e-12);
         }
 
-        self::assertSame('17.3', $structured->device->software);
+        self::assertSame('iOS 17.3', $structured->device->software);
 
         self::assertTrue($structured->scene->hdrScene);
         self::assertTrue($structured->scene->nightMode);


### PR DESCRIPTION
## Summary
- update the structured metadata builder to source device software exclusively from EXIF tags
- adjust the HEIF aggregation test fixture to provide EXIF processing software and expect it in the structured device metadata

## Testing
- composer ci:test:php:unit

------
https://chatgpt.com/codex/tasks/task_e_68ff361f43ec8323832860442ac796fe