### PR TITLE
feat: improve EXIF fallback metadata handling

### DIFF
--- a/src/Model/Exif/ExifDocument.php
+++ b/src/Model/Exif/ExifDocument.php
@@ -50,6 +50,7 @@ use function is_int;
 use function is_numeric;
 use function is_string;
 use function ord;
+use function preg_match;
 use function preg_replace;
 use function preg_split;
 use function round;
@@ -61,6 +62,7 @@ use function str_replace;
 use function strlen;
 use function strtoupper;
 use function substr;
+use function substr_count;
 use function trim;
 
 /**
@@ -1030,26 +1032,27 @@ final readonly class ExifDocument
         }
 
         if (strlen($raw) < 8) {
-            $trimmed = trim($raw, "\0 ");
-
-            return $trimmed === '' ? null : 'ASCII';
+            return $this->inferUserCommentEncoding($raw);
         }
 
-        $prefix   = substr($raw, 0, 8);
-        $encoding = strtoupper(trim($prefix, "\0 "));
-        $normalized = str_replace(['-', " "], "", $encoding);
-        $content  = trim(substr($raw, 8), "\0 ");
+        $prefix         = substr($raw, 0, 8);
+        $encoding       = strtoupper(trim($prefix, "\0 "));
+        $normalized     = str_replace(['-', " "], "", $encoding);
+        $hasKnownPrefix = in_array($normalized, ['ASCII', 'UTF8', 'UNICODE', 'JIS'], true);
+        $content        = $hasKnownPrefix && strlen($raw) > 8 ? substr($raw, 8) : $raw;
+        $normalizedForMatch = $hasKnownPrefix ? $normalized : '';
+        $hasContent = trim($content, "\0 ") !== '';
 
-        if ($normalized === '') {
-            return $content === '' ? null : 'ASCII';
+        if ($normalizedForMatch === '') {
+            return $this->inferUserCommentEncoding($content);
         }
 
-        return match ($normalized) {
-            'ASCII'   => $content === '' ? null : 'ASCII',
-            'UTF8'    => $content === '' ? null : 'UTF-8',
-            'UNICODE' => $content === '' ? null : 'UNICODE',
-            'JIS'     => $content === '' ? null : 'JIS',
-            default => $content === '' ? null : 'ASCII',
+        return match ($normalizedForMatch) {
+            'ASCII'   => $hasContent ? 'ASCII' : null,
+            'UTF8'    => $hasContent ? 'UTF-8' : null,
+            'UNICODE' => $hasContent ? 'UNICODE' : null,
+            'JIS'     => $hasContent ? 'JIS' : null,
+            default   => $this->inferUserCommentEncoding($content),
         };
     }
 
@@ -1063,7 +1066,18 @@ final readonly class ExifDocument
             return $encoding;
         }
 
-        return $this->userComment() !== null ? 'ASCII' : null;
+        $raw = $this->rawString($this->exifIfd, ExifTag::USER_COMMENT);
+        if ($raw === null) {
+            return null;
+        }
+
+        $prefix         = substr($raw, 0, 8);
+        $encoding       = strtoupper(trim($prefix, "\0 "));
+        $normalized     = str_replace(['-', " "], "", $encoding);
+        $hasKnownPrefix = in_array($normalized, ['ASCII', 'UTF8', 'UNICODE', 'JIS'], true);
+        $content        = $hasKnownPrefix && strlen($raw) > 8 ? substr($raw, 8) : $raw;
+
+        return $this->inferUserCommentEncoding($content);
     }
 
     /**
@@ -1196,6 +1210,15 @@ final readonly class ExifDocument
             return $iso;
         }
 
+        $tagPriority = [
+            ExifTag::STANDARD_OUTPUT_SENSITIVITY,
+            ExifTag::RECOMMENDED_EXPOSURE_INDEX,
+            ExifTag::ISO_SPEED,
+            ExifTag::PHOTOGRAPHIC_SENSITIVITY,
+            ExifTag::ISO_SPEED_RATINGS_LEGACY,
+            ExifTag::EXPOSURE_INDEX,
+        ];
+
         $fallbacks = [
             [$this->exifIfd, ExifTag::STANDARD_OUTPUT_SENSITIVITY],
             [$this->exifIfd, ExifTag::RECOMMENDED_EXPOSURE_INDEX],
@@ -1208,12 +1231,26 @@ final readonly class ExifDocument
             [$this->ifd1, ExifTag::PHOTOGRAPHIC_SENSITIVITY],
             [$this->ifd1, ExifTag::ISO_SPEED],
             [$this->ifd1, ExifTag::ISO_SPEED_RATINGS_LEGACY],
+            [$this->exifIfd, ExifTag::EXPOSURE_INDEX],
+            [$this->ifd0, ExifTag::EXPOSURE_INDEX],
+            [$this->ifd1, ExifTag::EXPOSURE_INDEX],
         ];
 
         foreach ($fallbacks as [$ifd, $tag]) {
             $value = $this->coerceIntValue($this->value($ifd, $tag));
             if ($value !== null) {
                 return $value;
+            }
+        }
+
+        if ($this->subIfds !== []) {
+            foreach ($this->subIfds as $subIfd) {
+                foreach ($tagPriority as $tag) {
+                    $value = $this->coerceIntValue($this->value($subIfd, $tag));
+                    if ($value !== null) {
+                        return $value;
+                    }
+                }
             }
         }
 
@@ -2516,6 +2553,11 @@ final readonly class ExifDocument
             }
         }
 
+        $gpsTimestamp = $this->gpsTimestamp();
+        if ($gpsTimestamp instanceof DateTimeImmutable) {
+            return $gpsTimestamp;
+        }
+
         return null;
     }
 
@@ -3138,11 +3180,19 @@ final readonly class ExifDocument
 
         if (is_string($value)) {
             $trimmed = trim($value);
-            if ($trimmed === '' || !is_numeric($trimmed)) {
+            if ($trimmed === '') {
                 return null;
             }
 
-            return (int) round((float) $trimmed);
+            if (is_numeric($trimmed)) {
+                return (int) round((float) $trimmed);
+            }
+
+            if (preg_match('/\d+/', $trimmed, $matches) === 1) {
+                return (int) $matches[0];
+            }
+
+            return null;
         }
 
         if ($value === null) {
@@ -3264,20 +3314,43 @@ final readonly class ExifDocument
         if (strlen($raw) <= 8) {
             $content = trim($raw, "\0");
 
-            return $content === '' ? null : $content;
+            if ($content === '') {
+                return null;
+            }
+
+            $encoding = $this->inferUserCommentEncoding($raw);
+            if ($encoding === 'UNICODE') {
+                return $this->decodeUnicodeComment($raw);
+            }
+
+            return $content;
         }
 
-        $prefix   = substr($raw, 0, 8);
-        $encoding = strtoupper(trim($prefix, "\0 "));
-        $normalized = str_replace(['-', " "], "", $encoding);
-        $content  = substr($raw, 8);
-        $content  = trim($content, "\0");
+        $prefix         = substr($raw, 0, 8);
+        $encoding       = strtoupper(trim($prefix, "\0 "));
+        $normalized     = str_replace(['-', " "], "", $encoding);
+        $hasKnownPrefix = in_array($normalized, ['ASCII', 'UTF8', 'UNICODE', 'JIS'], true);
+        $content        = $hasKnownPrefix && strlen($raw) > 8 ? substr($raw, 8) : $raw;
+        $normalizedForMatch = $hasKnownPrefix ? $normalized : '';
+        $sanitized      = trim($content, "\0 ");
 
-        return match ($normalized) {
-            'ASCII', 'UTF8', '' => $content !== '' ? $content : null,
+        $resolvedEncoding = match ($normalizedForMatch) {
+            'ASCII'   => $sanitized === '' ? null : 'ASCII',
+            'UTF8'    => $sanitized === '' ? null : 'UTF-8',
+            'UNICODE' => $sanitized === '' ? null : 'UNICODE',
+            'JIS'     => $sanitized === '' ? null : 'JIS',
+            ''        => $this->inferUserCommentEncoding($content),
+            default   => $this->inferUserCommentEncoding($content),
+        };
+
+        if ($resolvedEncoding === null) {
+            return null;
+        }
+
+        return match ($resolvedEncoding) {
             'UNICODE' => $this->decodeUnicodeComment($content),
-            'JIS'     => $this->decodeJisComment($content),
-            default   => $content !== '' ? $content : null,
+            'JIS'     => $this->decodeJisComment($sanitized),
+            default   => $sanitized === '' ? null : $sanitized,
         };
     }
 
@@ -3347,6 +3420,102 @@ final readonly class ExifDocument
         $stripped = trim($stripped, "\0");
 
         return $stripped === '' ? null : $stripped;
+    }
+
+    /**
+     * Infers the most likely user comment encoding based on the raw payload.
+     */
+    private function inferUserCommentEncoding(string $content): ?string
+    {
+        $trimmed = trim($content, "\0 ");
+        if ($trimmed === '') {
+            return null;
+        }
+
+        if ($this->looksLikeUtf16($content)) {
+            return 'UNICODE';
+        }
+
+        if ($this->looksLikeUtf8($trimmed)) {
+            return 'UTF-8';
+        }
+
+        return 'ASCII';
+    }
+
+    /**
+     * Heuristically determines whether the payload resembles UTF-16 text.
+     */
+    private function looksLikeUtf16(string $content): bool
+    {
+        $length = strlen($content);
+        if ($length < 2) {
+            return false;
+        }
+
+        $bom = substr($content, 0, 2);
+        if ($bom === "\xFF\xFE" || $bom === "\xFE\xFF") {
+            return true;
+        }
+
+        $nullCount = substr_count($content, "\x00");
+        if ($nullCount < 2) {
+            return false;
+        }
+
+        $sampleLength = min($length, 32);
+        $sample       = substr($content, 0, $sampleLength);
+
+        $nullsOnEven = 0;
+        $nullsOnOdd  = 0;
+
+        $sampleSize = strlen($sample);
+        for ($i = 0; $i < $sampleSize; ++$i) {
+            if ($sample[$i] === "\x00") {
+                if (($i % 2) === 0) {
+                    ++$nullsOnEven;
+                } else {
+                    ++$nullsOnOdd;
+                }
+            }
+        }
+
+        if ($nullsOnEven === 0 && $nullsOnOdd === 0) {
+            return false;
+        }
+
+        if ($nullsOnEven === 0 || $nullsOnOdd === 0) {
+            return true;
+        }
+
+        if ($nullCount <= 2) {
+            return false;
+        }
+
+        return $nullCount >= (int) ($length / 4);
+    }
+
+    /**
+     * Determines whether the provided string appears to be valid UTF-8 with non-ASCII characters.
+     */
+    private function looksLikeUtf8(string $content): bool
+    {
+        if ($content === '') {
+            return false;
+        }
+
+        if (preg_match('//u', $content) !== 1) {
+            return false;
+        }
+
+        $length = strlen($content);
+        for ($i = 0; $i < $length; ++$i) {
+            if (ord($content[$i]) > 0x7F) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/src/Parse/Tiff/TiffExifReader.php
+++ b/src/Parse/Tiff/TiffExifReader.php
@@ -31,6 +31,7 @@ use MagicSunday\ImageMeta\Model\Exif\IfdEntry;
 use MagicSunday\ImageMeta\Model\Exif\ValueConverters;
 
 use function array_slice;
+use function array_values;
 use function chr;
 use function function_exists;
 use function iconv;
@@ -93,6 +94,7 @@ final class TiffExifReader
         ExifTag::INTEROPERABILITY_IFD_POINTER,
         ExifTag::SUB_IFDS,
         ExifTag::JPEG_INTERCHANGE_FORMAT,
+        ExifTag::PREVIEW_IMAGE_START,
     ];
 
     private const int UTF16_HIGH_SURROGATE_START = 0xD800;
@@ -205,12 +207,9 @@ final class TiffExifReader
         $exifPointer = $ifd0->get(ExifTag::EXIF_IFD_POINTER);
         if ($exifPointer instanceof IfdEntry) {
             $exifIfd = $this->readIfd($this->pointerOffset($exifPointer));
-
-            $interopPointer = $exifIfd->get(ExifTag::INTEROPERABILITY_IFD_POINTER);
-            if ($interopPointer instanceof IfdEntry) {
-                $interopIfd = $this->readIfd($this->pointerOffset($interopPointer));
-            }
         }
+
+        $interopIfd = $this->locateInteropIfd($exifIfd, $ifd0);
 
         $gpsPointer = $ifd0->get(ExifTag::GPS_IFD_POINTER);
         if ($gpsPointer instanceof IfdEntry) {
@@ -236,6 +235,14 @@ final class TiffExifReader
             }
 
             $nextOffset = $nextIfd->nextIfdOffset;
+        }
+
+        if ($interopIfd === null && $additionalIfds !== []) {
+            $interopIfd = $this->locateInteropIfd(...$additionalIfds);
+        }
+
+        if ($interopIfd === null && $this->subIfds !== []) {
+            $interopIfd = $this->locateInteropIfd(...array_values($this->subIfds));
         }
 
         $makerNotes = $this->resolveMakerNotes($makerNotesRegistry, $ifd0, $exifIfd);
