### PR TITLE
refactor: rename maker notes metadata classes

### DIFF
--- a/src/Curate/Exif/ValueFactory.php
+++ b/src/Curate/Exif/ValueFactory.php
@@ -20,7 +20,7 @@ use MagicSunday\ImageMeta\Curate\Structured\ExposureMetadata;
 use MagicSunday\ImageMeta\Curate\Structured\FileMetadata;
 use MagicSunday\ImageMeta\Curate\Structured\GpsMetadata;
 use MagicSunday\ImageMeta\Curate\Structured\LensMetadata;
-use MagicSunday\ImageMeta\Curate\Structured\MakerNotesMetadata;
+use MagicSunday\ImageMeta\Curate\Structured\MakerNotesView;
 use MagicSunday\ImageMeta\Curate\Structured\MediaMetadata;
 use MagicSunday\ImageMeta\Curate\Structured\ProcessingMetadata;
 use MagicSunday\ImageMeta\Curate\Structured\RightsMetadata;
@@ -609,7 +609,7 @@ final class ValueFactory
             'processing' => new ProcessingMetadata($processing, $whiteBalanceDetails),
             'technical'  => new TechnicalMetadata($interop, $tiff, $standards, $flashPix, $xmp),
             'rights'     => new RightsMetadata($rights, $author, $related),
-            'makerNotes' => new MakerNotesMetadata($apple),
+            'makerNotes' => new MakerNotesView($apple),
         ];
     }
 

--- a/src/Curate/Structured/MakerNotesView.php
+++ b/src/Curate/Structured/MakerNotesView.php
@@ -14,9 +14,9 @@ namespace MagicSunday\ImageMeta\Curate\Structured;
 use MagicSunday\ImageMeta\MakerNotes\Apple\AppleMakerNotes;
 
 /**
- * Exposes maker note details grouped by vendor.
+ * Exposes curated maker note details grouped by vendor.
  */
-final readonly class MakerNotesMetadata
+final readonly class MakerNotesView
 {
     public function __construct(
         public ?AppleMakerNotes $apple,

--- a/src/Curate/StructuredMetadata.php
+++ b/src/Curate/StructuredMetadata.php
@@ -17,7 +17,7 @@ use MagicSunday\ImageMeta\Curate\Structured\ExposureMetadata;
 use MagicSunday\ImageMeta\Curate\Structured\FileMetadata;
 use MagicSunday\ImageMeta\Curate\Structured\GpsMetadata;
 use MagicSunday\ImageMeta\Curate\Structured\LensMetadata;
-use MagicSunday\ImageMeta\Curate\Structured\MakerNotesMetadata;
+use MagicSunday\ImageMeta\Curate\Structured\MakerNotesView;
 use MagicSunday\ImageMeta\Curate\Structured\MediaMetadata;
 use MagicSunday\ImageMeta\Curate\Structured\ProcessingMetadata;
 use MagicSunday\ImageMeta\Curate\Structured\RightsMetadata;
@@ -41,7 +41,7 @@ final readonly class StructuredMetadata
         public ProcessingMetadata $processing,
         public TechnicalMetadata $technical,
         public RightsMetadata $rights,
-        public MakerNotesMetadata $makerNotes,
+        public MakerNotesView $makerNotes,
     ) {
     }
 }

--- a/src/MakerNotes/Apple/AppleMakerNotesMapper.php
+++ b/src/MakerNotes/Apple/AppleMakerNotesMapper.php
@@ -14,7 +14,7 @@ namespace MagicSunday\ImageMeta\MakerNotes\Apple;
 use MagicSunday\ImageMeta\MakerNotes\AppleMetadata;
 use MagicSunday\ImageMeta\MakerNotes\Apple\Support\QuickTimeLookup;
 use MagicSunday\ImageMeta\MakerNotes\Apple\Support\SemanticStyle;
-use MagicSunday\ImageMeta\MakerNotes\MakerNotesMetadata;
+use MagicSunday\ImageMeta\MakerNotes\MakerNotesRecord;
 use MagicSunday\ImageMeta\Model\QuickTimeMeta;
 
 use function array_key_exists;
