### PR TITLE
Fix ISO helper to respect EXIF sensitivity priorities

### DIFF
--- a/src/Convenience/ExifConvenience.php
+++ b/src/Convenience/ExifConvenience.php
@@ -143,9 +143,59 @@ final class ExifConvenience
      */
     public static function iso(ExifDocument $doc): ?int
     {
-        // ISO can be ExifIFD tag ExifTag::PHOTOGRAPHIC_SENSITIVITY or the newer ExifTag::ISO_SPEED
-        $entry = self::find($doc, ExifTag::ISO_SPEED) ?? self::find($doc, ExifTag::PHOTOGRAPHIC_SENSITIVITY);
+        $iso = self::isoFromSensitivityType($doc);
+        if ($iso !== null) {
+            return $iso;
+        }
 
+        $iso = self::isoFromEntry($doc->exifIfd?->get(ExifTag::ISO_SPEED));
+        if ($iso !== null) {
+            return $iso;
+        }
+
+        $iso = self::isoFromEntry($doc->exifIfd?->get(ExifTag::STANDARD_OUTPUT_SENSITIVITY));
+        if ($iso !== null) {
+            return $iso;
+        }
+
+        $iso = self::isoFromEntry($doc->exifIfd?->get(ExifTag::RECOMMENDED_EXPOSURE_INDEX));
+        if ($iso !== null) {
+            return $iso;
+        }
+
+        $iso = self::isoFromEntry($doc->exifIfd?->get(ExifTag::PHOTOGRAPHIC_SENSITIVITY));
+        if ($iso !== null) {
+            return $iso;
+        }
+
+        return self::isoFromEntry($doc->ifd0->get(ExifTag::PHOTOGRAPHIC_SENSITIVITY));
+    }
+
+    /**
+     * Resolves ISO sensitivity using the EXIF 3.x sensitivity type priority rules.
+     */
+    private static function isoFromSensitivityType(ExifDocument $doc): ?int
+    {
+        $type = self::isoFromEntry($doc->exifIfd?->get(ExifTag::SENSITIVITY_TYPE));
+        if ($type === null) {
+            return null;
+        }
+
+        foreach (self::sensitivityTagPriority($type) as $tag) {
+            $iso = self::isoFromEntry($doc->exifIfd?->get($tag));
+            if ($iso !== null) {
+                return $iso;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Converts various EXIF value representations into an ISO integer.
+     */
+    private static function isoFromEntry(?IfdEntry $entry): ?int
+    {
         if (!$entry instanceof IfdEntry) {
             return null;
         }
@@ -188,6 +238,25 @@ final class ExifConvenience
         }
 
         return null;
+    }
+
+    /**
+     * Maps sensitivity type enumerations to ISO tag priorities.
+     *
+     * @return list<int>
+     */
+    private static function sensitivityTagPriority(int $type): array
+    {
+        return match ($type) {
+            1       => [ExifTag::STANDARD_OUTPUT_SENSITIVITY],
+            2       => [ExifTag::RECOMMENDED_EXPOSURE_INDEX],
+            3       => [ExifTag::ISO_SPEED],
+            4       => [ExifTag::STANDARD_OUTPUT_SENSITIVITY, ExifTag::RECOMMENDED_EXPOSURE_INDEX],
+            5       => [ExifTag::STANDARD_OUTPUT_SENSITIVITY, ExifTag::ISO_SPEED],
+            6       => [ExifTag::RECOMMENDED_EXPOSURE_INDEX, ExifTag::ISO_SPEED],
+            7       => [ExifTag::STANDARD_OUTPUT_SENSITIVITY, ExifTag::RECOMMENDED_EXPOSURE_INDEX, ExifTag::ISO_SPEED],
+            default => [],
+        };
     }
 
     /**

--- a/tests/Convenience/ExifConvenienceTest.php
+++ b/tests/Convenience/ExifConvenienceTest.php
@@ -126,6 +126,35 @@ final class ExifConvenienceTest extends TestCase
     }
 
     /**
+     * Validates EXIF 3.0 sensitivity metadata honours the documented priority rules and supports
+     * files that only populate the newer tags.
+     */
+    #[Test]
+    public function isoRespectsSensitivityTypePriority(): void
+    {
+        $ifd0 = new Ifd([]);
+
+        $sosOnly = new Ifd([
+            ExifTag::SENSITIVITY_TYPE           => new IfdEntry(ExifTag::SENSITIVITY_TYPE, 3, 1, 1),
+            ExifTag::STANDARD_OUTPUT_SENSITIVITY => new IfdEntry(ExifTag::STANDARD_OUTPUT_SENSITIVITY, 3, 1, 250),
+        ]);
+
+        $docWithSosOnly = new ExifDocument($ifd0, $sosOnly, null, null, null);
+
+        self::assertSame(250, ExifConvenience::iso($docWithSosOnly));
+
+        $priorityIfd = new Ifd([
+            ExifTag::SENSITIVITY_TYPE             => new IfdEntry(ExifTag::SENSITIVITY_TYPE, 3, 1, 6),
+            ExifTag::RECOMMENDED_EXPOSURE_INDEX   => new IfdEntry(ExifTag::RECOMMENDED_EXPOSURE_INDEX, 3, 1, 320),
+            ExifTag::ISO_SPEED                    => new IfdEntry(ExifTag::ISO_SPEED, 3, 1, 640),
+        ]);
+
+        $docWithPriority = new ExifDocument($ifd0, $priorityIfd, null, null, null);
+
+        self::assertSame(320, ExifConvenience::iso($docWithPriority));
+    }
+
+    /**
      * Reads capture timestamp tags and verifies the helper delegates to the document parser to
      * return a timezone-aware DateTime.
      */


### PR DESCRIPTION
## Summary
- align `ExifConvenience::iso()` with `ExifDocument::iso()` so sensitivity-type priority and newer EXIF 3.0 tags are honoured
- extend PHPUnit coverage to cover EXIF 3.0 payloads that only provide the newer sensitivity tags

## Testing
- composer ci:test:php:unit

------
https://chatgpt.com/codex/tasks/task_e_69006d1a53ec83239a980e722fb4dd35