### PR TITLE
Fix QuickTime software fallback in device metadata

### DIFF
--- a/src/Curate/StructuredMetadataBuilder.php
+++ b/src/Curate/StructuredMetadataBuilder.php
@@ -582,11 +582,11 @@ final class StructuredMetadataBuilder
     }
 
     /**
-     * Builds the device metadata aggregate by combining EXIF, QuickTime and XMP sources.
+     * Builds the device metadata aggregate by combining EXIF helpers with QuickTime fallbacks.
      *
-     * @param ExifDocument   $exif              Resolver exposing EXIF tag helpers.
-     * @param QuickTimeMeta|null $quickTime QuickTime metadata container exposing QuickTime fields.
-     * @param XmpDocument|null   $xmpDocument      XMP document exposing metadata fields.
+     * @param ExifDocument|null   $exif        Resolver exposing EXIF tag helpers.
+     * @param QuickTimeMeta|null  $quickTime   QuickTime metadata container exposing software fields.
+     * @param XmpDocument|null    $xmpDocument Placeholder for future XMP backed device metadata.
      *
      * @return Device Device value object describing capture hardware and software.
      */
@@ -598,6 +598,14 @@ final class StructuredMetadataBuilder
             $softwareCandidates[] = static fn (): ?string => $exif->software();
             $softwareCandidates[] = static fn (): ?string => $exif->hostComputer();
         }
+
+        $softwareCandidates[] = fn (): ?string => $this->quickTimeString(
+            $quickTime,
+            'com.apple.quicktime.software',
+            'Software',
+            'com.apple.quicktime.softwareversion',
+            'com.apple.quicktime.software.version',
+        );
 
         return new Device(
             software: CompositeResolver::first($softwareCandidates),

--- a/tests/Curate/StructuredMetadataBuilderTest.php
+++ b/tests/Curate/StructuredMetadataBuilderTest.php
@@ -737,6 +737,23 @@ final class StructuredMetadataBuilderTest extends TestCase
         self::assertSame('PowerMac G4', $structured->device->software);
     }
 
+    #[Test]
+    public function fallsBackToQuickTimeSoftwareWhenExifMissing(): void
+    {
+        $ifd0 = new Ifd([]);
+
+        $exifDocument = new ExifDocument($ifd0, null, null, null, null);
+
+        $quickTime = new QuickTimeMeta([
+            'com.apple.quicktime.software' => 'QuickTime Studio',
+        ]);
+
+        $metadata   = new Metadata(['primary'], $quickTime, $exifDocument);
+        $structured = (new StructuredMetadataBuilder())->build($metadata);
+
+        self::assertSame('QuickTime Studio', $structured->device->software);
+    }
+
     /**
      * Ensures maker notes Apple data is preferred over QuickTime metadata and propagates to white balance and motion.
      */


### PR DESCRIPTION
## Summary
- fall back to QuickTime software metadata when EXIF lacks software or host computer values
- document the device builder data sources and consult common QuickTime software aliases
- cover the behaviour with a dedicated StructuredMetadataBuilder test

## Testing
- composer ci:test:php:unit -- --filter StructuredMetadataBuilderTest

------
https://chatgpt.com/codex/tasks/task_e_68ff466a612c8323a9257d2a1bbed5fb