### PR TITLE
feat: expose EXIF preview metadata

### DIFF
--- a/src/Api/ExifDocument.php
+++ b/src/Api/ExifDocument.php
@@ -397,11 +397,22 @@ final class ExifDocument
 
     private function createPreviewValue(?ModelExifDocument $document): PreviewValue
     {
+        $previewColorSpace = null;
+        if ($document instanceof ModelExifDocument) {
+            $previewColorSpace = ColorSpace::fromExifValue($document->previewColorSpace());
+        }
+
         return new PreviewValue(
             hasThumbnail: $document?->hasThumbnail(),
             hasPreview: $document?->hasPreviewImage(),
             previewWidth: $document?->previewImageWidth(),
             previewHeight: $document?->previewImageHeight(),
+            previewColorSpace: $previewColorSpace,
+            previewBitDepth: $document?->previewImageBitDepth(),
+            previewEncoding: $document?->previewImageEncoding(),
+            previewMimeType: $document?->previewImageMimeType(),
+            previewOffset: $document?->previewImageOffset(),
+            previewLength: $document?->previewImageLength(),
         );
     }
 

--- a/src/Curate/Exif/Structured/Preview.php
+++ b/src/Curate/Exif/Structured/Preview.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace MagicSunday\ImageMeta\Curate\Exif\Structured;
 
+use MagicSunday\ImageMeta\Value\Enum\ColorSpace;
 use MagicSunday\ImageMeta\Value\Preview as PreviewValue;
 
 /**
@@ -26,11 +27,29 @@ final readonly class Preview
 
     public ?int $previewHeight;
 
+    public ?ColorSpace $previewColorSpace;
+
+    public ?int $previewBitDepth;
+
+    public ?string $previewEncoding;
+
+    public ?string $previewMimeType;
+
+    public ?int $previewOffset;
+
+    public ?int $previewLength;
+
     public function __construct(PreviewValue $preview)
     {
-        $this->hasThumbnail  = $preview->hasThumbnail;
-        $this->hasPreview    = $preview->hasPreview;
-        $this->previewWidth  = $preview->previewWidth;
-        $this->previewHeight = $preview->previewHeight;
+        $this->hasThumbnail      = $preview->hasThumbnail;
+        $this->hasPreview        = $preview->hasPreview;
+        $this->previewWidth      = $preview->previewWidth;
+        $this->previewHeight     = $preview->previewHeight;
+        $this->previewColorSpace = $preview->previewColorSpace;
+        $this->previewBitDepth   = $preview->previewBitDepth;
+        $this->previewEncoding   = $preview->previewEncoding;
+        $this->previewMimeType   = $preview->previewMimeType;
+        $this->previewOffset     = $preview->previewOffset;
+        $this->previewLength     = $preview->previewLength;
     }
 }

--- a/src/Curate/Exif/ValueFactory.php
+++ b/src/Curate/Exif/ValueFactory.php
@@ -343,6 +343,12 @@ final class ValueFactory
             $exifDocument?->hasPreviewImage(),
             $exifDocument?->previewImageWidth(),
             $exifDocument?->previewImageHeight(),
+            ColorSpace::fromExifValue($exifDocument?->previewColorSpace()),
+            $exifDocument?->previewImageBitDepth(),
+            $exifDocument?->previewImageEncoding(),
+            $exifDocument?->previewImageMimeType(),
+            $exifDocument?->previewImageOffset(),
+            $exifDocument?->previewImageLength(),
         );
 
         $video = new Video(

--- a/src/Model/Exif/ExifDocument.php
+++ b/src/Model/Exif/ExifDocument.php
@@ -771,6 +771,30 @@ final readonly class ExifDocument
     }
 
     /**
+     * Returns the preview image encoding identifier when present.
+     */
+    public function previewImageEncoding(): ?string
+    {
+        return $this->str($this->exifIfd, ExifTag::PREVIEW_IMAGE_ENCODING);
+    }
+
+    /**
+     * Returns the preview image MIME type.
+     */
+    public function previewImageMimeType(): ?string
+    {
+        return $this->str($this->exifIfd, ExifTag::PREVIEW_IMAGE_MIME_TYPE);
+    }
+
+    /**
+     * Returns the preview image bit depth when provided by the metadata.
+     */
+    public function previewImageBitDepth(): ?int
+    {
+        return $this->int($this->exifIfd, ExifTag::PREVIEW_IMAGE_BIT_DEPTH);
+    }
+
+    /**
      * Returns the preview image colour space identifier when present.
      */
     public function previewColorSpace(): ?int

