### PR TITLE
refactor(core): deduplicate big-endian readers

### DIFF
--- a/src/Core/ByteReader.php
+++ b/src/Core/ByteReader.php
@@ -1,0 +1,104 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\ImageMeta\Core;
+
+use Closure;
+use MagicSunday\ImageMeta\Core\Util\UInt64;
+use MagicSunday\ImageMeta\Core\Util\Unpack;
+
+use function ord;
+
+/**
+ * Provides shared unsigned integer read helpers for byte-oriented data sources.
+ */
+final class ByteReader
+{
+    private readonly Closure $read;
+
+    private readonly Closure $tell;
+
+    private readonly Closure $seek;
+
+    public function __construct(
+        callable $read,
+        callable $tell,
+        callable $seek,
+        private readonly string $context,
+    ) {
+        $this->read = Closure::fromCallable($read);
+        $this->tell = Closure::fromCallable($tell);
+        $this->seek = Closure::fromCallable($seek);
+    }
+
+    /**
+     * Reads an unsigned 8-bit integer.
+     */
+    public function readU8(): int
+    {
+        $bytes = ($this->read)(1);
+
+        return ord($bytes);
+    }
+
+    /**
+     * Reads an unsigned 16-bit big-endian integer.
+     */
+    public function readU16BE(): int
+    {
+        return $this->unpackInt('n', 2);
+    }
+
+    /**
+     * Reads an unsigned 32-bit big-endian integer.
+     */
+    public function readU32BE(): int
+    {
+        return $this->unpackInt('N', 4);
+    }
+
+    /**
+     * Reads an unsigned 64-bit big-endian integer.
+     */
+    public function readU64BE(): UInt64
+    {
+        $hi = $this->readU32BE();
+        $lo = $this->readU32BE();
+
+        return Unpack::combineUint32($hi, $lo);
+    }
+
+    /**
+     * Reads bytes and unpacks the first value according to the provided format.
+     */
+    public function unpackInt(string $format, int $length): int
+    {
+        $bytes = ($this->read)($length);
+
+        return Unpack::int($format, $bytes, 'integer from ' . $this->context);
+    }
+
+    /**
+     * Returns the current cursor position of the underlying data source.
+     */
+    public function tell(): int
+    {
+        return ($this->tell)();
+    }
+
+    /**
+     * Moves the cursor of the underlying data source.
+     */
+    public function seek(int|UInt64 $offset): void
+    {
+        ($this->seek)($offset);
+    }
+}

--- a/src/Core/MemoryBuffer.php
+++ b/src/Core/MemoryBuffer.php
@@ -14,7 +14,6 @@ namespace MagicSunday\ImageMeta\Core;
 use MagicSunday\ImageMeta\Core\Util\UInt64;
 use MagicSunday\ImageMeta\Core\Util\Unpack;
 
