### PR TITLE
Refactor Apple maker note enrichment into mapper

### DIFF
--- a/src/Curate/Exif/ValueFactory.php
+++ b/src/Curate/Exif/ValueFactory.php
@@ -17,7 +17,6 @@ use Exception;
 use MagicSunday\ImageMeta\Model\Exif\ValueConverters;
 use MagicSunday\ImageMeta\Model\Exif\ExifDocument;
 use MagicSunday\ImageMeta\MakerNotes\Apple\AppleMakerNotes;
-use MagicSunday\ImageMeta\MakerNotes\AppleMetadata;
 use MagicSunday\ImageMeta\Model\Metadata;
 use MagicSunday\ImageMeta\Model\QuickTimeMeta;
 use MagicSunday\ImageMeta\Model\Xmp\XmpDocument;
@@ -60,7 +59,6 @@ use MagicSunday\ImageMeta\Value\Preview;
 use MagicSunday\ImageMeta\Value\ProcessingSettings;
 use MagicSunday\ImageMeta\Value\Regions;
 use MagicSunday\ImageMeta\Value\Regions\RegionType;
-use MagicSunday\ImageMeta\Value\RunTime;
 use MagicSunday\ImageMeta\Value\RelatedAssets;
 use MagicSunday\ImageMeta\Value\Rights;
 use MagicSunday\ImageMeta\Value\Scene;
@@ -74,7 +72,6 @@ use MagicSunday\ImageMeta\Value\Xmp;
 use MagicSunday\ImageMeta\Value\WhiteBalanceDetails;
 
 use function abs;
-use function array_is_list;
 use function array_key_exists;
 use function count;
 use function intdiv;
@@ -82,10 +79,8 @@ use function is_array;
 use function is_bool;
 use function is_float;
 use function is_int;
-use function is_numeric;
 use function is_string;
 use function preg_replace;
-use function preg_split;
 use function sprintf;
 use function str_pad;
 use function substr;
@@ -283,7 +278,7 @@ final class ValueFactory
 
         $device = $this->buildDevice($exifDocument, $quickTimeMeta, $xmpDocument);
 