--- a/src/Value/Preview.php
+++ b/src/Value/Preview.php
@@ -11,22 +11,36 @@ declare(strict_types=1);
 
 namespace MagicSunday\ImageMeta\Value;
 
+use MagicSunday\ImageMeta\Value\Enum\ColorSpace;
+
 /**
  * Describes the availability of embedded previews or thumbnails.
  */
 final readonly class Preview
 {
     /**
-     * @param bool|null $hasThumbnail  Whether an embedded thumbnail exists.
-     * @param bool|null $hasPreview    Whether an embedded preview image exists.
-     * @param int|null  $previewWidth  Width of the preview image in pixels.
-     * @param int|null  $previewHeight Height of the preview image in pixels.
+     * @param bool|null      $hasThumbnail      Whether an embedded thumbnail exists.
+     * @param bool|null      $hasPreview        Whether an embedded preview image exists.
+     * @param int|null       $previewWidth      Width of the preview image in pixels.
+     * @param int|null       $previewHeight     Height of the preview image in pixels.
+     * @param ColorSpace|null $previewColorSpace Colour space of the preview image.
+     * @param int|null       $previewBitDepth   Bit depth of the preview image.
+     * @param string|null    $previewEncoding   Encoding name for the preview image payload.
+     * @param string|null    $previewMimeType   MIME type of the preview image.
+     * @param int|null       $previewOffset     Byte offset to the preview image inside the file.
+     * @param int|null       $previewLength     Byte length of the preview image data.
      */
     public function __construct(
         public ?bool $hasThumbnail,
         public ?bool $hasPreview,
         public ?int $previewWidth,
         public ?int $previewHeight,
+        public ?ColorSpace $previewColorSpace,
+        public ?int $previewBitDepth,
+        public ?string $previewEncoding,
+        public ?string $previewMimeType,
+        public ?int $previewOffset,
+        public ?int $previewLength,
     ) {
     }
 }

--- a/tests/Api/ExifReaderTest.php
+++ b/tests/Api/ExifReaderTest.php
@@ -54,6 +54,12 @@ final class ExifReaderTest extends TestCase
         $preview = $document->preview();
         self::assertTrue($preview->hasThumbnail);
         self::assertNull($preview->hasPreview);
+        self::assertNull($preview->previewEncoding);
+        self::assertNull($preview->previewMimeType);
+        self::assertNull($preview->previewBitDepth);
+        self::assertNull($preview->previewColorSpace);
+        self::assertNull($preview->previewOffset);
+        self::assertNull($preview->previewLength);
     }
 
     #[Test]

--- a/tests/Curate/ExifAssemblerTest.php
+++ b/tests/Curate/ExifAssemblerTest.php
@@ -127,12 +127,15 @@ final class ExifAssemblerTest extends TestCase
             ExifTag::PREVIEW_IMAGE_LENGTH      => new IfdEntry(ExifTag::PREVIEW_IMAGE_LENGTH, 4, 1, 65_536),
             ExifTag::PREVIEW_IMAGE_WIDTH       => new IfdEntry(ExifTag::PREVIEW_IMAGE_WIDTH, 4, 1, 2_048),
             ExifTag::PREVIEW_IMAGE_HEIGHT      => new IfdEntry(ExifTag::PREVIEW_IMAGE_HEIGHT, 4, 1, 1_152),
+            ExifTag::PREVIEW_IMAGE_ENCODING    => new IfdEntry(ExifTag::PREVIEW_IMAGE_ENCODING, 2, 4, 'JPEG'),
+            ExifTag::PREVIEW_IMAGE_MIME_TYPE   => new IfdEntry(ExifTag::PREVIEW_IMAGE_MIME_TYPE, 2, 10, 'image/jpeg'),
             ExifTag::PREVIEW_IMAGE_COLOR_SPACE => new IfdEntry(
                 ExifTag::PREVIEW_IMAGE_COLOR_SPACE,
                 3,
                 1,
                 ColorSpace::ADOBE_RGB->value,
             ),
