### PR TITLE
feat: improve EXIF fallback getters

### DIFF
--- a/src/Convenience/ExifConvenience.php
+++ b/src/Convenience/ExifConvenience.php
@@ -130,6 +130,15 @@ final class ExifConvenience
      */
     public static function iso(ExifDocument $doc): ?int
     {
+        try {
+            $iso = $doc->isoBestEffort();
+            if ($iso !== null) {
+                return $iso;
+            }
+        } catch (Throwable) {
+            // ignore and fall back to manual resolution
+        }
+
         $iso = self::isoFromSensitivityType($doc);
         if ($iso !== null) {
             return $iso;

--- a/src/Curate/Exif/ValueFactory.php
+++ b/src/Curate/Exif/ValueFactory.php
@@ -745,39 +745,87 @@ final class ValueFactory
             return [null, null, null];
         }
 
-        $offset = $document->offsetTimeOriginal();
-        if ($offset === null) {
-            $zoneOffsets = $document->timeZoneOffsetMinutes();
-            if (is_array($zoneOffsets) && array_key_exists(0, $zoneOffsets)) {
+        $original = $document->dateTimeOriginalBestEffort();
+
+        $zoneOffsets = $document->timeZoneOffsetMinutes();
+        $offset      = $document->offsetTimeOriginal();
+        if ($offset === null && is_array($zoneOffsets) && array_key_exists(0, $zoneOffsets)) {
+            $offset = $zoneOffsets[0];
+        }
+
+        if ($offset === null && $this->dateTimeStringEmpty($document->dateTimeOriginalRaw())) {
+            $offset = $document->offsetTimeDigitized();
+            if ($offset === null && is_array($zoneOffsets) && array_key_exists(1, $zoneOffsets)) {
+                $offset = $zoneOffsets[1];
+            }
+        }
+
+        if (
+            $offset === null
+            && $this->dateTimeStringEmpty($document->dateTimeOriginalRaw())
+            && $this->dateTimeStringEmpty($document->dateTimeDigitizedRaw())
+        ) {
+            $offset = $document->offsetTime();
+            if ($offset === null && is_array($zoneOffsets) && array_key_exists(0, $zoneOffsets)) {
                 $offset = $zoneOffsets[0];
             }
         }
 
-        if (is_int($offset)) {
-            $absOffset = abs($offset);
-            $hours     = $absOffset;
-            $minutes   = 0;
+        $offsetString = $this->normaliseOffsetValue($offset);
+        $timezone     = ValueConverters::parseOffset($offsetString);
 
-            if ($absOffset > 14) {
-                $hours   = intdiv($absOffset, 60);
-                $minutes = $absOffset % 60;
-            }
-
-            if ($hours > 14 || ($hours === 14 && $minutes !== 0)) {
-                $offset = null;
-            } else {
-                $sign   = $offset < 0 ? '-' : '+';
-                $offset = sprintf('%s%02d:%02d', $sign, $hours, $minutes);
-            }
+        if ($timezone instanceof DateTimeZone && $original instanceof DateTimeImmutable) {
+            $original = $original->setTimezone($timezone);
         }
 
-        $timezone = ValueConverters::parseOffset(is_string($offset) ? $offset : null);
+        $subSeconds = $document->subSecTimeOriginal();
 
         return [
-            $document->captureDateTime(),
-            $timezone,
-            $document->subSecTimeOriginal(),
+            $original,
+            $timezone instanceof DateTimeZone ? $timezone : null,
+            $subSeconds,
         ];
+    }
+
+    /**
+     * Determines whether an EXIF date/time string is empty after trimming whitespace.
+     */
+    private function dateTimeStringEmpty(?string $value): bool
+    {
+        return $value === null || trim($value) === '';
+    }
+
+    /**
+     * Normalises textual or numeric offsets to a canonical ±HH:MM representation.
+     */
+    private function normaliseOffsetValue(int|string|null $offset): ?string
+    {
+        if ($offset === null) {
+            return null;
+        }
+
+        if (is_string($offset)) {
+            $trimmed = trim($offset);
+
+            return $trimmed === '' ? null : $trimmed;
+        }
+
+        $absOffset = abs($offset);
+        $hours     = $absOffset;
+        $minutes   = 0;
+
+        if ($absOffset > 14) {
+            $hours   = intdiv($absOffset, 60);
+            $minutes = $absOffset % 60;
+        }
+
+        if ($hours > 14 || ($hours === 14 && $minutes !== 0)) {
+            return null;
+        }
+
+        $sign = $offset < 0 ? '-' : '+';
+
+        return sprintf('%s%02d:%02d', $sign, $hours, $minutes);
     }
 
     /**

--- a/tests/Convenience/ExifConvenienceTest.php
+++ b/tests/Convenience/ExifConvenienceTest.php
@@ -125,6 +125,35 @@ final class ExifConvenienceTest extends TestCase
         self::assertSame(320, ExifConvenience::iso($doc));
     }
 
+    #[Test]
+    public function isoParsesIsoPrefixedAsciiValues(): void
+    {
+        $exifIfd = new Ifd([
+            ExifTag::ISO_SPEED => new IfdEntry(ExifTag::ISO_SPEED, 2, 7, 'ISO 800'),
+        ]);
+
+        $doc = new ExifDocument(new Ifd([]), $exifIfd, null, null, null);
+
+        self::assertSame(800, ExifConvenience::iso($doc));
+    }
+
+    #[Test]
+    public function isoReadsValuesFromSubIfds(): void
+    {
+        $subIfd = new Ifd([
+            ExifTag::PHOTOGRAPHIC_SENSITIVITY => new IfdEntry(
+                ExifTag::PHOTOGRAPHIC_SENSITIVITY,
+                3,
+                1,
+                640,
+            ),
+        ]);
+
+        $doc = new ExifDocument(new Ifd([]), null, null, null, null, null, [], [256 => $subIfd]);
+
+        self::assertSame(640, ExifConvenience::iso($doc));
+    }
+
     /**
      * Validates EXIF 3.0 sensitivity metadata honours the documented priority rules and supports
      * files that only populate the newer tags.

--- a/tests/Curate/ExifAssemblerTest.php
+++ b/tests/Curate/ExifAssemblerTest.php
@@ -1535,6 +1535,32 @@ final class ExifAssemblerTest extends TestCase
     }
 
     /**
+     * Ensures the original timestamp falls back to DateTimeDigitized metadata when necessary.
+     */
+    #[Test]
+    public function temporalOriginalFallsBackToDigitizedTimestamp(): void
+    {
+        $ifd0 = new Ifd([]);
+
+        $exifIfd = new Ifd([
+            ExifTag::DATETIME_DIGITIZED    => new IfdEntry(ExifTag::DATETIME_DIGITIZED, 2, 1, '2024:07:03 10:11:12'),
+            ExifTag::OFFSET_TIME_DIGITIZED => new IfdEntry(ExifTag::OFFSET_TIME_DIGITIZED, 2, 1, '+02:30'),
+            ExifTag::SUB_SEC_TIME_DIGITIZED => new IfdEntry(ExifTag::SUB_SEC_TIME_DIGITIZED, 2, 1, '987'),
+        ]);
+
+        $exifDocument = new ExifDocument($ifd0, $exifIfd, null, null, null);
+        $metadata     = new Metadata(['primary'], null, $exifDocument);
+
+        $structured = (new ExifAssembler())->assemble($metadata);
+
+        self::assertSame('2024-07-03T10:11:12+02:30', $structured->capture->temporal->original?->format('c'));
+        self::assertSame('+02:30', $structured->capture->temporal->tz?->getName());
+        self::assertNull($structured->capture->temporal->subSecTimeOriginal);
+        self::assertSame('987', $structured->capture->temporal->subSecTimeDigitized);
+        self::assertSame('987', $structured->capture->temporal->subSecTime);
+    }
+
+    /**
      * Ensures DateTimeOriginal does not leak the PHP default timezone when offset metadata is missing.
      */
     #[Test]


### PR DESCRIPTION
# Summary
- route ExifConvenience::iso through the model's best-effort resolution before falling back to legacy parsing
- derive temporal offsets from digitized metadata when DateTimeOriginal is absent and normalise offset handling in the value factory
- cover the new fallback behaviour with integration tests for convenience ISO reads and temporal digitized fallbacks

# Testing
- `composer ci:test:php:unit`


------
https://chatgpt.com/codex/tasks/task_e_690095ff97c08323ba2794986c939d7b