### PR TITLE
Refactor EXIF flash decoding helpers

### DIFF
--- a/src/Curate/Exif/ValueFactory.php
+++ b/src/Curate/Exif/ValueFactory.php
@@ -58,6 +58,7 @@ use MagicSunday\ImageMeta\Value\Enum\ResolutionUnit;
 use MagicSunday\ImageMeta\Value\Enum\WhiteBalance;
 use MagicSunday\ImageMeta\Value\Exposure;
 use MagicSunday\ImageMeta\Value\File;
+use MagicSunday\ImageMeta\Value\ExifFlash;
 use MagicSunday\ImageMeta\Value\FlashInfo;
 use MagicSunday\ImageMeta\Value\FlashPix;
 use MagicSunday\ImageMeta\Value\Focus;
@@ -269,7 +270,7 @@ final class ValueFactory
             $whiteBalance = WhiteBalance::tryFrom($whiteBalanceCode);
         }
 
-        $flashInfo = FlashInfo::fromExifValue($exifDocument?->flash());
+        $flashInfo = ExifFlash::fromExifValue($exifDocument?->flash());
 
         $exposure = new Exposure(
             iso: $exifDocument?->iso(),

--- a/src/Model/Exif/ValueConverters.php
+++ b/src/Model/Exif/ValueConverters.php
@@ -17,6 +17,7 @@ use DateTimeZone;
 use Exception;
 use JsonException;
 use MagicSunday\ImageMeta\Value\Enum\CfaPatternColor;
+use MagicSunday\ImageMeta\Value\ExifFlash;
 use MagicSunday\ImageMeta\Value\FlashInfo;
 use Throwable;
 
@@ -1233,11 +1234,11 @@ final readonly class ValueConverters
         }
 
         if (is_float($value) || is_int($value)) {
-            return FlashInfo::fromExifValue((int) $value);
+            return ExifFlash::fromExifValue((int) $value);
         }
 
         if (is_string($value) && is_numeric($value)) {
-            return FlashInfo::fromExifValue((int) $value);
+            return ExifFlash::fromExifValue((int) $value);
         }
 
         return null;

--- a/src/Value/Enum/FlashFunction.php
+++ b/src/Value/Enum/FlashFunction.php
@@ -22,14 +22,4 @@ enum FlashFunction: int
 
     case PRESENT = 0;
     case ABSENT  = 1;
-
-    /**
-     * Converts the flash bit field into an enum instance.
-     */
-    public static function fromFlashBits(int $value): ?self
-    {
-        $functionBit = ($value >> 5) & 0x01;
-
-        return self::tryFrom($functionBit);
-    }
 }

--- a/src/Value/Enum/FlashMode.php
+++ b/src/Value/Enum/FlashMode.php
@@ -24,14 +24,4 @@ enum FlashMode: int
     case COMPULSORY_FIRE     = 1;
     case COMPULSORY_SUPPRESS = 2;
     case AUTO                = 3;
-
-    /**
-     * Builds an enum instance from the bit field representation.
-     */
-    public static function fromFlashBits(int $value): ?self
-    {
-        $modeBits = ($value >> 3) & 0x03;
-
-        return self::tryFrom($modeBits);
-    }
 }

--- a/src/Value/Enum/FlashReturn.php
+++ b/src/Value/Enum/FlashReturn.php
@@ -23,14 +23,4 @@ enum FlashReturn: int
     case NO_STROBE_DETECTION = 0;
     case RETURN_NOT_DETECTED = 2;
     case RETURN_DETECTED     = 3;
-
-    /**
-     * Creates an enum instance from the flash bit field.
-     */
-    public static function fromFlashBits(int $value): ?self
-    {
-        $returnBits = ($value >> 1) & 0x03;
-
-        return self::tryFrom($returnBits);
-    }
 }