-use function ord;
 use function strlen;
 
 /**
@@ -26,6 +25,8 @@ use function strlen;
  */
 final class MemoryBuffer
 {
+    private readonly ByteReader $byteReader;
+
     /**
      * @param string $data raw binary payload to expose as a seekable buffer
      * @param int    $pos  initial read position within the buffer
@@ -34,6 +35,14 @@ final class MemoryBuffer
         private readonly string $data,
         private int $pos = 0,
     ) {
+        $this->byteReader = new ByteReader(
+            read: fn (int $length): string => $this->read($length),
+            tell: fn (): int => $this->pos,
+            seek: function (int|UInt64 $offset): void {
+                $this->seekInternal($offset);
+            },
+            context: 'buffer',
+        );
     }
 
     /**
@@ -53,7 +62,7 @@ final class MemoryBuffer
      */
     public function tell(): int
     {
-        return $this->pos;
+        return $this->byteReader->tell();
     }
 
     /**
@@ -65,8 +74,7 @@ final class MemoryBuffer
      */
     public function seek(int|UInt64 $offset): void
     {
-        $offsetInt   = $this->normaliseOffset($offset, 0, 'MemoryBuffer seek out of range');
-        $this->pos   = $offsetInt;
+        $this->byteReader->seek($offset);
     }
 
     /**
@@ -111,7 +119,7 @@ final class MemoryBuffer
      */
     public function readU8(): int
     {
-        return ord($this->read(1));
+        return $this->byteReader->readU8();
     }
 
     /**
@@ -121,7 +129,7 @@ final class MemoryBuffer
      */
     public function readU16LE(): int
     {
-        return $this->unpackInt('v', 2);
+        return $this->byteReader->unpackInt('v', 2);
     }
 
     /**
@@ -131,7 +139,7 @@ final class MemoryBuffer
      */
     public function readU16BE(): int
     {
-        return $this->unpackInt('n', 2);
+        return $this->byteReader->readU16BE();
     }
 
     /**
@@ -141,7 +149,7 @@ final class MemoryBuffer
      */
     public function readU32LE(): int
     {
-        return $this->unpackInt('V', 4);
+        return $this->byteReader->unpackInt('V', 4);
     }
 
     /**
@@ -151,7 +159,7 @@ final class MemoryBuffer
      */
     public function readU32BE(): int
     {
-        return $this->unpackInt('N', 4);
+        return $this->byteReader->readU32BE();
     }
 
     /**
@@ -174,25 +182,12 @@ final class MemoryBuffer
      */
     public function readU64BE(): UInt64
     {
-        $hi = $this->readU32BE();
-        $lo = $this->readU32BE();
-
-        return Unpack::combineUint32($hi, $lo);
+        return $this->byteReader->readU64BE();
     }
 
-    /**
-     * Reads bytes from the buffer and unpacks the first value using the provided format.
-     *
-     * @param string $format Format accepted by {@see Unpack::int}.
-     * @param int    $length Number of bytes to consume before unpacking.
-     *
-     * @return int
-     */
-    private function unpackInt(string $format, int $length): int
+    private function seekInternal(int|UInt64 $offset): void
     {
-        $bytes = $this->read($length);
-
-        return Unpack::int($format, $bytes, 'integer from buffer');
+        $this->pos = $this->normaliseOffset($offset, 0, 'MemoryBuffer seek out of range');
     }
 
     private function normaliseOffset(int|UInt64 $offset, int $length, string $message): int

--- a/src/Core/Stream.php
+++ b/src/Core/Stream.php
@@ -12,14 +12,12 @@ declare(strict_types=1);
 namespace MagicSunday\ImageMeta\Core;
 
 use MagicSunday\ImageMeta\Core\Util\UInt64;
-use MagicSunday\ImageMeta\Core\Util\Unpack;
 
 use function fopen;
 use function fread;
 use function fseek;
 use function fstat;
 use function is_array;
-use function ord;
 use function strlen;
 
 /**
@@ -33,6 +31,8 @@ final class Stream
     private readonly int $size;
 
     private int $pos = 0;
+
+    private readonly ByteReader $byteReader;
 
     /**
      * Opens the given path for binary reading and wraps it in a stream instance.
@@ -68,6 +68,14 @@ final class Stream
     {
         $this->fh   = $fh;
         $this->size = $size;
+        $this->byteReader = new ByteReader(
+            read: fn (int $length): string => $this->read($length),
+            tell: fn (): int => $this->pos,
+            seek: function (int|UInt64 $offset): void {
+                $this->seekInternal($offset);
+            },
+            context: 'stream',
+        );
     }
 
     /**
@@ -87,7 +95,7 @@ final class Stream
      */
     public function tell(): int
     {
-        return $this->pos;
+        return $this->byteReader->tell();
     }
 
     /**
@@ -97,12 +105,7 @@ final class Stream
      */
     public function seek(int $offset): void
     {
-        if ($offset < 0 || $offset > $this->size) {
-            throw new BoundsError('seek out of range: ' . $offset);
-        }
-
-        fseek($this->fh, $offset);
-        $this->pos = $offset;
+        $this->byteReader->seek($offset);
     }
 
     /**
@@ -139,7 +142,7 @@ final class Stream
      */
     public function readU8(): int
     {
-        return ord($this->read(1));
+        return $this->byteReader->readU8();
     }
 
     /**
@@ -149,7 +152,7 @@ final class Stream
      */
     public function readU16BE(): int
     {
-        return $this->unpackInt('n', 2);
+        return $this->byteReader->readU16BE();
     }
 
     /**
@@ -159,7 +162,7 @@ final class Stream
      */
     public function readU32BE(): int
     {
-        return $this->unpackInt('N', 4);
+        return $this->byteReader->readU32BE();
     }
 
     /**
@@ -169,10 +172,7 @@ final class Stream
      */
     public function readU64BE(): UInt64
     {
-        $hi = $this->readU32BE();
-        $lo = $this->readU32BE();
-
-        return Unpack::combineUint32($hi, $lo);
+        return $this->byteReader->readU64BE();
     }
 
     /**
@@ -190,18 +190,25 @@ final class Stream
         return new StreamWindow($this, $offset, $length);
     }
 
-    /**
-     * Reads the requested number of bytes and unpacks the first value using the provided format.
-     *
-     * @param string $format Format string understood by {@see Unpack::int}.
-     * @param int    $length Number of bytes to consume from the stream.
-     *
-     * @return int
-     */
-    private function unpackInt(string $format, int $length): int
+    private function seekInternal(int|UInt64 $offset): void
     {
-        $bytes = $this->read($length);
+        if ($offset instanceof UInt64) {
+            if ($offset->compareInt($this->size) > 0) {
+                throw new BoundsError('seek out of range: ' . $offset->toHex());
+            }
 
-        return Unpack::int($format, $bytes, 'integer from stream');
+            $offsetValue = $offset->toInt('seek out of range');
+            $messageValue = $offset->toHex();
+        } else {
+            $offsetValue  = $offset;
+            $messageValue = (string) $offset;
+        }
+
+        if ($offsetValue < 0 || $offsetValue > $this->size) {
+            throw new BoundsError('seek out of range: ' . $messageValue);
+        }
+
+        fseek($this->fh, $offsetValue);
+        $this->pos = $offsetValue;
     }
 }