@@ -35,10 +35,10 @@ final class AppleMakerNotesMapper
      * Merges decoded Apple maker notes with QuickTime metadata fallbacks.
      */
     public function map(
-        ?MakerNotesMetadata $makerNotes,
+        ?MakerNotesRecord $makerNotes,
         ?QuickTimeMeta $quickTime,
-    ): ?MakerNotesMetadata {
-        if ($makerNotes instanceof MakerNotesMetadata && $makerNotes->vendor() !== 'Apple') {
+    ): ?MakerNotesRecord {
+        if ($makerNotes instanceof MakerNotesRecord && $makerNotes->vendor() !== 'Apple') {
             return $makerNotes;
         }
 
@@ -48,8 +48,8 @@ final class AppleMakerNotesMapper
             return $makerNotes;
         }
 
-        if ($makerNotes instanceof MakerNotesMetadata) {
-            return new MakerNotesMetadata(
+        if ($makerNotes instanceof MakerNotesRecord) {
+            return new MakerNotesRecord(
                 $makerNotes->vendor(),
                 $makerNotes->length(),
                 $makerNotes->sha1(),
@@ -59,7 +59,7 @@ final class AppleMakerNotesMapper
         }
 
         if ($quickTime instanceof QuickTimeMeta) {
-            return new MakerNotesMetadata('Apple', 0, str_repeat('0', 40), $apple);
+            return new MakerNotesRecord('Apple', 0, str_repeat('0', 40), $apple);
         }
 
         return $makerNotes;

--- a/src/MakerNotes/AppleDecoder.php
+++ b/src/MakerNotes/AppleDecoder.php
@@ -98,10 +98,10 @@ final class AppleDecoder implements MakerNotesDecoderInterface
      * @param string      $make  Reported camera make string.
      * @param string|null $model Optional camera model identifier.
      */
-    public function decode(string $raw, string $make, ?string $model): MakerNotesMetadata
+    public function decode(string $raw, string $make, ?string $model): MakerNotesRecord
     {
         $appleData = $this->parseAppleData($raw);
-        $metadata  = new MakerNotesMetadata(
+        $metadata  = new MakerNotesRecord(
             'Apple',
             strlen($raw),
             sha1($raw),

--- a/src/MakerNotes/CanonDecoder.php
+++ b/src/MakerNotes/CanonDecoder.php
@@ -26,9 +26,9 @@ final class CanonDecoder implements MakerNotesDecoderInterface
      * @param string      $make  Reported camera make string.
      * @param string|null $model Optional camera model identifier for the payload.
      */
-    public function decode(string $raw, string $make, ?string $model): MakerNotesMetadata
+    public function decode(string $raw, string $make, ?string $model): MakerNotesRecord
     {
-        return new MakerNotesMetadata(
+        return new MakerNotesRecord(
             'Canon',
             strlen($raw),
             sha1($raw)

--- a/src/MakerNotes/MakerNotesDecoderInterface.php
+++ b/src/MakerNotes/MakerNotesDecoderInterface.php
@@ -23,7 +23,7 @@ interface MakerNotesDecoderInterface
      * @param string      $make  Camera make identifier associated with the payload.
      * @param string|null $model Optional camera model identifier when available.
      *
-     * @return MakerNotesMetadata Normalised metadata describing the payload.
+     * @return MakerNotesRecord Normalised metadata describing the payload.
      */
-    public function decode(string $raw, string $make, ?string $model): MakerNotesMetadata;
+    public function decode(string $raw, string $make, ?string $model): MakerNotesRecord;
 }

--- a/src/MakerNotes/MakerNotesRecord.php
+++ b/src/MakerNotes/MakerNotesRecord.php
@@ -17,9 +17,9 @@ use MagicSunday\ImageMeta\MakerNotes\Apple\AppleMakerNotes;
 use function preg_match;
 
 /**
- * Immutable value object that describes normalised maker note metadata.
+ * Immutable value object that describes a normalised maker note payload.
  */
-final readonly class MakerNotesMetadata
+final readonly class MakerNotesRecord
 {
     /**
      * @param string               $vendor Vendor responsible for the maker note payload. Must not be empty.

--- a/src/MakerNotes/NikonDecoder.php
+++ b/src/MakerNotes/NikonDecoder.php
@@ -26,9 +26,9 @@ final class NikonDecoder implements MakerNotesDecoderInterface
      * @param string      $make  Reported camera make string.
      * @param string|null $model Optional camera model identifier for the payload.
      */
-    public function decode(string $raw, string $make, ?string $model): MakerNotesMetadata
+    public function decode(string $raw, string $make, ?string $model): MakerNotesRecord
     {
-        return new MakerNotesMetadata(
+        return new MakerNotesRecord(
             'Nikon',
             strlen($raw),
             sha1($raw)

--- a/src/MakerNotes/SonyDecoder.php
+++ b/src/MakerNotes/SonyDecoder.php
@@ -26,9 +26,9 @@ final class SonyDecoder implements MakerNotesDecoderInterface
      * @param string      $make  Reported camera make string.
      * @param string|null $model Optional camera model identifier for the payload.
      */
-    public function decode(string $raw, string $make, ?string $model): MakerNotesMetadata
+    public function decode(string $raw, string $make, ?string $model): MakerNotesRecord
     {
-        return new MakerNotesMetadata(
+        return new MakerNotesRecord(
             'Sony',
             strlen($raw),
             sha1($raw)

--- a/src/Model/Exif/ExifDocument.php
+++ b/src/Model/Exif/ExifDocument.php
@@ -16,7 +16,7 @@ use DateTimeZone;
 use Exception;
 use MagicSunday\ImageMeta\Core\ExifCapabilities;
 use MagicSunday\ImageMeta\Core\Util\UInt64;
-use MagicSunday\ImageMeta\MakerNotes\MakerNotesMetadata;
+use MagicSunday\ImageMeta\MakerNotes\MakerNotesRecord;
 use MagicSunday\ImageMeta\Value\Enum\CfaPatternColor;
 use MagicSunday\ImageMeta\Value\Enum\Compression;
 use MagicSunday\ImageMeta\Value\Enum\ExposureMode;
@@ -87,7 +87,7 @@ final readonly class ExifDocument
      * @param Ifd|null                $gpsIfd         Sub IFD containing GPS-related tags.
      * @param Ifd|null                $interopIfd     Sub IFD containing interoperability tags.
      * @param Ifd|null                $ifd1           Optional next IFD, typically thumbnails.
-     * @param MakerNotesMetadata|null $makerNotes     Decoded maker note metadata provided by vendor decoders.
+     * @param MakerNotesRecord|null $makerNotes     Decoded maker note metadata provided by vendor decoders.
      * @param list<Ifd>               $subsequentIfds Additional linked IFDs discovered via the next-pointer chain.
      * @param array<int, Ifd>         $subIfds        Parsed SubIFDs indexed by their file offsets.
      */
@@ -97,7 +97,7 @@ final readonly class ExifDocument
         public ?Ifd $gpsIfd,
         public ?Ifd $interopIfd,
         public ?Ifd $ifd1,
-        public ?MakerNotesMetadata $makerNotes = null,
+        public ?MakerNotesRecord $makerNotes = null,
         public array $subsequentIfds = [],
         public array $subIfds = [],
     ) {
@@ -116,7 +116,7 @@ final readonly class ExifDocument
     /**
      * Returns the decoded maker note metadata when a decoder is available.
      */
-    public function makerNotes(): ?MakerNotesMetadata
+    public function makerNotes(): ?MakerNotesRecord
     {
         return $this->makerNotes;
     }

--- a/src/Model/Metadata.php
+++ b/src/Model/Metadata.php
@@ -13,7 +13,7 @@ namespace MagicSunday\ImageMeta\Model;
 
 use MagicSunday\ImageMeta\Curate\StructuredMetadata;
 use MagicSunday\ImageMeta\Curate\ExifAssembler;
-use MagicSunday\ImageMeta\MakerNotes\MakerNotesMetadata;
+use MagicSunday\ImageMeta\MakerNotes\MakerNotesRecord;
 use MagicSunday\ImageMeta\Model\Exif\ExifDocument;
 use MagicSunday\ImageMeta\Model\Jpeg\JpegAudioStream;
 use MagicSunday\ImageMeta\Model\Mpf\MpfDocument;
@@ -41,7 +41,7 @@ final class Metadata
 
     public readonly ?XmpDocument $xmpDoc;
 
-    public readonly ?MakerNotesMetadata $makerNotes;
+    public readonly ?MakerNotesRecord $makerNotes;
 
     public readonly ?string $iccProfile;
 
@@ -92,7 +92,7 @@ final class Metadata
      * @param ExifDocument|null                                    $exifDoc                  Parsed representation of the primary EXIF document.
      * @param list<string>                                         $xmpBlobs                 XMP packets (RDF/XML), first is primary
      * @param XmpDocument|null                                     $xmpDoc                   Parsed representation of the primary XMP packet.
-     * @param MakerNotesMetadata|null                              $makerNotes               Decoded maker notes metadata for the primary EXIF blob.
+     * @param MakerNotesRecord|null                              $makerNotes               Decoded maker notes metadata for the primary EXIF blob.
      * @param string|null                                          $iccProfile               Binary ICC profile when available.
      * @param list<string>                                         $iccSegments              Raw ICC APP2 segments in encounter order.
      * @param array<int, string>                                   $flashPixStreams          Concatenated FlashPix extension streams keyed by identifier.
@@ -116,7 +116,7 @@ final class Metadata
         ?ExifDocument $exifDoc = null,
         array $xmpBlobs = [],
         ?XmpDocument $xmpDoc = null,
-        ?MakerNotesMetadata $makerNotes = null,
+        ?MakerNotesRecord $makerNotes = null,
         ?string $iccProfile = null,
         array $iccSegments = [],
         array $flashPixStreams = [],

--- a/src/Parse/Tiff/TiffExifReader.php
+++ b/src/Parse/Tiff/TiffExifReader.php
@@ -18,7 +18,7 @@ use MagicSunday\ImageMeta\Core\ParseError;
 use MagicSunday\ImageMeta\Core\Util\UInt64;
 use MagicSunday\ImageMeta\Core\Util\Unpack;
 use MagicSunday\ImageMeta\MakerNotes\MakerNotesDecoderInterface;
-use MagicSunday\ImageMeta\MakerNotes\MakerNotesMetadata;
+use MagicSunday\ImageMeta\MakerNotes\MakerNotesRecord;
 use MagicSunday\ImageMeta\MakerNotes\Registry;
 use MagicSunday\ImageMeta\Model\Exif\ExifDocument;
 use MagicSunday\ImageMeta\Model\Exif\ExifNumericList;
@@ -1041,7 +1041,7 @@ final class TiffExifReader
     /**
      * Resolves maker note metadata using the provided registry when available.
      */
-    private function resolveMakerNotes(?Registry $registry, Ifd $ifd0, ?Ifd $exifIfd): ?MakerNotesMetadata
+    private function resolveMakerNotes(?Registry $registry, Ifd $ifd0, ?Ifd $exifIfd): ?MakerNotesRecord
     {
         if ($this->makerNoteRaw === null) {
             return null;
@@ -1073,23 +1073,23 @@ final class TiffExifReader
     /**
      * Creates a digest metadata instance for unknown maker notes.
      */
-    private function makerNotesDigest(?bool $isSafe): MakerNotesMetadata
+    private function makerNotesDigest(?bool $isSafe): MakerNotesRecord
     {
         $raw = $this->makerNoteRaw ?? '';
 
-        return new MakerNotesMetadata('Unknown', strlen($raw), sha1($raw), null, $isSafe);
+        return new MakerNotesRecord('Unknown', strlen($raw), sha1($raw), null, $isSafe);
     }
 
     /**
      * Applies the maker note safety flag to the provided metadata instance.
      */
-    private function applyMakerNoteSafety(MakerNotesMetadata $metadata, ?bool $isSafe): MakerNotesMetadata
+    private function applyMakerNoteSafety(MakerNotesRecord $metadata, ?bool $isSafe): MakerNotesRecord
     {
         if ($metadata->isSafe() === $isSafe) {
             return $metadata;
         }
 
-        return new MakerNotesMetadata(
+        return new MakerNotesRecord(
             $metadata->vendor(),
             $metadata->length(),
             $metadata->sha1(),

--- a/tests/Curate/ExifAssemblerTest.php
+++ b/tests/Curate/ExifAssemblerTest.php
@@ -15,7 +15,7 @@ use DateTimeImmutable;
 use MagicSunday\ImageMeta\Curate\ExifAssembler;
 use MagicSunday\ImageMeta\MakerNotes\Apple\AppleMakerNotes;
 use MagicSunday\ImageMeta\MakerNotes\AppleDecoder;
-use MagicSunday\ImageMeta\MakerNotes\MakerNotesMetadata;
+use MagicSunday\ImageMeta\MakerNotes\MakerNotesRecord;
 use MagicSunday\ImageMeta\Model\Exif\ExifDocument;
 use MagicSunday\ImageMeta\Model\Exif\ExifNumericList;
 use MagicSunday\ImageMeta\Model\Exif\ExifRational;
@@ -798,7 +798,7 @@ final class ExifAssemblerTest extends TestCase
             afConfidence: 0.76,
         );
 
-        $makerNotes = new MakerNotesMetadata('Apple', 64, str_repeat('a', 40), $appleMakerNotes, false);
+        $makerNotes = new MakerNotesRecord('Apple', 64, str_repeat('a', 40), $appleMakerNotes, false);
 
         $ifd0         = new Ifd([]);
         $exifDocument = new ExifDocument($ifd0, null, null, null, null, $makerNotes);
@@ -894,7 +894,7 @@ final class ExifAssemblerTest extends TestCase
 
         self::assertInstanceOf(AppleMakerNotes::class, $appleMakerNotes);
 
-        $makerNotes = new MakerNotesMetadata(
+        $makerNotes = new MakerNotesRecord(
             'Apple',
             64,
             str_repeat('b', 40),
@@ -1009,7 +1009,7 @@ final class ExifAssemblerTest extends TestCase
             accelerationVector: null,
         );
 
-        $makerNotes = new MakerNotesMetadata('Apple', 0, str_repeat('a', 40), $appleMakerNotes);
+        $makerNotes = new MakerNotesRecord('Apple', 0, str_repeat('a', 40), $appleMakerNotes);
 
         $metadata = new Metadata(
             ['primary'],
@@ -1069,7 +1069,7 @@ final class ExifAssemblerTest extends TestCase
             hdrImageType: 'Standard',
         );
 
-        $makerNotes   = new MakerNotesMetadata('Apple', 8, str_repeat('c', 40), $standardMakerNotes);
+        $makerNotes   = new MakerNotesRecord('Apple', 8, str_repeat('c', 40), $standardMakerNotes);
         $exifDocument = new ExifDocument(new Ifd([]), null, null, null, null, $makerNotes);
         $metadata     = new Metadata(['primary'], new QuickTimeMeta([]), $exifDocument, [], null, $makerNotes);
 
@@ -1104,7 +1104,7 @@ final class ExifAssemblerTest extends TestCase
             hdrImageType: 'Standard',
         );
 
-        $headroomMakerNotesMeta = new MakerNotesMetadata('Apple', 9, str_repeat('d', 40), $headroomMakerNotes);
+        $headroomMakerNotesMeta = new MakerNotesRecord('Apple', 9, str_repeat('d', 40), $headroomMakerNotes);
         $headroomExif           = new ExifDocument(new Ifd([]), null, null, null, null, $headroomMakerNotesMeta);
         $headroomMetadata       = new Metadata(['primary'], new QuickTimeMeta([]), $headroomExif, [], null, $headroomMakerNotesMeta);
 
@@ -1139,7 +1139,7 @@ final class ExifAssemblerTest extends TestCase
             hdrImageType: 'Standard',
         );
 
-        $flagMakerNotesMeta = new MakerNotesMetadata('Apple', 10, str_repeat('e', 40), $flagMakerNotes);
+        $flagMakerNotesMeta = new MakerNotesRecord('Apple', 10, str_repeat('e', 40), $flagMakerNotes);
         $flagExif           = new ExifDocument(new Ifd([]), null, null, null, null, $flagMakerNotesMeta);
         $flagMetadata       = new Metadata(['primary'], new QuickTimeMeta([]), $flagExif, [], null, $flagMakerNotesMeta);
 
@@ -1180,7 +1180,7 @@ final class ExifAssemblerTest extends TestCase
             accelerationVector: null,
         );
 
-        $makerNotes = new MakerNotesMetadata('Apple', 0, str_repeat('a', 40), $appleMakerNotes);
+        $makerNotes = new MakerNotesRecord('Apple', 0, str_repeat('a', 40), $appleMakerNotes);
 
         $metadata = new Metadata(
             ['primary'],
@@ -1226,7 +1226,7 @@ final class ExifAssemblerTest extends TestCase
             accelerationVector: null,
         );
 
-        $makerNotes = new MakerNotesMetadata('Apple', 32, str_repeat('a', 40), $makerNotesWithHeadroom);
+        $makerNotes = new MakerNotesRecord('Apple', 32, str_repeat('a', 40), $makerNotesWithHeadroom);
 
         $exifDocument = new ExifDocument(new Ifd([]), null, null, null, null, $makerNotes);
         $metadata     = new Metadata(['primary'], new QuickTimeMeta([]), $exifDocument, [], null, $makerNotes);
@@ -1258,7 +1258,7 @@ final class ExifAssemblerTest extends TestCase
             accelerationVector: null,
         );
 
-        $makerNotesFlags = new MakerNotesMetadata('Apple', 16, str_repeat('b', 40), $makerNotesWithFlags);
+        $makerNotesFlags = new MakerNotesRecord('Apple', 16, str_repeat('b', 40), $makerNotesWithFlags);
 
         $exifDocumentFlags = new ExifDocument(new Ifd([]), null, null, null, null, $makerNotesFlags);
         $metadataFlags     = new Metadata(['primary'], new QuickTimeMeta([]), $exifDocumentFlags, [], null, $makerNotesFlags);
@@ -2229,7 +2229,7 @@ final class ExifAssemblerTest extends TestCase
             runTime: null,
         );
 
-        $makerNotes = new MakerNotesMetadata(
+        $makerNotes = new MakerNotesRecord(
             'Apple',
             128,
             '0123456789abcdef0123456789abcdef01234567',

--- a/tests/MakerNotes/Apple/AppleMakerNotesMapperTest.php
+++ b/tests/MakerNotes/Apple/AppleMakerNotesMapperTest.php
@@ -13,7 +13,7 @@ namespace MagicSunday\ImageMeta\Tests\MakerNotes\Apple;
 
 use MagicSunday\ImageMeta\MakerNotes\Apple\AppleMakerNotes;
 use MagicSunday\ImageMeta\MakerNotes\Apple\AppleMakerNotesMapper;
-use MagicSunday\ImageMeta\MakerNotes\MakerNotesMetadata;
+use MagicSunday\ImageMeta\MakerNotes\MakerNotesRecord;
 use MagicSunday\ImageMeta\Model\QuickTimeMeta;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -28,7 +28,7 @@ final class AppleMakerNotesMapperTest extends TestCase
     #[Test]
     public function mapPrefersMakerNotesValues(): void
     {
-        $makerNotes = new MakerNotesMetadata(
+        $makerNotes = new MakerNotesRecord(
             'Apple',
             128,
             str_repeat('1', 40),
@@ -109,7 +109,7 @@ final class AppleMakerNotesMapperTest extends TestCase
     #[Test]
     public function mapFillsMissingValuesFromQuickTime(): void
     {
-        $makerNotes = new MakerNotesMetadata(
+        $makerNotes = new MakerNotesRecord(
             'Apple',
             64,
             str_repeat('2', 40),
@@ -204,7 +204,7 @@ final class AppleMakerNotesMapperTest extends TestCase
         $mapper = new AppleMakerNotesMapper();
         $mapped = $mapper->map(null, $quickTime);
 
-        self::assertInstanceOf(MakerNotesMetadata::class, $mapped);
+        self::assertInstanceOf(MakerNotesRecord::class, $mapped);
         self::assertSame('Apple', $mapped->vendor());
         self::assertSame(0, $mapped->length());
         self::assertSame(str_repeat('0', 40), $mapped->sha1());
@@ -219,7 +219,7 @@ final class AppleMakerNotesMapperTest extends TestCase
     #[Test]
     public function mapMergesQuickTimeFlags(): void
     {
-        $makerNotes = new MakerNotesMetadata(
+        $makerNotes = new MakerNotesRecord(
             'Apple',
             16,
             str_repeat('3', 40),

--- a/tests/MakerNotes/AppleDecoder/AppleDecoderTest.php
+++ b/tests/MakerNotes/AppleDecoder/AppleDecoderTest.php
@@ -14,7 +14,7 @@ namespace MagicSunday\ImageMeta\Tests\MakerNotes\AppleDecoder;
 use MagicSunday\ImageMeta\MakerNotes\Apple\AppleMakerNotes;
 use MagicSunday\ImageMeta\Value\RunTime;
 use MagicSunday\ImageMeta\MakerNotes\AppleDecoder;
-use MagicSunday\ImageMeta\MakerNotes\MakerNotesMetadata;
+use MagicSunday\ImageMeta\MakerNotes\MakerNotesRecord;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -57,7 +57,7 @@ final class AppleDecoderTest extends TestCase
 
         $metadata = $decoder->decode($raw, 'Apple', 'iPhone');
 
-        self::assertInstanceOf(MakerNotesMetadata::class, $metadata);
+        self::assertInstanceOf(MakerNotesRecord::class, $metadata);
 
         $apple = $metadata->apple();
         self::assertInstanceOf(AppleMakerNotes::class, $apple);
@@ -96,7 +96,7 @@ final class AppleDecoderTest extends TestCase
 
         $metadata = $decoder->decode($raw, 'Apple', 'iPhone');
 
-        self::assertInstanceOf(MakerNotesMetadata::class, $metadata);
+        self::assertInstanceOf(MakerNotesRecord::class, $metadata);
 
         $apple = $metadata->apple();
         self::assertInstanceOf(AppleMakerNotes::class, $apple);
@@ -133,7 +133,7 @@ final class AppleDecoderTest extends TestCase
 
         $metadata = $decoder->decode($raw, 'Apple', 'iPhone');
 
-        self::assertInstanceOf(MakerNotesMetadata::class, $metadata);
+        self::assertInstanceOf(MakerNotesRecord::class, $metadata);
         self::assertSame('Apple', $metadata->vendor());
         self::assertSame(strlen($raw), $metadata->length());
         self::assertSame(sha1($raw), $metadata->sha1());
@@ -167,7 +167,7 @@ final class AppleDecoderTest extends TestCase
 
         $metadata = $decoder->decode($raw, 'Apple', 'iPhone');
 
-        self::assertInstanceOf(MakerNotesMetadata::class, $metadata);
+        self::assertInstanceOf(MakerNotesRecord::class, $metadata);
 
         $apple = $metadata->apple();
         self::assertInstanceOf(AppleMakerNotes::class, $apple);
@@ -184,7 +184,7 @@ final class AppleDecoderTest extends TestCase
 
         $metadata = $decoder->decode($raw, 'Apple', 'iPhone');
 
-        self::assertInstanceOf(MakerNotesMetadata::class, $metadata);
+        self::assertInstanceOf(MakerNotesRecord::class, $metadata);
 
         $apple = $metadata->apple();
         self::assertInstanceOf(AppleMakerNotes::class, $apple);
@@ -213,7 +213,7 @@ final class AppleDecoderTest extends TestCase
 
         $metadata = $decoder->decode($raw, 'Apple', 'iPhone');
 
-        self::assertInstanceOf(MakerNotesMetadata::class, $metadata);
+        self::assertInstanceOf(MakerNotesRecord::class, $metadata);
 
         $apple = $metadata->apple();
         self::assertInstanceOf(AppleMakerNotes::class, $apple);
@@ -228,7 +228,7 @@ final class AppleDecoderTest extends TestCase
 
         $metadata = $decoder->decode($raw, 'Apple', 'iPhone');
 
-        self::assertInstanceOf(MakerNotesMetadata::class, $metadata);
+        self::assertInstanceOf(MakerNotesRecord::class, $metadata);
 
         $apple = $metadata->apple();
         self::assertInstanceOf(AppleMakerNotes::class, $apple);
@@ -453,7 +453,7 @@ final class AppleDecoderTest extends TestCase
 
         $metadata = $decoder->decode($raw, 'Apple', 'iPhone');
 
-        self::assertInstanceOf(MakerNotesMetadata::class, $metadata);
+        self::assertInstanceOf(MakerNotesRecord::class, $metadata);
         $apple = $metadata->apple();
         self::assertInstanceOf(AppleMakerNotes::class, $apple);
         self::assertSame('textual', $apple->contentIdentifier);
@@ -630,7 +630,7 @@ final class AppleDecoderTest extends TestCase
 
         $metadata = $decoder->decode('Apple iOS' . str_repeat("\x00", 32), 'Apple', 'iPhone');
 
-        self::assertInstanceOf(MakerNotesMetadata::class, $metadata);
+        self::assertInstanceOf(MakerNotesRecord::class, $metadata);
         self::assertNull($metadata->apple());
     }
 

--- a/tests/MakerNotes/CanonDecoder/CanonDecoderTest.php
+++ b/tests/MakerNotes/CanonDecoder/CanonDecoderTest.php
@@ -12,7 +12,7 @@ declare(strict_types=1);
 namespace MagicSunday\ImageMeta\Tests\MakerNotes\CanonDecoder;
 
 use MagicSunday\ImageMeta\MakerNotes\CanonDecoder;
-use MagicSunday\ImageMeta\MakerNotes\MakerNotesMetadata;
+use MagicSunday\ImageMeta\MakerNotes\MakerNotesRecord;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
@@ -37,7 +37,7 @@ final class CanonDecoderTest extends TestCase
 
         $metadata = $decoder->decode($raw, 'Canon', 'Canon EOS R5');
 
-        self::assertInstanceOf(MakerNotesMetadata::class, $metadata);
+        self::assertInstanceOf(MakerNotesRecord::class, $metadata);
         self::assertSame('Canon', $metadata->vendor());
         self::assertSame(strlen($raw), $metadata->length());
         self::assertSame(sha1($raw), $metadata->sha1());

--- a/tests/MakerNotes/MakerNotesPropagationTest.php
+++ b/tests/MakerNotes/MakerNotesPropagationTest.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
 
 namespace MagicSunday\ImageMeta\Tests\MakerNotes;
 
-use MagicSunday\ImageMeta\MakerNotes\MakerNotesMetadata;
+use MagicSunday\ImageMeta\MakerNotes\MakerNotesRecord;
 use MagicSunday\ImageMeta\Model\Exif\ExifDocument;
 use MagicSunday\ImageMeta\Model\Exif\Ifd;
 use MagicSunday\ImageMeta\Model\Metadata;
@@ -31,7 +31,7 @@ final class MakerNotesPropagationTest extends TestCase
     #[Test]
     public function exifDocumentReturnsMakerNotes(): void
     {
-        $makerNotes = new MakerNotesMetadata('Acme', 4, str_repeat('0', 40));
+        $makerNotes = new MakerNotesRecord('Acme', 4, str_repeat('0', 40));
         $document   = new ExifDocument(new Ifd([]), null, null, null, null, $makerNotes);
 
         self::assertSame($makerNotes, $document->makerNotes());
@@ -43,7 +43,7 @@ final class MakerNotesPropagationTest extends TestCase
     #[Test]
     public function metadataAggregateCarriesMakerNotes(): void
     {
-        $makerNotes = new MakerNotesMetadata('Acme', 4, str_repeat('0', 40));
+        $makerNotes = new MakerNotesRecord('Acme', 4, str_repeat('0', 40));
         $metadata   = new Metadata([], null, null, [], null, $makerNotes);
 
         self::assertSame($makerNotes, $metadata->makerNotes);

--- a/tests/MakerNotes/MakerNotesRecord/MakerNotesRecordTest.php
+++ b/tests/MakerNotes/MakerNotesRecord/MakerNotesRecordTest.php
@@ -9,20 +9,20 @@
 
 declare(strict_types=1);
 
-namespace MagicSunday\ImageMeta\Tests\MakerNotes\MakerNotesMetadata;
+namespace MagicSunday\ImageMeta\Tests\MakerNotes\MakerNotesRecord;
 
 use InvalidArgumentException;
-use MagicSunday\ImageMeta\MakerNotes\MakerNotesMetadata;
+use MagicSunday\ImageMeta\MakerNotes\MakerNotesRecord;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
- * Validates the maker notes metadata value object.
+ * Validates the maker notes record value object.
  *
- * @covers \MagicSunday\ImageMeta\MakerNotes\MakerNotesMetadata
+ * @covers \MagicSunday\ImageMeta\MakerNotes\MakerNotesRecord
  */
-final class MakerNotesMetadataTest extends TestCase
+final class MakerNotesRecordTest extends TestCase
 {
     /**
      * Ensures the metadata value object accepts valid arguments and exposes the expected values.
@@ -30,7 +30,7 @@ final class MakerNotesMetadataTest extends TestCase
     #[Test]
     public function constructorAcceptsValidArguments(): void
     {
-        $metadata = new MakerNotesMetadata('Contoso', 123, '0123456789abcdef0123456789abcdef01234567');
+        $metadata = new MakerNotesRecord('Contoso', 123, '0123456789abcdef0123456789abcdef01234567');
 
         self::assertSame('Contoso', $metadata->vendor());
         self::assertSame(123, $metadata->length());
@@ -38,7 +38,7 @@ final class MakerNotesMetadataTest extends TestCase
         self::assertNull($metadata->apple());
         self::assertNull($metadata->isSafe());
 
-        $safeMetadata = new MakerNotesMetadata('Contoso', 123, '0123456789abcdef0123456789abcdef01234567', null, true);
+        $safeMetadata = new MakerNotesRecord('Contoso', 123, '0123456789abcdef0123456789abcdef01234567', null, true);
 
         self::assertTrue($safeMetadata->isSafe());
     }
@@ -70,6 +70,6 @@ final class MakerNotesMetadataTest extends TestCase
     {
         $this->expectException(InvalidArgumentException::class);
 
-        new MakerNotesMetadata($vendor, $length, $sha1);
+        new MakerNotesRecord($vendor, $length, $sha1);
     }
 }

--- a/tests/MakerNotes/NikonDecoder/NikonDecoderTest.php
+++ b/tests/MakerNotes/NikonDecoder/NikonDecoderTest.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
 
 namespace MagicSunday\ImageMeta\Tests\MakerNotes\NikonDecoder;
 
-use MagicSunday\ImageMeta\MakerNotes\MakerNotesMetadata;
+use MagicSunday\ImageMeta\MakerNotes\MakerNotesRecord;
 use MagicSunday\ImageMeta\MakerNotes\NikonDecoder;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -37,7 +37,7 @@ final class NikonDecoderTest extends TestCase
 
         $metadata = $decoder->decode($raw, 'Nikon Corporation', 'NIKON Z 8');
 
-        self::assertInstanceOf(MakerNotesMetadata::class, $metadata);
+        self::assertInstanceOf(MakerNotesRecord::class, $metadata);
         self::assertSame('Nikon', $metadata->vendor());
         self::assertSame(strlen($raw), $metadata->length());
         self::assertSame(sha1($raw), $metadata->sha1());

--- a/tests/MakerNotes/RegistryTest.php
+++ b/tests/MakerNotes/RegistryTest.php
@@ -13,7 +13,7 @@ namespace MagicSunday\ImageMeta\Tests\MakerNotes;
 
 use MagicSunday\ImageMeta\MakerNotes\CanonDecoder;
 use MagicSunday\ImageMeta\MakerNotes\MakerNotesDecoderInterface;
-use MagicSunday\ImageMeta\MakerNotes\MakerNotesMetadata;
+use MagicSunday\ImageMeta\MakerNotes\MakerNotesRecord;
 use MagicSunday\ImageMeta\MakerNotes\NikonDecoder;
 use MagicSunday\ImageMeta\MakerNotes\Registry;
 use MagicSunday\ImageMeta\MakerNotes\RegistryFactory;
@@ -58,11 +58,11 @@ final class RegistryTest extends TestCase
              * @param string      $make  The make string associated with the image metadata.
              * @param string|null $model The optional model string associated with the image metadata.
              *
-             * @return MakerNotesMetadata The decoded maker notes metadata instance.
+             * @return MakerNotesRecord The decoded maker notes metadata instance.
              */
-            public function decode(string $raw, string $make, ?string $model): MakerNotesMetadata
+            public function decode(string $raw, string $make, ?string $model): MakerNotesRecord
             {
-                return new MakerNotesMetadata('Test', 0, '0000000000000000000000000000000000000000');
+                return new MakerNotesRecord('Test', 0, '0000000000000000000000000000000000000000');
             }
         };
 
@@ -87,11 +87,11 @@ final class RegistryTest extends TestCase
              * @param string      $make  The make string associated with the image metadata.
              * @param string|null $model The optional model string associated with the image metadata.
              *
-             * @return MakerNotesMetadata The decoded maker notes metadata instance.
+             * @return MakerNotesRecord The decoded maker notes metadata instance.
              */
-            public function decode(string $raw, string $make, ?string $model): MakerNotesMetadata
+            public function decode(string $raw, string $make, ?string $model): MakerNotesRecord
             {
-                return new MakerNotesMetadata('Canon', 0, '0000000000000000000000000000000000000000');
+                return new MakerNotesRecord('Canon', 0, '0000000000000000000000000000000000000000');
             }
         });
 

--- a/tests/MakerNotes/SonyDecoder/SonyDecoderTest.php
+++ b/tests/MakerNotes/SonyDecoder/SonyDecoderTest.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
 
 namespace MagicSunday\ImageMeta\Tests\MakerNotes\SonyDecoder;
 
-use MagicSunday\ImageMeta\MakerNotes\MakerNotesMetadata;
+use MagicSunday\ImageMeta\MakerNotes\MakerNotesRecord;
 use MagicSunday\ImageMeta\MakerNotes\SonyDecoder;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -37,7 +37,7 @@ final class SonyDecoderTest extends TestCase
 
         $metadata = $decoder->decode($raw, 'Sony', 'ILCE-7RM5');
 
-        self::assertInstanceOf(MakerNotesMetadata::class, $metadata);
+        self::assertInstanceOf(MakerNotesRecord::class, $metadata);
         self::assertSame('Sony', $metadata->vendor());
         self::assertSame(strlen($raw), $metadata->length());
         self::assertSame(sha1($raw), $metadata->sha1());

--- a/tests/MetadataReader/MetadataReaderTest.php
+++ b/tests/MetadataReader/MetadataReaderTest.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
 
 namespace MagicSunday\ImageMeta\Tests\MetadataReader;
 
-use MagicSunday\ImageMeta\MakerNotes\MakerNotesMetadata;
+use MagicSunday\ImageMeta\MakerNotes\MakerNotesRecord;
 use MagicSunday\ImageMeta\MetadataReader;
 use MagicSunday\ImageMeta\Model\Exif\ExifDocument;
 use MagicSunday\ImageMeta\Model\Exif\ExifTag;
@@ -79,7 +79,7 @@ final class MetadataReaderTest extends TestCase
         self::assertNull($metadata->quickTime);
         self::assertInstanceOf(ExifDocument::class, $metadata->exifDoc);
         self::assertInstanceOf(XmpDocument::class, $metadata->xmpDoc);
-        self::assertInstanceOf(MakerNotesMetadata::class, $metadata->makerNotes);
+        self::assertInstanceOf(MakerNotesRecord::class, $metadata->makerNotes);
         self::assertSame('Nikon', $metadata->makerNotes->vendor());
         self::assertSame(strlen($makerNote), $metadata->makerNotes->length());
         self::assertSame(sha1($makerNote), $metadata->makerNotes->sha1());
@@ -196,7 +196,7 @@ final class MetadataReaderTest extends TestCase
         self::assertSame($identifier, $metadata->quickTime->contentIdentifier());
         self::assertInstanceOf(ExifDocument::class, $metadata->exifDoc);
         self::assertInstanceOf(XmpDocument::class, $metadata->xmpDoc);
-        self::assertInstanceOf(MakerNotesMetadata::class, $metadata->makerNotes);
+        self::assertInstanceOf(MakerNotesRecord::class, $metadata->makerNotes);
         self::assertSame('Sony', $metadata->makerNotes->vendor());
         self::assertSame(strlen($makerNote), $metadata->makerNotes->length());
         self::assertSame(sha1($makerNote), $metadata->makerNotes->sha1());

--- a/tests/Parse/Tiff/TiffExifReaderTest.php
+++ b/tests/Parse/Tiff/TiffExifReaderTest.php
@@ -15,7 +15,7 @@ use MagicSunday\ImageMeta\Core\BoundsError;
 use MagicSunday\ImageMeta\Core\Endian;
 use MagicSunday\ImageMeta\Core\ParseError;
 use MagicSunday\ImageMeta\MakerNotes\MakerNotesDecoderInterface;
-use MagicSunday\ImageMeta\MakerNotes\MakerNotesMetadata;
+use MagicSunday\ImageMeta\MakerNotes\MakerNotesRecord;
 use MagicSunday\ImageMeta\MakerNotes\Registry;
 use MagicSunday\ImageMeta\Model\Exif\ExifDocument;
 use MagicSunday\ImageMeta\Model\Exif\ExifNumericList;
@@ -604,13 +604,13 @@ final class TiffExifReaderTest extends TestCase
         [$blob, $makerNoteData] = $this->buildClassicMakerNoteBlob();
 
         $decoder = new class implements MakerNotesDecoderInterface {
-            public function decode(string $raw, string $make, ?string $model): MakerNotesMetadata
+            public function decode(string $raw, string $make, ?string $model): MakerNotesRecord
             {
                 $offset  = unpack('Voffset', substr($raw, 0, 4));
                 $pointer = $offset['offset'] ?? 0;
                 $vendor  = substr($raw, $pointer, 4);
 
-                return new MakerNotesMetadata($vendor !== '' ? $vendor : 'Unknown', strlen($raw), sha1($raw));
+                return new MakerNotesRecord($vendor !== '' ? $vendor : 'Unknown', strlen($raw), sha1($raw));
             }
         };
 
@@ -620,7 +620,7 @@ final class TiffExifReaderTest extends TestCase
         $document   = (new TiffExifReader())->parseFromBlob($blob, $registry);
         $makerNotes = $document->makerNotes();
 
-        self::assertInstanceOf(MakerNotesMetadata::class, $makerNotes);
+        self::assertInstanceOf(MakerNotesRecord::class, $makerNotes);
         self::assertSame('DATA', $makerNotes->vendor());
         self::assertSame(strlen($makerNoteData), $makerNotes->length());
         self::assertSame(sha1($makerNoteData), $makerNotes->sha1());
@@ -637,16 +637,16 @@ final class TiffExifReaderTest extends TestCase
 
         $registry = new Registry();
         $registry->register('Other', new class implements MakerNotesDecoderInterface {
-            public function decode(string $raw, string $make, ?string $model): MakerNotesMetadata
+            public function decode(string $raw, string $make, ?string $model): MakerNotesRecord
             {
-                return new MakerNotesMetadata('Other', strlen($raw), sha1($raw));
+                return new MakerNotesRecord('Other', strlen($raw), sha1($raw));
             }
         });
 
         $document   = (new TiffExifReader())->parseFromBlob($blob, $registry);
         $makerNotes = $document->makerNotes();
 
-        self::assertInstanceOf(MakerNotesMetadata::class, $makerNotes);
+        self::assertInstanceOf(MakerNotesRecord::class, $makerNotes);
         self::assertSame('Unknown', $makerNotes->vendor());
         self::assertSame(strlen($makerNoteData), $makerNotes->length());
         self::assertSame(sha1($makerNoteData), $makerNotes->sha1());
@@ -662,9 +662,9 @@ final class TiffExifReaderTest extends TestCase
         [$blob] = $this->buildClassicMakerNoteBlob(1);
 
         $decoder = new class implements MakerNotesDecoderInterface {
-            public function decode(string $raw, string $make, ?string $model): MakerNotesMetadata
+            public function decode(string $raw, string $make, ?string $model): MakerNotesRecord
             {
-                return new MakerNotesMetadata('SafeVendor', strlen($raw), sha1($raw));
+                return new MakerNotesRecord('SafeVendor', strlen($raw), sha1($raw));
             }
         };
 
@@ -674,7 +674,7 @@ final class TiffExifReaderTest extends TestCase
         $document   = (new TiffExifReader())->parseFromBlob($blob, $registry);
         $makerNotes = $document->makerNotes();
 
-        self::assertInstanceOf(MakerNotesMetadata::class, $makerNotes);
+        self::assertInstanceOf(MakerNotesRecord::class, $makerNotes);
         self::assertTrue($document->makerNoteSafety());
         self::assertTrue($makerNotes->isSafe());
 
@@ -692,7 +692,7 @@ final class TiffExifReaderTest extends TestCase
         $document   = (new TiffExifReader())->parseFromBlob($blob);
         $makerNotes = $document->makerNotes();
 
-        self::assertInstanceOf(MakerNotesMetadata::class, $makerNotes);
+        self::assertInstanceOf(MakerNotesRecord::class, $makerNotes);
         self::assertFalse($document->makerNoteSafety());
         self::assertFalse($makerNotes->isSafe());
 


### PR DESCRIPTION
## Summary
- rename the raw maker notes value object to `MakerNotesRecord`
- rename the curated maker notes view to `MakerNotesView`
- update decoders, models, and tests to reference the new class names

## Testing
- composer ci:test:php:unit

------
https://chatgpt.com/codex/tasks/task_e_68ffa22e6b7c8323b9a4f509a4320683