### PR TITLE
feat: harmonize EXIF preview metadata outputs

### DIFF
--- a/src/Api/ExifDocument.php
+++ b/src/Api/ExifDocument.php
@@ -24,6 +24,7 @@ use MagicSunday\ImageMeta\Model\Exif\ExifTag;
 use MagicSunday\ImageMeta\Model\Exif\ValueConverters;
 use MagicSunday\ImageMeta\Value\Camera as CameraValue;
 use MagicSunday\ImageMeta\Value\Derived;
+use MagicSunday\ImageMeta\Value\Enum\Compression;
 use MagicSunday\ImageMeta\Value\Enum\ColorSpace;
 use MagicSunday\ImageMeta\Value\Enum\ExposureProgram;
 use MagicSunday\ImageMeta\Value\Enum\MeteringMode;
@@ -34,6 +35,7 @@ use MagicSunday\ImageMeta\Value\Exposure as ExposureValue;
 use MagicSunday\ImageMeta\Value\Gps as GpsValue;
 use MagicSunday\ImageMeta\Value\Image as ImageValue;
 use MagicSunday\ImageMeta\Value\Lens as LensValue;
+use MagicSunday\ImageMeta\Value\Interop as InteropValue;
 use MagicSunday\ImageMeta\Value\Preview as PreviewValue;
 
 use function is_float;
@@ -58,6 +60,8 @@ final class ExifDocument
 
     private readonly StructuredPreview $preview;
 
+    private readonly InteropValue $interop;
+
     public function __construct(
         ?ModelExifDocument $document,
         ?int $fallbackWidth = null,
@@ -73,6 +77,13 @@ final class ExifDocument
         $gpsValue      = $this->createGpsValue($document);
         $imageValue    = $this->createImageValue($document, $fallbackWidth, $fallbackHeight, $fallbackBitsPerSample);
         $previewValue  = $this->createPreviewValue($document);
+        $interopValue  = new InteropValue(
+            index: $document?->interopIndex(),
+            version: $document?->interopVersion(),
+            relatedImageFileFormat: $document?->relatedImageFileFormat(),
+            relatedImageWidth: $document?->relatedImageWidth(),
+            relatedImageLength: $document?->relatedImageLength(),
+        );
 
         $this->camera   = new StructuredCamera($cameraValue);
         $this->lens     = new StructuredLens($lensValue, $derived);
@@ -80,6 +91,7 @@ final class ExifDocument
         $this->gps      = new StructuredGps($gpsValue);
         $this->image    = new StructuredImage($imageValue);
         $this->preview  = new StructuredPreview($previewValue);
+        $this->interop  = $interopValue;
     }
 
     public function camera(): StructuredCamera
@@ -110,6 +122,11 @@ final class ExifDocument
     public function preview(): StructuredPreview
     {
         return $this->preview;
+    }
+
+    public function interop(): InteropValue
+    {
+        return $this->interop;
     }
 
     public function hasData(): bool
@@ -392,14 +409,17 @@ final class ExifDocument
             compressedBitsPerPixel: $document?->compressedBitsPerPixel(),
             interlace: $document?->interlace(),
             userComment: $document?->userComment(),
