### PR TITLE
refactor: centralise EXIF conversion helpers

### DIFF
--- a/src/Model/Exif/ExifDocument.php
+++ b/src/Model/Exif/ExifDocument.php
@@ -126,13 +126,9 @@ final readonly class ExifDocument
      */
     public function makerNoteSafety(): ?bool
     {
-        $value = $this->int($this->exifIfd, ExifTag::MAKER_NOTE_SAFETY);
+        $value = $this->value($this->exifIfd, ExifTag::MAKER_NOTE_SAFETY);
 
-        return match ($value) {
-            0       => false,
-            1       => true,
-            default => null,
-        };
+        return ValueConverters::makerNoteSafety($value);
     }
 
     /**
@@ -863,7 +859,9 @@ final readonly class ExifDocument
      */
     public function componentsConfiguration(): ?array
     {
-        return $this->numericList($this->exifIfd, ExifTag::COMPONENTS_CONFIGURATION);
+        $value = $this->value($this->exifIfd, ExifTag::COMPONENTS_CONFIGURATION);
+
+        return ValueConverters::componentsConfiguration($value);
     }
 
     /**
@@ -873,9 +871,9 @@ final readonly class ExifDocument
      */
     public function componentsConfigurationLabels(): ?array
     {
-        $components = $this->componentsConfiguration();
+        $value = $this->value($this->exifIfd, ExifTag::COMPONENTS_CONFIGURATION);
 
-        return $components !== null ? ValueConverters::componentsConfigurationLabels($components) : null;
+        return ValueConverters::componentsConfigurationLabels($value);
     }
 
     /**
@@ -883,9 +881,9 @@ final readonly class ExifDocument
      */
     public function componentsConfigurationDescription(): ?string
     {
-        $components = $this->componentsConfiguration();
+        $value = $this->value($this->exifIfd, ExifTag::COMPONENTS_CONFIGURATION);
 
-        return $components !== null ? ValueConverters::componentsConfigurationDescription($components) : null;
+        return ValueConverters::componentsConfigurationDescription($value);
     }
 
     /**

--- a/src/Model/Exif/ValueConverters.php
+++ b/src/Model/Exif/ValueConverters.php
@@ -595,6 +595,40 @@ final readonly class ValueConverters
     }
 
     /**
+     * Converts the maker note safety flag into a boolean representation.
+     *
+     * @param ExifNumericList|int|float|string|null $value Raw maker note safety value.
+     */
+    public static function makerNoteSafety(ExifNumericList|int|float|string|null $value): ?bool
+    {
+        if ($value instanceof ExifNumericList) {
+            $value = $value->values[0] ?? null;
+        }
+
+        if ($value === null) {
+            return null;
+        }
+
+        if (is_float($value)) {
+            $value = (int) $value;
+        }
+
+        if (is_string($value) && ctype_digit($value)) {
+            $value = (int) $value;
+        }
+
+        if (!is_int($value)) {
+            return null;
+        }
+
+        return match ($value) {
+            0 => false,
+            1 => true,
+            default => null,
+        };
+    }
+
+    /**
      * Normalises the TIFF/EP standard identifier to both byte and string representations.
      *
      * @param list<int>|null $bytes Raw TIFF/EP identifier bytes.
@@ -983,6 +1017,18 @@ final readonly class ValueConverters
             ],
             'values' => $values,
         ];
+    }
+
+    /**
+     * Normalises the components configuration tag into a list of component identifiers.
+     *
+     * @param array<int, int|float|string>|ExifNumericList|string|int|null $value Raw EXIF value representation.
+     *
+     * @return list<int>|null
+     */
+    public static function componentsConfiguration(array|ExifNumericList|string|int|null $value): ?array
+    {
+        return self::toIntList($value);
     }
 
     /**

--- a/src/Parse/Tiff/TiffExifReader.php
+++ b/src/Parse/Tiff/TiffExifReader.php
@@ -27,6 +27,7 @@ use MagicSunday\ImageMeta\Model\Exif\ExifRationalList;
 use MagicSunday\ImageMeta\Model\Exif\ExifTag;
 use MagicSunday\ImageMeta\Model\Exif\Ifd;
 use MagicSunday\ImageMeta\Model\Exif\IfdEntry;
+use MagicSunday\ImageMeta\Model\Exif\ValueConverters;
 
 use function array_slice;
 use function chr;
@@ -1111,25 +1112,7 @@ final class TiffExifReader
             return null;
         }
 
-        $value = $entry->value;
-
-        if ($value instanceof ExifNumericList) {
-            $value = $value->values[0] ?? null;
-        }
-
-        if (is_float($value)) {
-            $value = (int) $value;
-        }
-
-        if (!is_int($value)) {
-            return null;
-        }
-
-        return match ($value) {
-            0       => false,
-            1       => true,
-            default => null,
-        };
+        return ValueConverters::makerNoteSafety($entry->value);
     }
 
     /**

--- a/tests/Model/Exif/ValueConvertersTest.php
+++ b/tests/Model/Exif/ValueConvertersTest.php
@@ -162,6 +162,33 @@ final class ValueConvertersTest extends TestCase
     }
 
     /**
+     * Ensures components configuration payloads normalise to integer component lists.
+     */
+    #[Test]
+    public function normalisesComponentsConfigurationPayloads(): void
+    {
+        $values = new ExifNumericList([1, 2, 3, 0]);
+
+        self::assertSame([1, 2, 3, 0], ValueConverters::componentsConfiguration($values));
+        self::assertSame([4, 5], ValueConverters::componentsConfiguration([4, 5]));
+        self::assertNull(ValueConverters::componentsConfiguration(new ExifNumericList([])));
+        self::assertNull(ValueConverters::componentsConfiguration(null));
+    }
+
+    /**
+     * Ensures maker note safety flags convert to booleans.
+     */
+    #[Test]
+    public function convertsMakerNoteSafetyFlags(): void
+    {
+        self::assertTrue(ValueConverters::makerNoteSafety(1));
+        self::assertFalse(ValueConverters::makerNoteSafety(0));
+        self::assertTrue(ValueConverters::makerNoteSafety(new ExifNumericList([1])));
+        self::assertNull(ValueConverters::makerNoteSafety(new ExifNumericList([])));
+        self::assertNull(ValueConverters::makerNoteSafety('invalid'));
+    }
+
+    /**
      * @return iterable<string, array{mixed, float|null}>
      */
     public static function provideApexValues(): iterable


### PR DESCRIPTION
## Summary
- add dedicated ValueConverters helpers for maker note safety and components configuration values
- update ExifDocument and TiffExifReader to delegate these conversions to the shared helpers
- extend ValueConverters unit coverage for the new conversion utilities

## Testing
- composer ci:test:php:unit
- composer ci:test:php:phpstan *(fails: existing baseline violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68ff943c19ec8323a813a58f0ec51dc4