@@ -583,6 +590,25 @@ final class TiffExifReader
         }
 
         $this->buf->seek($returnPos);
+    }
+
+    /**
+     * Attempts to resolve an interoperability IFD from the provided directories.
+     */
+    private function locateInteropIfd(?Ifd ...$ifds): ?Ifd
+    {
+        foreach ($ifds as $ifd) {
+            if (!$ifd instanceof Ifd) {
+                continue;
+            }
+
+            $entry = $ifd->get(ExifTag::INTEROPERABILITY_IFD_POINTER);
+            if ($entry instanceof IfdEntry) {
+                return $this->readIfd($this->pointerOffset($entry));
+            }
+        }
+
+        return null;
     }
 
     /**

--- a/tests/Model/Exif/ExifDocumentTest.php
+++ b/tests/Model/Exif/ExifDocumentTest.php
@@ -540,6 +540,30 @@ final class ExifDocumentTest extends TestCase
         self::assertSame('2019-07-08T09:10:11.456+02:00', $original->format(self::ISO_8601_MILLISECONDS));
     }
 
+    #[Test]
+    public function captureDateTimeFallsBackToGpsTimestamp(): void
+    {
+        $gpsIfd = new Ifd([
+            ExifTag::GPS_DATE_STAMP => new IfdEntry(ExifTag::GPS_DATE_STAMP, 2, 10, '2024:08:09'),
+            ExifTag::GPS_TIME_STAMP => new IfdEntry(
+                ExifTag::GPS_TIME_STAMP,
+                5,
+                3,
+                new ExifRationalList([
+                    new ExifRational(10, 1),
+                    new ExifRational(11, 1),
+                    new ExifRational(12, 1),
+                ]),
+            ),
+        ]);
+
+        $doc = new ExifDocument(new Ifd([]), null, $gpsIfd, null, null);
+
+        $capture = $doc->captureDateTime();
+        self::assertInstanceOf(DateTimeImmutable::class, $capture);
+        self::assertSame('2024-08-09T10:11:12+00:00', $capture->format(DATE_ATOM));
+    }
+
     /**
      * Uses the legacy TimeZoneOffset tag when explicit offset tags are unavailable.
      */
