### PR TITLE
Refactor: replace inline hex literals with shared constants

### DIFF
--- a/src/Core/BitMask.php
+++ b/src/Core/BitMask.php
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\ImageMeta\Core;
+
+/**
+ * Provides reusable bit mask constants to avoid magic numbers.
+ */
+final class BitMask
+{
+    public const int BIT_0 = 0x01;
+    public const int BIT_1 = 0x02;
+    public const int BIT_2 = 0x04;
+    public const int BIT_3 = 0x08;
+    public const int BIT_4 = 0x10;
+    public const int BIT_5 = 0x20;
+    public const int BIT_6 = 0x40;
+    public const int BIT_7 = 0x80;
+
+    public const int LOW_NIBBLE = 0x0F;
+    public const int HIGH_NIBBLE = 0xF0;
+
+    public const int LOW_BYTE = 0xFF;
+    public const int HIGH_BYTE = 0xFF00;
+
+    public const int SIX_BIT_MASK = 0x3F;
+    public const int SEVEN_BIT_MASK = 0x7F;
+    public const int INT31_MAX = 0x7FFF_FFFF;
+
+    public const int SIGN_BIT_16 = 0x8000;
+    public const int SIGN_BIT_32 = 0x8000_0000;
+
+    public const int UINT16_MAX = 0xFFFF;
+    public const int UINT16_BASE = 0x1_0000;
+    public const int UINT32_MAX = 0xFFFF_FFFF;
+    public const int UINT32_BASE = 0x1_0000_0000;
+
+    private function __construct()
+    {
+    }
+}

--- a/src/Core/Util/UInt64.php
+++ b/src/Core/Util/UInt64.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace MagicSunday\ImageMeta\Core\Util;
 
+use MagicSunday\ImageMeta\Core\BitMask;
 use MagicSunday\ImageMeta\Core\ParseError;
 
 use function intdiv;
@@ -109,10 +110,10 @@ final class UInt64
     public function fitsSignedInt(): bool
     {
         if (PHP_INT_SIZE >= 8) {
-            return $this->hi <= 0x7FFFFFFF;
+            return $this->hi <= BitMask::INT31_MAX;
         }
 
-        return $this->hi === 0 && $this->lo <= 0x7FFFFFFF;
+        return $this->hi === 0 && $this->lo <= BitMask::INT31_MAX;
     }
 
     public function toInt(string $context): int

--- a/src/MakerNotes/Apple/BinaryPlistDecoder.php
+++ b/src/MakerNotes/Apple/BinaryPlistDecoder.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace MagicSunday\ImageMeta\MakerNotes\Apple;
 
+use MagicSunday\ImageMeta\Core\BitMask;
 use MagicSunday\ImageMeta\Core\ParseError;
 
 use function array_key_exists;