+            userCommentEncoding: $document?->userCommentEncoding(),
         );
     }
 
     private function createPreviewValue(?ModelExifDocument $document): PreviewValue
     {
-        $previewColorSpace = null;
+        $previewColorSpace   = null;
+        $previewCompression = null;
         if ($document instanceof ModelExifDocument) {
-            $previewColorSpace = ColorSpace::fromExifValue($document->previewColorSpace());
+            $previewColorSpace   = ColorSpace::fromExifValue($document->previewColorSpace());
+            $previewCompression = Compression::fromExifValue($document->previewImageCompression());
         }
 
         return new PreviewValue(
@@ -409,6 +429,8 @@ final class ExifDocument
             previewHeight: $document?->previewImageHeight(),
             previewColorSpace: $previewColorSpace,
             previewBitDepth: $document?->previewImageBitDepth(),
+            previewCompression: $previewCompression,
+            previewScale: $document?->previewImageScale(),
             previewEncoding: $document?->previewImageEncoding(),
             previewMimeType: $document?->previewImageMimeType(),
             previewOffset: $document?->previewImageOffset(),

--- a/src/Curate/Exif/Structured/Image.php
+++ b/src/Curate/Exif/Structured/Image.php
@@ -51,6 +51,8 @@ final readonly class Image
 
     public ?string $userComment;
 
+    public ?string $userCommentEncoding;
+
     public function __construct(ImageValue $image)
     {
         $this->width                   = $image->width;
@@ -67,5 +69,6 @@ final readonly class Image
         $this->compressedBitsPerPixel  = $image->compressedBitsPerPixel;
         $this->interlace               = $image->interlace;
         $this->userComment             = $image->userComment;
+        $this->userCommentEncoding     = $image->userCommentEncoding;
     }
 }

--- a/src/Curate/Exif/Structured/Preview.php
+++ b/src/Curate/Exif/Structured/Preview.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 namespace MagicSunday\ImageMeta\Curate\Exif\Structured;
 
 use MagicSunday\ImageMeta\Value\Enum\ColorSpace;
+use MagicSunday\ImageMeta\Value\Enum\Compression;
 use MagicSunday\ImageMeta\Value\Preview as PreviewValue;
 
 /**
@@ -31,6 +32,10 @@ final readonly class Preview
 
     public ?int $previewBitDepth;
 
+    public ?Compression $previewCompression;
+
+    public ?float $previewScale;
+
     public ?string $previewEncoding;
 
     public ?string $previewMimeType;
@@ -47,6 +52,8 @@ final readonly class Preview
         $this->previewHeight     = $preview->previewHeight;
         $this->previewColorSpace = $preview->previewColorSpace;
         $this->previewBitDepth   = $preview->previewBitDepth;
+        $this->previewCompression = $preview->previewCompression;
+        $this->previewScale       = $preview->previewScale;
         $this->previewEncoding   = $preview->previewEncoding;
         $this->previewMimeType   = $preview->previewMimeType;
         $this->previewOffset     = $preview->previewOffset;

--- a/src/Curate/Exif/ValueFactory.php
+++ b/src/Curate/Exif/ValueFactory.php
@@ -51,6 +51,7 @@ use MagicSunday\ImageMeta\Value\Container;
 use MagicSunday\ImageMeta\Value\Derived;
 use MagicSunday\ImageMeta\Value\Device;
 use MagicSunday\ImageMeta\Value\Enum\ColorSpace;
+use MagicSunday\ImageMeta\Value\Enum\Compression;
 use MagicSunday\ImageMeta\Value\Enum\DngProfileGainTableTag;
 use MagicSunday\ImageMeta\Value\Enum\ExposureProgram;
 use MagicSunday\ImageMeta\Value\Enum\MeteringMode;
@@ -345,6 +346,8 @@ final class ValueFactory
             $exifDocument?->previewImageHeight(),
             ColorSpace::fromExifValue($exifDocument?->previewColorSpace()),
             $exifDocument?->previewImageBitDepth(),
+            Compression::fromExifValue($exifDocument?->previewImageCompression()),
+            $exifDocument?->previewImageScale(),
             $exifDocument?->previewImageEncoding(),
             $exifDocument?->previewImageMimeType(),
             $exifDocument?->previewImageOffset(),
@@ -892,6 +895,7 @@ final class ValueFactory
             compressedBitsPerPixel: $exifDocument?->compressedBitsPerPixel(),
             interlace: $exifDocument?->interlace(),
             userComment: $exifDocument?->userComment(),
+            userCommentEncoding: $exifDocument?->userCommentEncoding(),
         );
     }
 

--- a/src/Model/Exif/ExifDocument.php
+++ b/src/Model/Exif/ExifDocument.php
@@ -795,6 +795,22 @@ final readonly class ExifDocument
     }
 
     /**
+     * Returns the preview image compression identifier when provided.
+     */
+    public function previewImageCompression(): ?int
+    {
+        return $this->int($this->exifIfd, ExifTag::PREVIEW_IMAGE_COMPRESSION);
+    }
+
+    /**
+     * Returns the preview image scale factor when provided.
+     */
+    public function previewImageScale(): ?float
+    {
+        return $this->rational($this->exifIfd, ExifTag::PREVIEW_IMAGE_SCALE);
+    }
+
+    /**
      * Returns the preview image colour space identifier when present.
      */
     public function previewColorSpace(): ?int
@@ -944,6 +960,36 @@ final readonly class ExifDocument
         $raw = $this->rawString($this->exifIfd, ExifTag::USER_COMMENT);
 
         return $raw !== null ? $this->decodeUserComment($raw) : null;
+    }
+
+    /**
+     * Returns the encoding declared in the EXIF user comment prefix.
+     */
+    public function userCommentEncoding(): ?string
+    {
+        $raw = $this->rawString($this->exifIfd, ExifTag::USER_COMMENT);
+        if ($raw === null) {
+            return null;
+        }
+
+        if (strlen($raw) < 8) {
+            $trimmed = trim($raw, "\0 ");
+
+            return $trimmed === '' ? null : 'ASCII';
+        }
+
+        $prefix   = substr($raw, 0, 8);
+        $encoding = strtoupper(trim($prefix, "\0 "));
+        $content  = trim(substr($raw, 8), "\0 ");
+
+        if ($encoding === '') {
+            return $content === '' ? null : 'ASCII';
+        }
+
+        return match ($encoding) {
+            'ASCII', 'UTF8', 'UNICODE', 'JIS' => $content === '' ? null : $encoding,
+            default                                   => $content === '' ? null : 'ASCII',
+        };
     }
 
     /**
@@ -1904,6 +1950,24 @@ final readonly class ExifDocument
     public function dateTimeOriginalRaw(): ?string
     {
         return $this->str($this->exifIfd, ExifTag::DATETIME_ORIGINAL);
+    }
+
+    /**
+     * Returns the DateTimeOriginal tag combined with fractional seconds and offsets when available.
+     */
+    public function dateTimeOriginal(): ?DateTimeImmutable
+    {
+        $dateTime = $this->parseExifDateTime(
+            $this->dateTimeOriginalRaw(),
+            $this->offsetTimeOriginal(),
+            $this->subSecTimeOriginal(),
+        );
+
+        if ($dateTime instanceof DateTimeImmutable) {
+            return $dateTime;
+        }
+
+        return $this->dateTimeDigitized();
     }
 
     /**

--- a/src/Model/Exif/ExifTag.php
+++ b/src/Model/Exif/ExifTag.php
@@ -188,6 +188,10 @@ final readonly class ExifTag
 
     public const int PREVIEW_DATE_TIME_DIGITIZED = 0xC524;
 
+    public const int PREVIEW_IMAGE_COMPRESSION = 0xC525;
+
+    public const int PREVIEW_IMAGE_SCALE = 0xC526;
+
     public const int YCBCR_COEFFICIENTS = 0x0211;
 
     public const int YCBCR_SUB_SAMPLING = 0x0212;

--- a/src/Value/Image.php
+++ b/src/Value/Image.php
@@ -35,6 +35,7 @@ final readonly class Image
      * @param float|null       $compressedBitsPerPixel  Average bits per pixel after compression.
      * @param int|null         $interlace               Interlace indicator reported by the camera.
      * @param string|null      $userComment             Arbitrary user comment stored by the device.
+     * @param string|null      $userCommentEncoding     Declared encoding for the user comment payload.
      */
     public function __construct(
         public ?int $width,
@@ -51,6 +52,7 @@ final readonly class Image
         public ?float $compressedBitsPerPixel,
         public ?int $interlace,
         public ?string $userComment,
+        public ?string $userCommentEncoding,
     ) {
     }
 }

