### PR TITLE
fix: handle EXIF user comments without encoding prefix

### DIFF
--- a/src/Model/Exif/ExifDocument.php
+++ b/src/Model/Exif/ExifDocument.php
@@ -3015,7 +3015,9 @@ final readonly class ExifDocument
     private function decodeUserComment(string $raw): ?string
     {
         if (strlen($raw) <= 8) {
-            return null;
+            $content = trim($raw, "\0");
+
+            return $content === '' ? null : $content;
         }
 
         $prefix   = substr($raw, 0, 8);

--- a/tests/Model/Exif/ExifDocumentTest.php
+++ b/tests/Model/Exif/ExifDocumentTest.php
@@ -1143,6 +1143,25 @@ final class ExifDocumentTest extends TestCase
     }
 
     /**
+     * Preserves ASCII user comments when the encoding prefix is omitted.
+     */
+    #[Test]
+    public function preservesAsciiUserCommentsWithoutEncodingPrefix(): void
+    {
+        $ifd0 = new Ifd([]);
+
+        $payload = "Note\0\0";
+
+        $exifIfd = new Ifd([
+            ExifTag::USER_COMMENT => new IfdEntry(ExifTag::USER_COMMENT, 7, 1, $payload),
+        ]);
+
+        $doc = new ExifDocument($ifd0, $exifIfd, null, null, null);
+
+        self::assertSame('Note', $doc->userComment());
+    }
+
+    /**
      * Decodes user comments tagged as Shift-JIS into UTF-8 strings.
      */
     #[Test]


### PR DESCRIPTION
## Summary
- treat short EXIF user comment payloads as ASCII strings instead of discarding them
- cover user comment decoding without an encoding prefix with a PHPUnit regression test

## Testing
- composer ci:test:php:unit

------
https://chatgpt.com/codex/tasks/task_e_69006e84b5d083238a89435a2ab4dc8d