### PR TITLE
feat: expose lens metadata properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,19 +10,18 @@ The library exposes a structured and fully typed metadata aggregate via `Metadat
 <?php
 use MagicSunday\ImageMeta\MetadataReader;
 
-$meta = (new MetadataReader())->read('photo.heic');
-$structured = $meta->structured();
+$meta = (new MetadataReader())->read('photo.heic')->structured();
 
-$structured->file->mimeType;
-$structured->camera->device->software;
-$structured->lens->model();
-$structured->lens->focalLength();
-$structured->lens->equivalent35mm();
-$structured->exposure->program;
-$structured->gps->latitude?->toFloat();
-$structured->makerNotes->apple?->cameraType;
-$structured->processing->whiteBalance->kelvin;
-$structured->sensor->hardware->focalPlaneXResolution;
+$meta->file->mimeType;
+$meta->camera->device->software;
+$meta->lens->model;
+$meta->lens->focalLength;
+$meta->lens->equivalent35mm();
+$meta->exposure->program;
+$meta->gps->latitude?->toFloat();
+$meta->makerNotes->apple?->cameraType;
+$meta->processing->whiteBalance->kelvin;
+$meta->sensor->hardware->focalPlaneXResolution;
 ```
 
 ### Mapping overview
@@ -71,14 +70,14 @@ used directly without consulting tag identifiers.
 ```php
 $s = $meta->structured();
 $s->tiff->compression;              // Compression::JPEG
-$s->lens->lensSpecification;       // [minF, minAperture, maxF, maxAperture]
+$s->lens->specification;       // [minF, minAperture, maxF, maxAperture]
 $s->composite->type;                // CompositeImage::GeneralComposite
 $s->standards->exifVersion;         // "3.00"
 ```
 
 The aggregate always instantiates each value object. Consumers therefore never have to deal with tag identifiers or container-specific key names.
 
-The diagonal field of view exposed via `lens->fieldOfViewDiagonal()` corresponds to the value previously documented as `fovDeg`. The new horizontal and vertical helpers provide axis-specific angles so clients can present per-dimension compositions without additional trigonometry.
+The diagonal field of view exposed via `lens->fieldOfViewDiagonal` corresponds to the value previously documented as `fovDeg`. The new horizontal and vertical helpers provide axis-specific angles so clients can present per-dimension compositions without additional trigonometry.
 
 The expanded temporal aggregate surfaces raw EXIF offset tags alongside a resolved `DateTimeZone` instance. This makes it possible to reconstruct original capture times even when the offset varies between creation, digitisation and modification steps. File level metadata now reports size, extension and cryptographic digests to help consumers correlate assets or detect tampering.
 

