### PR TITLE
test: cover enum normalization helper

### DIFF
--- a/src/Exif/Support/EnumFromIntStringNullable.php
+++ b/src/Exif/Support/EnumFromIntStringNullable.php
@@ -15,19 +15,17 @@ use function is_int;
 use function is_numeric;
 
 /**
- * Reusable helper for backed enums converting mixed EXIF values to enum instances.
+ * Reusable helper for backed-enums: normalizes int|string|null to ?self.
  */
 trait EnumFromIntStringNullable
 {
-    /**
-     * Normalizes EXIF values to backed enums.
-     */
     public static function fromExifValue(int|string|null $value): ?self
     {
         if ($value === null || $value === '') {
             return null;
         }
 
+        // int|string → int
         $int = is_int($value) ? $value : (is_numeric($value) ? (int) $value : null);
         if ($int === null) {
             return null;

--- a/tests/Value/Enum/EnumMappingTest.php
+++ b/tests/Value/Enum/EnumMappingTest.php
@@ -60,6 +60,21 @@ final class EnumMappingTest extends TestCase
     }
 
     #[Test]
+    public function normalizesStringInputs(): void
+    {
+        self::assertSame(Compression::JPEG, Compression::fromExifValue('7'));
+        self::assertSame(CompositeImage::CAPTURED_WHILE_SHOOTING, CompositeImage::fromExifValue('3'));
+        self::assertSame(LightSource::UNKNOWN, LightSource::fromExifValue('0'));
+    }
+
+    #[Test]
+    public function returnsNullForEmptyOrNonNumericStrings(): void
+    {
+        self::assertNull(Compression::fromExifValue(''));
+        self::assertNull(Compression::fromExifValue('foo'));
+    }
+
+    #[Test]
     public function ignoresVendorSpecificFileSource(): void
     {
         self::assertNull(FileSource::fromExifValue(0x8000));


### PR DESCRIPTION
## Summary
- clarify the EnumFromIntStringNullable helper documentation for backed enums
- extend EnumMappingTest with string and invalid EXIF value scenarios to assert the shared helper

## Testing
- .build/bin/phpunit --configuration .build/phpunit.xml --filter EnumMappingTest

------
https://chatgpt.com/codex/tasks/task_e_68ff70f7bfbc83238343660ae7f9e8d7