@@ -1439,6 +1463,44 @@ final class ExifDocumentTest extends TestCase
         self::assertSame('JIS', $doc->userCommentEncoding());
     }
 
+    #[Test]
+    public function decodesUtf16UserCommentsWithoutEncodingPrefix(): void
+    {
+        $ifd0 = new Ifd([]);
+
+        $encoded = iconv('UTF-8', 'UTF-16LE', 'Grüße aus Köln');
+        self::assertIsString($encoded);
+        $payload = $encoded . "\0\0";
+
+        $exifIfd = new Ifd([
+            ExifTag::USER_COMMENT => new IfdEntry(ExifTag::USER_COMMENT, 7, strlen($payload), $payload),
+        ]);
+
+        $doc = new ExifDocument($ifd0, $exifIfd, null, null, null);
+
+        self::assertSame('Grüße aus Köln', $doc->userComment());
+        self::assertSame('UNICODE', $doc->userCommentEncoding());
+        self::assertSame('UNICODE', $doc->userCommentEncodingBestEffort());
+    }
+
+    #[Test]
+    public function userCommentEncodingBestEffortDetectsUtf8WithoutPrefix(): void
+    {
+        $ifd0 = new Ifd([]);
+
+        $payload = "Café 🌟";
+
+        $exifIfd = new Ifd([
+            ExifTag::USER_COMMENT => new IfdEntry(ExifTag::USER_COMMENT, 7, strlen($payload), $payload),
+        ]);
+
+        $doc = new ExifDocument($ifd0, $exifIfd, null, null, null);
+
+        self::assertSame('Café 🌟', $doc->userComment());
+        self::assertSame('UTF-8', $doc->userCommentEncoding());
+        self::assertSame('UTF-8', $doc->userCommentEncodingBestEffort());
+    }
+
     /**
      * Ensures image dimension getters fall back to values stored within IFD0 when EXIF tags are absent.
      */