--- a/src/Curate/Structured/LensMetadata.php
+++ b/src/Curate/Structured/LensMetadata.php
@@ -19,76 +19,53 @@ use MagicSunday\ImageMeta\Value\Lens as LensValue;
  */
 final readonly class LensMetadata
 {
+    public ?string $make;
+
+    public ?string $model;
+
+    public ?string $serialNumber;
+
+    public ?float $focalLength;
+
+    public ?float $maximumAperture;
+
     /**
-     * @param LensValue $lens    Base lens values curated from metadata sources.
-     * @param Derived   $derived Derived optical metrics calculated from capture data.
+     * @var array{0:float,1:float,2:float,3:float}|null
      */
+    public ?array $specification;
+
+    public ?float $cropFactor;
+
+    public ?float $hyperfocalDistance;
+
+    public ?float $fieldOfViewHorizontal;
+
+    public ?float $fieldOfViewVertical;
+
+    public ?float $fieldOfViewDiagonal;
+
+    private ?int $equivalent35mm;
+
     public function __construct(
-        private LensValue $lens,
-        private Derived $derived,
+        LensValue $lens,
+        Derived $derived,
     ) {
-    }
-
-    public function make(): ?string
-    {
-        return $this->lens->lensMake;
-    }
-
-    public function model(): ?string
-    {
-        return $this->lens->lensModel;
-    }
-
-    public function serialNumber(): ?string
-    {
-        return $this->lens->lensSerialNumber;
-    }
-
-    public function focalLength(): ?float
-    {
-        return $this->lens->focalLengthMm;
-    }
-
-    public function maximumAperture(): ?float
-    {
-        return $this->lens->maxApertureFNumber;
-    }
-
-    /**
-     * @return array{0:float,1:float,2:float,3:float}|null
-     */
-    public function specification(): ?array
-    {
-        return $this->lens->lensSpecification;
+        $this->make = $lens->lensMake;
+        $this->model = $lens->lensModel;
+        $this->serialNumber = $lens->lensSerialNumber;
+        $this->focalLength = $lens->focalLengthMm;
+        $this->maximumAperture = $lens->maxApertureFNumber;
+        $this->specification = $lens->lensSpecification;
+        $this->equivalent35mm = $lens->focalLengthIn35mm ?? $derived->focalLength35mm;
+        $this->cropFactor = $derived->cropFactor;
+        $this->hyperfocalDistance = $derived->hyperfocalM;
+        $this->fieldOfViewHorizontal = $derived->fovHorizontalDeg;
+        $this->fieldOfViewVertical = $derived->fovVerticalDeg;
+        $this->fieldOfViewDiagonal = $derived->fovDiagonalDeg;
     }
 
     public function equivalent35mm(): ?int
     {
-        return $this->lens->focalLengthIn35mm ?? $this->derived->focalLength35mm;
-    }
-
-    public function cropFactor(): ?float
-    {
-        return $this->derived->cropFactor;
-    }
-
-    public function hyperfocalDistance(): ?float
-    {
-        return $this->derived->hyperfocalM;
-    }
-
-    public function fieldOfViewHorizontal(): ?float
-    {
-        return $this->derived->fovHorizontalDeg;
-    }
-
-    public function fieldOfViewVertical(): ?float
-    {
-        return $this->derived->fovVerticalDeg;
-    }
-
-    public function fieldOfViewDiagonal(): ?float
-    {
-        return $this->derived->fovDiagonalDeg;
+        return $this->equivalent35mm;
     }
 }

--- a/test-images/TruthComparisonTest.php
+++ b/test-images/TruthComparisonTest.php
@@ -144,13 +144,13 @@ final class TruthComparisonTest extends TestCase
 
         // Lens information
         if (isset($exif['EXIF:FocalLength'])) {
-            $this->assertEqualsWithDelta((float)$exif['EXIF:FocalLength'], (float)($meta->lens->focalLength() ?? $meta->media->image->focalLengthMm ?? 0.0), Normalizer::DELTA, "$file: FocalLength");
+            $this->assertEqualsWithDelta((float)$exif['EXIF:FocalLength'], (float)($meta->lens->focalLength ?? $meta->media->image->focalLengthMm ?? 0.0), Normalizer::DELTA, "$file: FocalLength");
         }
         if (isset($exif['EXIF:FocalLengthIn35mmFormat'])) {
             $this->assertSame((int)$exif['EXIF:FocalLengthIn35mmFormat'], (int)($meta->lens->equivalent35mm() ?? 0), "$file: FocalLength35mm");
         }
         if (isset($exif['EXIF:LensModel'])) {
-            $this->assertSame($exif['EXIF:LensModel'], $meta->lens->model() ?? null, "$file: LensModel");
+            $this->assertSame($exif['EXIF:LensModel'], $meta->lens->model ?? null, "$file: LensModel");
         }
 
         // Temporal metadata (ISO-8601)

--- a/tests/Curate/ExifAssemblerTest.php
+++ b/tests/Curate/ExifAssemblerTest.php
@@ -293,17 +293,17 @@ final class ExifAssemblerTest extends TestCase
         self::assertSame(SensingMethod::ONE_CHIP_COLOR_AREA, $structured->camera->sensingMethod);
         self::assertSame([], $structured->technical->flashPix->streams);
 