--- a/src/Value/Preview.php
+++ b/src/Value/Preview.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 namespace MagicSunday\ImageMeta\Value;
 
 use MagicSunday\ImageMeta\Value\Enum\ColorSpace;
+use MagicSunday\ImageMeta\Value\Enum\Compression;
 
 /**
  * Describes the availability of embedded previews or thumbnails.
@@ -25,6 +26,8 @@ final readonly class Preview
      * @param int|null       $previewHeight     Height of the preview image in pixels.
      * @param ColorSpace|null $previewColorSpace Colour space of the preview image.
      * @param int|null       $previewBitDepth   Bit depth of the preview image.
+     * @param Compression|null $previewCompression Compression applied to the preview payload.
+     * @param float|null     $previewScale      Scale factor applied to the preview relative to the main image.
      * @param string|null    $previewEncoding   Encoding name for the preview image payload.
      * @param string|null    $previewMimeType   MIME type of the preview image.
      * @param int|null       $previewOffset     Byte offset to the preview image inside the file.
@@ -37,6 +40,8 @@ final readonly class Preview
         public ?int $previewHeight,
         public ?ColorSpace $previewColorSpace,
         public ?int $previewBitDepth,
+        public ?Compression $previewCompression,
+        public ?float $previewScale,
         public ?string $previewEncoding,
         public ?string $previewMimeType,
         public ?int $previewOffset,

--- a/tests/Api/ExifReaderTest.php
+++ b/tests/Api/ExifReaderTest.php
@@ -41,11 +41,19 @@ final class ExifReaderTest extends TestCase
 
         $image = $document->image();
         self::assertSame(4000, $image->width);
+        self::assertSame('ASCII', $image->userCommentEncoding);
         self::assertSame(3000, $image->height);
         self::assertSame(Orientation::TOP_LEFT, $image->orientation);
         self::assertSame(ColorSpace::SRGB, $image->colorSpace);
 
         $gps = $document->gps();
+
+        $interop = $document->interop();
+        self::assertSame('R98', $interop->index);
+        self::assertSame('0100', $interop->version);
+        self::assertNull($interop->relatedImageFileFormat);
+        self::assertSame(4000, $interop->relatedImageWidth);
+        self::assertSame(3000, $interop->relatedImageLength);
         self::assertNotNull($gps->latitude);
         self::assertEqualsWithDelta(41.888948, $gps->latitude->toFloat() ?? 0.0, 1e-6);
         self::assertNotNull($gps->longitude);
@@ -58,6 +66,8 @@ final class ExifReaderTest extends TestCase
         self::assertNull($preview->previewMimeType);
         self::assertNull($preview->previewBitDepth);
         self::assertNull($preview->previewColorSpace);
+        self::assertNull($preview->previewCompression);
+        self::assertNull($preview->previewScale);
         self::assertNull($preview->previewOffset);
         self::assertNull($preview->previewLength);
     }

--- a/tests/Curate/ExifAssemblerTest.php
+++ b/tests/Curate/ExifAssemblerTest.php
@@ -136,6 +136,8 @@ final class ExifAssemblerTest extends TestCase
                 ColorSpace::ADOBE_RGB->value,
             ),
             ExifTag::PREVIEW_IMAGE_BIT_DEPTH   => new IfdEntry(ExifTag::PREVIEW_IMAGE_BIT_DEPTH, 3, 1, 12),
+            ExifTag::PREVIEW_IMAGE_COMPRESSION => new IfdEntry(ExifTag::PREVIEW_IMAGE_COMPRESSION, 3, 1, Compression::JPEG->value),
+            ExifTag::PREVIEW_IMAGE_SCALE       => new IfdEntry(ExifTag::PREVIEW_IMAGE_SCALE, 5, 1, new ExifRational(1, 1)),
             ExifTag::PREVIEW_DATE_TIME           => new IfdEntry(ExifTag::PREVIEW_DATE_TIME, 2, 19, '2024:05:01 12:40:00'),
             ExifTag::PREVIEW_DATE_TIME_DIGITIZED => new IfdEntry(ExifTag::PREVIEW_DATE_TIME_DIGITIZED, 2, 19, '2024:05:01 12:35:00'),
             ExifTag::PHOTOGRAPHIC_SENSITIVITY    => new IfdEntry(ExifTag::PHOTOGRAPHIC_SENSITIVITY, 3, 1, 400),
@@ -320,6 +322,7 @@ final class ExifAssemblerTest extends TestCase
         self::assertSame(4.5, $structured->media->image->compressedBitsPerPixel);
         self::assertSame(1, $structured->media->image->interlace);
         self::assertSame('Shot with ND filter', $structured->media->image->userComment);
+        self::assertSame('ASCII', $structured->media->image->userCommentEncoding);
         self::assertSame('Developed in Raw Studio', $structured->file->integrity->imageHistory);
         self::assertTrue($structured->file->integrity->makerNotesSafe);
         self::assertTrue($structured->media->preview->hasThumbnail);
@@ -328,6 +331,8 @@ final class ExifAssemblerTest extends TestCase
         self::assertSame(1_152, $structured->media->preview->previewHeight);
         self::assertSame(ColorSpace::ADOBE_RGB, $structured->media->preview->previewColorSpace);
         self::assertSame(12, $structured->media->preview->previewBitDepth);
+        self::assertSame(Compression::JPEG, $structured->media->preview->previewCompression);
+        self::assertSame(1.0, $structured->media->preview->previewScale);
         self::assertSame('JPEG', $structured->media->preview->previewEncoding);
         self::assertSame('image/jpeg', $structured->media->preview->previewMimeType);
         self::assertSame(131_072, $structured->media->preview->previewOffset);

--- a/tests/Model/Exif/ExifDocumentTest.php
+++ b/tests/Model/Exif/ExifDocumentTest.php
@@ -23,11 +23,13 @@ use MagicSunday\ImageMeta\Model\Exif\ValueConverters;
 use MagicSunday\ImageMeta\Parse\Tiff\TiffExifReader;
 use MagicSunday\ImageMeta\Tests\Support\GpsTiffBuilder;
 use MagicSunday\ImageMeta\Value\Enum\ColorSpace;
+use MagicSunday\ImageMeta\Value\Enum\Compression;
 use MagicSunday\ImageMeta\Value\Enum\CfaPatternColor;
 use MagicSunday\ImageMeta\Value\Enum\CompositeImage;
 use MagicSunday\ImageMeta\Value\Enum\CustomRendered;
 use MagicSunday\ImageMeta\Value\Enum\SceneType;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
@@ -294,6 +296,8 @@ final class ExifDocumentTest extends TestCase
                 ColorSpace::ADOBE_RGB->value,
             ),
             ExifTag::PREVIEW_IMAGE_BIT_DEPTH     => new IfdEntry(ExifTag::PREVIEW_IMAGE_BIT_DEPTH, 3, 1, 8),
+            ExifTag::PREVIEW_IMAGE_COMPRESSION  => new IfdEntry(ExifTag::PREVIEW_IMAGE_COMPRESSION, 3, 1, Compression::JPEG->value),
+            ExifTag::PREVIEW_IMAGE_SCALE        => new IfdEntry(ExifTag::PREVIEW_IMAGE_SCALE, 5, 1, new ExifRational(1, 2)),
             ExifTag::PREVIEW_DATE_TIME           => new IfdEntry(ExifTag::PREVIEW_DATE_TIME, 2, 19, '2024:10:25 18:45:30'),
             ExifTag::PREVIEW_DATE_TIME_DIGITIZED => new IfdEntry(ExifTag::PREVIEW_DATE_TIME_DIGITIZED, 2, 19, '2024:10:25 18:40:00'),
         ]);
@@ -309,6 +313,8 @@ final class ExifDocumentTest extends TestCase
         self::assertSame('JPEG', $document->previewImageEncoding());
         self::assertSame('image/jpeg', $document->previewImageMimeType());
         self::assertSame(8, $document->previewImageBitDepth());
+        self::assertSame(Compression::JPEG->value, $document->previewImageCompression());
+        self::assertEqualsWithDelta(0.5, $document->previewImageScale(), 1e-6);
         self::assertSame(ColorSpace::ADOBE_RGB->value, $document->previewColorSpace());
 
         $previewDateTime = $document->previewDateTime();
@@ -339,6 +345,42 @@ final class ExifDocumentTest extends TestCase
         $capture = $doc->captureDateTime();
         self::assertNotNull($capture);
         self::assertSame('2015-06-07T08:09:10.234-04:00', $capture->format(self::ISO_8601_MILLISECONDS));
+    }
+
+    #[Test]
+    public function dateTimeOriginalReturnsParsedTimestamp(): void
+    {
+        $ifd0 = new Ifd([]);
+
+        $exifIfd = new Ifd([
+            ExifTag::DATETIME_ORIGINAL     => new IfdEntry(ExifTag::DATETIME_ORIGINAL, 2, 1, '2022:03:04 05:06:07'),
+            ExifTag::SUB_SEC_TIME_ORIGINAL => new IfdEntry(ExifTag::SUB_SEC_TIME_ORIGINAL, 2, 1, '123'),
+            ExifTag::OFFSET_TIME_ORIGINAL  => new IfdEntry(ExifTag::OFFSET_TIME_ORIGINAL, 2, 1, '-05:30'),
+        ]);
+
+        $doc = new ExifDocument($ifd0, $exifIfd, null, null, null);
+
+        $original = $doc->dateTimeOriginal();
+        self::assertInstanceOf(DateTimeImmutable::class, $original);
+        self::assertSame('2022-03-04T05:06:07.123-05:30', $original->format(self::ISO_8601_MILLISECONDS));
+    }
+
+    #[Test]
+    public function dateTimeOriginalFallsBackToDigitizedWhenAbsent(): void
+    {
+        $ifd0 = new Ifd([]);
+
+        $exifIfd = new Ifd([
+            ExifTag::DATETIME_DIGITIZED     => new IfdEntry(ExifTag::DATETIME_DIGITIZED, 2, 1, '2019:07:08 09:10:11'),
+            ExifTag::SUB_SEC_TIME_DIGITIZED => new IfdEntry(ExifTag::SUB_SEC_TIME_DIGITIZED, 2, 1, '456'),
+            ExifTag::OFFSET_TIME_DIGITIZED  => new IfdEntry(ExifTag::OFFSET_TIME_DIGITIZED, 2, 1, '+02:00'),
+        ]);
+
+        $doc = new ExifDocument($ifd0, $exifIfd, null, null, null);
+
+        $original = $doc->dateTimeOriginal();
+        self::assertInstanceOf(DateTimeImmutable::class, $original);
+        self::assertSame('2019-07-08T09:10:11.456+02:00', $original->format(self::ISO_8601_MILLISECONDS));
     }
 
     /**
@@ -1165,6 +1207,7 @@ final class ExifDocumentTest extends TestCase
         $doc = new ExifDocument($ifd0, $exifIfd, null, null, null);
 
         self::assertSame('Note', $doc->userComment());
+        self::assertSame('ASCII', $doc->userCommentEncoding());
     }
 
     /**
@@ -1193,6 +1236,7 @@ final class ExifDocumentTest extends TestCase
             $doc->userComment(),
             'Expected Shift-JIS encoded bytes to decode to the documented UTF-8 phrase',
         );
+        self::assertSame('JIS', $doc->userCommentEncoding());
     }
 
     /**
@@ -1217,6 +1261,7 @@ final class ExifDocumentTest extends TestCase
             $doc->userComment(),
             'Fallback should strip non-ASCII bytes and trim the decoded output',
         );
+        self::assertSame('JIS', $doc->userCommentEncoding());
     }
 
     /**
@@ -1415,6 +1460,38 @@ final class ExifDocumentTest extends TestCase
         self::assertNull($doc->imageEditingSoftwareVersion());
         self::assertSame('Metadata Tool Z', $doc->metadataEditingSoftware());
         self::assertNull($doc->metadataEditingSoftwareVersion());
+    }
+
+    #[Test]
+    #[DataProvider('provideExifVersionMatrix')]
+    public function normalizesExifVersions(string $raw, string $expectedVersion, string $expectedProfile): void
+    {
+        $ifd0    = new Ifd([]);
+
+        $exifIfd = new Ifd([
+            ExifTag::EXIF_VERSION => new IfdEntry(ExifTag::EXIF_VERSION, 7, strlen($raw), $raw),
+        ]);
+
+        $doc = new ExifDocument($ifd0, $exifIfd, null, null, null);
+
+        self::assertSame($expectedVersion, $doc->exifVersion());
+        self::assertSame($expectedProfile, $doc->exifProfile());
+    }
+
+    /**
+     * @return iterable<string, array{string,string,string}>
+     */
+    public static function provideExifVersionMatrix(): iterable
+    {
+        yield '1.0' => ['0100', '1.00', '1.0'];
+        yield '1.1' => ['0110', '1.10', '1.1'];
+        yield '2.1' => ['0210', '2.10', '2.1'];
+        yield '2.2' => ['0220', '2.20', '2.2'];
+        yield '2.21' => ['0221', '2.21', '2.21'];
+        yield '2.3' => ['0230', '2.30', '2.3'];
+        yield '2.31' => ['0231', '2.31', '2.31'];
+        yield '2.32' => ['0232', '2.32', '2.32'];
+        yield '3.0' => ['0300', '3.00', '3.0'];
     }
 
     /**

--- a/tests/Model/Exif/ExifTagTest.php
+++ b/tests/Model/Exif/ExifTagTest.php
@@ -118,6 +118,10 @@ final class ExifTagTest extends TestCase
             'PREVIEW_IMAGE_BIT_DEPTH'        => 0xC522,
             'PREVIEW_DATE_TIME'              => 0xC523,
             'PREVIEW_DATE_TIME_DIGITIZED'    => 0xC524,
+
+            'PREVIEW_IMAGE_COMPRESSION'      => 0xC525,
+            'PREVIEW_IMAGE_SCALE'            => 0xC526,
+
             'YCBCR_COEFFICIENTS'             => 0x0211,
             'YCBCR_SUB_SAMPLING'             => 0x0212,
             'YCBCR_POSITIONING'              => 0x0213,


### PR DESCRIPTION
## Summary
- expose preview compression, scale, and encoding metadata via the public ExifDocument API
- propagate user comment encoding and interoperability fields through structured value objects
- expand API and model tests to cover EXIF 3.0 preview tags, user comment decoding, and interop fallbacks

## Testing
- `composer ci:test:php:unit`
- `composer ci:test:php:phpstan` *(fails: existing type, casting, and comparison rule violations across ExifDocument and support builders)*

------
https://chatgpt.com/codex/tasks/task_e_69006f42443083239c7ee7ebdc02aa2a