### PR TITLE
feat: expose EXIF-only API facade

### DIFF
--- a/src/Api/ExifDocument.php
+++ b/src/Api/ExifDocument.php
@@ -1,0 +1,459 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\ImageMeta\Api;
+
+use DateTimeImmutable;
+use MagicSunday\ImageMeta\Curate\Exif\Structured\Camera as StructuredCamera;
+use MagicSunday\ImageMeta\Curate\Exif\Structured\Exposure as StructuredExposure;
+use MagicSunday\ImageMeta\Curate\Exif\Structured\Gps as StructuredGps;
+use MagicSunday\ImageMeta\Curate\Exif\Structured\Image as StructuredImage;
+use MagicSunday\ImageMeta\Curate\Exif\Structured\Lens as StructuredLens;
+use MagicSunday\ImageMeta\Curate\Exif\Structured\Preview as StructuredPreview;
+use MagicSunday\ImageMeta\Model\Exif\ExifDocument as ModelExifDocument;
+use MagicSunday\ImageMeta\Model\Exif\ExifNumericList;
+use MagicSunday\ImageMeta\Model\Exif\ExifTag;
+use MagicSunday\ImageMeta\Model\Exif\ValueConverters;
+use MagicSunday\ImageMeta\Value\Camera as CameraValue;
+use MagicSunday\ImageMeta\Value\Derived;
+use MagicSunday\ImageMeta\Value\Enum\ColorSpace;
+use MagicSunday\ImageMeta\Value\Enum\ExposureProgram;
+use MagicSunday\ImageMeta\Value\Enum\MeteringMode;
+use MagicSunday\ImageMeta\Value\Enum\Orientation;
+use MagicSunday\ImageMeta\Value\Enum\WhiteBalance;
+use MagicSunday\ImageMeta\Value\ExifFlash;
+use MagicSunday\ImageMeta\Value\Exposure as ExposureValue;
+use MagicSunday\ImageMeta\Value\Gps as GpsValue;
+use MagicSunday\ImageMeta\Value\Image as ImageValue;
+use MagicSunday\ImageMeta\Value\Lens as LensValue;
+use MagicSunday\ImageMeta\Value\Preview as PreviewValue;
+
+use function is_float;
+use function is_int;
+
+/**
+ * Provides an EXIF-only structured view derived from a parsed document.
+ */
+final class ExifDocument
+{
+    private readonly ?ModelExifDocument $raw;
+
+    private readonly StructuredCamera $camera;
+
+    private readonly StructuredLens $lens;
+
+    private readonly StructuredExposure $exposure;
+
+    private readonly StructuredGps $gps;
+
+    private readonly StructuredImage $image;
+
+    private readonly StructuredPreview $preview;
+
+    public function __construct(
+        ?ModelExifDocument $document,
+        ?int $fallbackWidth = null,
+        ?int $fallbackHeight = null,
+        ?int $fallbackBitsPerSample = null,
+    ) {
+        $this->raw = $document;
+
+        $cameraValue   = $this->createCameraValue($document);
+        $lensValue     = $this->createLensValue($document);
+        $exposureValue = $this->createExposureValue($document);
+        $derived       = $this->createDerivedValues($lensValue, $exposureValue);
+        $gpsValue      = $this->createGpsValue($document);
+        $imageValue    = $this->createImageValue($document, $fallbackWidth, $fallbackHeight, $fallbackBitsPerSample);
+        $previewValue  = $this->createPreviewValue($document);
+
+        $this->camera   = new StructuredCamera($cameraValue);
+        $this->lens     = new StructuredLens($lensValue, $derived);
+        $this->exposure = new StructuredExposure($exposureValue, $derived);
+        $this->gps      = new StructuredGps($gpsValue);
+        $this->image    = new StructuredImage($imageValue);
+        $this->preview  = new StructuredPreview($previewValue);
+    }
+
+    public function camera(): StructuredCamera
+    {
+        return $this->camera;
+    }
+
+    public function lens(): StructuredLens
+    {
+        return $this->lens;
+    }
+
+    public function exposure(): StructuredExposure
+    {
+        return $this->exposure;
+    }
+
+    public function gps(): StructuredGps
+    {
+        return $this->gps;
+    }
+
+    public function image(): StructuredImage
+    {
+        return $this->image;
+    }
+
+    public function preview(): StructuredPreview
+    {
+        return $this->preview;
+    }
+
+    public function hasData(): bool
+    {
+        return $this->raw instanceof ModelExifDocument;
+    }
+
+    public function raw(): ?ModelExifDocument
+    {
+        return $this->raw;
+    }
+
+    private function createCameraValue(?ModelExifDocument $document): CameraValue
+    {
+        if (!$document instanceof ModelExifDocument) {
+            return new CameraValue(null, null, null, null, null, null, null);
+        }
+
+        $firmware = $document->cameraFirmware();
+        if ($firmware === null && (float) $document->exifProfile() < 3.0) {
+            $firmware = $document->cameraFirmwareVersion();
+        }
+        if ($firmware === null) {
+            $firmware = $document->software();
+        }
+
+        return new CameraValue(
+            make: $document->cameraMake(),
+            model: $document->cameraModel(),
+            ownerName: $document->ownerName(),
+            serialNumber: $document->cameraSerialNumber(),
+            firmware: $firmware,
+            fileSource: $document->fileSource(),
+            sensingMethod: $document->sensingMethod(),
+        );
+    }
+
+    private function createLensValue(?ModelExifDocument $document): LensValue
+    {
+        if (!$document instanceof ModelExifDocument) {
+            return new LensValue(null, null, null, null, null, null, null);
+        }
+
+        $maxApex = $document->maxApertureApex();
+        $maxF    = $maxApex !== null ? ValueConverters::apexToFNumber($maxApex) : null;
+
+        return new LensValue(
+            lensMake: $document->lensMake(),
+            lensModel: $document->lensModel(),
+            lensSerialNumber: $document->lensSerialNumber(),
+            focalLengthMm: $document->focalLengthMm(),
+            focalLengthIn35mm: $document->focalLength35Mm(),
+            maxApertureFNumber: $maxF,
+            lensSpecification: $document->lensSpecification(),
+        );
+    }
+
+    private function createExposureValue(?ModelExifDocument $document): ExposureValue
+    {
+        $program      = null;
+        $metering     = null;
+        $whiteBalance = null;
+        $iso          = null;
+
+        if ($document instanceof ModelExifDocument) {
+            $programCode = $document->exposureProgram();
+            if ($programCode !== null) {
+                $program = ExposureProgram::tryFrom($programCode);
+            }
+
+            $meteringCode = $document->meteringMode();
+            if ($meteringCode !== null) {
+                $metering = MeteringMode::tryFrom($meteringCode);
+            }
+
+            $whiteBalanceCode = $document->whiteBalance();
+            if ($whiteBalanceCode !== null) {
+                $whiteBalance = WhiteBalance::tryFrom($whiteBalanceCode);
+            }
+
+            $flashInfo = ExifFlash::fromExifValue($document->flash());
+            $iso       = $this->resolveIso($document);
+
+            return new ExposureValue(
+                iso: $iso,
+                exposureTimeSec: $document->exposureTime(),
+                fNumber: $document->fNumber(),
+                exposureBiasEv: $document->exposureBias(),
+                program: $program,
+                meteringMode: $metering,
+                flash: $flashInfo,
+                whiteBalance: $whiteBalance,
+                brightnessEv: $document->brightnessValue(),
+                exposureMode: $document->exposureMode(),
+                gainControl: $document->gainControl(),
+                contrast: $document->contrast(),
+                saturation: $document->saturation(),
+                sharpness: $document->sharpness(),
+                digitalZoomRatio: $document->digitalZoomRatio(),
+                shutterSpeedEv: $document->shutterSpeedEv(),
+                apertureEv: $document->apertureEv(),
+                isoLatitudeYyy: $document->isoLatitudeYyy(),
+                isoLatitudeZzz: $document->isoLatitudeZzz(),
+                exposureIndex: $document->exposureIndex(),
+                flashEnergy: $document->flashEnergy(),
+            );
+        }
+
+        return new ExposureValue(
+            iso: null,
+            exposureTimeSec: null,
+            fNumber: null,
+            exposureBiasEv: null,
+            program: null,
+            meteringMode: null,
+            flash: null,
+            whiteBalance: null,
+            brightnessEv: null,
+            exposureMode: null,
+            gainControl: null,
+            contrast: null,
+            saturation: null,
+            sharpness: null,
+            digitalZoomRatio: null,
+            shutterSpeedEv: null,
+            apertureEv: null,
+            isoLatitudeYyy: null,
+            isoLatitudeZzz: null,
+            exposureIndex: null,
+            flashEnergy: null,
+        );
+    }
+
+    private function createDerivedValues(LensValue $lens, ExposureValue $exposure): Derived
+    {
+        $cropFactor          = ValueConverters::calcCropFactor($lens->focalLengthIn35mm, $lens->focalLengthMm);
+        $circleOfConfusionMm = ValueConverters::calcCircleOfConfusionMm($cropFactor);
+
+        return new Derived(
+            ev100: ValueConverters::calcEv100(
+                $exposure->exposureTimeSec,
+                $exposure->fNumber,
+                $exposure->iso,
+            ),
+            hyperfocalM: ValueConverters::calcHyperfocalM(
+                $lens->focalLengthMm,
+                $exposure->fNumber,
+                $circleOfConfusionMm,
+            ),
+            fovDiagonalDeg: ValueConverters::calcFovDeg($lens->focalLengthIn35mm, $cropFactor, $lens->focalLengthMm),
+            fovHorizontalDeg: ValueConverters::calcHorizontalFovDeg($lens->focalLengthIn35mm, $cropFactor, $lens->focalLengthMm),
+            fovVerticalDeg: ValueConverters::calcVerticalFovDeg($lens->focalLengthIn35mm, $cropFactor, $lens->focalLengthMm),
+            focalLength35mm: $lens->focalLengthIn35mm,
+            cropFactor: $cropFactor,
+        );
+    }
+
+    private function createGpsValue(?ModelExifDocument $document): GpsValue
+    {
+        if (!$document instanceof ModelExifDocument) {
+            return new GpsValue();
+        }
+
+        /** @var array{
+         *     lat_ref:?string,
+         *     lat:?float,
+         *     lon_ref:?string,
+         *     lon:?float,
+         *     alt_ref:?int,
+         *     alt:?float,
+         *     version:?string,
+         *     version_raw:?string,
+         *     satellites:?string,
+         *     status:?string,
+         *     measure_mode:?string,
+         *     dop:?float,
+         *     speed_ref:?string,
+         *     speed_ms:?float,
+         *     speed_original_ref:?string,
+         *     speed_original:?float,
+         *     track_ref:?string,
+         *     track:?float,
+         *     img_direction_ref:?string,
+         *     img_direction:?float,
+         *     map_datum:?string,
+         *     dest_lat_ref:?string,
+         *     dest_lat:?float,
+         *     dest_lon_ref:?string,
+         *     dest_lon:?float,
+         *     dest_bearing_ref:?string,
+         *     dest_bearing:?float,
+         *     dest_distance_ref:?string,
+         *     dest_distance_m:?float,
+         *     dest_distance_original_ref:?string,
+         *     dest_distance_original:?float,
+         *     processing_method:?string,
+         *     area_information:?string,
+         *     date:?string,
+         *     date_raw:?string,
+         *     time:?string,
+         *     timestamp:?DateTimeImmutable,
+         *     differential:?int,
+         *     h_positioning_error:?float
+         * } $map */
+        $map = $document->gps();
+
+        return new GpsValue(
+            latitude: $map['lat'],
+            longitude: $map['lon'],
+            latitudeRef: $map['lat_ref'],
+            longitudeRef: $map['lon_ref'],
+            altitude: $map['alt'],
+            altitudeRef: $map['alt_ref'],
+            version: $map['version'],
+            versionRaw: $map['version_raw'],
+            satellites: $map['satellites'],
+            status: $map['status'],
+            measureMode: $map['measure_mode'],
+            dop: $map['dop'],
+            speedRef: $map['speed_ref'],
+            speedMs: $map['speed_ms'],
+            speedOriginalRef: $map['speed_original_ref'],
+            speedOriginal: $map['speed_original'],
+            trackRef: $map['track_ref'],
+            track: $map['track'],
+            imageDirectionRef: $map['img_direction_ref'],
+            imageDirection: $map['img_direction'],
+            mapDatum: $map['map_datum'],
+            destinationLatitudeRef: $map['dest_lat_ref'],
+            destinationLatitude: $map['dest_lat'],
+            destinationLongitudeRef: $map['dest_lon_ref'],
+            destinationLongitude: $map['dest_lon'],
+            destinationBearingRef: $map['dest_bearing_ref'],
+            destinationBearing: $map['dest_bearing'],
+            destinationDistanceRef: $map['dest_distance_ref'],
+            destinationDistanceMetres: $map['dest_distance_m'],
+            destinationDistanceOriginalRef: $map['dest_distance_original_ref'],
+            destinationDistanceOriginal: $map['dest_distance_original'],
+            processingMethod: $map['processing_method'],
+            areaInformation: $map['area_information'],
+            date: $map['date'],
+            dateRaw: $map['date_raw'],
+            time: $map['time'],
+            timestamp: $map['timestamp'],
+            differential: $map['differential'],
+            horizontalPositioningError: $map['h_positioning_error'],
+        );
+    }
+
+    private function createImageValue(
+        ?ModelExifDocument $document,
+        ?int $fallbackWidth,
+        ?int $fallbackHeight,
+        ?int $fallbackBitsPerSample,
+    ): ImageValue {
+        $orientation = Orientation::fromExifValue($document?->orientation());
+
+        $colorSpace = null;
+        if ($document instanceof ModelExifDocument) {
+            $colorSpace = ColorSpace::fromExifValue($document->colorSpace());
+        }
+
+        $bitsPerSample = $document?->bitsPerSample();
+        if ($bitsPerSample === null) {
+            $bitsPerSample = $fallbackBitsPerSample;
+        }
+
+        return new ImageValue(
+            width: $document?->imageWidth() ?? $fallbackWidth,
+            height: $document?->imageHeight() ?? $fallbackHeight,
+            orientation: $orientation,
+            bitsPerSample: $bitsPerSample,
+            colorSpace: $colorSpace,
+            imageUniqueId: $document?->imageUniqueId(),
+            imageNumber: $document?->imageNumber(),
+            documentName: $document?->documentName(),
+            description: $document?->imageDescription(),
+            title: $document?->imageTitle(),
+            componentsConfiguration: $document?->componentsConfiguration(),
+            compressedBitsPerPixel: $document?->compressedBitsPerPixel(),
+            interlace: $document?->interlace(),
+            userComment: $document?->userComment(),
+        );
+    }
+
+    private function createPreviewValue(?ModelExifDocument $document): PreviewValue
+    {
+        return new PreviewValue(
+            hasThumbnail: $document?->hasThumbnail(),
+            hasPreview: $document?->hasPreviewImage(),
+            previewWidth: $document?->previewImageWidth(),
+            previewHeight: $document?->previewImageHeight(),
+        );
+    }
+
+    private function resolveIso(ModelExifDocument $document): ?int
+    {
+        $iso = $document->iso();
+        if ($iso !== null) {
+            return $iso;
+        }
+
+        $candidates = [
+            ExifTag::PHOTOGRAPHIC_SENSITIVITY,
+            ExifTag::STANDARD_OUTPUT_SENSITIVITY,
+            ExifTag::RECOMMENDED_EXPOSURE_INDEX,
+            ExifTag::ISO_SPEED,
+        ];
+
+        foreach ($candidates as $tag) {
+            $entry    = $document->exifIfd?->get($tag);
+            $resolved = $this->extractInt($entry?->value);
+            if ($resolved !== null) {
+                return $resolved;
+            }
+        }
+
+        $fallback = $document->ifd0->get(ExifTag::PHOTOGRAPHIC_SENSITIVITY);
+
+        return $this->extractInt($fallback?->value);
+    }
+
+    private function extractInt(mixed $value): ?int
+    {
+        if (is_int($value)) {
+            return $value;
+        }
+
+        if (is_float($value)) {
+            return (int) round($value);
+        }
+
+        if ($value instanceof ExifNumericList) {
+            $first = $value->values[0] ?? null;
+
+            if (is_int($first)) {
+                return $first;
+            }
+
+            if (is_float($first)) {
+                return (int) round($first);
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/Api/ExifReader.php
+++ b/src/Api/ExifReader.php
@@ -1,0 +1,61 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\ImageMeta\Api;
+
+use MagicSunday\ImageMeta\Core\Stream;
+use MagicSunday\ImageMeta\Detect\ContainerType;
+use MagicSunday\ImageMeta\Detect\FormatDetector;
+use MagicSunday\ImageMeta\Parse\IsoBmff\IsoBmffExtractor;
+use MagicSunday\ImageMeta\Parse\Jpeg\JpegExtractor;
+use MagicSunday\ImageMeta\Parse\Tiff\TiffExifReader;
+
+/**
+ * Facade exposing EXIF-only access for supported container formats.
+ */
+final class ExifReader
+{
+    private readonly TiffExifReader $tiffReader;
+
+    public function __construct(?TiffExifReader $tiffReader = null)
+    {
+        $this->tiffReader = $tiffReader ?? new TiffExifReader();
+    }
+
+    public function read(string $path): ExifDocument
+    {
+        $stream = Stream::fromPath($path);
+        $type   = FormatDetector::detect($stream);
+
+        $exifBlobs             = [];
+        $fallbackWidth         = null;
+        $fallbackHeight        = null;
+        $fallbackBitsPerSample = null;
+
+        if ($type === ContainerType::JPEG) {
+            $jpeg                  = new JpegExtractor($stream);
+            $exifBlobs             = $jpeg->extractExifBlobs();
+            $fallbackWidth         = $jpeg->getFrameWidth();
+            $fallbackHeight        = $jpeg->getFrameHeight();
+            $fallbackBitsPerSample = $jpeg->getFrameSamplePrecision();
+        } else {
+            $isoExtractor = new IsoBmffExtractor($stream);
+            [$exifBlobs]  = $isoExtractor->extract();
+        }
+
+        $document = null;
+        if ($exifBlobs !== []) {
+            $document = $this->tiffReader->parseFromBlob($exifBlobs[0]);
+        }
+
+        return new ExifDocument($document, $fallbackWidth, $fallbackHeight, $fallbackBitsPerSample);
+    }
+}

--- a/src/Curate/Exif/Structured/Camera.php
+++ b/src/Curate/Exif/Structured/Camera.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\ImageMeta\Curate\Exif\Structured;
+
+use MagicSunday\ImageMeta\Value\Camera as CameraValue;
+use MagicSunday\ImageMeta\Value\Enum\FileSource;
+use MagicSunday\ImageMeta\Value\Enum\SensingMethod;
+
+/**
+ * Provides EXIF backed camera metadata without container fallbacks.
+ */
+final readonly class Camera
+{
+    public ?string $make;
+
+    public ?string $model;
+
+    public ?string $ownerName;
+
+    public ?string $serialNumber;
+
+    public ?string $firmware;
+
+    public ?FileSource $fileSource;
+
+    public ?SensingMethod $sensingMethod;
+
+    public function __construct(CameraValue $camera)
+    {
+        $this->make          = $camera->make;
+        $this->model         = $camera->model;
+        $this->ownerName     = $camera->ownerName;
+        $this->serialNumber  = $camera->serialNumber;
+        $this->firmware      = $camera->firmware;
+        $this->fileSource    = $camera->fileSource;
+        $this->sensingMethod = $camera->sensingMethod;
+    }
+}

--- a/src/Curate/Exif/Structured/Exposure.php
+++ b/src/Curate/Exif/Structured/Exposure.php
@@ -1,0 +1,100 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\ImageMeta\Curate\Exif\Structured;
+
+use MagicSunday\ImageMeta\Value\Derived;
+use MagicSunday\ImageMeta\Value\Enum\Contrast;
+use MagicSunday\ImageMeta\Value\Enum\ExposureMode;
+use MagicSunday\ImageMeta\Value\Enum\ExposureProgram;
+use MagicSunday\ImageMeta\Value\Enum\GainControl;
+use MagicSunday\ImageMeta\Value\Enum\MeteringMode;
+use MagicSunday\ImageMeta\Value\Enum\Saturation;
+use MagicSunday\ImageMeta\Value\Enum\Sharpness;
+use MagicSunday\ImageMeta\Value\Enum\WhiteBalance;
+use MagicSunday\ImageMeta\Value\Exposure as ExposureValue;
+use MagicSunday\ImageMeta\Value\FlashInfo;
+
+/**
+ * Captures EXIF exposure values alongside derived exposure metrics.
+ */
+final readonly class Exposure
+{
+    public ?int $iso;
+
+    public ?float $exposureTimeSec;
+
+    public ?float $fNumber;
+
+    public ?float $exposureBiasEv;
+
+    public ?ExposureProgram $program;
+
+    public ?MeteringMode $meteringMode;
+
+    public ?FlashInfo $flash;
+
+    public ?WhiteBalance $whiteBalance;
+
+    public ?float $brightnessEv;
+
+    public ?ExposureMode $exposureMode;
+
+    public ?GainControl $gainControl;
+
+    public ?Contrast $contrast;
+
+    public ?Saturation $saturation;
+
+    public ?Sharpness $sharpness;
+
+    public ?float $digitalZoomRatio;
+
+    public ?float $shutterSpeedEv;
+
+    public ?float $apertureEv;
+
+    public ?int $isoLatitudeYyy;
+
+    public ?int $isoLatitudeZzz;
+
+    public ?float $exposureIndex;
+
+    public ?float $flashEnergy;
+
+    public ?float $ev100;
+
+    public function __construct(ExposureValue $exposure, Derived $derived)
+    {
+        $this->iso              = $exposure->iso;
+        $this->exposureTimeSec  = $exposure->exposureTimeSec;
+        $this->fNumber          = $exposure->fNumber;
+        $this->exposureBiasEv   = $exposure->exposureBiasEv;
+        $this->program          = $exposure->program;
+        $this->meteringMode     = $exposure->meteringMode;
+        $this->flash            = $exposure->flash;
+        $this->whiteBalance     = $exposure->whiteBalance;
+        $this->brightnessEv     = $exposure->brightnessEv;
+        $this->exposureMode     = $exposure->exposureMode;
+        $this->gainControl      = $exposure->gainControl;
+        $this->contrast         = $exposure->contrast;
+        $this->saturation       = $exposure->saturation;
+        $this->sharpness        = $exposure->sharpness;
+        $this->digitalZoomRatio = $exposure->digitalZoomRatio;
+        $this->shutterSpeedEv   = $exposure->shutterSpeedEv;
+        $this->apertureEv       = $exposure->apertureEv;
+        $this->isoLatitudeYyy   = $exposure->isoLatitudeYyy;
+        $this->isoLatitudeZzz   = $exposure->isoLatitudeZzz;
+        $this->exposureIndex    = $exposure->exposureIndex;
+        $this->flashEnergy      = $exposure->flashEnergy;
+        $this->ev100            = $derived->ev100;
+    }
+}

--- a/src/Curate/Exif/Structured/Gps.php
+++ b/src/Curate/Exif/Structured/Gps.php
@@ -1,0 +1,135 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\ImageMeta\Curate\Exif\Structured;
+
+use DateTimeImmutable;
+use MagicSunday\ImageMeta\Curate\Structured\GpsCoordinate;
+use MagicSunday\ImageMeta\Value\Gps as GpsValue;
+
+/**
+ * Offers EXIF GPS metadata without external augmentation.
+ */
+final readonly class Gps
+{
+    public ?GpsCoordinate $latitude;
+
+    public ?GpsCoordinate $longitude;
+
+    public ?float $altitude;
+
+    public ?int $altitudeReference;
+
+    public ?string $version;
+
+    public ?string $versionRaw;
+
+    public ?string $satellites;
+
+    public ?string $status;
+
+    public ?string $measureMode;
+
+    public ?float $dilutionOfPrecision;
+
+    public ?string $speedReference;
+
+    public ?float $speedMs;
+
+    public ?string $speedOriginalReference;
+
+    public ?float $speedOriginal;
+
+    public ?string $trackReference;
+
+    public ?float $track;
+
+    public ?string $imageDirectionReference;
+
+    public ?float $imageDirection;
+
+    public ?string $mapDatum;
+
+    public ?GpsCoordinate $destinationLatitude;
+
+    public ?GpsCoordinate $destinationLongitude;
+
+    public ?string $destinationBearingReference;
+
+    public ?float $destinationBearing;
+
+    public ?string $destinationDistanceReference;
+
+    public ?float $destinationDistanceMetres;
+
+    public ?string $destinationDistanceOriginalReference;
+
+    public ?float $destinationDistanceOriginal;
+
+    public ?string $processingMethod;
+
+    public ?string $areaInformation;
+
+    public ?string $date;
+
+    public ?string $dateRaw;
+
+    public ?string $time;
+
+    public ?DateTimeImmutable $timestamp;
+
+    public ?int $differential;
+
+    public ?float $horizontalPositioningError;
+
+    public function __construct(GpsValue $gps)
+    {
+        $this->latitude                = $gps->latitude !== null ? new GpsCoordinate($gps->latitude, $gps->latitudeRef) : null;
+        $this->longitude               = $gps->longitude !== null ? new GpsCoordinate($gps->longitude, $gps->longitudeRef) : null;
+        $this->altitude                = $gps->altitude;
+        $this->altitudeReference       = $gps->altitudeRef;
+        $this->version                 = $gps->version;
+        $this->versionRaw              = $gps->versionRaw;
+        $this->satellites              = $gps->satellites;
+        $this->status                  = $gps->status;
+        $this->measureMode             = $gps->measureMode;
+        $this->dilutionOfPrecision     = $gps->dop;
+        $this->speedReference          = $gps->speedRef;
+        $this->speedMs                 = $gps->speedMs;
+        $this->speedOriginalReference  = $gps->speedOriginalRef;
+        $this->speedOriginal           = $gps->speedOriginal;
+        $this->trackReference          = $gps->trackRef;
+        $this->track                   = $gps->track;
+        $this->imageDirectionReference = $gps->imageDirectionRef;
+        $this->imageDirection          = $gps->imageDirection;
+        $this->mapDatum                = $gps->mapDatum;
+        $this->destinationLatitude     = $gps->destinationLatitude !== null
+            ? new GpsCoordinate($gps->destinationLatitude, $gps->destinationLatitudeRef)
+            : null;
+        $this->destinationLongitude = $gps->destinationLongitude !== null
+            ? new GpsCoordinate($gps->destinationLongitude, $gps->destinationLongitudeRef)
+            : null;
+        $this->destinationBearingReference          = $gps->destinationBearingRef;
+        $this->destinationBearing                   = $gps->destinationBearing;
+        $this->destinationDistanceReference         = $gps->destinationDistanceRef;
+        $this->destinationDistanceMetres            = $gps->destinationDistanceMetres;
+        $this->destinationDistanceOriginalReference = $gps->destinationDistanceOriginalRef;
+        $this->destinationDistanceOriginal          = $gps->destinationDistanceOriginal;
+        $this->processingMethod                     = $gps->processingMethod;
+        $this->areaInformation                      = $gps->areaInformation;
+        $this->date                                 = $gps->date;
+        $this->dateRaw                              = $gps->dateRaw;
+        $this->time                                 = $gps->time;
+        $this->timestamp                            = $gps->timestamp;
+        $this->differential                         = $gps->differential;
+        $this->horizontalPositioningError           = $gps->horizontalPositioningError;
+    }
+}

--- a/src/Curate/Exif/Structured/Image.php
+++ b/src/Curate/Exif/Structured/Image.php
@@ -1,0 +1,71 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\ImageMeta\Curate\Exif\Structured;
+
+use MagicSunday\ImageMeta\Value\Enum\ColorSpace;
+use MagicSunday\ImageMeta\Value\Enum\Orientation;
+use MagicSunday\ImageMeta\Value\Image as ImageValue;
+
+/**
+ * Holds EXIF image attributes without QuickTime fallbacks.
+ */
+final readonly class Image
+{
+    public ?int $width;
+
+    public ?int $height;
+
+    public ?Orientation $orientation;
+
+    public ?int $bitsPerSample;
+
+    public ?ColorSpace $colorSpace;
+
+    public ?string $imageUniqueId;
+
+    public ?int $imageNumber;
+
+    public ?string $documentName;
+
+    public ?string $description;
+
+    public ?string $title;
+
+    /**
+     * @var list<int>|null
+     */
+    public ?array $componentsConfiguration;
+
+    public ?float $compressedBitsPerPixel;
+
+    public ?int $interlace;
+
+    public ?string $userComment;
+
+    public function __construct(ImageValue $image)
+    {
+        $this->width                   = $image->width;
+        $this->height                  = $image->height;
+        $this->orientation             = $image->orientation;
+        $this->bitsPerSample           = $image->bitsPerSample;
+        $this->colorSpace              = $image->colorSpace;
+        $this->imageUniqueId           = $image->imageUniqueId;
+        $this->imageNumber             = $image->imageNumber;
+        $this->documentName            = $image->documentName;
+        $this->description             = $image->description;
+        $this->title                   = $image->title;
+        $this->componentsConfiguration = $image->componentsConfiguration;
+        $this->compressedBitsPerPixel  = $image->compressedBitsPerPixel;
+        $this->interlace               = $image->interlace;
+        $this->userComment             = $image->userComment;
+    }
+}

--- a/src/Curate/Exif/Structured/Lens.php
+++ b/src/Curate/Exif/Structured/Lens.php
@@ -1,0 +1,64 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\ImageMeta\Curate\Exif\Structured;
+
+use MagicSunday\ImageMeta\Value\Derived;
+use MagicSunday\ImageMeta\Value\Lens as LensValue;
+
+/**
+ * Represents EXIF lens metadata enriched with derived optical metrics.
+ */
+final readonly class Lens
+{
+    public ?string $make;
+
+    public ?string $model;
+
+    public ?string $serialNumber;
+
+    public ?float $focalLength;
+
+    public ?float $maximumAperture;
+
+    /**
+     * @var array{0:float,1:float,2:float,3:float}|null
+     */
+    public ?array $specification;
+
+    public ?int $equivalent35mm;
+
+    public ?float $cropFactor;
+
+    public ?float $hyperfocalDistance;
+
+    public ?float $fieldOfViewHorizontal;
+
+    public ?float $fieldOfViewVertical;
+
+    public ?float $fieldOfViewDiagonal;
+
+    public function __construct(LensValue $lens, Derived $derived)
+    {
+        $this->make                  = $lens->lensMake;
+        $this->model                 = $lens->lensModel;
+        $this->serialNumber          = $lens->lensSerialNumber;
+        $this->focalLength           = $lens->focalLengthMm;
+        $this->maximumAperture       = $lens->maxApertureFNumber;
+        $this->specification         = $lens->lensSpecification;
+        $this->equivalent35mm        = $lens->focalLengthIn35mm ?? $derived->focalLength35mm;
+        $this->cropFactor            = $derived->cropFactor;
+        $this->hyperfocalDistance    = $derived->hyperfocalM;
+        $this->fieldOfViewHorizontal = $derived->fovHorizontalDeg;
+        $this->fieldOfViewVertical   = $derived->fovVerticalDeg;
+        $this->fieldOfViewDiagonal   = $derived->fovDiagonalDeg;
+    }
+}

--- a/src/Curate/Exif/Structured/Preview.php
+++ b/src/Curate/Exif/Structured/Preview.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\ImageMeta\Curate\Exif\Structured;
+
+use MagicSunday\ImageMeta\Value\Preview as PreviewValue;
+
+/**
+ * Indicates the availability of previews and thumbnails from EXIF.
+ */
+final readonly class Preview
+{
+    public ?bool $hasThumbnail;
+
+    public ?bool $hasPreview;
+
+    public ?int $previewWidth;
+
+    public ?int $previewHeight;
+
+    public function __construct(PreviewValue $preview)
+    {
+        $this->hasThumbnail  = $preview->hasThumbnail;
+        $this->hasPreview    = $preview->hasPreview;
+        $this->previewWidth  = $preview->previewWidth;
+        $this->previewHeight = $preview->previewHeight;
+    }
+}

--- a/src/Model/Exif/ValueConverters.php
+++ b/src/Model/Exif/ValueConverters.php
@@ -54,12 +54,11 @@ use function rad2deg;
 use function round;
 use function rtrim;
 use function sprintf;
-use function strpos;
 use function str_contains;
 use function str_replace;
 use function str_starts_with;
 use function strlen;
-use function strtolower;
+use function strpos;
 use function strtoupper;
 use function substr;
 use function trim;
@@ -80,6 +79,7 @@ use const JSON_THROW_ON_ERROR;
  *     alt_ref:?int,
  *     alt:?float,
  *     version:?string,
+ *     version_raw:?string,
  *     satellites:?string,
  *     status:?string,
  *     measure_mode:?string,
@@ -106,6 +106,7 @@ use const JSON_THROW_ON_ERROR;
  *     processing_method:?string,
  *     area_information:?string,
  *     date:?string,
+ *     date_raw:?string,
  *     time:?string,
  *     timestamp:?DateTimeImmutable,
  *     differential:?int,
@@ -114,18 +115,18 @@ use const JSON_THROW_ON_ERROR;
  */
 final readonly class ValueConverters
 {
-    private const float FULL_FRAME_WIDTH_MM = 36.0;
-    private const float FULL_FRAME_HEIGHT_MM = 24.0;
-    private const float FULL_FRAME_DIAGONAL_MM = 43.2666153056;
+    private const float FULL_FRAME_WIDTH_MM               = 36.0;
+    private const float FULL_FRAME_HEIGHT_MM              = 24.0;
+    private const float FULL_FRAME_DIAGONAL_MM            = 43.2666153056;
     private const float FULL_FRAME_CIRCLE_OF_CONFUSION_MM = 0.030;
 
-    private const MAX_SRATIONAL_MATRIX_DIMENSION = 64;
-    private const MAX_SRATIONAL_MATRIX_LABEL_LENGTH = 255;
-    private const SRATIONAL_VALUE_SIZE = 8;
+    private const MAX_SRATIONAL_MATRIX_DIMENSION      = 64;
+    private const MAX_SRATIONAL_MATRIX_LABEL_LENGTH   = 255;
+    private const SRATIONAL_VALUE_SIZE                = 8;
     private const MAX_PRINT_IMAGE_MATCHING_PARAMETERS = 512;
-    private const PRINTABLE_ASCII_MIN = 0x20;
-    private const PRINTABLE_ASCII_MAX = 0x7E;
-    private const DEFAULT_GPS_VERSION = '2.0.0.0';
+    private const PRINTABLE_ASCII_MIN                 = 0x20;
+    private const PRINTABLE_ASCII_MAX                 = 0x7E;
+    private const DEFAULT_GPS_VERSION                 = '2.0.0.0';
 
     /**
      * Converts a TIFF RATIONAL or scalar value into a floating point value.
@@ -624,8 +625,8 @@ final readonly class ValueConverters
         }
 
         return match ($value) {
-            0 => false,
-            1 => true,
+            0       => false,
+            1       => true,
             default => null,
         };
     }
@@ -953,9 +954,9 @@ final readonly class ValueConverters
             return null;
         }
 
-        $offset = 4;
+        $offset       = 4;
         $columnLabels = [];
-        for ($i = 0; $i < $columns; $i++) {
+        for ($i = 0; $i < $columns; ++$i) {
             $labelData = self::consumeSrationalMatrixLabel($payload, $offset, $length);
             if ($labelData === null) {
                 return null;
@@ -966,7 +967,7 @@ final readonly class ValueConverters
         }
 
         $rowLabels = [];
-        for ($i = 0; $i < $rows; $i++) {
+        for ($i = 0; $i < $rows; ++$i) {
             $labelData = self::consumeSrationalMatrixLabel($payload, $offset, $length);
             if ($labelData === null) {
                 return null;
@@ -987,11 +988,11 @@ final readonly class ValueConverters
         }
 
         $values = [];
-        for ($rowIndex = 0; $rowIndex < $rows; $rowIndex++) {
+        for ($rowIndex = 0; $rowIndex < $rows; ++$rowIndex) {
             $rowValues = [];
 
-            for ($colIndex = 0; $colIndex < $columns; $colIndex++) {
-                $numerator = self::readSrationalInt32($payload, $offset, $length);
+            for ($colIndex = 0; $colIndex < $columns; ++$colIndex) {
+                $numerator   = self::readSrationalInt32($payload, $offset, $length);
                 $denominator = self::readSrationalInt32($payload, $offset + 4, $length);
                 if ($numerator === null || $denominator === null) {
                     return null;
@@ -1012,10 +1013,10 @@ final readonly class ValueConverters
 
         return [
             'columns' => $columns,
-            'rows' => $rows,
-            'labels' => [
+            'rows'    => $rows,
+            'labels'  => [
                 'columns' => $columnLabels,
-                'rows' => $rowLabels,
+                'rows'    => $rowLabels,
             ],
             'values' => $values,
         ];
@@ -1344,43 +1345,43 @@ final readonly class ValueConverters
     public static function emptyGpsResult(): array
     {
         return [
-            'lat_ref'             => null,
-            'lat'                 => null,
-            'lon_ref'             => null,
-            'lon'                 => null,
-            'alt_ref'             => null,
-            'alt'                 => null,
-            'version'             => null,
-            'satellites'          => null,
-            'status'              => null,
-            'measure_mode'        => null,
-            'dop'                 => null,
-            'speed_ref'           => null,
-            'speed_ms'            => null,
-            'speed_original_ref'  => null,
-            'speed_original'      => null,
-            'track_ref'           => null,
-            'track'               => null,
-            'img_direction_ref'   => null,
-            'img_direction'       => null,
-            'map_datum'           => null,
-            'dest_lat_ref'        => null,
-            'dest_lat'            => null,
-            'dest_lon_ref'        => null,
-            'dest_lon'            => null,
-            'dest_bearing_ref'    => null,
-            'dest_bearing'        => null,
-            'dest_distance_ref'   => null,
-            'dest_distance_m'     => null,
+            'lat_ref'                    => null,
+            'lat'                        => null,
+            'lon_ref'                    => null,
+            'lon'                        => null,
+            'alt_ref'                    => null,
+            'alt'                        => null,
+            'version'                    => null,
+            'satellites'                 => null,
+            'status'                     => null,
+            'measure_mode'               => null,
+            'dop'                        => null,
+            'speed_ref'                  => null,
+            'speed_ms'                   => null,
+            'speed_original_ref'         => null,
+            'speed_original'             => null,
+            'track_ref'                  => null,
+            'track'                      => null,
+            'img_direction_ref'          => null,
+            'img_direction'              => null,
+            'map_datum'                  => null,
+            'dest_lat_ref'               => null,
+            'dest_lat'                   => null,
+            'dest_lon_ref'               => null,
+            'dest_lon'                   => null,
+            'dest_bearing_ref'           => null,
+            'dest_bearing'               => null,
+            'dest_distance_ref'          => null,
+            'dest_distance_m'            => null,
             'dest_distance_original_ref' => null,
             'dest_distance_original'     => null,
-            'processing_method'   => null,
-            'area_information'    => null,
-            'date'                => null,
-            'time'                => null,
-            'timestamp'           => null,
-            'differential'        => null,
-            'h_positioning_error' => null,
+            'processing_method'          => null,
+            'area_information'           => null,
+            'date'                       => null,
+            'time'                       => null,
+            'timestamp'                  => null,
+            'differential'               => null,
+            'h_positioning_error'        => null,
         ];
     }
 
@@ -1462,7 +1463,7 @@ final readonly class ValueConverters
         $dateEntry        = $gps->get(ExifTag::GPS_DATE_STAMP);
         $timeEntry        = $gps->get(ExifTag::GPS_TIME_STAMP);
 
-        $versionParts            = self::formatGpsVersion($versionEntry?->value);
+        $versionParts           = self::formatGpsVersion($versionEntry?->value);
         $result['version']      = $versionParts['normalized'];
         $result['version_raw']  = $versionParts['raw'];
         $result['satellites']   = self::sanitizeString($satellitesEntry?->value);
@@ -1508,18 +1509,18 @@ final readonly class ValueConverters
         $result['dest_bearing']     = self::normalizeBearing($destBearingValue);
 
         $destDistanceRefValue                 = $destDistRefEntry?->value;
-        $result['dest_distance_ref']            = is_string($destDistanceRefValue) ? strtoupper(trim($destDistanceRefValue)) : null;
-        $result['dest_distance_original_ref']   = self::sanitizeString($destDistanceRefValue);
-        $result['dest_distance_original']       = self::rationalToFloat($destDistEntry?->value);
-        $result['dest_distance_m']              = self::gpsDistanceToMetres($result['dest_distance_ref'], $destDistEntry?->value);
+        $result['dest_distance_ref']          = is_string($destDistanceRefValue) ? strtoupper(trim($destDistanceRefValue)) : null;
+        $result['dest_distance_original_ref'] = self::sanitizeString($destDistanceRefValue);
+        $result['dest_distance_original']     = self::rationalToFloat($destDistEntry?->value);
+        $result['dest_distance_m']            = self::gpsDistanceToMetres($result['dest_distance_ref'], $destDistEntry?->value);
 
         $result['processing_method'] = self::decodeUndefinedString($processEntry?->value);
         $result['area_information']  = self::decodeUndefinedString($areaEntry?->value);
 
-        $dateParts       = self::normalizeGpsDate($dateEntry?->value);
-        $result['date'] = $dateParts['normalized'];
+        $dateParts          = self::normalizeGpsDate($dateEntry?->value);
+        $result['date']     = $dateParts['normalized'];
         $result['date_raw'] = $dateParts['raw'];
-        $timeParts      = $timeEntry instanceof IfdEntry && $timeEntry->value instanceof ExifRationalList
+        $timeParts          = $timeEntry instanceof IfdEntry && $timeEntry->value instanceof ExifRationalList
             ? self::parseGpsTime($timeEntry->value)
             : null;
         $result['time']      = self::formatGpsTime($timeParts);
@@ -1706,7 +1707,7 @@ final readonly class ValueConverters
     private static function formatGpsVersion(
         string|int|float|ExifRational|ExifRationalList|ExifNumericList|null $value,
     ): array {
-        $raw = is_string($value) ? $value : null;
+        $raw        = is_string($value) ? $value : null;
         $normalized = null;
 
         if ($value instanceof ExifNumericList) {
@@ -1719,7 +1720,7 @@ final readonly class ValueConverters
 
             return [
                 'normalized' => $normalized,
-                'raw' => $raw,
+                'raw'        => $raw,
             ];
         }
 
@@ -1730,13 +1731,13 @@ final readonly class ValueConverters
 
                 return [
                     'normalized' => $normalized,
-                    'raw' => $raw,
+                    'raw'        => $raw,
                 ];
             }
 
             return [
                 'normalized' => self::DEFAULT_GPS_VERSION,
-                'raw' => $raw,
+                'raw'        => $raw,
             ];
         }
 
@@ -1745,7 +1746,7 @@ final readonly class ValueConverters
 
             return [
                 'normalized' => $normalized,
-                'raw' => null,
+                'raw'        => null,
             ];
         }
 
@@ -1754,13 +1755,13 @@ final readonly class ValueConverters
 
             return [
                 'normalized' => $normalized,
-                'raw' => null,
+                'raw'        => null,
             ];
         }
 
         return [
             'normalized' => self::DEFAULT_GPS_VERSION,
-            'raw' => $raw,
+            'raw'        => $raw,
         ];
     }
 
@@ -1797,8 +1798,8 @@ final readonly class ValueConverters
         $encoding = null;
 
         $prefixes = [
-            "ASCII\0\0\0"    => 'ASCII',
-            "UNICODE\0"        => 'UNICODE',
+            "ASCII\0\0\0"   => 'ASCII',
+            "UNICODE\0"     => 'UNICODE',
             "JIS\0\0\0\0\0" => 'JIS',
         ];
 
@@ -1874,7 +1875,7 @@ final readonly class ValueConverters
         if (!is_string($value)) {
             return [
                 'normalized' => null,
-                'raw' => $raw,
+                'raw'        => $raw,
             ];
         }
 
@@ -1882,20 +1883,20 @@ final readonly class ValueConverters
         if ($clean === '') {
             return [
                 'normalized' => null,
-                'raw' => $raw,
+                'raw'        => $raw,
             ];
         }
 
         if (preg_match('/^\d{4}:\d{2}:\d{2}$/', $clean) !== 1) {
             return [
                 'normalized' => null,
-                'raw' => $raw,
+                'raw'        => $raw,
             ];
         }
 
         return [
             'normalized' => str_replace(':', '-', $clean),
-            'raw' => $raw,
+            'raw'        => $raw,
         ];
     }
 

--- a/tests/Api/ExifReaderTest.php
+++ b/tests/Api/ExifReaderTest.php
@@ -1,0 +1,85 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\ImageMeta\Tests\Api;
+
+use MagicSunday\ImageMeta\Api\ExifReader;
+use MagicSunday\ImageMeta\Value\Enum\ColorSpace;
+use MagicSunday\ImageMeta\Value\Enum\Orientation;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class ExifReaderTest extends TestCase
+{
+    #[Test]
+    public function readsExifMetadataFromJpeg(): void
+    {
+        $reader = new ExifReader();
+        $path   = dirname(__DIR__, 2) . '/test-images/Images/gps_exif_example.jpg';
+
+        $document = $reader->read($path);
+
+        self::assertTrue($document->hasData());
+        self::assertSame('Canon', $document->camera()->make);
+        self::assertSame('Canon PowerShot SX130 IS', $document->camera()->model);
+
+        $exposure = $document->exposure();
+        self::assertSame(80, $exposure->iso);
+        self::assertEqualsWithDelta(0.01, $exposure->exposureTimeSec, 1e-5);
+        self::assertEqualsWithDelta(3.4, $exposure->fNumber, 1e-2);
+
+        $lens = $document->lens();
+        self::assertEqualsWithDelta(5.0, $lens->focalLength ?? 0.0, 1e-6);
+
+        $image = $document->image();
+        self::assertSame(4000, $image->width);
+        self::assertSame(3000, $image->height);
+        self::assertSame(Orientation::TOP_LEFT, $image->orientation);
+        self::assertSame(ColorSpace::SRGB, $image->colorSpace);
+
+        $gps = $document->gps();
+        self::assertNotNull($gps->latitude);
+        self::assertEqualsWithDelta(41.888948, $gps->latitude->toFloat() ?? 0.0, 1e-6);
+        self::assertNotNull($gps->longitude);
+        self::assertEqualsWithDelta(-87.624494, $gps->longitude->toFloat() ?? 0.0, 1e-6);
+
+        $preview = $document->preview();
+        self::assertTrue($preview->hasThumbnail);
+        self::assertNull($preview->hasPreview);
+    }
+
+    #[Test]
+    public function returnsEmptyDocumentWhenExifIsMissing(): void
+    {
+        $reader = new ExifReader();
+
+        $image = imagecreatetruecolor(1, 1);
+        $white = imagecolorallocate($image, 255, 255, 255);
+        self::assertNotFalse($white);
+        imagefill($image, 0, 0, $white);
+
+        $path = tempnam(sys_get_temp_dir(), 'exif');
+        self::assertIsString($path);
+        imagejpeg($image, $path);
+        imagedestroy($image);
+
+        try {
+            $document = $reader->read($path);
+
+            self::assertFalse($document->hasData());
+            self::assertNull($document->camera()->make);
+            self::assertNull($document->lens()->focalLength);
+            self::assertNull($document->gps()->latitude);
+        } finally {
+            @unlink($path);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add Api\ExifReader facade that extracts EXIF from JPEG and ISOBMFF streams via existing detectors
- provide Api\ExifDocument wrapper with EXIF-only structured value objects for camera, lens, exposure, GPS, image, and preview metadata
- expose raw GPS date/version values and cover new API flow with PHPUnit tests

## Testing
- composer ci:test:php:unit
- .build/bin/phpstan analyse --configuration .build/phpstan.neon src/Api src/Curate/Exif/Structured tests/Api
- composer ci:cgl -- --dry-run *(fails: repo-wide style violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68ffb13874a883238d757db9b0e8bc50