### PR TITLE
fix: expand capture datetime fallback in convenience helpers

### DIFF
--- a/src/Convenience/ExifConvenience.php
+++ b/src/Convenience/ExifConvenience.php
@@ -23,8 +23,6 @@ use Throwable;
 
 use function is_float;
 use function is_int;
-use function is_string;
-use function strlen;
 
 /**
  * Helper routines that extract frequently-used EXIF values in a safe manner.
@@ -56,17 +54,6 @@ final class ExifConvenience
      */
     public static function captureDateTime(ExifDocument $doc): ?DateTimeImmutable
     {
-        $rawDateTime = $doc->dateTimeOriginalRaw(); // "YYYY:MM:DD HH:MM:SS"
-
-        if (!is_string($rawDateTime) || $rawDateTime === '') {
-            return null;
-        }
-
-        // Ensure that the timestamp contains both a date and a time component.
-        if (strlen($rawDateTime) < 19) {
-            return null;
-        }
-
         try {
             return $doc->captureDateTime();
         } catch (Throwable) {

--- a/tests/Convenience/CaptureDateResolverTest.php
+++ b/tests/Convenience/CaptureDateResolverTest.php
@@ -13,6 +13,10 @@ namespace MagicSunday\ImageMeta\Tests\Convenience;
 
 use DateTimeImmutable;
 use MagicSunday\ImageMeta\Convenience\CaptureDateResolver;
+use MagicSunday\ImageMeta\Model\Exif\ExifDocument;
+use MagicSunday\ImageMeta\Model\Exif\ExifTag;
+use MagicSunday\ImageMeta\Model\Exif\Ifd;
+use MagicSunday\ImageMeta\Model\Exif\IfdEntry;
 use MagicSunday\ImageMeta\Model\Metadata;
 use MagicSunday\ImageMeta\Model\Xmp\XmpDocument;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -25,6 +29,9 @@ use PHPUnit\Framework\TestCase;
  */
 #[CoversClass(CaptureDateResolver::class)]
 #[UsesClass(Metadata::class)]
+#[UsesClass(ExifDocument::class)]
+#[UsesClass(Ifd::class)]
+#[UsesClass(IfdEntry::class)]
 #[UsesClass(XmpDocument::class)]
 final class CaptureDateResolverTest extends TestCase
 {
@@ -97,5 +104,47 @@ final class CaptureDateResolverTest extends TestCase
 
         self::assertInstanceOf(DateTimeImmutable::class, $result);
         self::assertSame('2024-03-30T12:34:56+00:00', $result->format(DATE_ATOM));
+    }
+
+    /**
+     * Ensures EXIF capture timestamps are preferred and that fallback logic covers digitised
+     * timestamps when DateTimeOriginal is not provided.
+     */
+    #[Test]
+    public function prefersExifCaptureDateWhenAvailable(): void
+    {
+        $exifDoc = new ExifDocument(
+            new Ifd([]),
+            new Ifd([
+                ExifTag::DATETIME_DIGITIZED    => new IfdEntry(
+                    ExifTag::DATETIME_DIGITIZED,
+                    2,
+                    19,
+                    '2024:04:05 01:02:03',
+                ),
+                ExifTag::OFFSET_TIME_DIGITIZED => new IfdEntry(
+                    ExifTag::OFFSET_TIME_DIGITIZED,
+                    2,
+                    6,
+                    '+01:00',
+                ),
+            ]),
+            null,
+            null,
+            null,
+        );
+
+        $metadata = new Metadata(
+            exifBlobs: [],
+            quickTime: null,
+            exifDoc: $exifDoc,
+            xmpBlobs: [],
+            xmpDoc: null,
+        );
+
+        $result = CaptureDateResolver::bestCaptureDateTime($metadata);
+
+        self::assertInstanceOf(DateTimeImmutable::class, $result);
+        self::assertSame('2024-04-05T01:02:03+01:00', $result->format(DATE_ATOM));
     }
 }

--- a/tests/Convenience/ExifConvenienceTest.php
+++ b/tests/Convenience/ExifConvenienceTest.php
@@ -159,6 +159,52 @@ final class ExifConvenienceTest extends TestCase
     }
 
     /**
+     * Provides digitised and modify date tags to confirm the helper relies on the document's
+     * fallback search order when DateTimeOriginal is absent.
+     */
+    #[Test]
+    public function captureDateTimeFallsBackToDigitizedAndModifyDates(): void
+    {
+        $digitizedIfd = new Ifd([
+            ExifTag::DATETIME_DIGITIZED      => new IfdEntry(
+                ExifTag::DATETIME_DIGITIZED,
+                2,
+                19,
+                '2023:12:24 06:30:45',
+            ),
+            ExifTag::OFFSET_TIME_DIGITIZED   => new IfdEntry(
+                ExifTag::OFFSET_TIME_DIGITIZED,
+                2,
+                6,
+                '-05:30',
+            ),
+        ]);
+
+        $docWithDigitized = new ExifDocument(new Ifd([]), $digitizedIfd, null, null, null);
+
+        $digitized = ExifConvenience::captureDateTime($docWithDigitized);
+
+        self::assertNotNull($digitized);
+        self::assertSame('2023-12-24T06:30:45-05:30', $digitized->format(DATE_ATOM));
+
+        $modifyDateIfd0 = new Ifd([
+            ExifTag::DATETIME => new IfdEntry(
+                ExifTag::DATETIME,
+                2,
+                19,
+                '2023:11:10 09:08:07',
+            ),
+        ]);
+
+        $docWithModifyDate = new ExifDocument($modifyDateIfd0, new Ifd([]), null, null, null);
+
+        $modify = ExifConvenience::captureDateTime($docWithModifyDate);
+
+        self::assertNotNull($modify);
+        self::assertSame('2023-11-10T09:08:07+00:00', $modify->format(DATE_ATOM));
+    }
+
+    /**
      * Supplies an incomplete timestamp string to ensure the helper refuses values lacking time
      * components.
      */


### PR DESCRIPTION
## Summary
- delegate `ExifConvenience::captureDateTime()` to the document so it can apply its own fallbacks
- extend convenience and resolver tests to cover DateTimeDigitized/ModifyDate-only images

## Testing
- composer ci:test:php:unit -- tests/Convenience

------
https://chatgpt.com/codex/tasks/task_e_69006d1fb58083239a8a48db62be3237