### PR TITLE
Refactor Apple helper usage into shared utilities

### DIFF
--- a/src/Curate/Exif/ValueFactory.php
+++ b/src/Curate/Exif/ValueFactory.php
@@ -27,6 +27,7 @@ use MagicSunday\ImageMeta\Curate\Structured\RightsMetadata;
 use MagicSunday\ImageMeta\Curate\Structured\SensorMetadata;
 use MagicSunday\ImageMeta\Curate\Structured\TechnicalMetadata;
 use MagicSunday\ImageMeta\MakerNotes\Apple\AppleMakerNotes;
+use MagicSunday\ImageMeta\MakerNotes\Apple\Support\QuickTimeLookup;
 use MagicSunday\ImageMeta\Model\Exif\ExifDocument;
 use MagicSunday\ImageMeta\Model\Exif\ValueConverters;
 use MagicSunday\ImageMeta\Model\Metadata;
@@ -183,6 +184,7 @@ final class ValueFactory
         $multiPicture    = $this->createMultiPicture($metadata);
         $exifDocument    = $metadata->exifDoc;
         $quickTimeMeta   = $metadata->quickTime;
+        $quickTimeLookup = new QuickTimeLookup($quickTimeMeta);
         $appleMakerNotes = $metadata->makerNotes?->apple();
 
         $interop = new Interop(
@@ -321,22 +323,16 @@ final class ValueFactory
         );
 
         $container = new Container(
-            format: $this->quickTimeString($quickTimeMeta, QuickTimeMeta::MAJOR_BRAND_KEY),
-            encoder: $this->quickTimeString(
-                $quickTimeMeta,
-                'com.apple.quicktime.encoder',
+            format: $quickTimeLookup->string(QuickTimeMeta::MAJOR_BRAND_KEY),
+            encoder: $quickTimeLookup->string('com.apple.quicktime.encoder',
                 'Encoder',
             ),
-            bitrate: $this->quickTimeInt($quickTimeMeta, 'AvgBitrate', 'Bitrate'),
-            videoCodec: $this->quickTimeString(
-                $quickTimeMeta,
-                QuickTimeMeta::COMPRESSOR_NAME_KEY,
+            bitrate: $quickTimeLookup->int('AvgBitrate', 'Bitrate'),
+            videoCodec: $quickTimeLookup->string(QuickTimeMeta::COMPRESSOR_NAME_KEY,
                 QuickTimeMeta::VIDEO_CODEC_KEY,
                 QuickTimeMeta::HANDLER_DESCRIPTION_KEY,
             ),
-            audioCodec: $this->quickTimeString(
-                $quickTimeMeta,
-                QuickTimeMeta::AUDIO_FORMAT_KEY,
+            audioCodec: $quickTimeLookup->string(QuickTimeMeta::AUDIO_FORMAT_KEY,
                 QuickTimeMeta::AUDIO_CODEC_KEY,
             ),
         );
@@ -349,29 +345,25 @@ final class ValueFactory
         );
 
         $video = new Video(
-            durationSec: $this->quickTimeFloat($quickTimeMeta, 'com.apple.quicktime.duration'),
-            frameRate: $this->quickTimeFloat($quickTimeMeta, 'com.apple.quicktime.videoFrameRate'),
-            width: $this->quickTimeInt($quickTimeMeta, QuickTimeMeta::VIDEO_WIDTH_KEY),
-            height: $this->quickTimeInt($quickTimeMeta, QuickTimeMeta::VIDEO_HEIGHT_KEY),
-            codec: $this->quickTimeString(
-                $quickTimeMeta,
-                QuickTimeMeta::COMPRESSOR_NAME_KEY,
+            durationSec: $quickTimeLookup->float('com.apple.quicktime.duration'),
+            frameRate: $quickTimeLookup->float('com.apple.quicktime.videoFrameRate'),
+            width: $quickTimeLookup->int(QuickTimeMeta::VIDEO_WIDTH_KEY),
+            height: $quickTimeLookup->int(QuickTimeMeta::VIDEO_HEIGHT_KEY),
+            codec: $quickTimeLookup->string(QuickTimeMeta::COMPRESSOR_NAME_KEY,
                 QuickTimeMeta::VIDEO_CODEC_KEY,
             ),
-            hdr: $this->quickTimeBool($quickTimeMeta, 'com.apple.quicktime.hdrFormat'),
-            transferFunction: $this->quickTimeString($quickTimeMeta, 'com.apple.quicktime.transferFunction'),
-            colorPrimaries: $this->quickTimeString($quickTimeMeta, 'com.apple.quicktime.colorPrimaries'),
+            hdr: $quickTimeLookup->bool('com.apple.quicktime.hdrFormat'),
+            transferFunction: $quickTimeLookup->string('com.apple.quicktime.transferFunction'),
+            colorPrimaries: $quickTimeLookup->string('com.apple.quicktime.colorPrimaries'),
         );
 
         $audio = new Audio(
-            channels: $this->quickTimeInt($quickTimeMeta, QuickTimeMeta::AUDIO_CHANNELS_KEY),
-            sampleRate: $this->quickTimeInt($quickTimeMeta, QuickTimeMeta::AUDIO_SAMPLE_RATE_KEY),
-            codec: $this->quickTimeString(
-                $quickTimeMeta,
-                QuickTimeMeta::AUDIO_FORMAT_KEY,
+            channels: $quickTimeLookup->int(QuickTimeMeta::AUDIO_CHANNELS_KEY),
+            sampleRate: $quickTimeLookup->int(QuickTimeMeta::AUDIO_SAMPLE_RATE_KEY),
+            codec: $quickTimeLookup->string(QuickTimeMeta::AUDIO_FORMAT_KEY,
                 QuickTimeMeta::AUDIO_CODEC_KEY,
             ),
-            bitDepth: $this->quickTimeInt($quickTimeMeta, QuickTimeMeta::AUDIO_BITS_PER_SAMPLE_KEY),
+            bitDepth: $quickTimeLookup->int(QuickTimeMeta::AUDIO_BITS_PER_SAMPLE_KEY),
         );
 
         $embeddedAudio = AudioClips::fromJpegAudioStreams($metadata->jpegAudioStreams);
@@ -460,7 +452,7 @@ final class ValueFactory
 
         $whiteBalanceKelvin = $apple->colorTemperature;
         if ($whiteBalanceKelvin === null) {
-            $whiteBalanceKelvin = $this->quickTimeInt($quickTimeMeta, 'ColorTemperature');
+            $whiteBalanceKelvin = $quickTimeLookup->int('ColorTemperature');
         }
 
         $whiteBalanceDetails = new WhiteBalanceDetails(
@@ -559,10 +551,10 @@ final class ValueFactory
         $panoramaFlag = $xmpDocument?->bool('http://ns.google.com/photos/1.0/panorama/', 'UsePanoramaViewer');
         $related      = new RelatedAssets(
             livePhotoPairId: $metadata->quickTime?->contentIdentifier(),
-            burstId: $this->quickTimeString($quickTimeMeta, 'BurstUUID'),
-            isPrimaryInBurst: $this->quickTimeBool($quickTimeMeta, 'BurstSelected'),
+            burstId: $quickTimeLookup->string('BurstUUID'),
+            isPrimaryInBurst: $quickTimeLookup->bool('BurstSelected'),
             panoramaId: $panoramaFlag === true ? 'panorama' : null,
-            depthDataId: $this->quickTimeString($quickTimeMeta, 'DepthData'),
+            depthDataId: $quickTimeLookup->string('DepthData'),
             relatedSoundFile: $exifDocument?->relatedSoundFile(),
         );
 
@@ -641,9 +633,10 @@ final class ValueFactory
             }
         }
 
+        $lookup = new QuickTimeLookup($quickTime);
+
         if ($software === null) {
-            $software = $this->quickTimeString(
-                $quickTime,
+            $software = $lookup->string(
                 'com.apple.quicktime.software',
                 'Software',
                 'com.apple.quicktime.softwareversion',
@@ -679,8 +672,9 @@ final class ValueFactory
         $xmpCreate       = $this->parseFlexibleDate($xmpDocument?->string('http://ns.adobe.com/xap/1.0/', 'CreateDate'));
         $xmpModify       = $this->parseFlexibleDate($xmpDocument?->string('http://ns.adobe.com/xap/1.0/', 'ModifyDate'));
         $xmpDateCreated  = $this->parseFlexibleDate($xmpDocument?->string('http://ns.adobe.com/photoshop/1.0/', 'DateCreated'));
-        $quickTimeCreate = $this->parseFlexibleDate($this->quickTimeString($quickTime, 'CreationDate'));
-        $quickTimeModify = $this->parseFlexibleDate($this->quickTimeString($quickTime, 'ModifyDate'));
+        $lookup = new QuickTimeLookup($quickTime);
+        $quickTimeCreate = $this->parseFlexibleDate($lookup->string('CreationDate'));
+        $quickTimeModify = $this->parseFlexibleDate($lookup->string('ModifyDate'));
 
         $create = $exifCreate ?? $xmpCreate ?? $quickTimeCreate ?? $xmpDateCreated;
         $modify = $exifModify ?? $xmpModify ?? $quickTimeModify;
@@ -935,11 +929,13 @@ final class ValueFactory
             $flags = [];
         }
 
+        $lookup = new QuickTimeLookup($quickTime);
+
         $hdr = $apple->hdrImageType;
         if ($hdr === null) {
-            $hdr = $this->quickTimeString($quickTime, 'HDRImageType');
+            $hdr = $lookup->string('HDRImageType');
         }
-        $night = $this->quickTimeBool($quickTime, 'NightMode');
+        $night = $lookup->bool('NightMode');
         if ($night === null) {
             $night = $this->appleFlag($flags, 'nightMode');
         }
@@ -1031,44 +1027,46 @@ final class ValueFactory
 
     private function buildUav(?ExifDocument $exif, ?QuickTimeMeta $quickTime): Uav
     {
+        $lookup = new QuickTimeLookup($quickTime);
+
         $manufacturer = $exif?->aircraftMake();
         if ($manufacturer === null) {
-            $manufacturer = $this->quickTimeString($quickTime, 'com.apple.quicktime.make');
+            $manufacturer = $lookup->string('com.apple.quicktime.make');
         }
 
         $model = $exif?->aircraftModel();
         if ($model === null) {
-            $model = $this->quickTimeString($quickTime, 'com.apple.quicktime.model');
+            $model = $lookup->string('com.apple.quicktime.model');
         }
 
         $flightYaw = $exif?->flightYawDeg();
         if ($flightYaw === null) {
-            $flightYaw = $this->quickTimeFloat($quickTime, 'com.apple.quicktime.flightYawDegree');
+            $flightYaw = $lookup->float('com.apple.quicktime.flightYawDegree');
         }
 
         $flightPitch = $exif?->flightPitchDeg();
         if ($flightPitch === null) {
-            $flightPitch = $this->quickTimeFloat($quickTime, 'com.apple.quicktime.flightPitchDegree');
+            $flightPitch = $lookup->float('com.apple.quicktime.flightPitchDegree');
         }
 
         $flightRoll = $exif?->flightRollDeg();
         if ($flightRoll === null) {
-            $flightRoll = $this->quickTimeFloat($quickTime, 'com.apple.quicktime.flightRollDegree');
+            $flightRoll = $lookup->float('com.apple.quicktime.flightRollDegree');
         }
 
         $gimbalYaw = $exif?->gimbalYawDeg();
         if ($gimbalYaw === null) {
-            $gimbalYaw = $this->quickTimeFloat($quickTime, 'com.apple.quicktime.gimbalYawDegree');
+            $gimbalYaw = $lookup->float('com.apple.quicktime.gimbalYawDegree');
         }
 
         $gimbalPitch = $exif?->gimbalPitchDeg();
         if ($gimbalPitch === null) {
-            $gimbalPitch = $this->quickTimeFloat($quickTime, 'com.apple.quicktime.gimbalPitchDegree');
+            $gimbalPitch = $lookup->float('com.apple.quicktime.gimbalPitchDegree');
         }
 
         $gimbalRoll = $exif?->gimbalRollDeg();
         if ($gimbalRoll === null) {
-            $gimbalRoll = $this->quickTimeFloat($quickTime, 'com.apple.quicktime.gimbalRollDegree');
+            $gimbalRoll = $lookup->float('com.apple.quicktime.gimbalRollDegree');
         }
 
         return new Uav(
@@ -1107,94 +1105,6 @@ final class ValueFactory
             flags: [],
             accelerationVector: null,
         );
-    }
-
-    /**
-     * Resolves the first non-empty QuickTime string value from the supplied keys.
-     *
-     * @param QuickTimeMeta|null $quickTime QuickTime metadata container used to read QuickTime keys.
-     * @param string             ...$keys   Candidate metadata keys to inspect in order.
-     *
-     * @return string|null First matching string value or null when no value is present.
-     */
-    private function quickTimeString(?QuickTimeMeta $quickTime, string ...$keys): ?string
-    {
-        if ($quickTime === null) {
-            return null;
-        }
-
-        foreach ($keys as $key) {
-            $value = $quickTime->stringValue($key);
-            if ($value !== null && $value !== '') {
-                return $value;
-            }
-        }
-
-        return null;
-    }
-
-    /**
-     * Resolves the first available QuickTime float value from the provided keys.
-     *
-     * @param QuickTimeMeta|null $quickTime QuickTime metadata container used to read QuickTime keys.
-     * @param string             ...$keys   Candidate metadata keys to inspect in order.
-     *
-     * @return float|null First matching float value or null when no value is present.
-     */
-    private function quickTimeFloat(?QuickTimeMeta $quickTime, string ...$keys): ?float
-    {
-        if ($quickTime === null) {
-            return null;
-        }
-
-        foreach ($keys as $key) {
-            $value = $quickTime->floatValue($key);
-            if ($value !== null) {
-                return $value;
-            }
-        }
-
-        return null;
-    }
-
-    private function quickTimeBool(?QuickTimeMeta $quickTime, string ...$keys): ?bool
-    {
-        if ($quickTime === null) {
-            return null;
-        }
-
-        foreach ($keys as $key) {
-            $value = $quickTime->boolValue($key);
-            if ($value !== null) {
-                return $value;
-            }
-        }
-
-        return null;
-    }
-
-    /**
-     * Resolves the first available QuickTime integer value from the provided keys.
-     *
-     * @param QuickTimeMeta|null $quickTime QuickTime metadata container used to read QuickTime keys.
-     * @param string             ...$keys   Candidate metadata keys to inspect in order.
-     *
-     * @return int|null First matching integer value or null when no value is present.
-     */
-    private function quickTimeInt(?QuickTimeMeta $quickTime, string ...$keys): ?int
-    {
-        if ($quickTime === null) {
-            return null;
-        }
-
-        foreach ($keys as $key) {
-            $value = $quickTime->intValue($key);
-            if ($value !== null) {
-                return $value;
-            }
-        }
-
-        return null;
     }
 
     /**

--- a/src/MakerNotes/Apple/AppleMakerNotesMapper.php
+++ b/src/MakerNotes/Apple/AppleMakerNotesMapper.php
@@ -12,16 +12,14 @@ declare(strict_types=1);
 namespace MagicSunday\ImageMeta\MakerNotes\Apple;
 
 use MagicSunday\ImageMeta\MakerNotes\AppleMetadata;
+use MagicSunday\ImageMeta\MakerNotes\Apple\Support\QuickTimeLookup;
+use MagicSunday\ImageMeta\MakerNotes\Apple\Support\SemanticStyle;
 use MagicSunday\ImageMeta\MakerNotes\MakerNotesMetadata;
 use MagicSunday\ImageMeta\Model\QuickTimeMeta;
 
-use function array_is_list;
 use function array_key_exists;
 use function get_object_vars;
 use function is_array;
-use function is_bool;
-use function is_float;
-use function is_int;
 use function is_numeric;
 use function is_string;
 use function preg_split;
@@ -46,6 +44,10 @@ final class AppleMakerNotesMapper
 
         $apple = $this->buildAppleMakerNotes($makerNotes?->apple(), $quickTime);
 
+        if (!$this->hasAppleData($apple)) {
+            return $makerNotes;
+        }
+
         if ($makerNotes instanceof MakerNotesMetadata) {
             return new MakerNotesMetadata(
                 $makerNotes->vendor(),
@@ -56,7 +58,7 @@ final class AppleMakerNotesMapper
             );
         }
 
-        if ($quickTime instanceof QuickTimeMeta && $this->hasAppleData($apple)) {
+        if ($quickTime instanceof QuickTimeMeta) {
             return new MakerNotesMetadata('Apple', 0, str_repeat('0', 40), $apple);
         }
 
@@ -70,61 +72,62 @@ final class AppleMakerNotesMapper
         ?AppleMakerNotes $makerNotes,
         ?QuickTimeMeta $quickTime,
     ): AppleMakerNotes {
+        $lookup = new QuickTimeLookup($quickTime);
         $contentIdentifier = $makerNotes?->contentIdentifier ?? $quickTime?->contentIdentifier();
 
         $cameraType = $makerNotes?->cameraType;
         if ($cameraType === null) {
-            $cameraType = $this->quickTimeString($quickTime, 'CameraType');
+            $cameraType = $lookup->string('CameraType');
         }
 
         $hdrHeadroom = $makerNotes?->hdrHeadroom;
         if ($hdrHeadroom === null) {
-            $hdrHeadroom = $this->quickTimeFloat($quickTime, 'HdrHeadroom', 'HDRHeadroom');
+            $hdrHeadroom = $lookup->float('HdrHeadroom', 'HDRHeadroom');
         }
 
         $hdrGain = $makerNotes?->hdrGain;
         if ($hdrGain === null) {
-            $hdrGain = $this->quickTimeFloatList($quickTime, 'HdrGain', 'HDRGain');
+            $hdrGain = $this->quickTimeFloatList($lookup, 'HdrGain', 'HDRGain');
         }
 
         $snr = $makerNotes?->snr;
         if ($snr === null) {
-            $snr = $this->quickTimeFloat($quickTime, 'SNRSetting', 'SNR');
+            $snr = $lookup->float('SNRSetting', 'SNR');
         }
 
         $focusPosition = $makerNotes?->focusPosition;
         if ($focusPosition === null) {
-            $focusPosition = $this->quickTimeFloat($quickTime, 'FocusPosition');
+            $focusPosition = $lookup->float('FocusPosition');
         }
 
         $livePhotoIndex = $makerNotes?->livePhotoIndex;
         if ($livePhotoIndex === null) {
-            $livePhotoIndex = $this->quickTimeInt($quickTime, 'LivePhotoVideoIndex', 'LivePhotoMovieIndex');
+            $livePhotoIndex = $lookup->int('LivePhotoVideoIndex', 'LivePhotoMovieIndex');
         }
 
         $livePhotoTime = $makerNotes?->livePhotoTime;
 
         $colorTemperature = $makerNotes?->colorTemperature;
         if ($colorTemperature === null) {
-            $colorTemperature = $this->quickTimeInt($quickTime, 'ColorTemperature');
+            $colorTemperature = $lookup->int('ColorTemperature');
         }
 
         $semanticPreset = $makerNotes?->semanticStylePreset;
         if ($semanticPreset === null) {
-            $semanticPreset = $this->quickTimeString($quickTime, 'SemanticStylePreset');
+            $semanticPreset = $lookup->string('SemanticStylePreset');
         }
 
         $semanticWarmth = $makerNotes?->semanticStyleWarmth;
         if ($semanticWarmth === null) {
-            $semanticWarmth = $this->quickTimeFloat($quickTime, 'SemanticStyleWarmth');
+            $semanticWarmth = $lookup->float('SemanticStyleWarmth');
         }
 
         $semanticTone = $makerNotes?->semanticStyleTone;
         if ($semanticTone === null) {
-            $semanticTone = $this->quickTimeFloat($quickTime, 'SemanticStyleTone');
+            $semanticTone = $lookup->float('SemanticStyleTone');
         }
 
-        $semanticStyleComposite = $this->quickTimeSemanticStyle($quickTime);
+        $semanticStyleComposite = SemanticStyle::fromQuickTime($quickTime);
         if ($semanticStyleComposite !== null) {
             [$compositePreset, $compositeWarmth, $compositeTone] = $semanticStyleComposite;
 
@@ -143,7 +146,7 @@ final class AppleMakerNotesMapper
 
         $accelerationVector = $makerNotes?->accelerationVector;
         if ($accelerationVector === null) {
-            $accelerationVector = $this->quickTimeFloatList($quickTime, 'AccelerationVector');
+            $accelerationVector = $this->quickTimeFloatList($lookup, 'AccelerationVector');
         }
 
         $flags = $makerNotes?->flags ?? [];
@@ -156,67 +159,67 @@ final class AppleMakerNotesMapper
 
         $imageCaptureRequestId = $makerNotes?->imageCaptureRequestId;
         if ($imageCaptureRequestId === null) {
-            $imageCaptureRequestId = $this->quickTimeString($quickTime, 'ImageCaptureRequestID');
+            $imageCaptureRequestId = $lookup->string('ImageCaptureRequestID');
         }
 
         $qualityHint = $makerNotes?->qualityHint;
         if ($qualityHint === null) {
-            $qualityHint = $this->quickTimeStringOrNumeric($quickTime, 'QualityHint');
+            $qualityHint = $this->quickTimeStringOrNumeric($lookup, 'QualityHint');
         }
 
         $colorCorrectionMatrix = $makerNotes?->colorCorrectionMatrix;
         if ($colorCorrectionMatrix === null) {
-            $colorCorrectionMatrix = $this->quickTimeFloatList($quickTime, 'ColorCorrectionMatrix');
+            $colorCorrectionMatrix = $this->quickTimeFloatList($lookup, 'ColorCorrectionMatrix');
         }
 
         $makerNoteVersion = $makerNotes?->makerNoteVersion;
         if ($makerNoteVersion === null) {
-            $makerNoteVersion = $this->quickTimeString($quickTime, 'MakerNoteVersion');
+            $makerNoteVersion = $lookup->string('MakerNoteVersion');
         }
 
         $hdrImageType = $this->normalizeEnumerated($makerNotes?->hdrImageType, AppleMetadata::HDR_IMAGE_TYPES);
         if ($hdrImageType === null) {
-            $hdrImageType = $this->quickTimeEnumerated($quickTime, AppleMetadata::HDR_IMAGE_TYPES, 'HDRImageType', 'HdrImageType');
+            $hdrImageType = $this->quickTimeEnumerated($lookup, AppleMetadata::HDR_IMAGE_TYPES, 'HDRImageType', 'HdrImageType');
         }
 
         $burstUuid = $makerNotes?->burstUuid;
         if ($burstUuid === null) {
-            $burstUuid = $this->quickTimeString($quickTime, 'BurstUUID');
+            $burstUuid = $lookup->string('BurstUUID');
         }
 
         $focusDistanceRange = $makerNotes?->focusDistanceRange;
         if ($focusDistanceRange === null) {
-            $focusDistanceRange = $this->quickTimeFocusDistanceRange($quickTime);
+            $focusDistanceRange = $this->quickTimeFocusDistanceRange($lookup);
         }
 
         $oisMode = $makerNotes?->oisMode;
         if ($oisMode === null) {
-            $oisMode = $this->quickTimeStringOrNumeric($quickTime, 'OISMode');
+            $oisMode = $this->quickTimeStringOrNumeric($lookup, 'OISMode');
         }
 
         $imageCaptureType = $this->normalizeEnumerated($makerNotes?->imageCaptureType, AppleMetadata::IMAGE_CAPTURE_TYPES);
         if ($imageCaptureType === null) {
-            $imageCaptureType = $this->quickTimeEnumerated($quickTime, AppleMetadata::IMAGE_CAPTURE_TYPES, 'ImageCaptureType');
+            $imageCaptureType = $this->quickTimeEnumerated($lookup, AppleMetadata::IMAGE_CAPTURE_TYPES, 'ImageCaptureType');
         }
 
         $imageUniqueId = $makerNotes?->imageUniqueId;
         if ($imageUniqueId === null) {
-            $imageUniqueId = $this->quickTimeString($quickTime, 'ImageUniqueID');
+            $imageUniqueId = $lookup->string('ImageUniqueID');
         }
 
         $photoIdentifier = $makerNotes?->photoIdentifier;
         if ($photoIdentifier === null) {
-            $photoIdentifier = $this->quickTimeString($quickTime, 'PhotoIdentifier');
+            $photoIdentifier = $lookup->string('PhotoIdentifier');
         }
 
         $afMeasuredDepth = $makerNotes?->afMeasuredDepth;
         if ($afMeasuredDepth === null) {
-            $afMeasuredDepth = $this->quickTimeFloat($quickTime, 'AFMeasuredDepth');
+            $afMeasuredDepth = $lookup->float('AFMeasuredDepth');
         }
 
         $afConfidence = $makerNotes?->afConfidence;
         if ($afConfidence === null) {
-            $afConfidence = $this->quickTimeFloat($quickTime, 'AFConfidence');
+            $afConfidence = $lookup->float('AFConfidence');
         }
 
         return new AppleMakerNotes(
@@ -288,65 +291,13 @@ final class AppleMakerNotesMapper
         return false;
     }
 
-    private function quickTimeString(?QuickTimeMeta $quickTime, string ...$keys): ?string
-    {
-        if ($quickTime === null) {
-            return null;
-        }
-
-        foreach ($keys as $key) {
-            $value = $quickTime->stringValue($key);
-            if ($value !== null && $value !== '') {
-                return $value;
-            }
-        }
-
-        return null;
-    }
-
-    private function quickTimeFloat(?QuickTimeMeta $quickTime, string ...$keys): ?float
-    {
-        if ($quickTime === null) {
-            return null;
-        }
-
-        foreach ($keys as $key) {
-            $value = $quickTime->floatValue($key);
-            if ($value !== null) {
-                return $value;
-            }
-        }
-
-        return null;
-    }
-
-    private function quickTimeInt(?QuickTimeMeta $quickTime, string ...$keys): ?int
-    {
-        if ($quickTime === null) {
-            return null;
-        }
-
-        foreach ($keys as $key) {
-            $value = $quickTime->intValue($key);
-            if ($value !== null) {
-                return $value;
-            }
-        }
-
-        return null;
-    }
-
     /**
      * @return list<float>|null
      */
-    private function quickTimeFloatList(?QuickTimeMeta $quickTime, string ...$keys): ?array
+    private function quickTimeFloatList(QuickTimeLookup $lookup, string ...$keys): ?array
     {
-        if ($quickTime === null) {
-            return null;
-        }
-
         foreach ($keys as $key) {
-            $raw = $this->quickTimeString($quickTime, $key);
+            $raw = $lookup->string($key);
             if ($raw === null) {
                 continue;
             }
@@ -378,15 +329,15 @@ final class AppleMakerNotesMapper
     /**
      * @return list<float>|null
      */
-    private function quickTimeFocusDistanceRange(?QuickTimeMeta $quickTime): ?array
+    private function quickTimeFocusDistanceRange(QuickTimeLookup $lookup): ?array
     {
-        $range = $this->quickTimeFloatList($quickTime, 'FocusDistanceRange');
+        $range = $this->quickTimeFloatList($lookup, 'FocusDistanceRange');
         if ($range !== null) {
             return $range;
         }
 
-        $near = $this->quickTimeFloat($quickTime, 'FocusDistanceRangeNear', 'FocusDistanceNear');
-        $far = $this->quickTimeFloat($quickTime, 'FocusDistanceRangeFar', 'FocusDistanceFar');
+        $near = $lookup->float('FocusDistanceRangeNear', 'FocusDistanceNear');
+        $far  = $lookup->float('FocusDistanceRangeFar', 'FocusDistanceFar');
 
         $values = [];
         if ($near !== null) {
@@ -400,24 +351,20 @@ final class AppleMakerNotesMapper
         return $values !== [] ? $values : null;
     }
 
-    private function quickTimeStringOrNumeric(?QuickTimeMeta $quickTime, string ...$keys): ?string
+    private function quickTimeStringOrNumeric(QuickTimeLookup $lookup, string ...$keys): ?string
     {
-        if ($quickTime === null) {
-            return null;
-        }
-
         foreach ($keys as $key) {
-            $value = $this->quickTimeString($quickTime, $key);
+            $value = $lookup->string($key);
             if ($value !== null) {
                 return $value;
             }
 
-            $intValue = $quickTime->intValue($key);
+            $intValue = $lookup->int($key);
             if ($intValue !== null) {
                 return (string) $intValue;
             }
 
-            $floatValue = $quickTime->floatValue($key);
+            $floatValue = $lookup->float($key);
             if ($floatValue !== null) {
                 return (string) $floatValue;
             }
@@ -452,14 +399,10 @@ final class AppleMakerNotesMapper
     /**
      * @param array<int, string> $map
      */
-    private function quickTimeEnumerated(?QuickTimeMeta $quickTime, array $map, string ...$keys): ?string
+    private function quickTimeEnumerated(QuickTimeLookup $lookup, array $map, string ...$keys): ?string
     {
-        if ($quickTime === null) {
-            return null;
-        }
-
         foreach ($keys as $key) {
-            $string = $this->quickTimeString($quickTime, $key);
+            $string = $lookup->string($key);
             if ($string !== null) {
                 if (is_numeric($string)) {
                     $code = (int) $string;
@@ -470,7 +413,7 @@ final class AppleMakerNotesMapper
                 return $string;
             }
 
-            $code = $quickTime->intValue($key);
+            $code = $lookup->int($key);
             if ($code !== null) {
                 return $map[$code] ?? (string) $code;
             }
@@ -482,123 +425,6 @@ final class AppleMakerNotesMapper
     /**
      * @return array{0:?string,1:?float,2:?float}|null
      */
-    private function quickTimeSemanticStyle(?QuickTimeMeta $meta = null): ?array
-    {
-        if ($meta === null) {
-            return null;
-        }
-
-        $value = $meta->keys['SemanticStyle'] ?? null;
-        if (!is_array($value)) {
-            return null;
-        }
-
-        $entries = $this->normaliseSemanticStyleEntries($value);
-        if ($entries === null) {
-            return null;
-        }
-
-        $presetRaw = $this->semanticStyleEntry($entries, 0);
-        $legacyWarmth = $this->semanticStyleEntry($entries, 1);
-        $modernWarmth = $legacyWarmth === null ? $this->semanticStyleEntry($entries, 2) : null;
-        $warmthRaw = $legacyWarmth ?? $modernWarmth;
-        $toneRawLegacy = $legacyWarmth !== null ? $this->semanticStyleEntry($entries, 2) : null;
-        $toneRawModern = $legacyWarmth === null ? $this->semanticStyleEntry($entries, 3, 2) : null;
-        $toneRaw = $toneRawLegacy ?? $toneRawModern;
-
-        $preset = $this->semanticStylePreset($presetRaw);
-        $warmth = $this->semanticStyleFloat($warmthRaw);
-        $tone = $this->semanticStyleFloat($toneRaw);
-
-        if ($preset === null && $warmth === null && $tone === null) {
-            return null;
-        }
-
-        return [$preset, $warmth, $tone];
-    }
-
-    /**
-     * @param array<int|string, mixed> $semantic
-     *
-     * @return array<int|string, string|int|float|bool|null>|null
-     */
-    private function normaliseSemanticStyleEntries(array $semantic): ?array
-    {
-        if (!array_is_list($semantic)) {
-            foreach (['values', 'Values'] as $key) {
-                if (array_key_exists($key, $semantic) && is_array($semantic[$key])) {
-                    return $this->normaliseSemanticStyleEntries($semantic[$key]);
-                }
-            }
-        }
-
-        return $semantic;
-    }
-
-    /**
-     * @param array<int|string, string|int|float|bool|null> $entries
-     */
-    private function semanticStyleEntry(array $entries, int ...$indexes): string|int|float|bool|null
-    {
-        foreach ($indexes as $index) {
-            $candidates = [$index, (string) $index, '_' . $index];
-            foreach ($candidates as $key) {
-                if (!array_key_exists($key, $entries)) {
-                    continue;
-                }
-
-                $value = $entries[$key];
-                if (is_array($value)) {
-                    foreach (['value', 'Value'] as $innerKey) {
-                        if (array_key_exists($innerKey, $value)) {
-                            $inner = $value[$innerKey];
-                            if (!is_array($inner)) {
-                                $value = $inner;
-                            }
-
-                            break;
-                        }
-                    }
-
-                    if (is_array($value)) {
-                        continue;
-                    }
-                }
-
-                if (is_string($value) || is_int($value) || is_float($value) || is_bool($value)) {
-                    return $value;
-                }
-            }
-        }
-
-        return null;
-    }
-
-    private function semanticStylePreset(string|int|float|bool|null $value): ?string
-    {
-        if (is_string($value)) {
-            $trimmed = trim($value);
-            if ($trimmed !== '') {
-                return $trimmed;
-            }
-        }
-
-        return null;
-    }
-
-    private function semanticStyleFloat(string|int|float|bool|null $value): ?float
-    {
-        if (is_float($value)) {
-            return $value;
-        }
-
-        if (is_int($value) || is_numeric($value)) {
-            return (float) $value;
-        }
-
-        return null;
-    }
-
     /**
      * @return array<string, bool>
      */

--- a/src/MakerNotes/Apple/Support/QuickTimeLookup.php
+++ b/src/MakerNotes/Apple/Support/QuickTimeLookup.php
@@ -1,0 +1,89 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\ImageMeta\MakerNotes\Apple\Support;
+
+use MagicSunday\ImageMeta\Model\QuickTimeMeta;
+
+
+/**
+ * Helper that resolves QuickTime metadata values with fallback support.
+ */
+final class QuickTimeLookup
+{
+    public function __construct(private readonly ?QuickTimeMeta $quickTime)
+    {
+    }
+
+    public function string(string ...$keys): ?string
+    {
+        if (!$this->quickTime instanceof QuickTimeMeta) {
+            return null;
+        }
+
+        foreach ($keys as $key) {
+            $value = $this->quickTime->stringValue($key);
+            if ($value !== null && $value !== '') {
+                return $value;
+            }
+        }
+
+        return null;
+    }
+
+    public function float(string ...$keys): ?float
+    {
+        if (!$this->quickTime instanceof QuickTimeMeta) {
+            return null;
+        }
+
+        foreach ($keys as $key) {
+            $value = $this->quickTime->floatValue($key);
+            if ($value !== null) {
+                return $value;
+            }
+        }
+
+        return null;
+    }
+
+    public function int(string ...$keys): ?int
+    {
+        if (!$this->quickTime instanceof QuickTimeMeta) {
+            return null;
+        }
+
+        foreach ($keys as $key) {
+            $value = $this->quickTime->intValue($key);
+            if ($value !== null) {
+                return $value;
+            }
+        }
+
+        return null;
+    }
+
+    public function bool(string ...$keys): ?bool
+    {
+        if (!$this->quickTime instanceof QuickTimeMeta) {
+            return null;
+        }
+
+        foreach ($keys as $key) {
+            $value = $this->quickTime->boolValue($key);
+            if ($value !== null) {
+                return $value;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/MakerNotes/Apple/Support/SemanticStyle.php
+++ b/src/MakerNotes/Apple/Support/SemanticStyle.php
@@ -1,0 +1,187 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\ImageMeta\MakerNotes\Apple\Support;
+
+use MagicSunday\ImageMeta\Model\QuickTimeMeta;
+
+use function array_is_list;
+use function array_key_exists;
+use function is_array;
+use function is_bool;
+use function is_float;
+use function is_int;
+use function is_numeric;
+use function is_string;
+use function trim;
+
+/**
+ * Normalises Apple semantic style payloads into preset, warmth and tone tuples.
+ */
+final class SemanticStyle
+{
+    /**
+     * Extracts semantic style values from QuickTime metadata payloads.
+     *
+     * @return array{0:?string,1:?float,2:?float}|null
+     */
+    public static function fromQuickTime(?QuickTimeMeta $quickTime): ?array
+    {
+        if (!$quickTime instanceof QuickTimeMeta) {
+            return null;
+        }
+
+        $value = $quickTime->keys['SemanticStyle'] ?? null;
+
+        return self::fromValue($value);
+    }
+
+    /**
+     * Extracts semantic style values from a dictionary containing a `SemanticStyle` entry.
+     *
+     * @param array<int|string, mixed> $dictionary
+     *
+     * @return array{0:?string,1:?float,2:?float}|null
+     */
+    public static function fromDictionary(array $dictionary): ?array
+    {
+        if (!array_key_exists('SemanticStyle', $dictionary)) {
+            return null;
+        }
+
+        return self::fromValue($dictionary['SemanticStyle']);
+    }
+
+    /**
+     * Normalises the supplied semantic style collection when possible.
+     *
+     * @param mixed $value
+     *
+     * @return array{0:?string,1:?float,2:?float}|null
+     */
+    public static function fromValue(mixed $value): ?array
+    {
+        if (!is_array($value)) {
+            return null;
+        }
+
+        /** @var array<int|string, mixed> $semantic */
+        $semantic = $value;
+
+        $entries = self::normaliseEntries($semantic);
+        if ($entries === null) {
+            return null;
+        }
+
+        $presetRaw     = self::entry($entries, 0);
+        $legacyWarmth  = self::entry($entries, 1);
+        $modernWarmth  = $legacyWarmth === null ? self::entry($entries, 2) : null;
+        $warmthRaw     = $legacyWarmth ?? $modernWarmth;
+        $toneRawLegacy = $legacyWarmth !== null ? self::entry($entries, 2) : null;
+        $toneRawModern = $legacyWarmth === null ? self::entry($entries, 3, 2) : null;
+        $toneRaw       = $toneRawLegacy ?? $toneRawModern;
+
+        $preset = self::preset($presetRaw);
+        $warmth = self::float($warmthRaw);
+        $tone   = self::float($toneRaw);
+
+        if ($preset === null && $warmth === null && $tone === null) {
+            return null;
+        }
+
+        return [$preset, $warmth, $tone];
+    }
+
+    /**
+     * @param array<int|string, mixed> $semantic
+     *
+     * @return array<int|string, string|int|float|bool|null>|null
+     */
+    private static function normaliseEntries(array $semantic): ?array
+    {
+        if (!array_is_list($semantic)) {
+            foreach (['values', 'Values'] as $key) {
+                if (array_key_exists($key, $semantic) && is_array($semantic[$key])) {
+                    /** @var array<int|string, mixed> $values */
+                    $values = $semantic[$key];
+
+                    return self::normaliseEntries($values);
+                }
+            }
+        }
+
+        return $semantic;
+    }
+
+    /**
+     * @param array<int|string, string|int|float|bool|null> $entries
+     */
+    private static function entry(array $entries, int ...$indexes): string|int|float|bool|null
+    {
+        foreach ($indexes as $index) {
+            $candidates = [$index, (string) $index, '_' . $index];
+            foreach ($candidates as $key) {
+                if (!array_key_exists($key, $entries)) {
+                    continue;
+                }
+
+                $value = $entries[$key];
+                if (is_array($value)) {
+                    foreach (['value', 'Value'] as $innerKey) {
+                        if (array_key_exists($innerKey, $value)) {
+                            $inner = $value[$innerKey];
+                            if (!is_array($inner)) {
+                                $value = $inner;
+                            }
+
+                            break;
+                        }
+                    }
+
+                    if (is_array($value)) {
+                        continue;
+                    }
+                }
+
+                if (is_string($value) || is_int($value) || is_float($value) || is_bool($value)) {
+                    return $value;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private static function preset(string|int|float|bool|null $value): ?string
+    {
+        if (is_string($value)) {
+            $trimmed = trim($value);
+            if ($trimmed !== '') {
+                return $trimmed;
+            }
+        }
+
+        return null;
+    }
+
+    private static function float(string|int|float|bool|null $value): ?float
+    {
+        if (is_float($value)) {
+            return $value;
+        }
+
+        if (is_int($value) || is_numeric($value)) {
+            return (float) $value;
+        }
+
+        return null;
+    }
+}

--- a/src/MakerNotes/AppleDecoder.php
+++ b/src/MakerNotes/AppleDecoder.php
@@ -13,6 +13,8 @@ namespace MagicSunday\ImageMeta\MakerNotes;
 
 use MagicSunday\ImageMeta\Core\ParseError;
 use MagicSunday\ImageMeta\MakerNotes\Apple\AppleMakerNotes;
+use MagicSunday\ImageMeta\MakerNotes\Apple\AppleMakerNotesMapper;
+use MagicSunday\ImageMeta\MakerNotes\Apple\Support\SemanticStyle;
 use MagicSunday\ImageMeta\MakerNotes\AppleMetadata;
 use MagicSunday\ImageMeta\MakerNotes\Apple\BinaryPlistDecoder;
 use MagicSunday\ImageMeta\MakerNotes\Apple\KeyedArchiveUnarchiver;
@@ -99,13 +101,14 @@ final class AppleDecoder implements MakerNotesDecoderInterface
     public function decode(string $raw, string $make, ?string $model): MakerNotesMetadata
     {
         $appleData = $this->parseAppleData($raw);
-
-        return new MakerNotesMetadata(
+        $metadata  = new MakerNotesMetadata(
             'Apple',
             strlen($raw),
             sha1($raw),
             $appleData
         );
+
+        return (new AppleMakerNotesMapper())->map($metadata, null) ?? $metadata;
     }
 
     /**
@@ -589,7 +592,7 @@ final class AppleDecoder implements MakerNotesDecoderInterface
             && !array_key_exists('SemanticStyleWarmth', $dictionary)
             && !array_key_exists('SemanticStyleTone', $dictionary)
         ) {
-            $semanticStyleCompact = $this->semanticStyleFromCollection($dictionary);
+            $semanticStyleCompact = SemanticStyle::fromDictionary($dictionary);
             if ($semanticStyleCompact !== null) {
                 [$compactPreset, $compactWarmth, $compactTone] = $semanticStyleCompact;
 
@@ -638,7 +641,7 @@ final class AppleDecoder implements MakerNotesDecoderInterface
         $semanticStylePreset  = $this->stringValue($dictionary, 'SemanticStylePreset');
         $semanticStyleWarmth  = $this->floatValue($dictionary, 'SemanticStyleWarmth');
         $semanticStyleTone    = $this->floatValue($dictionary, 'SemanticStyleTone');
-        $semanticStyleCompact ??= $this->semanticStyleFromCollection($dictionary);
+        $semanticStyleCompact ??= SemanticStyle::fromDictionary($dictionary);
         if ($semanticStyleCompact !== null) {
             [$compactPreset, $compactWarmth, $compactTone] = $semanticStyleCompact;
 
@@ -1397,129 +1400,6 @@ final class AppleDecoder implements MakerNotesDecoderInterface
      *
      * @return array{0:?string,1:?float,2:?float}|null
      */
-    private function semanticStyleFromCollection(array $dictionary): ?array
-    {
-        if (!array_key_exists('SemanticStyle', $dictionary)) {
-            return null;
-        }
-
-        $value = $dictionary['SemanticStyle'];
-        if (!is_array($value)) {
-            return null;
-        }
-
-        /** @var array<int|string, mixed> $semantic */
-        $semantic = $value;
-
-        $entries = $this->semanticStyleEntries($semantic);
-        if ($entries === null) {
-            return null;
-        }
-
-        $presetRaw      = $this->semanticStyleEntry($entries, 0);
-        $legacyWarmth   = $this->semanticStyleEntry($entries, 1);
-        $modernWarmth   = $legacyWarmth === null ? $this->semanticStyleEntry($entries, 2) : null;
-        $warmthRaw      = $legacyWarmth ?? $modernWarmth;
-        $toneRawLegacy  = $legacyWarmth !== null ? $this->semanticStyleEntry($entries, 2) : null;
-        $toneRawModern  = $legacyWarmth === null ? $this->semanticStyleEntry($entries, 3, 2) : null;
-        $toneRaw        = $toneRawLegacy ?? $toneRawModern;
-
-        $preset = $this->semanticStylePreset($presetRaw);
-        $warmth = $this->semanticStyleFloat($warmthRaw);
-        $tone   = $this->semanticStyleFloat($toneRaw);
-
-        if ($preset === null && $warmth === null && $tone === null) {
-            return null;
-        }
-
-        return [$preset, $warmth, $tone];
-    }
-
-    /**
-     * @param array<int|string, mixed> $semantic
-     *
-     * @return array<int|string, string|int|float|bool|null>|null
-     */
-    private function semanticStyleEntries(array $semantic): ?array
-    {
-        if (!array_is_list($semantic)) {
-            foreach (['values', 'Values'] as $key) {
-                if (array_key_exists($key, $semantic) && is_array($semantic[$key])) {
-                    /** @var array<int|string, mixed> $values */
-                    $values = $semantic[$key];
-
-                    return $this->semanticStyleEntries($values);
-                }
-            }
-        }
-
-        return $semantic;
-    }
-
-    /**
-     * @param array<int|string, string|int|float|bool|null> $entries
-     */
-    private function semanticStyleEntry(array $entries, int ...$indexes): string|int|float|bool|null
-    {
-        foreach ($indexes as $index) {
-            $candidates = [$index, (string) $index, '_' . $index];
-            foreach ($candidates as $key) {
-                if (!array_key_exists($key, $entries)) {
-                    continue;
-                }
-
-                $value = $entries[$key];
-                if (is_array($value)) {
-                    foreach (['value', 'Value'] as $innerKey) {
-                        if (array_key_exists($innerKey, $value)) {
-                            $inner = $value[$innerKey];
-                            if (!is_array($inner)) {
-                                $value = $inner;
-                            }
-
-                            break;
-                        }
-                    }
-
-                    if (is_array($value)) {
-                        continue;
-                    }
-                }
-
-                if (is_string($value) || is_int($value) || is_float($value) || is_bool($value)) {
-                    return $value;
-                }
-            }
-        }
-
-        return null;
-    }
-
-    private function semanticStylePreset(string|int|float|bool|null $value): ?string
-    {
-        if (is_string($value)) {
-            $trimmed = trim($value);
-            if ($trimmed !== '') {
-                return $trimmed;
-            }
-        }
-
-        return null;
-    }
-
-    private function semanticStyleFloat(string|int|float|bool|null $value): ?float
-    {
-        if (is_float($value)) {
-            return $value;
-        }
-
-        if (is_int($value) || is_numeric($value)) {
-            return (float) $value;
-        }
-
-        return null;
-    }
-
     /**
      * @param array<int|string, array<int|string, mixed>|bool|float|int|string|null> $dictionary
      *

--- a/tests/MakerNotes/Apple/Support/QuickTimeLookupTest.php
+++ b/tests/MakerNotes/Apple/Support/QuickTimeLookupTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MagicSunday\ImageMeta\Tests\MakerNotes\Apple\Support;
+
+use MagicSunday\ImageMeta\MakerNotes\Apple\Support\QuickTimeLookup;
+use MagicSunday\ImageMeta\Model\QuickTimeMeta;
+use PHPUnit\Framework\TestCase;
+
+final class QuickTimeLookupTest extends TestCase
+{
+    public function testStringReturnsFirstNonEmptyCandidate(): void
+    {
+        $meta = new QuickTimeMeta([
+            'Primary' => '',
+            'Secondary' => '  value  ',
+        ]);
+
+        $lookup = new QuickTimeLookup($meta);
+
+        self::assertSame('value', $lookup->string('Primary', 'Secondary'));
+    }
+
+    public function testFloatFallsBackToNumericString(): void
+    {
+        $meta = new QuickTimeMeta([
+            'First' => 'not-a-number',
+            'Second' => '42.5',
+        ]);
+
+        $lookup = new QuickTimeLookup($meta);
+
+        self::assertSame(42.5, $lookup->float('First', 'Second'));
+    }
+
+    public function testIntReturnsNullWhenMissing(): void
+    {
+        $lookup = new QuickTimeLookup(null);
+
+        self::assertNull($lookup->int('Missing'));
+    }
+
+    public function testBoolReturnsFirstResolvableValue(): void
+    {
+        $meta = new QuickTimeMeta([
+            'Primary' => 'false',
+            'Secondary' => true,
+        ]);
+
+        $lookup = new QuickTimeLookup($meta);
+
+        self::assertFalse($lookup->bool('Primary'));
+        self::assertTrue($lookup->bool('Unknown', 'Secondary'));
+    }
+}

--- a/tests/MakerNotes/Apple/Support/SemanticStyleTest.php
+++ b/tests/MakerNotes/Apple/Support/SemanticStyleTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MagicSunday\ImageMeta\Tests\MakerNotes\Apple\Support;
+
+use MagicSunday\ImageMeta\MakerNotes\Apple\Support\SemanticStyle;
+use MagicSunday\ImageMeta\Model\QuickTimeMeta;
+use PHPUnit\Framework\TestCase;
+
+final class SemanticStyleTest extends TestCase
+{
+    public function testFromQuickTimeParsesModernStructure(): void
+    {
+        $meta = new QuickTimeMeta([
+            'SemanticStyle' => [
+                '_0' => 'Vivid',
+                '_2' => 0.15,
+                '_3' => ['value' => '0.25'],
+            ],
+        ]);
+
+        self::assertSame(['Vivid', 0.15, 0.25], SemanticStyle::fromQuickTime($meta));
+    }
+
+    public function testFromDictionaryParsesLegacyStructure(): void
+    {
+        $dictionary = [
+            'SemanticStyle' => [
+                'values' => [
+                    0 => 'Warm',
+                    1 => ['value' => 0.5],
+                    2 => ['Value' => '0.75'],
+                ],
+            ],
+        ];
+
+        self::assertSame(['Warm', 0.5, 0.75], SemanticStyle::fromDictionary($dictionary));
+    }
+
+    public function testFromValueReturnsNullWhenNoComponents(): void
+    {
+        self::assertNull(SemanticStyle::fromValue(['values' => []]));
+    }
+}


### PR DESCRIPTION
## Summary
- add a QuickTimeLookup support helper and cover the lookup contract with unit tests
- extract semantic style parsing into a reusable support class shared by the decoder and mapper
- update the Apple decoder, mapper and EXIF value factory to consume the new helpers

## Testing
- composer ci:test:php:unit
- composer ci:test:php:phpstan *(fails: existing issues reported by analyzer)*

------
https://chatgpt.com/codex/tasks/task_e_68ff9e74d9f083239dc740b0f2b22eab