--- a/src/Value/ExifFlash.php
+++ b/src/Value/ExifFlash.php
@@ -1,0 +1,60 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\ImageMeta\Value;
+
+use MagicSunday\ImageMeta\Value\Enum\FlashFunction;
+use MagicSunday\ImageMeta\Value\Enum\FlashMode;
+use MagicSunday\ImageMeta\Value\Enum\FlashReturn;
+
+use function is_int;
+
+/**
+ * Provides helpers to decode the EXIF flash bit field into structured values.
+ */
+final class ExifFlash
+{
+    private const FIRED_MASK = 0x01;
+    private const RETURN_SHIFT = 1;
+    private const MODE_SHIFT = 3;
+    private const FUNCTION_SHIFT = 5;
+    private const TWO_BIT_MASK = 0x03;
+    private const ONE_BIT_MASK = 0x01;
+    private const RED_EYE_MASK = 0x40;
+
+    private function __construct()
+    {
+    }
+
+    /**
+     * Creates a FlashInfo instance from the numeric EXIF Flash tag value.
+     */
+    public static function fromExifValue(int|string|null $value): ?FlashInfo
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        $intValue = is_int($value) ? $value : (int) $value;
+
+        $returnBits = ($intValue >> self::RETURN_SHIFT) & self::TWO_BIT_MASK;
+        $modeBits = ($intValue >> self::MODE_SHIFT) & self::TWO_BIT_MASK;
+        $functionBit = ($intValue >> self::FUNCTION_SHIFT) & self::ONE_BIT_MASK;
+
+        return new FlashInfo(
+            fired: ($intValue & self::FIRED_MASK) !== 0,
+            mode: FlashMode::tryFrom($modeBits),
+            returnDetection: FlashReturn::tryFrom($returnBits),
+            functionPresence: FlashFunction::tryFrom($functionBit),
+            redEyeReduction: ($intValue & self::RED_EYE_MASK) !== 0,
+        );
+    }
+}

--- a/src/Value/FlashInfo.php
+++ b/src/Value/FlashInfo.php
@@ -15,8 +15,6 @@ use MagicSunday\ImageMeta\Value\Enum\FlashFunction;
 use MagicSunday\ImageMeta\Value\Enum\FlashMode;
 use MagicSunday\ImageMeta\Value\Enum\FlashReturn;
 
-use function is_int;
-
 /**
  * Represents flash related capture information as exposed by EXIF and XMP.
  */
@@ -36,25 +34,5 @@ final readonly class FlashInfo
         public ?FlashFunction $functionPresence = null,
         public bool $redEyeReduction = false,
     ) {
-    }
-
-    /**
-     * Creates an instance from the numeric EXIF Flash tag value.
-     */
-    public static function fromExifValue(int|string|null $value): ?self
-    {
-        if ($value === null) {
-            return null;
-        }
-
-        $intValue = is_int($value) ? $value : (int) $value;
-
-        return new self(
-            fired: (bool) ($intValue & 0x01),
-            mode: FlashMode::fromFlashBits($intValue),
-            returnDetection: FlashReturn::fromFlashBits($intValue),
-            functionPresence: FlashFunction::fromFlashBits($intValue),
-            redEyeReduction: (bool) ($intValue & 0x40),
-        );
     }
 }

--- a/tests/Curate/Value/ExifFlashTest.php
+++ b/tests/Curate/Value/ExifFlashTest.php
@@ -14,14 +14,14 @@ namespace MagicSunday\ImageMeta\Tests\Curate\Value;
 use MagicSunday\ImageMeta\Value\Enum\FlashFunction;
 use MagicSunday\ImageMeta\Value\Enum\FlashMode;
 use MagicSunday\ImageMeta\Value\Enum\FlashReturn;
-use MagicSunday\ImageMeta\Value\FlashInfo;
+use MagicSunday\ImageMeta\Value\ExifFlash;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
- * @covers \MagicSunday\ImageMeta\Value\FlashInfo
+ * @covers \MagicSunday\ImageMeta\Value\ExifFlash
  */
-final class FlashInfoTest extends TestCase
+final class ExifFlashTest extends TestCase
 {
     /**
      * Ensures flash bit fields are decoded into typed information.
@@ -29,7 +29,7 @@ final class FlashInfoTest extends TestCase
     #[Test]
     public function createsInstanceFromExifBitField(): void
     {
-        $info = FlashInfo::fromExifValue(127);
+        $info = ExifFlash::fromExifValue(127);
 
         self::assertNotNull($info);
         self::assertTrue($info->fired);
@@ -45,6 +45,6 @@ final class FlashInfoTest extends TestCase
     #[Test]
     public function returnsNullWhenNoValueIsProvided(): void
     {
-        self::assertNull(FlashInfo::fromExifValue(null));
+        self::assertNull(ExifFlash::fromExifValue(null));
     }
 }


### PR DESCRIPTION
## Summary
- add a dedicated `ExifFlash` helper to decode the EXIF flash bitmask into `FlashInfo`
- keep flash-related enums independent from bit parsing utilities
- update metadata factories and tests to consume the new helper

## Testing
- composer ci:test:php:unit

------
https://chatgpt.com/codex/tasks/task_e_68ff9e87f0c08323a18da6ac593ec76f