@@ -1761,6 +1823,52 @@ final class ExifDocumentTest extends TestCase
 
         self::assertSame(200, $doc->iso());
         self::assertSame(200, $doc->isoBestEffort());
+    }
+
+    #[Test]
+    public function isoBestEffortParsesIsoPrefixedStrings(): void
+    {
+        $exifIfd = new Ifd([
+            ExifTag::ISO_SPEED => new IfdEntry(ExifTag::ISO_SPEED, 2, 7, 'ISO 800'),
+        ]);
+
+        $doc = new ExifDocument(new Ifd([]), $exifIfd, null, null, null);
+
+        self::assertSame(800, $doc->isoBestEffort());
+    }
+
+    #[Test]
+    public function isoBestEffortFallsBackToExposureIndex(): void
+    {
+        $exifIfd = new Ifd([
+            ExifTag::EXPOSURE_INDEX => new IfdEntry(
+                ExifTag::EXPOSURE_INDEX,
+                5,
+                1,
+                new ExifRational(400, 1),
+            ),
+        ]);
+
+        $doc = new ExifDocument(new Ifd([]), $exifIfd, null, null, null);
+
+        self::assertSame(400, $doc->isoBestEffort());
+    }
+
+    #[Test]
+    public function isoBestEffortReadsFromSubIfds(): void
+    {
+        $subIfd = new Ifd([
+            ExifTag::PHOTOGRAPHIC_SENSITIVITY => new IfdEntry(
+                ExifTag::PHOTOGRAPHIC_SENSITIVITY,
+                3,
+                1,
+                640,
+            ),
+        ]);
+
+        $doc = new ExifDocument(new Ifd([]), null, null, null, null, null, [], [256 => $subIfd]);
+
+        self::assertSame(640, $doc->isoBestEffort());
     }
 
     /**

--- a/tests/Parse/Tiff/TiffExifReaderTest.php
+++ b/tests/Parse/Tiff/TiffExifReaderTest.php
@@ -262,6 +262,36 @@ final class TiffExifReaderTest extends TestCase
     }
 
     #[Test]
+    public function resolvesInteropPointerLocatedInIfd0(): void
+    {
+        $blob      = self::buildClassicInteropPointerInIfd0Blob();
+        $document = (new TiffExifReader())->parseFromBlob($blob);
+
+        self::assertSame('R98', $document->interopIndex());
+        self::assertSame('0100', $document->interopVersion());
+    }
+
+    #[Test]
+    public function resolvesInteropPointerLocatedInIfd1(): void
+    {
+        $blob      = self::buildClassicInteropPointerInIfd1Blob();
+        $document = (new TiffExifReader())->parseFromBlob($blob);
+
+        self::assertSame('R98', $document->interopIndex());
+        self::assertSame('0100', $document->interopVersion());
+    }
+
+    #[Test]
+    public function resolvesInteropPointerLocatedInSubIfd(): void
+    {
+        $blob      = self::buildClassicInteropPointerInSubIfdBlob();
+        $document = (new TiffExifReader())->parseFromBlob($blob);
+
+        self::assertSame('R98', $document->interopIndex());
+        self::assertSame('0100', $document->interopVersion());
+    }
+
+    #[Test]
     public function parsesLinkedIfdChain(): void
     {
         $blob      = $this->buildClassicLinkedIfdBlob();
@@ -1164,6 +1194,90 @@ final class TiffExifReaderTest extends TestCase
 
         return $blob;
     }
+    /**
+     * Builds a Classic TIFF blob with the interoperability pointer stored in IFD0.
+     */
+    private static function buildClassicInteropPointerInIfd0Blob(): string
+    {
+        $header = 'II' . pack('v', 0x002A) . pack('V', 8);
+
+        $ifdEntryCount = 1;
+        $ifdLength     = 2 + ($ifdEntryCount * 12) + 4;
+        $interopOffset = 8 + $ifdLength;
+
+        $ifd0 = pack('v', $ifdEntryCount)
+            . self::packClassicEntry(ExifTag::INTEROPERABILITY_IFD_POINTER, 4, 1, $interopOffset)
+            . pack('V', 0);
+
+        $interopEntries = [
+            self::packClassicEntry(ExifTag::INTEROPERABILITY_INDEX, 2, 4, self::inlineAsciiToInt('R98', 4)),
+            self::packClassicEntry(ExifTag::INTEROPERABILITY_VERSION, 2, 4, self::inlineAsciiToInt('0100', 4)),
+        ];
+
+        $interopIfd = pack('v', count($interopEntries)) . implode('', $interopEntries) . pack('V', 0);
+
+        return $header . $ifd0 . $interopIfd;
+    }
+
+    /**
+     * Builds a Classic TIFF blob with the interoperability pointer in the second IFD.
+     */
+    private static function buildClassicInteropPointerInIfd1Blob(): string
+    {
+        $header = 'II' . pack('v', 0x002A) . pack('V', 8);
+
+        $ifd0Length  = 2 + 4;
+        $ifd1Offset  = 8 + $ifd0Length;
+        $ifd1Length  = 2 + 12 + 4;
+        $interopOffset = $ifd1Offset + $ifd1Length;
+
+        $ifd0 = pack('v', 0)
+            . pack('V', $ifd1Offset);
+
+        $ifd1 = pack('v', 1)
+            . self::packClassicEntry(ExifTag::INTEROPERABILITY_IFD_POINTER, 4, 1, $interopOffset)
+            . pack('V', 0);
+
+        $interopEntries = [
+            self::packClassicEntry(ExifTag::INTEROPERABILITY_INDEX, 2, 4, self::inlineAsciiToInt('R98', 4)),
+            self::packClassicEntry(ExifTag::INTEROPERABILITY_VERSION, 2, 4, self::inlineAsciiToInt('0100', 4)),
+        ];
+
+        $interopIfd = pack('v', count($interopEntries)) . implode('', $interopEntries) . pack('V', 0);
+
+        return $header . $ifd0 . $ifd1 . $interopIfd;
+    }
+
+    /**
+     * Builds a Classic TIFF blob with the interoperability pointer referenced from a SubIFD.
+     */
+    private static function buildClassicInteropPointerInSubIfdBlob(): string
+    {
+        $header = 'II' . pack('v', 0x002A) . pack('V', 8);
+
+        $ifd0Length    = 2 + 12 + 4;
+        $subIfdOffset  = 8 + $ifd0Length;
+        $subIfdLength  = 2 + 12 + 4;
+        $interopOffset = $subIfdOffset + $subIfdLength;
+
+        $ifd0 = pack('v', 1)
+            . self::packClassicEntry(ExifTag::SUB_IFDS, 4, 1, $subIfdOffset)
+            . pack('V', 0);
+
+        $subIfd = pack('v', 1)
+            . self::packClassicEntry(ExifTag::INTEROPERABILITY_IFD_POINTER, 4, 1, $interopOffset)
+            . pack('V', 0);
+
+        $interopEntries = [
+            self::packClassicEntry(ExifTag::INTEROPERABILITY_INDEX, 2, 4, self::inlineAsciiToInt('R98', 4)),
+            self::packClassicEntry(ExifTag::INTEROPERABILITY_VERSION, 2, 4, self::inlineAsciiToInt('0100', 4)),
+        ];
+
+        $interopIfd = pack('v', count($interopEntries)) . implode('', $interopEntries) . pack('V', 0);
+
+        return $header . $ifd0 . $subIfd . $interopIfd;
+    }
+
     /**
      * Builds a Classic TIFF blob that only exposes the legacy DocumentName tag.
      */


### PR DESCRIPTION
## Summary
- extend ISO and capture timestamp fallbacks to cover additional tags, SubIFDs, and GPS timestamps
- infer EXIF user comment encodings for prefixless UTF-16/UTF-8 payloads and harmonise preview pointer handling
- follow interoperability pointers from any IFD and cover new behaviours with unit tests across EXIF versions

## Testing
- composer ci:test:php:unit

------
https://chatgpt.com/codex/tasks/task_e_69008d8840d4832394a7ce180935f8b9