+            ExifTag::PREVIEW_IMAGE_BIT_DEPTH   => new IfdEntry(ExifTag::PREVIEW_IMAGE_BIT_DEPTH, 3, 1, 12),
             ExifTag::PREVIEW_DATE_TIME           => new IfdEntry(ExifTag::PREVIEW_DATE_TIME, 2, 19, '2024:05:01 12:40:00'),
             ExifTag::PREVIEW_DATE_TIME_DIGITIZED => new IfdEntry(ExifTag::PREVIEW_DATE_TIME_DIGITIZED, 2, 19, '2024:05:01 12:35:00'),
             ExifTag::PHOTOGRAPHIC_SENSITIVITY    => new IfdEntry(ExifTag::PHOTOGRAPHIC_SENSITIVITY, 3, 1, 400),
@@ -323,6 +326,12 @@ final class ExifAssemblerTest extends TestCase
         self::assertTrue($structured->media->preview->hasPreview);
         self::assertSame(2_048, $structured->media->preview->previewWidth);
         self::assertSame(1_152, $structured->media->preview->previewHeight);
+        self::assertSame(ColorSpace::ADOBE_RGB, $structured->media->preview->previewColorSpace);
+        self::assertSame(12, $structured->media->preview->previewBitDepth);
+        self::assertSame('JPEG', $structured->media->preview->previewEncoding);
+        self::assertSame('image/jpeg', $structured->media->preview->previewMimeType);
+        self::assertSame(131_072, $structured->media->preview->previewOffset);
+        self::assertSame(65_536, $structured->media->preview->previewLength);
 
         self::assertSame(400, $structured->exposure->iso);
         self::assertSame(0.008, $structured->exposure->exposureTimeSec);

--- a/tests/Model/Exif/ExifDocumentTest.php
+++ b/tests/Model/Exif/ExifDocumentTest.php
@@ -285,12 +285,15 @@ final class ExifDocumentTest extends TestCase
             ExifTag::PREVIEW_IMAGE_LENGTH        => new IfdEntry(ExifTag::PREVIEW_IMAGE_LENGTH, 4, 1, 16_384),
             ExifTag::PREVIEW_IMAGE_WIDTH         => new IfdEntry(ExifTag::PREVIEW_IMAGE_WIDTH, 4, 1, 1_600),
             ExifTag::PREVIEW_IMAGE_HEIGHT        => new IfdEntry(ExifTag::PREVIEW_IMAGE_HEIGHT, 4, 1, 900),
+            ExifTag::PREVIEW_IMAGE_ENCODING      => new IfdEntry(ExifTag::PREVIEW_IMAGE_ENCODING, 2, 4, 'JPEG'),
+            ExifTag::PREVIEW_IMAGE_MIME_TYPE     => new IfdEntry(ExifTag::PREVIEW_IMAGE_MIME_TYPE, 2, 10, 'image/jpeg'),
             ExifTag::PREVIEW_IMAGE_COLOR_SPACE   => new IfdEntry(
                 ExifTag::PREVIEW_IMAGE_COLOR_SPACE,
                 3,
                 1,
                 ColorSpace::ADOBE_RGB->value,
             ),
+            ExifTag::PREVIEW_IMAGE_BIT_DEPTH     => new IfdEntry(ExifTag::PREVIEW_IMAGE_BIT_DEPTH, 3, 1, 8),
             ExifTag::PREVIEW_DATE_TIME           => new IfdEntry(ExifTag::PREVIEW_DATE_TIME, 2, 19, '2024:10:25 18:45:30'),
             ExifTag::PREVIEW_DATE_TIME_DIGITIZED => new IfdEntry(ExifTag::PREVIEW_DATE_TIME_DIGITIZED, 2, 19, '2024:10:25 18:40:00'),
         ]);
@@ -303,6 +306,9 @@ final class ExifDocumentTest extends TestCase
         self::assertTrue($document->hasPreviewImage());
         self::assertSame(1_600, $document->previewImageWidth());
         self::assertSame(900, $document->previewImageHeight());
+        self::assertSame('JPEG', $document->previewImageEncoding());
+        self::assertSame('image/jpeg', $document->previewImageMimeType());
+        self::assertSame(8, $document->previewImageBitDepth());
         self::assertSame(ColorSpace::ADOBE_RGB->value, $document->previewColorSpace());
 
         $previewDateTime = $document->previewDateTime();


### PR DESCRIPTION
## Summary
- add ExifDocument getters for preview encoding, MIME type, bit depth, and related metadata
- propagate preview metadata through API and curated preview value objects
- extend coverage in EXIF document, API reader, and assembler tests for the new preview properties

## Testing
- composer ci:test:php:unit

------
https://chatgpt.com/codex/tasks/task_e_69006d241a288323ab4909eb2d50c92e