-        self::assertSame('EF 85mm f/1.4L', $structured->lens->model());
-        self::assertSame(85.0, $structured->lens->focalLength());
+        self::assertSame('EF 85mm f/1.4L', $structured->lens->model);
+        self::assertSame(85.0, $structured->lens->focalLength);
         self::assertSame(85, $structured->lens->equivalent35mm());
-        self::assertSame([35.0, 4.0, 150.0, 5.6], $structured->lens->specification());
-        self::assertEqualsWithDelta(1.9965, $structured->lens->maximumAperture(), 0.001);
+        self::assertSame([35.0, 4.0, 150.0, 5.6], $structured->lens->specification);
+        self::assertEqualsWithDelta(1.9965, $structured->lens->maximumAperture, 0.001);
 
-        self::assertEqualsWithDelta(43.09095238095239, $structured->lens->hyperfocalDistance(), 1e-6);
-        self::assertEqualsWithDelta(28.558322, $structured->lens->fieldOfViewDiagonal(), 1e-6);
-        self::assertEqualsWithDelta(23.913168, $structured->lens->fieldOfViewHorizontal(), 1e-6);
-        self::assertEqualsWithDelta(16.071421, $structured->lens->fieldOfViewVertical(), 1e-6);
-        self::assertEqualsWithDelta(1.0, $structured->lens->cropFactor(), 1e-6);
+        self::assertEqualsWithDelta(43.09095238095239, $structured->lens->hyperfocalDistance, 1e-6);
+        self::assertEqualsWithDelta(28.558322, $structured->lens->fieldOfViewDiagonal, 1e-6);
+        self::assertEqualsWithDelta(23.913168, $structured->lens->fieldOfViewHorizontal, 1e-6);
+        self::assertEqualsWithDelta(16.071421, $structured->lens->fieldOfViewVertical, 1e-6);
+        self::assertEqualsWithDelta(1.0, $structured->lens->cropFactor, 1e-6);
 
         self::assertSame(6720, $structured->media->image->width);
         self::assertSame(4480, $structured->media->image->height);
@@ -356,7 +356,7 @@ final class ExifAssemblerTest extends TestCase
         self::assertSame([1, 0, 0, 0], $structured->technical->standards->tiffEpStandardId);
         self::assertSame('1.0.0.0', $structured->technical->standards->tiffEpStandardString);
 
-        self::assertEqualsWithDelta(1.9965, $structured->lens->maximumAperture(), 0.001);
+        self::assertEqualsWithDelta(1.9965, $structured->lens->maximumAperture, 0.001);
 
         self::assertEqualsWithDelta(21.5, $structured->capture->details->temperatureC, 0.001);
         self::assertEqualsWithDelta(82.0, $structured->capture->details->batteryLevelPercent, 0.001);
@@ -1361,7 +1361,7 @@ final class ExifAssemblerTest extends TestCase
 
         self::assertNull($structured->camera->make);
         self::assertNull($structured->camera->model);
-        self::assertNull($structured->lens->model());
+        self::assertNull($structured->lens->model);
         self::assertNull($structured->media->image->documentName);
     }
 
@@ -1802,8 +1802,8 @@ final class ExifAssemblerTest extends TestCase
 
         $structured = (new ExifAssembler())->assemble($metadata);
 
-        self::assertNotNull($structured->lens->maximumAperture());
-        self::assertEqualsWithDelta(4.0, $structured->lens->maximumAperture(), 0.0001);
+        self::assertNotNull($structured->lens->maximumAperture);
+        self::assertEqualsWithDelta(4.0, $structured->lens->maximumAperture, 0.0001);
     }
 
     /**


### PR DESCRIPTION
## Summary
- expose lens metadata fields as public properties for the structured metadata API
- update tests and documentation to cover the property-based lens access pattern

## Testing
- composer ci:test:php:unit

------
https://chatgpt.com/codex/tasks/task_e_68ff7cc42c58832399d605d7dabad76d