-        $apple = $this->buildApple($appleMakerNotes, $quickTimeMeta, $exifDocument);
+        $apple = $appleMakerNotes ?? $this->emptyAppleMakerNotes();
         $xmp   = new Xmp($xmpDocument);
 
         $file = new File(
@@ -996,229 +991,6 @@ final class ValueFactory
     }
 
     /**
-     * Builds the Apple metadata aggregate by combining maker note values with QuickTime fallbacks.
-     *
-     * @param AppleMakerNotes|null $makerNotes        Parsed Apple maker note payload.
-     * @param QuickTimeMeta|null   $quickTime QuickTime metadata container exposing QuickTime entries.
-     * @param ExifDocument|null      $exifDocument      Resolver exposing EXIF fallback values.
-     *
-     * @return AppleMakerNotes Apple metadata value object with normalised fields.
-     */
-    private function buildApple(
-        ?AppleMakerNotes $makerNotes,
-        ?QuickTimeMeta $quickTime,
-        ?ExifDocument $exifDocument,
-    ): AppleMakerNotes {
-        $contentIdentifier = $makerNotes?->contentIdentifier;
-        if ($contentIdentifier === null) {
-            $contentIdentifier = $quickTime?->contentIdentifier();
-        }
-
-        $cameraType = $makerNotes?->cameraType;
-        if ($cameraType === null) {
-            $cameraType = $this->quickTimeString($quickTime, 'CameraType');
-        }
-
-        $hdrHeadroom = $makerNotes?->hdrHeadroom;
-        if ($hdrHeadroom === null) {
-            $hdrHeadroom = $this->quickTimeFloat($quickTime, 'HdrHeadroom', 'HDRHeadroom');
-        }
-
-        $hdrGain = $makerNotes?->hdrGain;
-        if ($hdrGain === null) {
-            $hdrGain = $this->quickTimeFloatList($quickTime, 'HdrGain', 'HDRGain');
-        }
-
-        $snr = $makerNotes?->snr;
-        if ($snr === null) {
-            $snr = $this->quickTimeFloat($quickTime, 'SNRSetting', 'SNR');
-        }
-
-        $focusPosition = $makerNotes?->focusPosition;
-        if ($focusPosition === null) {
-            $focusPosition = $this->quickTimeFloat($quickTime, 'FocusPosition');
-        }
-
-        $livePhotoIndex = $makerNotes?->livePhotoIndex;
-        if ($livePhotoIndex === null) {
-            $livePhotoIndex = $this->quickTimeInt($quickTime, 'LivePhotoVideoIndex', 'LivePhotoMovieIndex');
-        }
-
-        $livePhotoTime = $makerNotes?->livePhotoTime;
-
-        $colorTemperature = $makerNotes?->colorTemperature;
-        if ($colorTemperature === null) {
-            $colorTemperature = $this->quickTimeInt($quickTime, 'ColorTemperature');
-        }
-
-        $semanticPreset = $makerNotes?->semanticStylePreset;
-        if ($semanticPreset === null) {
-            $semanticPreset = $this->quickTimeString($quickTime, 'SemanticStylePreset');
-        }
-
-        $semanticWarmth = $makerNotes?->semanticStyleWarmth;
-        if ($semanticWarmth === null) {
-            $semanticWarmth = $this->quickTimeFloat($quickTime, 'SemanticStyleWarmth');
-        }
-
-        $semanticTone = $makerNotes?->semanticStyleTone;
-        if ($semanticTone === null) {
-            $semanticTone = $this->quickTimeFloat($quickTime, 'SemanticStyleTone');
-        }
-
-        $semanticStyleComposite = $this->quickTimeSemanticStyle($quickTime);
-        if ($semanticStyleComposite !== null) {
-            [$compositePreset, $compositeWarmth, $compositeTone] = $semanticStyleComposite;
-
-            if ($semanticPreset === null && $compositePreset !== null) {
-                $semanticPreset = $compositePreset;
-            }
-
-            if ($semanticWarmth === null && $compositeWarmth !== null) {
-                $semanticWarmth = $compositeWarmth;
-            }
-
-            if ($semanticTone === null && $compositeTone !== null) {
-                $semanticTone = $compositeTone;
-            }
-        }
-
-        $accelerationVector = $makerNotes?->accelerationVector;
-        if ($accelerationVector === null) {
-            $accelerationVector = $this->quickTimeFloatList($quickTime, 'AccelerationVector');
-        }
-
-        $flags          = $makerNotes instanceof AppleMakerNotes ? $makerNotes->flags : [];
-        $quickTimeFlags = $this->quickTimeFlags($quickTime);
-        foreach ($quickTimeFlags as $key => $value) {
-            if (!array_key_exists($key, $flags)) {
-                $flags[$key] = $value;
-            }
-        }
-
-        $runTime = $this->appleRunTime($makerNotes?->runTime);
-
-        $aeStable              = $makerNotes?->aeStable;
-        $aeTarget              = $makerNotes?->aeTarget;
-        $aeAverage             = $makerNotes?->aeAverage;
-        $afStable              = $makerNotes?->afStable;
-        $afPerformance         = $makerNotes?->afPerformance;
-        $signalToNoiseRatioType = $makerNotes?->signalToNoiseRatioType;
-        $luminanceNoiseAmplitude = $makerNotes?->luminanceNoiseAmplitude;
-
-        $imageCaptureRequestId = $makerNotes?->imageCaptureRequestId;
-        if ($imageCaptureRequestId === null) {
-            $imageCaptureRequestId = $this->quickTimeString($quickTime, 'ImageCaptureRequestID');
-        }
-
-        $qualityHint = $makerNotes?->qualityHint;
-        if ($qualityHint === null) {
-            $qualityHint = $this->quickTimeStringOrNumeric($quickTime, 'QualityHint');
-        }
-
-        $colorCorrectionMatrix = $makerNotes?->colorCorrectionMatrix;
-        if ($colorCorrectionMatrix === null) {
-            $colorCorrectionMatrix = $this->quickTimeFloatList($quickTime, 'ColorCorrectionMatrix');
-        }
-
-        $makerNoteVersion = $makerNotes?->makerNoteVersion;
-        if ($makerNoteVersion === null) {
-            $makerNoteVersion = $this->quickTimeString($quickTime, 'MakerNoteVersion');
-        }
-
-        $hdrImageType = $this->normalizeEnumerated($makerNotes?->hdrImageType, AppleMetadata::HDR_IMAGE_TYPES);
-        if ($hdrImageType === null) {
-            $hdrImageType = $this->quickTimeEnumerated($quickTime, AppleMetadata::HDR_IMAGE_TYPES, 'HDRImageType', 'HdrImageType');
-        }
-
-        $burstUuid = $makerNotes?->burstUuid;
-        if ($burstUuid === null) {
-            $burstUuid = $this->quickTimeString($quickTime, 'BurstUUID');
-        }
-
-        $focusDistanceRange = $makerNotes?->focusDistanceRange;
-        if ($focusDistanceRange === null) {
-            $focusDistanceRange = $this->quickTimeFocusDistanceRange($quickTime);
-        }
-
-        $oisMode = $makerNotes?->oisMode;
-        if ($oisMode === null) {
-            $oisMode = $this->quickTimeStringOrNumeric($quickTime, 'OISMode');
-        }
-
-        $imageCaptureType = $this->normalizeEnumerated($makerNotes?->imageCaptureType, AppleMetadata::IMAGE_CAPTURE_TYPES);
-        if ($imageCaptureType === null) {
-            $imageCaptureType = $this->quickTimeEnumerated($quickTime, AppleMetadata::IMAGE_CAPTURE_TYPES, 'ImageCaptureType');
-        }
-
-        $imageUniqueId = $makerNotes?->imageUniqueId;
-        if ($imageUniqueId === null) {
-            $imageUniqueId = $this->quickTimeString($quickTime, 'ImageUniqueID');
-        }
-
-        $photoIdentifier = $makerNotes?->photoIdentifier;
-        if ($photoIdentifier === null) {
-            $photoIdentifier = $this->quickTimeString($quickTime, 'PhotoIdentifier');
-        }
-
-        $afMeasuredDepth = $makerNotes?->afMeasuredDepth;
-        if ($afMeasuredDepth === null) {
-            $afMeasuredDepth = $this->quickTimeFloat($quickTime, 'AFMeasuredDepth');
-        }
-
-        $afConfidence = $makerNotes?->afConfidence;
-        if ($afConfidence === null) {
-            $afConfidence = $this->quickTimeFloat($quickTime, 'AFConfidence');
-        }
-
-        return new AppleMakerNotes(
-            contentIdentifier: $contentIdentifier,
-            cameraType: $cameraType,
-            hdrHeadroom: $hdrHeadroom,
-            hdrGain: $hdrGain,
-            snr: $snr,
-            aeStable: $aeStable,
-            aeTarget: $aeTarget,
-            aeAverage: $aeAverage,
-            afStable: $afStable,
-            afPerformance: $afPerformance,
-            signalToNoiseRatioType: $signalToNoiseRatioType,
-            luminanceNoiseAmplitude: $luminanceNoiseAmplitude,
-            focusPosition: $focusPosition,
-            livePhotoIndex: $livePhotoIndex,
-            colorTemperature: $colorTemperature,
-            semanticStylePreset: $semanticPreset,
-            semanticStyleWarmth: $semanticWarmth,
-            semanticStyleTone: $semanticTone,
-            flags: $flags,
-            accelerationVector: $accelerationVector,
-            imageCaptureRequestId: $imageCaptureRequestId,
-            qualityHint: $qualityHint,
-            colorCorrectionMatrix: $colorCorrectionMatrix,
-            livePhotoTime: $livePhotoTime,
-            runTime: $runTime,
-            makerNoteVersion: $makerNoteVersion,
-            hdrImageType: $hdrImageType,
-            burstUuid: $burstUuid,
-            focusDistanceRange: $focusDistanceRange,
-            oisMode: $oisMode,
-            imageCaptureType: $imageCaptureType,
-            imageUniqueId: $imageUniqueId,
-            photoIdentifier: $photoIdentifier,
-            afMeasuredDepth: $afMeasuredDepth,
-            afConfidence: $afConfidence,
-        );
-    }
-
-    /**
-     * Converts a maker note runtime structure into its curated representation.
-     */
-    private function appleRunTime(?RunTime $runTime): ?RunTime
-    {
-        return $runTime;
-    }
-
-    /**
      * Builds the motion metadata aggregate from EXIF and Apple motion sources.
      *
      * @param ExifDocument $exif  Resolver exposing EXIF camera orientation measurements.
@@ -1302,6 +1074,32 @@ final class ValueFactory
             gimbalYaw: $gimbalYaw,
             gimbalPitch: $gimbalPitch,
             gimbalRoll: $gimbalRoll,
+        );
+    }
+
+    private function emptyAppleMakerNotes(): AppleMakerNotes
+    {
+        return new AppleMakerNotes(
+            contentIdentifier: null,
+            cameraType: null,
+            hdrHeadroom: null,
+            hdrGain: null,
+            snr: null,
+            aeStable: null,
+            aeTarget: null,
+            aeAverage: null,
+            afStable: null,
+            afPerformance: null,
+            signalToNoiseRatioType: null,
+            luminanceNoiseAmplitude: null,
+            focusPosition: null,
+            livePhotoIndex: null,
+            colorTemperature: null,
+            semanticStylePreset: null,
+            semanticStyleWarmth: null,
+            semanticStyleTone: null,
+            flags: [],
+            accelerationVector: null,
         );
     }
 
@@ -1391,296 +1189,6 @@ final class ValueFactory
         }
 
         return null;
-    }
-
-    /**
-     * Resolves a list of floating point values from a space or comma separated QuickTime field.
-     *
-     * @param QuickTimeMeta|null $quickTime QuickTime metadata container used to read QuickTime keys.
-     * @param string            ...$keys  Candidate metadata keys to inspect in order.
-     *
-     * @return list<float>|null Normalised list of float values or null when unavailable.
-     */
-    private function quickTimeFloatList(?QuickTimeMeta $quickTime, string ...$keys): ?array
-    {
-        $raw = $this->quickTimeString($quickTime, ...$keys);
-        if ($raw === null) {
-            return null;
-        }
-
-        $parts = preg_split('/[\\s,]+/', $raw);
-        if ($parts === false) {
-            return null;
-        }
-
-        $values = [];
-        foreach ($parts as $part) {
-            if ($part === '') {
-                continue;
-            }
-
-            if (is_numeric($part)) {
-                $values[] = (float) $part;
-            }
-        }
-
-        return $values !== [] ? $values : null;
-    }
-
-    /**
-     * @return list<float>|null
-     */
-    private function quickTimeFocusDistanceRange(?QuickTimeMeta $quickTime): ?array
-    {
-        $range = $this->quickTimeFloatList($quickTime, 'FocusDistanceRange');
-        if ($range !== null) {
-            return $range;
-        }
-
-        $near = $this->quickTimeFloat($quickTime, 'FocusDistanceRangeNear', 'FocusDistanceNear');
-        $far  = $this->quickTimeFloat($quickTime, 'FocusDistanceRangeFar', 'FocusDistanceFar');
-
-        $values = [];
-        if ($near !== null) {
-            $values[] = $near;
-        }
-
-        if ($far !== null) {
-            $values[] = $far;
-        }
-
-        return $values !== [] ? $values : null;
-    }
-
-    private function quickTimeStringOrNumeric(?QuickTimeMeta $quickTime, string ...$keys): ?string
-    {
-        if ($quickTime === null) {
-            return null;
-        }
-
-        foreach ($keys as $key) {
-            $value = $this->quickTimeString($quickTime, $key);
-            if ($value !== null) {
-                return $value;
-            }
-
-            $intValue = $quickTime->intValue($key);
-            if ($intValue !== null) {
-                return (string) $intValue;
-            }
-
-            $floatValue = $quickTime->floatValue($key);
-            if ($floatValue !== null) {
-                return (string) $floatValue;
-            }
-        }
-
-        return null;
-    }
-
-    /**
-     * @param array<int, string> $map
-     */
-    private function normalizeEnumerated(?string $value, array $map): ?string
-    {
-        if ($value === null) {
-            return null;
-        }
-
-        $trimmed = trim($value);
-        if ($trimmed === '') {
-            return null;
-        }
-
-        if (is_numeric($trimmed)) {
-            $code = (int) $trimmed;
-
-            return $map[$code] ?? $trimmed;
-        }
-
-        return $trimmed;
-    }
-
-    /**
-     * @param array<int, string> $map
-     */
-    private function quickTimeEnumerated(?QuickTimeMeta $quickTime, array $map, string ...$keys): ?string
-    {
-        if ($quickTime === null) {
-            return null;
-        }
-
-        foreach ($keys as $key) {
-            $string = $this->quickTimeString($quickTime, $key);
-            if ($string !== null) {
-                if (is_numeric($string)) {
-                    $code = (int) $string;
-
-                    return $map[$code] ?? $string;
-                }
-
-                return $string;
-            }
-
-            $code = $quickTime->intValue($key);
-            if ($code !== null) {
-                return $map[$code] ?? (string) $code;
-            }
-        }
-
-        return null;
-    }
-
-    /**
-     * Extracts semantic style values from QuickTime composite metadata entries.
-     *
-     * @return array{0:?string,1:?float,2:?float}|null
-     */
-    private function quickTimeSemanticStyle(?QuickTimeMeta $meta): ?array
-    {
-        if ($meta === null) {
-            return null;
-        }
-
-        $value = $meta->keys['SemanticStyle'] ?? null;
-        if (!is_array($value)) {
-            return null;
-        }
-
-        /** @var array<int|string, mixed> $semantic */
-        $semantic = $value;
-
-        $entries = $this->normaliseSemanticStyleEntries($semantic);
-        if ($entries === null) {
-            return null;
-        }
-
-        $presetRaw      = $this->semanticStyleEntry($entries, 0);
-        $legacyWarmth   = $this->semanticStyleEntry($entries, 1);
-        $modernWarmth   = $legacyWarmth === null ? $this->semanticStyleEntry($entries, 2) : null;
-        $warmthRaw      = $legacyWarmth ?? $modernWarmth;
-        $toneRawLegacy  = $legacyWarmth !== null ? $this->semanticStyleEntry($entries, 2) : null;
-        $toneRawModern  = $legacyWarmth === null ? $this->semanticStyleEntry($entries, 3, 2) : null;
-        $toneRaw        = $toneRawLegacy ?? $toneRawModern;
-
-        $preset = $this->semanticStylePreset($presetRaw);
-        $warmth = $this->semanticStyleFloat($warmthRaw);
-        $tone   = $this->semanticStyleFloat($toneRaw);
-
-        if ($preset === null && $warmth === null && $tone === null) {
-            return null;
-        }
-
-        return [$preset, $warmth, $tone];
-    }
-
-    /**
-     * @param array<int|string, mixed> $semantic
-     *
-     * @return array<int|string, string|int|float|bool|null>|null
-     */
-    private function normaliseSemanticStyleEntries(array $semantic): ?array
-    {
-        if (!array_is_list($semantic)) {
-            foreach (['values', 'Values'] as $key) {
-                if (array_key_exists($key, $semantic) && is_array($semantic[$key])) {
-                    /** @var array<int|string, mixed> $values */
-                    $values = $semantic[$key];
-
-                    return $this->normaliseSemanticStyleEntries($values);
-                }
-            }
-        }
-
-        return $semantic;
-    }
-
-    /**
-     * @param array<int|string, string|int|float|bool|null> $entries
-     */
-    private function semanticStyleEntry(array $entries, int ...$indexes): string|int|float|bool|null
-    {
-        foreach ($indexes as $index) {
-            $candidates = [$index, (string) $index, '_' . $index];
-            foreach ($candidates as $key) {
-                if (!array_key_exists($key, $entries)) {
-                    continue;
-                }
-
-                $value = $entries[$key];
-                if (is_array($value)) {
-                    foreach (['value', 'Value'] as $innerKey) {
-                        if (array_key_exists($innerKey, $value)) {
-                            $inner = $value[$innerKey];
-                            if (!is_array($inner)) {
-                                $value = $inner;
-                            }
-
-                            break;
-                        }
-                    }
-
-                    if (is_array($value)) {
-                        continue;
-                    }
-                }
-
-                if (is_string($value) || is_int($value) || is_float($value) || is_bool($value)) {
-                    return $value;
-                }
-            }
-        }
-
-        return null;
-    }
-
-    private function semanticStylePreset(string|int|float|bool|null $value): ?string
-    {
-        if (is_string($value)) {
-            $trimmed = trim($value);
-            if ($trimmed !== '') {
-                return $trimmed;
-            }
-        }
-
-        return null;
-    }
-
-    private function semanticStyleFloat(string|int|float|bool|null $value): ?float
-    {
-        if (is_float($value)) {
-            return $value;
-        }
-
-        if (is_int($value) || is_numeric($value)) {
-            return (float) $value;
-        }
-
-        return null;
-    }
-
-    /**
-     * Builds a normalised map of QuickTime boolean flags relevant to Apple metadata.
-     *
-     * @param QuickTimeMeta|null $quickTime QuickTime metadata container used to read QuickTime keys.
-     *
-     * @return array<string, bool> Normalised flag map keyed by camelCase identifiers.
-     */
-    private function quickTimeFlags(?QuickTimeMeta $quickTime): array
-    {
-        if ($quickTime === null) {
-            return [];
-        }
-
-        $flags = [];
-        foreach (AppleMetadata::FLAG_MAP as $key => $normalized) {
-            $value = $quickTime->boolValue($key);
-            if ($value !== null) {
-                $flags[$normalized] = $value;
-            }
-        }
-
-        return $flags;
     }
 
     /**

--- a/src/MakerNotes/Apple/AppleMakerNotesMapper.php
+++ b/src/MakerNotes/Apple/AppleMakerNotesMapper.php
@@ -1,0 +1,621 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\ImageMeta\MakerNotes\Apple;
+
+use MagicSunday\ImageMeta\MakerNotes\AppleMetadata;
+use MagicSunday\ImageMeta\MakerNotes\MakerNotesMetadata;
+use MagicSunday\ImageMeta\Model\QuickTimeMeta;
+
+use function array_is_list;
+use function array_key_exists;
+use function get_object_vars;
+use function is_array;
+use function is_bool;
+use function is_float;
+use function is_int;
+use function is_numeric;
+use function is_string;
+use function preg_split;
+use function str_repeat;
+use function trim;
+
+/**
+ * Normalises Apple maker notes by enriching them with QuickTime metadata fallbacks.
+ */
+final class AppleMakerNotesMapper
+{
+    /**
+     * Merges decoded Apple maker notes with QuickTime metadata fallbacks.
+     */
+    public function map(
+        ?MakerNotesMetadata $makerNotes,
+        ?QuickTimeMeta $quickTime,
+    ): ?MakerNotesMetadata {
+        if ($makerNotes instanceof MakerNotesMetadata && $makerNotes->vendor() !== 'Apple') {
+            return $makerNotes;
+        }
+
+        $apple = $this->buildAppleMakerNotes($makerNotes?->apple(), $quickTime);
+
+        if ($makerNotes instanceof MakerNotesMetadata) {
+            return new MakerNotesMetadata(
+                $makerNotes->vendor(),
+                $makerNotes->length(),
+                $makerNotes->sha1(),
+                $apple,
+                $makerNotes->isSafe(),
+            );
+        }
+
+        if ($quickTime instanceof QuickTimeMeta && $this->hasAppleData($apple)) {
+            return new MakerNotesMetadata('Apple', 0, str_repeat('0', 40), $apple);
+        }
+
+        return $makerNotes;
+    }
+
+    /**
+     * Builds the Apple maker note value object by applying QuickTime fallbacks.
+     */
+    private function buildAppleMakerNotes(
+        ?AppleMakerNotes $makerNotes,
+        ?QuickTimeMeta $quickTime,
+    ): AppleMakerNotes {
+        $contentIdentifier = $makerNotes?->contentIdentifier ?? $quickTime?->contentIdentifier();
+
+        $cameraType = $makerNotes?->cameraType;
+        if ($cameraType === null) {
+            $cameraType = $this->quickTimeString($quickTime, 'CameraType');
+        }
+
+        $hdrHeadroom = $makerNotes?->hdrHeadroom;
+        if ($hdrHeadroom === null) {
+            $hdrHeadroom = $this->quickTimeFloat($quickTime, 'HdrHeadroom', 'HDRHeadroom');
+        }
+
+        $hdrGain = $makerNotes?->hdrGain;
+        if ($hdrGain === null) {
+            $hdrGain = $this->quickTimeFloatList($quickTime, 'HdrGain', 'HDRGain');
+        }
+
+        $snr = $makerNotes?->snr;
+        if ($snr === null) {
+            $snr = $this->quickTimeFloat($quickTime, 'SNRSetting', 'SNR');
+        }
+
+        $focusPosition = $makerNotes?->focusPosition;
+        if ($focusPosition === null) {
+            $focusPosition = $this->quickTimeFloat($quickTime, 'FocusPosition');
+        }
+
+        $livePhotoIndex = $makerNotes?->livePhotoIndex;
+        if ($livePhotoIndex === null) {
+            $livePhotoIndex = $this->quickTimeInt($quickTime, 'LivePhotoVideoIndex', 'LivePhotoMovieIndex');
+        }
+
+        $livePhotoTime = $makerNotes?->livePhotoTime;
+
+        $colorTemperature = $makerNotes?->colorTemperature;
+        if ($colorTemperature === null) {
+            $colorTemperature = $this->quickTimeInt($quickTime, 'ColorTemperature');
+        }
+
+        $semanticPreset = $makerNotes?->semanticStylePreset;
+        if ($semanticPreset === null) {
+            $semanticPreset = $this->quickTimeString($quickTime, 'SemanticStylePreset');
+        }
+
+        $semanticWarmth = $makerNotes?->semanticStyleWarmth;
+        if ($semanticWarmth === null) {
+            $semanticWarmth = $this->quickTimeFloat($quickTime, 'SemanticStyleWarmth');
+        }
+
+        $semanticTone = $makerNotes?->semanticStyleTone;
+        if ($semanticTone === null) {
+            $semanticTone = $this->quickTimeFloat($quickTime, 'SemanticStyleTone');
+        }
+
+        $semanticStyleComposite = $this->quickTimeSemanticStyle($quickTime);
+        if ($semanticStyleComposite !== null) {
+            [$compositePreset, $compositeWarmth, $compositeTone] = $semanticStyleComposite;
+
+            if ($semanticPreset === null && $compositePreset !== null) {
+                $semanticPreset = $compositePreset;
+            }
+
+            if ($semanticWarmth === null && $compositeWarmth !== null) {
+                $semanticWarmth = $compositeWarmth;
+            }
+
+            if ($semanticTone === null && $compositeTone !== null) {
+                $semanticTone = $compositeTone;
+            }
+        }
+
+        $accelerationVector = $makerNotes?->accelerationVector;
+        if ($accelerationVector === null) {
+            $accelerationVector = $this->quickTimeFloatList($quickTime, 'AccelerationVector');
+        }
+
+        $flags = $makerNotes?->flags ?? [];
+        $quickTimeFlags = $this->quickTimeFlags($quickTime);
+        foreach ($quickTimeFlags as $key => $value) {
+            if (!array_key_exists($key, $flags)) {
+                $flags[$key] = $value;
+            }
+        }
+
+        $imageCaptureRequestId = $makerNotes?->imageCaptureRequestId;
+        if ($imageCaptureRequestId === null) {
+            $imageCaptureRequestId = $this->quickTimeString($quickTime, 'ImageCaptureRequestID');
+        }
+
+        $qualityHint = $makerNotes?->qualityHint;
+        if ($qualityHint === null) {
+            $qualityHint = $this->quickTimeStringOrNumeric($quickTime, 'QualityHint');
+        }
+
+        $colorCorrectionMatrix = $makerNotes?->colorCorrectionMatrix;
+        if ($colorCorrectionMatrix === null) {
+            $colorCorrectionMatrix = $this->quickTimeFloatList($quickTime, 'ColorCorrectionMatrix');
+        }
+
+        $makerNoteVersion = $makerNotes?->makerNoteVersion;
+        if ($makerNoteVersion === null) {
+            $makerNoteVersion = $this->quickTimeString($quickTime, 'MakerNoteVersion');
+        }
+
+        $hdrImageType = $this->normalizeEnumerated($makerNotes?->hdrImageType, AppleMetadata::HDR_IMAGE_TYPES);
+        if ($hdrImageType === null) {
+            $hdrImageType = $this->quickTimeEnumerated($quickTime, AppleMetadata::HDR_IMAGE_TYPES, 'HDRImageType', 'HdrImageType');
+        }
+
+        $burstUuid = $makerNotes?->burstUuid;
+        if ($burstUuid === null) {
+            $burstUuid = $this->quickTimeString($quickTime, 'BurstUUID');
+        }
+
+        $focusDistanceRange = $makerNotes?->focusDistanceRange;
+        if ($focusDistanceRange === null) {
+            $focusDistanceRange = $this->quickTimeFocusDistanceRange($quickTime);
+        }
+
+        $oisMode = $makerNotes?->oisMode;
+        if ($oisMode === null) {
+            $oisMode = $this->quickTimeStringOrNumeric($quickTime, 'OISMode');
+        }
+
+        $imageCaptureType = $this->normalizeEnumerated($makerNotes?->imageCaptureType, AppleMetadata::IMAGE_CAPTURE_TYPES);
+        if ($imageCaptureType === null) {
+            $imageCaptureType = $this->quickTimeEnumerated($quickTime, AppleMetadata::IMAGE_CAPTURE_TYPES, 'ImageCaptureType');
+        }
+
+        $imageUniqueId = $makerNotes?->imageUniqueId;
+        if ($imageUniqueId === null) {
+            $imageUniqueId = $this->quickTimeString($quickTime, 'ImageUniqueID');
+        }
+
+        $photoIdentifier = $makerNotes?->photoIdentifier;
+        if ($photoIdentifier === null) {
+            $photoIdentifier = $this->quickTimeString($quickTime, 'PhotoIdentifier');
+        }
+
+        $afMeasuredDepth = $makerNotes?->afMeasuredDepth;
+        if ($afMeasuredDepth === null) {
+            $afMeasuredDepth = $this->quickTimeFloat($quickTime, 'AFMeasuredDepth');
+        }
+
+        $afConfidence = $makerNotes?->afConfidence;
+        if ($afConfidence === null) {
+            $afConfidence = $this->quickTimeFloat($quickTime, 'AFConfidence');
+        }
+
+        return new AppleMakerNotes(
+            contentIdentifier: $contentIdentifier,
+            cameraType: $cameraType,
+            hdrHeadroom: $hdrHeadroom,
+            hdrGain: $hdrGain,
+            snr: $snr,
+            aeStable: $makerNotes?->aeStable,
+            aeTarget: $makerNotes?->aeTarget,
+            aeAverage: $makerNotes?->aeAverage,
+            afStable: $makerNotes?->afStable,
+            afPerformance: $makerNotes?->afPerformance,
+            signalToNoiseRatioType: $makerNotes?->signalToNoiseRatioType,
+            luminanceNoiseAmplitude: $makerNotes?->luminanceNoiseAmplitude,
+            focusPosition: $focusPosition,
+            livePhotoIndex: $livePhotoIndex,
+            colorTemperature: $colorTemperature,
+            semanticStylePreset: $semanticPreset,
+            semanticStyleWarmth: $semanticWarmth,
+            semanticStyleTone: $semanticTone,
+            flags: $flags,
+            accelerationVector: $accelerationVector,
+            imageCaptureRequestId: $imageCaptureRequestId,
+            qualityHint: $qualityHint,
+            colorCorrectionMatrix: $colorCorrectionMatrix,
+            livePhotoTime: $livePhotoTime,
+            runTime: $makerNotes?->runTime,
+            makerNoteVersion: $makerNoteVersion,
+            hdrImageType: $hdrImageType,
+            burstUuid: $burstUuid,
+            focusDistanceRange: $focusDistanceRange,
+            oisMode: $oisMode,
+            imageCaptureType: $imageCaptureType,
+            imageUniqueId: $imageUniqueId,
+            photoIdentifier: $photoIdentifier,
+            afMeasuredDepth: $afMeasuredDepth,
+            afConfidence: $afConfidence,
+        );
+    }
+
+    /**
+     * Determines whether the Apple maker notes contain any populated values.
+     */
+    private function hasAppleData(AppleMakerNotes $apple): bool
+    {
+        foreach (get_object_vars($apple) as $key => $value) {
+            if ($key === 'flags') {
+                if ($value !== []) {
+                    return true;
+                }
+
+                continue;
+            }
+
+            if (is_array($value)) {
+                if ($value !== []) {
+                    return true;
+                }
+
+                continue;
+            }
+
+            if ($value !== null) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function quickTimeString(?QuickTimeMeta $quickTime, string ...$keys): ?string
+    {
+        if ($quickTime === null) {
+            return null;
+        }
+
+        foreach ($keys as $key) {
+            $value = $quickTime->stringValue($key);
+            if ($value !== null && $value !== '') {
+                return $value;
+            }
+        }
+
+        return null;
+    }
+
+    private function quickTimeFloat(?QuickTimeMeta $quickTime, string ...$keys): ?float
+    {
+        if ($quickTime === null) {
+            return null;
+        }
+
+        foreach ($keys as $key) {
+            $value = $quickTime->floatValue($key);
+            if ($value !== null) {
+                return $value;
+            }
+        }
+
+        return null;
+    }
+
+    private function quickTimeInt(?QuickTimeMeta $quickTime, string ...$keys): ?int
+    {
+        if ($quickTime === null) {
+            return null;
+        }
+
+        foreach ($keys as $key) {
+            $value = $quickTime->intValue($key);
+            if ($value !== null) {
+                return $value;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @return list<float>|null
+     */
+    private function quickTimeFloatList(?QuickTimeMeta $quickTime, string ...$keys): ?array
+    {
+        if ($quickTime === null) {
+            return null;
+        }
+
+        foreach ($keys as $key) {
+            $raw = $this->quickTimeString($quickTime, $key);
+            if ($raw === null) {
+                continue;
+            }
+
+            $parts = preg_split('/[ ,]+/', trim($raw));
+            if (!is_array($parts)) {
+                continue;
+            }
+
+            $values = [];
+            foreach ($parts as $part) {
+                if ($part === '') {
+                    continue;
+                }
+
+                if (is_numeric($part)) {
+                    $values[] = (float) $part;
+                }
+            }
+
+            if ($values !== []) {
+                return $values;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @return list<float>|null
+     */
+    private function quickTimeFocusDistanceRange(?QuickTimeMeta $quickTime): ?array
+    {
+        $range = $this->quickTimeFloatList($quickTime, 'FocusDistanceRange');
+        if ($range !== null) {
+            return $range;
+        }
+
+        $near = $this->quickTimeFloat($quickTime, 'FocusDistanceRangeNear', 'FocusDistanceNear');
+        $far = $this->quickTimeFloat($quickTime, 'FocusDistanceRangeFar', 'FocusDistanceFar');
+
+        $values = [];
+        if ($near !== null) {
+            $values[] = $near;
+        }
+
+        if ($far !== null) {
+            $values[] = $far;
+        }
+
+        return $values !== [] ? $values : null;
+    }
+
+    private function quickTimeStringOrNumeric(?QuickTimeMeta $quickTime, string ...$keys): ?string
+    {
+        if ($quickTime === null) {
+            return null;
+        }
+
+        foreach ($keys as $key) {
+            $value = $this->quickTimeString($quickTime, $key);
+            if ($value !== null) {
+                return $value;
+            }
+
+            $intValue = $quickTime->intValue($key);
+            if ($intValue !== null) {
+                return (string) $intValue;
+            }
+
+            $floatValue = $quickTime->floatValue($key);
+            if ($floatValue !== null) {
+                return (string) $floatValue;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param array<int, string> $map
+     */
+    private function normalizeEnumerated(?string $value, array $map): ?string
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        $trimmed = trim($value);
+        if ($trimmed === '') {
+            return null;
+        }
+
+        if (is_numeric($trimmed)) {
+            $code = (int) $trimmed;
+
+            return $map[$code] ?? $trimmed;
+        }
+
+        return $trimmed;
+    }
+
+    /**
+     * @param array<int, string> $map
+     */
+    private function quickTimeEnumerated(?QuickTimeMeta $quickTime, array $map, string ...$keys): ?string
+    {
+        if ($quickTime === null) {
+            return null;
+        }
+
+        foreach ($keys as $key) {
+            $string = $this->quickTimeString($quickTime, $key);
+            if ($string !== null) {
+                if (is_numeric($string)) {
+                    $code = (int) $string;
+
+                    return $map[$code] ?? $string;
+                }
+
+                return $string;
+            }
+
+            $code = $quickTime->intValue($key);
+            if ($code !== null) {
+                return $map[$code] ?? (string) $code;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @return array{0:?string,1:?float,2:?float}|null
+     */
+    private function quickTimeSemanticStyle(?QuickTimeMeta $meta = null): ?array
+    {
+        if ($meta === null) {
+            return null;
+        }
+
+        $value = $meta->keys['SemanticStyle'] ?? null;
+        if (!is_array($value)) {
+            return null;
+        }
+
+        $entries = $this->normaliseSemanticStyleEntries($value);
+        if ($entries === null) {
+            return null;
+        }
+
+        $presetRaw = $this->semanticStyleEntry($entries, 0);
+        $legacyWarmth = $this->semanticStyleEntry($entries, 1);
+        $modernWarmth = $legacyWarmth === null ? $this->semanticStyleEntry($entries, 2) : null;
+        $warmthRaw = $legacyWarmth ?? $modernWarmth;
+        $toneRawLegacy = $legacyWarmth !== null ? $this->semanticStyleEntry($entries, 2) : null;
+        $toneRawModern = $legacyWarmth === null ? $this->semanticStyleEntry($entries, 3, 2) : null;
+        $toneRaw = $toneRawLegacy ?? $toneRawModern;
+
+        $preset = $this->semanticStylePreset($presetRaw);
+        $warmth = $this->semanticStyleFloat($warmthRaw);
+        $tone = $this->semanticStyleFloat($toneRaw);
+
+        if ($preset === null && $warmth === null && $tone === null) {
+            return null;
+        }
+
+        return [$preset, $warmth, $tone];
+    }
+
+    /**
+     * @param array<int|string, mixed> $semantic
+     *
+     * @return array<int|string, string|int|float|bool|null>|null
+     */
+    private function normaliseSemanticStyleEntries(array $semantic): ?array
+    {
+        if (!array_is_list($semantic)) {
+            foreach (['values', 'Values'] as $key) {
+                if (array_key_exists($key, $semantic) && is_array($semantic[$key])) {
+                    return $this->normaliseSemanticStyleEntries($semantic[$key]);
+                }
+            }
+        }
+
+        return $semantic;
+    }
+
+    /**
+     * @param array<int|string, string|int|float|bool|null> $entries
+     */
+    private function semanticStyleEntry(array $entries, int ...$indexes): string|int|float|bool|null
+    {
+        foreach ($indexes as $index) {
+            $candidates = [$index, (string) $index, '_' . $index];
+            foreach ($candidates as $key) {
+                if (!array_key_exists($key, $entries)) {
+                    continue;
+                }
+
+                $value = $entries[$key];
+                if (is_array($value)) {
+                    foreach (['value', 'Value'] as $innerKey) {
+                        if (array_key_exists($innerKey, $value)) {
+                            $inner = $value[$innerKey];
+                            if (!is_array($inner)) {
+                                $value = $inner;
+                            }
+
+                            break;
+                        }
+                    }
+
+                    if (is_array($value)) {
+                        continue;
+                    }
+                }
+
+                if (is_string($value) || is_int($value) || is_float($value) || is_bool($value)) {
+                    return $value;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private function semanticStylePreset(string|int|float|bool|null $value): ?string
+    {
+        if (is_string($value)) {
+            $trimmed = trim($value);
+            if ($trimmed !== '') {
+                return $trimmed;
+            }
+        }
+
+        return null;
+    }
+
+    private function semanticStyleFloat(string|int|float|bool|null $value): ?float
+    {
+        if (is_float($value)) {
+            return $value;
+        }
+
+        if (is_int($value) || is_numeric($value)) {
+            return (float) $value;
+        }
+
+        return null;
+    }
+
+    /**
+     * @return array<string, bool>
+     */
+    private function quickTimeFlags(?QuickTimeMeta $quickTime): array
+    {
+        if ($quickTime === null) {
+            return [];
+        }
+
+        $flags = [];
+        foreach (AppleMetadata::FLAG_MAP as $key => $normalized) {
+            $value = $quickTime->boolValue($key);
+            if ($value !== null) {
+                $flags[$normalized] = $value;
+            }
+        }
+
+        return $flags;
+    }
+}

--- a/src/MetadataReader.php
+++ b/src/MetadataReader.php
@@ -15,6 +15,7 @@ use finfo;
 use MagicSunday\ImageMeta\Core\Stream;
 use MagicSunday\ImageMeta\Detect\ContainerType;
 use MagicSunday\ImageMeta\Detect\FormatDetector;
+use MagicSunday\ImageMeta\MakerNotes\Apple\AppleMakerNotesMapper;
 use MagicSunday\ImageMeta\MakerNotes\Registry;
 use MagicSunday\ImageMeta\MakerNotes\RegistryFactory;
 use MagicSunday\ImageMeta\Model\Metadata;
@@ -98,6 +99,8 @@ final class MetadataReader
         $sampling         = $jpeg->getFrameComponentSamplingFactors();
         $subSampling      = $jpeg->getFrameYCbCrSubSampling();
 
+        $appleMapper = new AppleMakerNotesMapper();
+
         $exifDoc    = null;
         $xmpDoc     = null;
         $makerNotes = null;
@@ -106,6 +109,8 @@ final class MetadataReader
             $exifDoc    = (new TiffExifReader())->parseFromBlob($exifBlobs[0], $registry);
             $makerNotes = $exifDoc->makerNotes();
         }
+
+        $makerNotes = $appleMapper->map($makerNotes, null);
 
         if ($xmpBlobs !== []) {
             $xmpDoc = (new XmpParser())->parse($xmpBlobs[0]);
@@ -158,6 +163,8 @@ final class MetadataReader
     ): Metadata {
         [$exifBlobs, $xmpBlobs, $qt] = (new IsoBmffExtractor($stream))->extract();
 
+        $appleMapper = new AppleMakerNotesMapper();
+
         $exifDoc    = null;
         $xmpDoc     = null;
         $makerNotes = null;
@@ -166,6 +173,8 @@ final class MetadataReader
             $exifDoc    = (new TiffExifReader())->parseFromBlob($exifBlobs[0], $registry);
             $makerNotes = $exifDoc->makerNotes();
         }
+
+        $makerNotes = $appleMapper->map($makerNotes, $qt);
 
         if ($xmpBlobs !== []) {
             $xmpDoc = (new XmpParser())->parse($xmpBlobs[0]);

--- a/tests/Curate/ExifAssemblerTest.php
+++ b/tests/Curate/ExifAssemblerTest.php
@@ -823,6 +823,8 @@ final class ExifAssemblerTest extends TestCase
         $metadata   = new Metadata(['primary'], $quickTime, $exifDocument, [], null, $makerNotes);
         $structured = (new ExifAssembler())->assemble($metadata);
 
+        self::assertSame($appleMakerNotes, $structured->apple);
+
         self::assertSame('maker-content', $structured->apple->contentIdentifier);
         self::assertSame('Maker Wide', $structured->apple->cameraType);
         self::assertSame([2.1, 2.2, 2.3], $structured->apple->hdrGain);
@@ -873,20 +875,6 @@ final class ExifAssemblerTest extends TestCase
         self::assertEqualsWithDelta(-0.1, $structured->motion->accelZ, 1e-12);
         self::assertFalse($structured->scene->nightMode);
         self::assertFalse($structured->integrity->makerNotesSafe);
-    }
-
-    #[Test]
-    public function usesQuickTimeMovieIndexWhenMakerNotesMissing(): void
-    {
-        $quickTime = new QuickTimeMeta([
-            'LivePhotoMovieIndex' => 6,
-        ]);
-
-        $metadata   = new Metadata([], $quickTime);
-        $structured = (new ExifAssembler())->assemble($metadata);
-
-        self::assertSame(6, $structured->apple->livePhotoIndex);
-        self::assertNull($structured->apple->livePhotoTime);
     }
 
     #[Test]
@@ -960,30 +948,6 @@ final class ExifAssemblerTest extends TestCase
     }
 
     /**
-     * Ensures QuickTime metadata provides an acceleration vector when maker notes are absent.
-     */
-    #[Test]
-    public function usesQuickTimeAccelerationVectorWhenMakerNotesMissing(): void
-    {
-        $quickTime = new QuickTimeMeta([
-            QuickTimeMeta::CONTENT_IDENTIFIER_KEY => 'qt-content',
-            'AccelerationVector'                  => '0.12 -0.34 0.56',
-        ]);
-
-        $metadata   = new Metadata(['primary'], $quickTime, null, []);
-        $structured = (new ExifAssembler())->assemble($metadata);
-
-        self::assertSame('qt-content', $structured->apple->contentIdentifier);
-        self::assertSame([0.12, -0.34, 0.56], $structured->apple->accelerationVector);
-        self::assertNull($structured->motion->rollDeg);
-        self::assertNull($structured->motion->pitchDeg);
-        self::assertNull($structured->motion->yawDeg);
-        self::assertEqualsWithDelta(0.12, $structured->motion->accelX, 1e-12);
-        self::assertEqualsWithDelta(-0.34, $structured->motion->accelY, 1e-12);
-        self::assertEqualsWithDelta(0.56, $structured->motion->accelZ, 1e-12);
-    }
-
-    /**
      * Ensures EXIF acceleration vector data is used when maker notes and QuickTime values are absent.
      */
     #[Test]
@@ -1014,59 +978,7 @@ final class ExifAssemblerTest extends TestCase
         self::assertEqualsWithDelta(0.35, $structured->motion->accelZ, 1e-12);
     }
 
-    #[Test]
-    public function usesQuickTimeEnumeratedValuesWhenMakerNotesMissing(): void
-    {
-        $quickTime = new QuickTimeMeta([
-            QuickTimeMeta::CONTENT_IDENTIFIER_KEY => 'qt-content',
-            'MakerNoteVersion'                    => '1.1',
-            'HDRImageType'                        => 2,
-            'BurstUUID'                           => 'qt-burst',
-            'FocusDistanceRange'                  => '0.5 1.9',
-            'OISMode'                             => 4,
-            'ImageCaptureType'                    => 6,
-            'ImageUniqueID'                       => 'qt-unique',
-            'PhotoIdentifier'                     => 'qt-photo',
-            'AFMeasuredDepth'                     => 1.4,
-            'AFConfidence'                        => 0.55,
-        ]);
 
-        $metadata   = new Metadata(['primary'], $quickTime, null, []);
-        $structured = (new ExifAssembler())->assemble($metadata);
-
-        self::assertSame('1.1', $structured->apple->makerNoteVersion);
-        self::assertSame('HDR2', $structured->apple->hdrImageType);
-        self::assertSame('qt-burst', $structured->apple->burstUuid);
-        self::assertSame([0.5, 1.9], $structured->apple->focusDistanceRange);
-        self::assertSame('4', $structured->apple->oisMode);
-        self::assertSame('Night Mode', $structured->apple->imageCaptureType);
-        self::assertSame('qt-unique', $structured->apple->imageUniqueId);
-        self::assertSame('qt-photo', $structured->apple->photoIdentifier);
-        self::assertEqualsWithDelta(1.4, $structured->apple->afMeasuredDepth, 1e-12);
-        self::assertEqualsWithDelta(0.55, $structured->apple->afConfidence, 1e-12);
-    }
-
-
-
-    #[Test]
-    public function usesQuickTimeSemanticStyleDictionaryWhenMakerNotesMissing(): void
-    {
-        $quickTime = new QuickTimeMeta([
-            QuickTimeMeta::CONTENT_IDENTIFIER_KEY => 'qt-content',
-            'SemanticStyle'                       => [
-                '_0' => 'CompositePreset',
-                '_2' => 0.4,
-                '_3' => -0.15,
-            ],
-        ]);
-
-        $metadata   = new Metadata(['primary'], $quickTime, null, []);
-        $structured = (new ExifAssembler())->assemble($metadata);
-
-        self::assertSame('CompositePreset', $structured->apple->semanticStylePreset);
-        self::assertEqualsWithDelta(0.4, $structured->apple->semanticStyleWarmth, 1e-12);
-        self::assertEqualsWithDelta(-0.15, $structured->apple->semanticStyleTone, 1e-12);
-    }
 
     /**
      * Ensures JPEG-only metadata uses the maker note night mode flag when QuickTime metadata is absent.

--- a/tests/MakerNotes/Apple/AppleMakerNotesMapperTest.php
+++ b/tests/MakerNotes/Apple/AppleMakerNotesMapperTest.php
@@ -1,0 +1,263 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\ImageMeta\Tests\MakerNotes\Apple;
+
+use MagicSunday\ImageMeta\MakerNotes\Apple\AppleMakerNotes;
+use MagicSunday\ImageMeta\MakerNotes\Apple\AppleMakerNotesMapper;
+use MagicSunday\ImageMeta\MakerNotes\MakerNotesMetadata;
+use MagicSunday\ImageMeta\Model\QuickTimeMeta;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+use function str_repeat;
+
+/**
+ * @covers \MagicSunday\ImageMeta\MakerNotes\Apple\AppleMakerNotesMapper
+ */
+final class AppleMakerNotesMapperTest extends TestCase
+{
+    #[Test]
+    public function mapPrefersMakerNotesValues(): void
+    {
+        $makerNotes = new MakerNotesMetadata(
+            'Apple',
+            128,
+            str_repeat('1', 40),
+            new AppleMakerNotes(
+                contentIdentifier: 'maker-note',
+                cameraType: 'Maker Camera',
+                hdrHeadroom: 2.1,
+                hdrGain: [1.1, 1.2, 1.3],
+                snr: 12.5,
+                aeStable: true,
+                aeTarget: 0.9,
+                aeAverage: 0.8,
+                afStable: false,
+                afPerformance: 0.5,
+                signalToNoiseRatioType: 'maker',
+                luminanceNoiseAmplitude: 0.5,
+                focusPosition: 0.4,
+                livePhotoIndex: 3,
+                colorTemperature: 5200,
+                semanticStylePreset: 'MakerPreset',
+                semanticStyleWarmth: 0.2,
+                semanticStyleTone: -0.1,
+                flags: ['nightMode' => true],
+                accelerationVector: [0.1, 0.2, 0.3],
+                imageCaptureRequestId: 'maker-req',
+                qualityHint: 'High',
+                colorCorrectionMatrix: [1.0, 0.0, 0.0],
+                livePhotoTime: 0.5,
+                runTime: null,
+                makerNoteVersion: '2.0',
+                hdrImageType: 'HDR',
+                burstUuid: 'maker-burst',
+                focusDistanceRange: [0.3, 1.2],
+                oisMode: 'Maker',
+                imageCaptureType: 'Portrait',
+                imageUniqueId: 'maker-unique',
+                photoIdentifier: 'maker-photo',
+                afMeasuredDepth: 1.4,
+                afConfidence: 0.7,
+            ),
+            false,
+        );
+
+        $quickTime = new QuickTimeMeta([
+            QuickTimeMeta::CONTENT_IDENTIFIER_KEY => 'qt-content',
+            'CameraType'                          => 'QuickTime Camera',
+            'HdrHeadroom'                         => 1.0,
+            'HdrGain'                             => '0.4 0.5 0.6',
+            'SNRSetting'                          => 8.0,
+            'LivePhotoVideoIndex'                 => 5,
+            'ColorTemperature'                    => 6300,
+            'SemanticStylePreset'                 => 'QuickPreset',
+            'SemanticStyleWarmth'                 => 0.1,
+            'SemanticStyleTone'                   => 0.05,
+            'OISMode'                             => 2,
+            'ImageCaptureType'                    => 6,
+        ]);
+
+        $mapper   = new AppleMakerNotesMapper();
+        $mapped   = $mapper->map($makerNotes, $quickTime);
+        $apple    = $mapped?->apple();
+
+        self::assertNotSame($makerNotes, $mapped);
+        self::assertSame('Apple', $mapped?->vendor());
+        self::assertSame(128, $mapped?->length());
+        self::assertSame(str_repeat('1', 40), $mapped?->sha1());
+
+        self::assertInstanceOf(AppleMakerNotes::class, $apple);
+        self::assertSame('maker-note', $apple?->contentIdentifier);
+        self::assertSame('Maker Camera', $apple?->cameraType);
+        self::assertSame([1.1, 1.2, 1.3], $apple?->hdrGain);
+        self::assertSame('MakerPreset', $apple?->semanticStylePreset);
+        self::assertSame('Portrait', $apple?->imageCaptureType);
+        self::assertSame('Maker', $apple?->oisMode);
+        self::assertSame('maker-burst', $apple?->burstUuid);
+    }
+
+    #[Test]
+    public function mapFillsMissingValuesFromQuickTime(): void
+    {
+        $makerNotes = new MakerNotesMetadata(
+            'Apple',
+            64,
+            str_repeat('2', 40),
+            new AppleMakerNotes(
+                contentIdentifier: null,
+                cameraType: null,
+                hdrHeadroom: null,
+                hdrGain: null,
+                snr: null,
+                aeStable: null,
+                aeTarget: null,
+                aeAverage: null,
+                afStable: null,
+                afPerformance: null,
+                signalToNoiseRatioType: null,
+                luminanceNoiseAmplitude: null,
+                focusPosition: null,
+                livePhotoIndex: null,
+                colorTemperature: null,
+                semanticStylePreset: null,
+                semanticStyleWarmth: null,
+                semanticStyleTone: null,
+                flags: [],
+                accelerationVector: null,
+            ),
+        );
+
+        $quickTime = new QuickTimeMeta([
+            QuickTimeMeta::CONTENT_IDENTIFIER_KEY => 'qt-content',
+            'CameraType'                          => 'Quick Camera',
+            'HdrHeadroom'                         => 1.25,
+            'HdrGain'                             => '0.9 1.0 1.1',
+            'SNRSetting'                          => 9.5,
+            'FocusPosition'                       => 0.45,
+            'LivePhotoVideoIndex'                 => 2,
+            'ColorTemperature'                    => 6100,
+            'SemanticStylePreset'                 => 'QuickPreset',
+            'SemanticStyleWarmth'                 => 0.25,
+            'SemanticStyleTone'                   => -0.05,
+            'AccelerationVector'                  => '0.2 0.1 -0.3',
+            'ImageCaptureRequestID'               => 'qt-request',
+            'QualityHint'                         => 'Medium',
+            'ColorCorrectionMatrix'               => '1 0 0',
+            'MakerNoteVersion'                    => '1.1',
+            'HDRImageType'                        => 2,
+            'BurstUUID'                           => 'qt-burst',
+            'FocusDistanceRange'                  => '0.5 1.8',
+            'OISMode'                             => 3,
+            'ImageCaptureType'                    => 6,
+            'ImageUniqueID'                       => 'qt-unique',
+            'PhotoIdentifier'                     => 'qt-photo',
+            'AFMeasuredDepth'                     => 1.2,
+            'AFConfidence'                        => 0.6,
+        ]);
+
+        $mapper = new AppleMakerNotesMapper();
+        $mapped = $mapper->map($makerNotes, $quickTime);
+        $apple  = $mapped?->apple();
+
+        self::assertSame('qt-content', $apple?->contentIdentifier);
+        self::assertSame('Quick Camera', $apple?->cameraType);
+        self::assertSame([0.9, 1.0, 1.1], $apple?->hdrGain);
+        self::assertSame(1.25, $apple?->hdrHeadroom);
+        self::assertSame(9.5, $apple?->snr);
+        self::assertSame(0.45, $apple?->focusPosition);
+        self::assertSame(2, $apple?->livePhotoIndex);
+        self::assertSame(6100, $apple?->colorTemperature);
+        self::assertSame('QuickPreset', $apple?->semanticStylePreset);
+        self::assertSame([0.2, 0.1, -0.3], $apple?->accelerationVector);
+        self::assertSame('qt-request', $apple?->imageCaptureRequestId);
+        self::assertSame('Medium', $apple?->qualityHint);
+        self::assertSame('1.1', $apple?->makerNoteVersion);
+        self::assertSame('HDR2', $apple?->hdrImageType);
+        self::assertSame([0.5, 1.8], $apple?->focusDistanceRange);
+        self::assertSame('3', $apple?->oisMode);
+        self::assertSame('Night Mode', $apple?->imageCaptureType);
+        self::assertSame('qt-unique', $apple?->imageUniqueId);
+        self::assertSame('qt-photo', $apple?->photoIdentifier);
+        self::assertSame(1.2, $apple?->afMeasuredDepth);
+        self::assertSame(0.6, $apple?->afConfidence);
+    }
+
+    #[Test]
+    public function mapCreatesMetadataFromQuickTimeWhenAbsent(): void
+    {
+        $quickTime = new QuickTimeMeta([
+            QuickTimeMeta::CONTENT_IDENTIFIER_KEY => 'qt-content',
+            'HDRImageType'                        => 1,
+            'AccelerationVector'                  => '0.3 -0.2 0.1',
+        ]);
+
+        $mapper = new AppleMakerNotesMapper();
+        $mapped = $mapper->map(null, $quickTime);
+
+        self::assertInstanceOf(MakerNotesMetadata::class, $mapped);
+        self::assertSame('Apple', $mapped->vendor());
+        self::assertSame(0, $mapped->length());
+        self::assertSame(str_repeat('0', 40), $mapped->sha1());
+
+        $apple = $mapped->apple();
+        self::assertInstanceOf(AppleMakerNotes::class, $apple);
+        self::assertSame('qt-content', $apple->contentIdentifier);
+        self::assertSame([0.3, -0.2, 0.1], $apple->accelerationVector);
+        self::assertSame('HDR', $apple->hdrImageType);
+    }
+
+    #[Test]
+    public function mapMergesQuickTimeFlags(): void
+    {
+        $makerNotes = new MakerNotesMetadata(
+            'Apple',
+            16,
+            str_repeat('3', 40),
+            new AppleMakerNotes(
+                contentIdentifier: null,
+                cameraType: null,
+                hdrHeadroom: null,
+                hdrGain: null,
+                snr: null,
+                aeStable: null,
+                aeTarget: null,
+                aeAverage: null,
+                afStable: null,
+                afPerformance: null,
+                signalToNoiseRatioType: null,
+                luminanceNoiseAmplitude: null,
+                focusPosition: null,
+                livePhotoIndex: null,
+                colorTemperature: null,
+                semanticStylePreset: null,
+                semanticStyleWarmth: null,
+                semanticStyleTone: null,
+                flags: ['nightMode' => true, 'hdrEnabled' => false],
+                accelerationVector: null,
+            ),
+        );
+
+        $quickTime = new QuickTimeMeta([
+            'NightMode' => false,
+            'HdrAuto'   => true,
+        ]);
+
+        $mapper = new AppleMakerNotesMapper();
+        $mapped = $mapper->map($makerNotes, $quickTime);
+
+        $flags = $mapped?->apple()?->flags ?? [];
+        self::assertSame(true, $flags['nightMode']);
+        self::assertSame(false, $flags['hdrEnabled']);
+        self::assertSame(true, $flags['hdrAuto']);
+    }
+}


### PR DESCRIPTION
## Summary
- extract an Apple maker-note mapper that enriches maker notes with QuickTime fallbacks
- update the metadata reader to apply the mapper so the assembler forwards maker notes unchanged
- add dedicated mapper tests and adjust assembler coverage accordingly

## Testing
- composer ci:test:php:unit

------
https://chatgpt.com/codex/tasks/task_e_68ff5c07411483238ac55a8f53c6a0e3