@@ -33,6 +34,34 @@ use function substr;
  */
 final class BinaryPlistDecoder
 {
+    private const int MARKER_TYPE_SIMPLE = 0;
+
+    private const int MARKER_TYPE_INTEGER = 1;
+
+    private const int MARKER_TYPE_REAL = 2;
+
+    private const int MARKER_TYPE_DATA = 4;
+
+    private const int MARKER_TYPE_ASCII = 5;
+
+    private const int MARKER_TYPE_UNICODE = 6;
+
+    private const int MARKER_TYPE_UID = 8;
+
+    private const int MARKER_TYPE_ARRAY = 10;
+
+    private const int MARKER_TYPE_DICTIONARY = 13;
+
+    private const int MARKER_SIMPLE_NULL = 0;
+
+    private const int MARKER_SIMPLE_FALSE = 8;
+
+    private const int MARKER_SIMPLE_TRUE = 9;
+
+    private const int MARKER_INFO_EXTENDED = 0x0F;
+
+    private const int MARKER_INFO_MASK = BitMask::LOW_NIBBLE;
+
     private string $data = '';
 
     /**
@@ -146,18 +175,18 @@ final class BinaryPlistDecoder
 
         $marker = ord($this->data[$offset]);
         $type   = $marker >> 4;
-        $info   = $marker & 0x0F;
+        $info   = $marker & self::MARKER_INFO_MASK;
 
         return match ($type) {
-            0x0     => $this->parseSimple($info),
-            0x1     => $this->parseInteger($offset, $info),
-            0x2     => $this->parseReal($offset, $info),
-            0x4     => $this->parseData($offset, $info),
-            0x5     => $this->parseAscii($offset, $info),
-            0x6     => $this->parseUnicode($offset, $info),
-            0x8     => $this->parseUid($offset, $info),
-            0xA     => $this->parseArray($offset, $info),
-            0xD     => $this->parseDictionary($offset, $info),
+            self::MARKER_TYPE_SIMPLE     => $this->parseSimple($info),
+            self::MARKER_TYPE_INTEGER    => $this->parseInteger($offset, $info),
+            self::MARKER_TYPE_REAL       => $this->parseReal($offset, $info),
+            self::MARKER_TYPE_DATA       => $this->parseData($offset, $info),
+            self::MARKER_TYPE_ASCII      => $this->parseAscii($offset, $info),
+            self::MARKER_TYPE_UNICODE    => $this->parseUnicode($offset, $info),
+            self::MARKER_TYPE_UID        => $this->parseUid($offset, $info),
+            self::MARKER_TYPE_ARRAY      => $this->parseArray($offset, $info),
+            self::MARKER_TYPE_DICTIONARY => $this->parseDictionary($offset, $info),
             default => throw new ParseError('Unsupported property list object type.'),
         };
     }
@@ -172,9 +201,9 @@ final class BinaryPlistDecoder
     private function parseSimple(int $info): ?bool
     {
         return match ($info) {
-            0x0     => null,
-            0x8     => false,
-            0x9     => true,
+            self::MARKER_SIMPLE_NULL  => null,
+            self::MARKER_SIMPLE_FALSE => false,
+            self::MARKER_SIMPLE_TRUE  => true,
             default => throw new ParseError('Unsupported simple property list object.'),
         };
     }
@@ -321,7 +350,7 @@ final class BinaryPlistDecoder
     {
         [$lengthValue, $header] = $this->readLength($offset, $info);
 
-        if ($info === 0x0F) {
+        if ($info === self::MARKER_INFO_EXTENDED) {
             $size = $lengthValue;
         } else {
             $size   = $lengthValue + 1;
@@ -459,7 +488,7 @@ final class BinaryPlistDecoder
      */
     private function readLength(int $offset, int $info): array
     {
-        if ($info !== 0x0F) {
+        if ($info !== self::MARKER_INFO_EXTENDED) {
             return [$info, 1];
         }
 
@@ -470,8 +499,8 @@ final class BinaryPlistDecoder
 
         $marker = ord($this->data[$sizeMarkerOffset]);
         $type   = $marker >> 4;
-        $info   = $marker & 0x0F;
-        if ($type !== 0x1) {
+        $info   = $marker & self::MARKER_INFO_MASK;
+        if ($type !== self::MARKER_TYPE_INTEGER) {
             throw new ParseError('Size marker does not encode an integer.');
         }
 

--- a/src/Model/Exif/ExifDocument.php
+++ b/src/Model/Exif/ExifDocument.php
@@ -122,7 +122,7 @@ final readonly class ExifDocument
     }
 
     /**
-     * Indicates whether the maker note is considered safe to modify according to EXIF tag 0xC635.
+     * Indicates whether the maker note is considered safe to modify according to EXIF tag ExifTag::MAKER_NOTE_SAFETY.
      */
     public function makerNoteSafety(): ?bool
     {

--- a/src/Model/Exif/ValueConverters.php
+++ b/src/Model/Exif/ValueConverters.php
@@ -16,6 +16,7 @@ use DateTimeImmutable;
 use DateTimeZone;
 use Exception;
 use JsonException;
+use MagicSunday\ImageMeta\Core\BitMask;
 use MagicSunday\ImageMeta\Value\Enum\CfaPatternColor;
 use MagicSunday\ImageMeta\Value\ExifFlash;
 use MagicSunday\ImageMeta\Value\FlashInfo;
@@ -652,7 +653,7 @@ final readonly class ValueConverters
                 return null;
             }
 
-            if ($byte < 0 || $byte > 0xFF) {
+            if ($byte < 0 || $byte > BitMask::LOW_BYTE) {
                 return null;
             }
 
@@ -1543,7 +1544,7 @@ final readonly class ValueConverters
     }
 
     /**
-     * Decodes the Epson Print Image Matching parameter block stored in tag 0xC4A5.
+     * Decodes the Epson Print Image Matching parameter block stored in tag ExifTag::PRINT_IMAGE_MATCHING.
      *
      * @param string|null $payload Raw UNDEFINED payload captured from the EXIF tag.
      *
@@ -1661,8 +1662,8 @@ final readonly class ValueConverters
         }
 
         $int = (int) $value[1];
-        if ($int >= 0x80000000) {
-            $int -= 0x100000000;
+        if ($int >= BitMask::SIGN_BIT_32) {
+            $int -= BitMask::UINT32_BASE;
         }
 
         return $int;

--- a/src/Model/Jpeg/Marker.php
+++ b/src/Model/Jpeg/Marker.php
@@ -1,0 +1,84 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\ImageMeta\Model\Jpeg;
+
+/**
+ * Defines marker codes used by JPEG streams.
+ */
+final class Marker
+{
+    public const int TEM = 0x01;
+
+    public const int SOI = 0xD8;
+    public const int EOI = 0xD9;
+    public const int SOS = 0xDA;
+    public const int DQT = 0xDB;
+    public const int DNL = 0xDC;
+    public const int DRI = 0xDD;
+    public const int DHP = 0xDE;
+    public const int EXP = 0xDF;
+
+    public const int DHT = 0xC4;
+    public const int DAC = 0xCC;
+
+    public const int SOF0 = 0xC0;
+    public const int SOF1 = 0xC1;
+    public const int SOF2 = 0xC2;
+    public const int SOF3 = 0xC3;
+    public const int SOF5 = 0xC5;
+    public const int SOF6 = 0xC6;
+    public const int SOF7 = 0xC7;
+    public const int SOF9 = 0xC9;
+    public const int SOF10 = 0xCA;
+    public const int SOF11 = 0xCB;
+    public const int SOF13 = 0xCD;
+    public const int SOF14 = 0xCE;
+    public const int SOF15 = 0xCF;
+
+    public const int RST0 = 0xD0;
+    public const int RST1 = 0xD1;
+    public const int RST2 = 0xD2;
+    public const int RST3 = 0xD3;
+    public const int RST4 = 0xD4;
+    public const int RST5 = 0xD5;
+    public const int RST6 = 0xD6;
+    public const int RST7 = 0xD7;
+
+    public const int APP0 = 0xE0;
+    public const int APP1 = 0xE1;
+    public const int APP2 = 0xE2;
+    public const int APP3 = 0xE3;
+    public const int APP4 = 0xE4;
+    public const int APP5 = 0xE5;
+    public const int APP6 = 0xE6;
+    public const int APP7 = 0xE7;
+    public const int APP8 = 0xE8;
+    public const int APP9 = 0xE9;
+    public const int APP10 = 0xEA;
+    public const int APP11 = 0xEB;
+    public const int APP12 = 0xEC;
+    public const int APP13 = 0xED;
+    public const int APP14 = 0xEE;
+    public const int APP15 = 0xEF;
+
+    public const int COM = 0xFE;
+
+    public const int RST_FIRST = self::RST0;
+    public const int RST_LAST = self::RST7;
+
+    public const int APP_FIRST = self::APP0;
+    public const int APP_LAST = self::APP15;
+
+    private function __construct()
+    {
+    }
+}

--- a/src/Parse/Icc/IccDecoder.php
+++ b/src/Parse/Icc/IccDecoder.php
@@ -13,6 +13,7 @@ namespace MagicSunday\ImageMeta\Parse\Icc;
 
 use Imagick;
 use ImagickPixel;
+use MagicSunday\ImageMeta\Core\BitMask;
 use MagicSunday\ImageMeta\Core\ParseError;
 use MagicSunday\ImageMeta\Value\Enum\IccRenderingIntent;
 use Throwable;
@@ -162,11 +163,11 @@ final class IccDecoder
         $minorBugfix   = ord($data[9]);
         $major         = $majorByte;
         $minor         = $minorBugfix >> 4;
-        $bugfixVersion = $minorBugfix & 0x0F;
+        $bugfixVersion = $minorBugfix & BitMask::LOW_NIBBLE;
 
-        if ($majorByte >= 0x10) {
+        if ($majorByte >= BitMask::BIT_4) {
             $major         = $majorByte >> 4;
-            $minor         = $majorByte & 0x0F;
+            $minor         = $majorByte & BitMask::LOW_NIBBLE;
             $bugfixVersion = $minorBugfix >> 4;
         }
 

--- a/src/Parse/IsoBmff/IsoBmffExtractor.php
+++ b/src/Parse/IsoBmff/IsoBmffExtractor.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace MagicSunday\ImageMeta\Parse\IsoBmff;
 
+use MagicSunday\ImageMeta\Core\BitMask;
 use MagicSunday\ImageMeta\Core\ParseError;
 use MagicSunday\ImageMeta\Core\Stream;
 use MagicSunday\ImageMeta\Core\StreamWindow;
@@ -1019,7 +1020,7 @@ final readonly class IsoBmffExtractor
             ];
         }
 
-        $id = ($flags & 0x0001) !== 0 ? $win->readU32BE() : $win->readU16BE();
+        $id = ($flags & BitMask::BIT_0) !== 0 ? $win->readU32BE() : $win->readU16BE();
         $win->readU16BE(); // protection index
         $itemType    = $win->read(4);
         $remaining   = $infe->contentSize - $win->tell();
@@ -1052,14 +1053,14 @@ final readonly class IsoBmffExtractor
         $flags   = $this->readUInt24($win);
 
         $offsetLengthSizes = $win->readU8();
-        $offsetSize        = $this->validateSizeNibble(($offsetLengthSizes >> 4) & 0x0F);
-        $lengthSize        = $this->validateSizeNibble($offsetLengthSizes & 0x0F);
+        $offsetSize        = $this->validateSizeNibble(($offsetLengthSizes >> 4) & BitMask::LOW_NIBBLE);
+        $lengthSize        = $this->validateSizeNibble($offsetLengthSizes & BitMask::LOW_NIBBLE);
 
         $baseField      = $win->readU8();
-        $baseOffsetSize = $this->validateSizeNibble(($baseField >> 4) & 0x0F);
+        $baseOffsetSize = $this->validateSizeNibble(($baseField >> 4) & BitMask::LOW_NIBBLE);
         $indexSize      = 0;
         if ($version === 1 || $version === 2) {
-            $indexSize = $this->validateSizeNibble($win->readU8() & 0x0F);
+            $indexSize = $this->validateSizeNibble($win->readU8() & BitMask::LOW_NIBBLE);
         }
 
         $itemCount = $version < 2 ? $win->readU16BE() : $win->readU32BE();
@@ -1068,7 +1069,7 @@ final readonly class IsoBmffExtractor
         for ($i = 0; $i < $itemCount; ++$i) {
             if ($version < 2) {
                 $itemId = $win->readU16BE();
-            } elseif (($flags & 0x0001) !== 0) {
+            } elseif (($flags & BitMask::BIT_0) !== 0) {
                 $itemId = $win->readU32BE();
             } else {
                 $itemId = $win->readU16BE();
@@ -1077,7 +1078,7 @@ final readonly class IsoBmffExtractor
             $constructionMethod = 0;
             if ($version === 1 || $version === 2) {
                 $tmp                = $win->readU16BE();
-                $constructionMethod = ($tmp >> 12) & 0x0F;
+                $constructionMethod = ($tmp >> 12) & BitMask::LOW_NIBBLE;
             }
 
             $dataReferenceIndex = $win->readU16BE();

--- a/src/Parse/Jpeg/JpegExtractor.php
+++ b/src/Parse/Jpeg/JpegExtractor.php
@@ -14,7 +14,9 @@ namespace MagicSunday\ImageMeta\Parse\Jpeg;
 use MagicSunday\ImageMeta\Core\BoundsError;
 use MagicSunday\ImageMeta\Core\ParseError;
 use MagicSunday\ImageMeta\Core\Stream;
+use MagicSunday\ImageMeta\Core\BitMask;
 use MagicSunday\ImageMeta\Model\Jpeg\JpegAudioStream;
+use MagicSunday\ImageMeta\Model\Jpeg\Marker;
 use MagicSunday\ImageMeta\Model\Mpf\MpfDocument;
 
 use function array_key_exists;
@@ -41,22 +43,6 @@ final class JpegExtractor
     private const int MAX_APP_SEGMENT_SIZE = 4_194_304; // 4 MiB payload limit
 
     /**
-     * APP marker codes carrying metadata of interest.
-     *
-     * APP1  (0xE1) exposes EXIF and XMP metadata, APP2 (0xE2) carries ICC
-     * profile fragments, and APP13 (0xED) contains IPTC/Photoshop resources.
-     */
-    private const int MARKER_APP1 = 0xE1;
-
-    private const int MARKER_APP2 = 0xE2;
-
-    private const int MARKER_APP13 = 0xED;
-
-    private const int MARKER_SOF0 = 0xC0;
-
-    private const int MARKER_SOF2 = 0xC2;
-
-    /**
      * Signatures identifying metadata-bearing APP segments.
      */
     private const string EXIF_SIGNATURE = "Exif\0\0";
@@ -80,13 +66,6 @@ final class JpegExtractor
     private const string IPTC_SIGNATURE = "Photoshop 3.0\0";
 
     private const string FPXR_SIGNATURE = 'FPXR';
-
-    /**
-     * Scan and termination markers that end metadata scanning.
-     */
-    private const int MARKER_SOS = 0xDA;
-
-    private const int MARKER_EOI = 0xD9;
 
     private bool $parsed = false;
 
@@ -335,30 +314,30 @@ final class JpegExtractor
         while (true) {
             [$marker, $offset] = $this->nextMarkerWithOffset();
 
-            if ($marker === self::MARKER_EOI) {
+            if ($marker === Marker::EOI) {
                 break;
             }
 
-            if ($marker === self::MARKER_SOS) {
+            if ($marker === Marker::SOS) {
                 break; // stop scanning metadata when scan data begins
             }
 
-            if ($marker === 0x01 || ($marker >= 0xD0 && $marker <= 0xD7)) {
+            if ($marker === Marker::TEM || ($marker >= Marker::RST_FIRST && $marker <= Marker::RST_LAST)) {
                 continue; // markers without payload
             }
 
-            $isAppSegment  = $marker >= 0xE0 && $marker <= 0xEF;
+            $isAppSegment  = $marker >= Marker::APP_FIRST && $marker <= Marker::APP_LAST;
             $segmentLength = $this->readSegmentLength($marker, $offset, $isAppSegment);
             $payloadLength = $segmentLength - 2;
             $payload       = $this->readSegmentPayload($marker, $offset, $payloadLength);
 
-            if ($marker === self::MARKER_APP1) {
+            if ($marker === Marker::APP1) {
                 $this->handleApp1($payload);
-            } elseif ($marker === self::MARKER_APP2) {
+            } elseif ($marker === Marker::APP2) {
                 $this->handleApp2($payload, $offset);
-            } elseif ($marker === self::MARKER_APP13) {
+            } elseif ($marker === Marker::APP13) {
                 $this->handleApp13($payload);
-            } elseif ($marker === self::MARKER_SOF0 || $marker === self::MARKER_SOF2) {
+            } elseif ($marker === Marker::SOF0 || $marker === Marker::SOF2) {
                 $this->handleStartOfFrame($marker, $payload, $offset);
             }
         }
@@ -805,7 +784,7 @@ final class JpegExtractor
             $componentId     = ord($payload[$index]);
             $samplingFactors = ord($payload[$index + 1]);
             $horizontal      = $samplingFactors >> 4;
-            $vertical        = $samplingFactors & 0x0F;
+            $vertical        = $samplingFactors & BitMask::LOW_NIBBLE;
 
             if ($horizontal === 0 || $vertical === 0) {
                 throw new ParseError(

--- a/src/Parse/Jpeg/MpfParser.php
+++ b/src/Parse/Jpeg/MpfParser.php
@@ -11,9 +11,11 @@ declare(strict_types=1);
 
 namespace MagicSunday\ImageMeta\Parse\Jpeg;
 
+use MagicSunday\ImageMeta\Core\BitMask;
 use MagicSunday\ImageMeta\Core\Endian;
 use MagicSunday\ImageMeta\Core\MemoryBuffer;
 use MagicSunday\ImageMeta\Core\ParseError;
+use MagicSunday\ImageMeta\Parse\Tiff\TiffConst;
 use MagicSunday\ImageMeta\Model\Mpf\MpfAttributes;
 use MagicSunday\ImageMeta\Model\Mpf\MpfDocument;
 use MagicSunday\ImageMeta\Model\Mpf\MpfEntry;
@@ -30,7 +32,7 @@ use function substr;
  */
 final class MpfParser
 {
-    private const int TIFF_MAGIC = 0x002A;
+    private const int TIFF_MAGIC = TiffConst::MAGIC_CLASSIC;
 
     private const int TYPE_BYTE = 1;
 
@@ -276,11 +278,11 @@ final class MpfParser
      */
     private function toSigned32(int $value): int
     {
-        if (($value & 0x8000_0000) !== 0) {
-            return -((~$value & 0xFFFF_FFFF) + 1);
+        if (($value & BitMask::SIGN_BIT_32) !== 0) {
+            return -((~$value & BitMask::UINT32_MAX) + 1);
         }
 
-        return $value & 0x7FFF_FFFF;
+        return $value & BitMask::INT31_MAX;
     }
 
     /**

--- a/src/Parse/Tiff/TiffConst.php
+++ b/src/Parse/Tiff/TiffConst.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\ImageMeta\Parse\Tiff;
+
+/**
+ * Shared constants describing TIFF headers and data types.
+ */
+final class TiffConst
+{
+    public const int MAGIC_CLASSIC = 0x002A;
+    public const int MAGIC_BIG = 0x002B;
+
+    public const int TYPE_BYTE = 1;
+    public const int TYPE_ASCII = 2;
+    public const int TYPE_SHORT = 3;
+    public const int TYPE_LONG = 4;
+    public const int TYPE_RATIONAL = 5;
+    public const int TYPE_SBYTE = 6;
+    public const int TYPE_UNDEFINED = 7;
+    public const int TYPE_SSHORT = 8;
+    public const int TYPE_SLONG = 9;
+    public const int TYPE_SRATIONAL = 10;
+    public const int TYPE_FLOAT = 11;
+    public const int TYPE_DOUBLE = 12;
+    public const int TYPE_IFD = 13;
+    public const int TYPE_LONG8 = 16;
+    public const int TYPE_SLONG8 = 17;
+    public const int TYPE_IFD8 = 18;
+
+    private function __construct()
+    {
+    }
+}

--- a/src/Parse/Tiff/TiffExifReader.php
+++ b/src/Parse/Tiff/TiffExifReader.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace MagicSunday\ImageMeta\Parse\Tiff;
 
+use MagicSunday\ImageMeta\Core\BitMask;
 use MagicSunday\ImageMeta\Core\BoundsError;
 use MagicSunday\ImageMeta\Core\Endian;
 use MagicSunday\ImageMeta\Core\MemoryBuffer;
@@ -56,42 +57,6 @@ use function substr;
  */
 final class TiffExifReader
 {
-    private const int TIFF_MAGIC_CLASSIC = 0x002A;
-
-    private const int TIFF_MAGIC_BIG = 0x002B;
-
-    private const int TYPE_BYTE = 1;
-
-    private const int TYPE_ASCII = 2;
-
-    private const int TYPE_SHORT = 3;
-
-    private const int TYPE_LONG = 4;
-
-    private const int TYPE_RATIONAL = 5;
-
-    private const int TYPE_SBYTE = 6;
-
-    private const int TYPE_UNDEFINED = 7;
-
-    private const int TYPE_SSHORT = 8;
-
-    private const int TYPE_SLONG = 9;
-
-    private const int TYPE_SRATIONAL = 10;
-
-    private const int TYPE_FLOAT = 11;
-
-    private const int TYPE_DOUBLE = 12;
-
-    private const int TYPE_IFD = 13;
-
-    private const int TYPE_LONG8 = 16;
-
-    private const int TYPE_SLONG8 = 17;
-
-    private const int TYPE_IFD8 = 18;
-
     /**
      * XP metadata tags stored as UTF-16LE byte sequences.
      *
@@ -129,6 +94,36 @@ final class TiffExifReader
         ExifTag::SUB_IFDS,
         ExifTag::JPEG_INTERCHANGE_FORMAT,
     ];
+
+    private const int UTF16_HIGH_SURROGATE_START = 0xD800;
+
+    private const int UTF16_HIGH_SURROGATE_END = 0xDBFF;
+
+    private const int UTF16_LOW_SURROGATE_START = 0xDC00;
+
+    private const int UTF16_LOW_SURROGATE_END = 0xDFFF;
+
+    private const int UTF16_SUPPLEMENTARY_OFFSET = 0x10000;
+
+    private const int UTF8_SINGLE_BYTE_MAX = 0x7F;
+
+    private const int UTF8_TWO_BYTE_MAX = 0x7FF;
+
+    private const int UTF8_THREE_BYTE_MAX = 0xFFFF;
+
+    private const int UTF8_MAX_CODE_POINT = 0x10FFFF;
+
+    private const int UTF8_TWO_BYTE_PREFIX = 0xC0;
+
+    private const int UTF8_THREE_BYTE_PREFIX = 0xE0;
+
+    private const int UTF8_FOUR_BYTE_PREFIX = 0xF0;
+
+    private const int ASCII_PRINTABLE_MIN = 0x20;
+
+    private const int ASCII_PRINTABLE_MAX = 0x7E;
+
+    private const int UTF8_CONTINUATION_PREFIX = 0x80;
 
     private const string UNICODE_REPLACEMENT = "\u{FFFD}";
 
@@ -182,12 +177,12 @@ final class TiffExifReader
         };
 
         $magic = $this->readU16();
-        if ($magic === self::TIFF_MAGIC_BIG) {
+        if ($magic === TiffConst::MAGIC_BIG) {
             $this->bigTiff = true;
             $this->parseBigTiffHeader();
             $firstIfd = $this->readBigTiffOffsetValue();
             $ifd0     = $this->readIfd($firstIfd);
-        } elseif ($magic === self::TIFF_MAGIC_CLASSIC) {
+        } elseif ($magic === TiffConst::MAGIC_CLASSIC) {
             $this->bigTiff = false;
             $firstIfd      = $this->readU32();
             $ifd0          = $this->readIfd($firstIfd);
@@ -195,8 +190,8 @@ final class TiffExifReader
             throw new ParseError(
                 sprintf(
                     'Unknown TIFF magic (expected 0x%04X or 0x%04X)',
-                    self::TIFF_MAGIC_CLASSIC,
-                    self::TIFF_MAGIC_BIG,
+                    TiffConst::MAGIC_CLASSIC,
+                    TiffConst::MAGIC_BIG,
                 ),
             );
         }
@@ -472,14 +467,14 @@ final class TiffExifReader
             $chunk = substr($rawBytes, $i * $componentSize, $componentSize);
 
             $value = match ($type) {
-                self::TYPE_SHORT => $this->unpackU16($chunk),
-                self::TYPE_SSHORT => $this->unpackS16($chunk),
-                self::TYPE_LONG,
-                self::TYPE_IFD => $this->unpackU32($chunk),
-                self::TYPE_SLONG => $this->unpackS32($chunk),
-                self::TYPE_LONG8,
-                self::TYPE_IFD8 => $this->unpackU64($chunk),
-                self::TYPE_SLONG8 => $this->unpackS64($chunk),
+                TiffConst::TYPE_SHORT => $this->unpackU16($chunk),
+                TiffConst::TYPE_SSHORT => $this->unpackS16($chunk),
+                TiffConst::TYPE_LONG,
+                TiffConst::TYPE_IFD => $this->unpackU32($chunk),
+                TiffConst::TYPE_SLONG => $this->unpackS32($chunk),
+                TiffConst::TYPE_LONG8,
+                TiffConst::TYPE_IFD8 => $this->unpackU64($chunk),
+                TiffConst::TYPE_SLONG8 => $this->unpackS64($chunk),
                 default => throw new ParseError('Unsupported numeric type for strip/tile field: ' . $type),
             };
 
@@ -560,9 +555,9 @@ final class TiffExifReader
     private function collectSubIfds(IfdEntry $entry): void
     {
         if (
-            $entry->type !== self::TYPE_IFD
-            && $entry->type !== self::TYPE_IFD8
-            && $entry->type !== self::TYPE_LONG
+            $entry->type !== TiffConst::TYPE_IFD
+            && $entry->type !== TiffConst::TYPE_IFD8
+            && $entry->type !== TiffConst::TYPE_LONG
         ) {
             return;
         }
@@ -647,11 +642,11 @@ final class TiffExifReader
         }
 
         // ASCII
-        if ($type === self::TYPE_ASCII) {
+        if ($type === TiffConst::TYPE_ASCII) {
             return rtrim($bytes, "\0");
         }
 
-        if ($type === self::TYPE_UNDEFINED) {
+        if ($type === TiffConst::TYPE_UNDEFINED) {
             if ($this->isPrintableAsciiOrNull($bytes)) {
                 return rtrim($bytes, "\0");
             }
@@ -660,11 +655,11 @@ final class TiffExifReader
         }
 
         // RATIONAL / SRATIONAL
-        if ($type === self::TYPE_RATIONAL || $type === self::TYPE_SRATIONAL) {
+        if ($type === TiffConst::TYPE_RATIONAL || $type === TiffConst::TYPE_SRATIONAL) {
             $rationalValues = [];
             for ($i = 0; $i < $count; ++$i) {
-                $num              = $this->read32FromBytes($bytes, $i * 8, $type === self::TYPE_SRATIONAL);
-                $den              = $this->read32FromBytes($bytes, $i * 8 + 4, $type === self::TYPE_SRATIONAL);
+                $num              = $this->read32FromBytes($bytes, $i * 8, $type === TiffConst::TYPE_SRATIONAL);
+                $den              = $this->read32FromBytes($bytes, $i * 8 + 4, $type === TiffConst::TYPE_SRATIONAL);
                 $rationalValues[] = new ExifRational($num, $den);
             }
 
@@ -678,27 +673,27 @@ final class TiffExifReader
         for ($i = 0; $i < $count; ++$i) {
             $vals[] = match ($type) {
                 // BYTE
-                self::TYPE_BYTE => ord($bytes[$cursor]),
+                TiffConst::TYPE_BYTE => ord($bytes[$cursor]),
                 // SBYTE
-                self::TYPE_SBYTE => $this->toSigned(ord($bytes[$cursor]), 8),
+                TiffConst::TYPE_SBYTE => $this->toSigned(ord($bytes[$cursor]), 8),
                 // SHORT
-                self::TYPE_SHORT => $this->unpackU16(substr($bytes, $cursor, 2)),
+                TiffConst::TYPE_SHORT => $this->unpackU16(substr($bytes, $cursor, 2)),
                 // SSHORT
-                self::TYPE_SSHORT => $this->unpackS16(substr($bytes, $cursor, 2)),
+                TiffConst::TYPE_SSHORT => $this->unpackS16(substr($bytes, $cursor, 2)),
                 // LONG
-                self::TYPE_LONG,
-                self::TYPE_IFD => $this->unpackU32(substr($bytes, $cursor, 4)),
+                TiffConst::TYPE_LONG,
+                TiffConst::TYPE_IFD => $this->unpackU32(substr($bytes, $cursor, 4)),
                 // SLONG
-                self::TYPE_SLONG => $this->unpackS32(substr($bytes, $cursor, 4)),
+                TiffConst::TYPE_SLONG => $this->unpackS32(substr($bytes, $cursor, 4)),
                 // LONG8 / IFD8
-                self::TYPE_LONG8,
-                self::TYPE_IFD8 => $this->unpackU64(substr($bytes, $cursor, 8)),
+                TiffConst::TYPE_LONG8,
+                TiffConst::TYPE_IFD8 => $this->unpackU64(substr($bytes, $cursor, 8)),
                 // SLONG8
-                self::TYPE_SLONG8 => $this->unpackS64(substr($bytes, $cursor, 8)),
+                TiffConst::TYPE_SLONG8 => $this->unpackS64(substr($bytes, $cursor, 8)),
                 // FLOAT
-                self::TYPE_FLOAT => $this->unpackFloat(substr($bytes, $cursor, 4)),
+                TiffConst::TYPE_FLOAT => $this->unpackFloat(substr($bytes, $cursor, 4)),
                 // DOUBLE
-                self::TYPE_DOUBLE => $this->unpackDouble(substr($bytes, $cursor, 8)),
+                TiffConst::TYPE_DOUBLE => $this->unpackDouble(substr($bytes, $cursor, 8)),
 
                 default => throw new ParseError('Unsupported type in decodeBytes: ' . $type),
             };
@@ -795,7 +790,7 @@ final class TiffExifReader
         for ($i = 0; $i + 1 < $length; $i += 2) {
             $unit = ord($bytes[$i]) | (ord($bytes[$i + 1]) << 8);
 
-            if ($unit >= 0xD800 && $unit <= 0xDBFF) {
+            if ($unit >= self::UTF16_HIGH_SURROGATE_START && $unit <= self::UTF16_HIGH_SURROGATE_END) {
                 if ($i + 3 >= $length) {
                     $result .= self::UNICODE_REPLACEMENT;
                     break;
@@ -803,14 +798,14 @@ final class TiffExifReader
 
                 $low = ord($bytes[$i + 2]) | (ord($bytes[$i + 3]) << 8);
 
-                if ($low < 0xDC00 || $low > 0xDFFF) {
+                if ($low < self::UTF16_LOW_SURROGATE_START || $low > self::UTF16_LOW_SURROGATE_END) {
                     $result .= self::UNICODE_REPLACEMENT;
                     continue;
                 }
 
-                $codePoint = 0x10000 + (($unit - 0xD800) << 10) + ($low - 0xDC00);
+                $codePoint = self::UTF16_SUPPLEMENTARY_OFFSET + (($unit - self::UTF16_HIGH_SURROGATE_START) << 10) + ($low - self::UTF16_LOW_SURROGATE_START);
                 $i += 2;
-            } elseif ($unit >= 0xDC00 && $unit <= 0xDFFF) {
+            } elseif ($unit >= self::UTF16_LOW_SURROGATE_START && $unit <= self::UTF16_LOW_SURROGATE_END) {
                 $result .= self::UNICODE_REPLACEMENT;
                 continue;
             } else {
@@ -828,27 +823,27 @@ final class TiffExifReader
      */
     private function codePointToUtf8(int $codePoint): string
     {
-        if ($codePoint <= 0x7F) {
+        if ($codePoint <= self::UTF8_SINGLE_BYTE_MAX) {
             return chr($codePoint);
         }
 
-        if ($codePoint <= 0x7FF) {
-            return chr(0xC0 | ($codePoint >> 6))
-                . chr(0x80 | ($codePoint & 0x3F));
+        if ($codePoint <= self::UTF8_TWO_BYTE_MAX) {
+            return chr(self::UTF8_TWO_BYTE_PREFIX | ($codePoint >> 6))
+                . chr(self::UTF8_CONTINUATION_PREFIX | ($codePoint & BitMask::SIX_BIT_MASK));
         }
 
-        if ($codePoint <= 0xFFFF) {
-            return chr(0xE0 | ($codePoint >> 12))
-                . chr(0x80 | (($codePoint >> 6) & 0x3F))
-                . chr(0x80 | ($codePoint & 0x3F));
+        if ($codePoint <= self::UTF8_THREE_BYTE_MAX) {
+            return chr(self::UTF8_THREE_BYTE_PREFIX | ($codePoint >> 12))
+                . chr(self::UTF8_CONTINUATION_PREFIX | (($codePoint >> 6) & BitMask::SIX_BIT_MASK))
+                . chr(self::UTF8_CONTINUATION_PREFIX | ($codePoint & BitMask::SIX_BIT_MASK));
         }
 
-        $codePoint = $codePoint > 0x10FFFF ? 0x10FFFF : $codePoint;
+        $codePoint = $codePoint > self::UTF8_MAX_CODE_POINT ? self::UTF8_MAX_CODE_POINT : $codePoint;
 
-        return chr(0xF0 | ($codePoint >> 18))
-            . chr(0x80 | (($codePoint >> 12) & 0x3F))
-            . chr(0x80 | (($codePoint >> 6) & 0x3F))
-            . chr(0x80 | ($codePoint & 0x3F));
+        return chr(self::UTF8_FOUR_BYTE_PREFIX | ($codePoint >> 18))
+            . chr(self::UTF8_CONTINUATION_PREFIX | (($codePoint >> 12) & BitMask::SIX_BIT_MASK))
+            . chr(self::UTF8_CONTINUATION_PREFIX | (($codePoint >> 6) & BitMask::SIX_BIT_MASK))
+            . chr(self::UTF8_CONTINUATION_PREFIX | ($codePoint & BitMask::SIX_BIT_MASK));
     }
 
     /**
@@ -865,7 +860,7 @@ final class TiffExifReader
                 continue;
             }
 
-            if ($value < 0x20 || $value > 0x7E) {
+            if ($value < self::ASCII_PRINTABLE_MIN || $value > self::ASCII_PRINTABLE_MAX) {
                 return false;
             }
         }
@@ -1148,28 +1143,28 @@ final class TiffExifReader
     {
         return match ($type) {
             // BYTE, ASCII, SBYTE, UNDEFINED
-            self::TYPE_BYTE,
-            self::TYPE_ASCII,
-            self::TYPE_SBYTE,
-            self::TYPE_UNDEFINED => 1,
+            TiffConst::TYPE_BYTE,
+            TiffConst::TYPE_ASCII,
+            TiffConst::TYPE_SBYTE,
+            TiffConst::TYPE_UNDEFINED => 1,
 
             // SHORT, SSHORT
-            self::TYPE_SHORT,
-            self::TYPE_SSHORT => 2,
+            TiffConst::TYPE_SHORT,
+            TiffConst::TYPE_SSHORT => 2,
 
             // LONG, SLONG, FLOAT
-            self::TYPE_LONG,
-            self::TYPE_IFD,
-            self::TYPE_SLONG,
-            self::TYPE_FLOAT => 4,
+            TiffConst::TYPE_LONG,
+            TiffConst::TYPE_IFD,
+            TiffConst::TYPE_SLONG,
+            TiffConst::TYPE_FLOAT => 4,
 
             // RATIONAL, SRATIONAL, DOUBLE
-            self::TYPE_RATIONAL,
-            self::TYPE_SRATIONAL,
-            self::TYPE_DOUBLE,
-            self::TYPE_LONG8,
-            self::TYPE_SLONG8,
-            self::TYPE_IFD8 => 8,
+            TiffConst::TYPE_RATIONAL,
+            TiffConst::TYPE_SRATIONAL,
+            TiffConst::TYPE_DOUBLE,
+            TiffConst::TYPE_LONG8,
+            TiffConst::TYPE_SLONG8,
+            TiffConst::TYPE_IFD8 => 8,
 
             default => throw new ParseError('Unsupported TIFF type: ' . $type),
         };
@@ -1227,8 +1222,8 @@ final class TiffExifReader
                 $hi = $v->high();
                 $lo = $v->low();
             } else {
-                $lo = $v & 0xFFFFFFFF;
-                $hi = (int) intdiv($v, 0x100000000);
+                $lo = $v & BitMask::UINT32_MAX;
+                $hi = (int) intdiv($v, BitMask::UINT32_BASE);
             }
 
             return $this->bo === Endian::Little ? pack('V2', $lo, $hi) : pack('N2', $hi, $lo);
@@ -1238,7 +1233,7 @@ final class TiffExifReader
         $bin = '';
         $value = $v instanceof UInt64 ? $v->toInt('Inline value') : $v;
         for ($i = 0; $i < $bytes; ++$i) {
-            $bin = chr(($value >> ($this->bo === Endian::Little ? ($i * 8) : (($bytes - 1 - $i) * 8))) & 0xFF) . $bin;
+            $bin = chr(($value >> ($this->bo === Endian::Little ? ($i * 8) : (($bytes - 1 - $i) * 8))) & BitMask::LOW_BYTE) . $bin;
         }
 
         return $bin;
@@ -1285,7 +1280,7 @@ final class TiffExifReader
     {
         $u = $this->unpackU16($b);
 
-        return $u >= 0x8000 ? $u - 0x10000 : $u;
+        return $u >= BitMask::SIGN_BIT_16 ? $u - BitMask::UINT16_BASE : $u;
     }
 
     /**
@@ -1313,7 +1308,7 @@ final class TiffExifReader
     {
         $u = $this->unpackU32($b);
 
-        return (($u & 0x80000000) !== 0) ? -((~$u & 0xFFFFFFFF) + 1) : $u;
+        return (($u & BitMask::SIGN_BIT_32) !== 0) ? -((~$u & BitMask::UINT32_MAX) + 1) : $u;
     }
 
     /**
@@ -1369,12 +1364,12 @@ final class TiffExifReader
         $hi       = $unsigned->high();
         $lo       = $unsigned->low();
 
-        if (($hi & 0x80000000) === 0) {
+        if (($hi & BitMask::SIGN_BIT_32) === 0) {
             return $unsigned->toInt('Signed 64-bit integer');
         }
 
-        $hiComplement = (~$hi) & 0xFFFFFFFF;
-        $loComplement = (~$lo) & 0xFFFFFFFF;
+        $hiComplement = (~$hi) & BitMask::UINT32_MAX;
+        $loComplement = (~$lo) & BitMask::UINT32_MAX;
         $magnitude    = Unpack::combineUint32($hiComplement, $loComplement)->addSmall(1)->toInt('Signed 64-bit integer magnitude');
 
         return -$magnitude;


### PR DESCRIPTION
## Summary
- add shared bit mask, JPEG marker, and TIFF constant collections
- replace inline hexadecimal literals in JPEG, TIFF, ICC, and MPF parsing logic with named constants
- align binary plist decoder and EXIF helpers with the new constants for consistent masking and validation

## Testing
- composer ci:test:php:unit
- composer ci:test:php:phpstan *(fails: existing phpstan issues in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68ffa60664e48323ac683f68de94163d