--- a/src/Core/StreamWindow.php
+++ b/src/Core/StreamWindow.php
@@ -12,9 +12,6 @@ declare(strict_types=1);
 namespace MagicSunday\ImageMeta\Core;
 
 use MagicSunday\ImageMeta\Core\Util\UInt64;
-use MagicSunday\ImageMeta\Core\Util\Unpack;
-
-use function ord;
 
 /**
  * Represents a bounded view into a parent stream with an independent cursor.
@@ -22,6 +19,8 @@ use function ord;
 final class StreamWindow
 {
     private int $cursor = 0;
+
+    private readonly ByteReader $byteReader;
 
     /**
      * Creates a window that restricts reads to a fixed region of the parent stream.
@@ -35,6 +34,14 @@ final class StreamWindow
         private readonly int $offset,
         private readonly int $length,
     ) {
+        $this->byteReader = new ByteReader(
+            read: fn (int $length): string => $this->read($length),
+            tell: fn (): int => $this->cursor,
+            seek: function (int|UInt64 $offset): void {
+                $this->seekInternal($offset);
+            },
+            context: 'window',
+        );
     }
 
     /**
@@ -54,7 +61,7 @@ final class StreamWindow
      */
     public function tell(): int
     {
-        return $this->cursor;
+        return $this->byteReader->tell();
     }
 
     /**
@@ -64,11 +71,7 @@ final class StreamWindow
      */
     public function seek(int $pos): void
     {
-        if ($pos < 0 || $pos > $this->length) {
-            throw new BoundsError('window seek out of range');
-        }
-
-        $this->cursor = $pos;
+        $this->byteReader->seek($pos);
     }
 
     /**
@@ -102,7 +105,7 @@ final class StreamWindow
      */
     public function readU8(): int
     {
-        return ord($this->read(1));
+        return $this->byteReader->readU8();
     }
 
     /**
@@ -112,7 +115,7 @@ final class StreamWindow
      */
     public function readU16BE(): int
     {
-        return $this->unpackInt('n', 2);
+        return $this->byteReader->readU16BE();
     }
 
     /**
@@ -122,7 +125,7 @@ final class StreamWindow
      */
     public function readU32BE(): int
     {
-        return $this->unpackInt('N', 4);
+        return $this->byteReader->readU32BE();
     }
 
     /**
@@ -132,24 +135,19 @@ final class StreamWindow
      */
     public function readU64BE(): UInt64
     {
-        $hi = $this->readU32BE();
-        $lo = $this->readU32BE();
-
-        return Unpack::combineUint32($hi, $lo);
+        return $this->byteReader->readU64BE();
     }
 
-    /**
-     * Reads a fixed number of bytes from the window and unpacks the first value using the given format.
-     *
-     * @param string $format Format string understood by {@see Unpack::int}.
-     * @param int    $length Number of bytes to read before unpacking.
-     *
-     * @return int
-     */
-    private function unpackInt(string $format, int $length): int
+    private function seekInternal(int|UInt64 $pos): void
     {
-        $bytes = $this->read($length);
+        if ($pos instanceof UInt64) {
+            $pos = $pos->toInt('window seek out of range');
+        }
 
-        return Unpack::int($format, $bytes, 'integer from window');
+        if ($pos < 0 || $pos > $this->length) {
+            throw new BoundsError('window seek out of range');
+        }
+
+        $this->cursor = $pos;
     }
 }


### PR DESCRIPTION
## Summary
- add `Core\ByteReader` to provide reusable big-endian integer helpers
- migrate `MemoryBuffer`, `Stream`, and `StreamWindow` to delegate read/tell/seek logic to the shared byte reader

## Testing
- composer ci:test:php:unit
- composer ci:test:php:phpstan *(fails: existing type issues in EXIF model/value converters)*


------
https://chatgpt.com/codex/tasks/task_e_68ff9228b1808323b0cffa7a20f3b75e