### PR TITLE
Fix preview offset handling for large UInt64 values

### DIFF
--- a/src/Model/Exif/ExifDocument.php
+++ b/src/Model/Exif/ExifDocument.php
@@ -3129,9 +3129,9 @@ final readonly class ExifDocument
     /**
      * Retrieves the raw entry value for the provided tag.
      *
-     * @return int|float|string|ExifRational|ExifRationalList|ExifNumericList|null
+     * @return int|float|string|ExifRational|ExifRationalList|ExifNumericList|UInt64|null
      */
-    private function value(?Ifd $ifd, int $tag): int|float|string|ExifRational|ExifRationalList|ExifNumericList|null
+    private function value(?Ifd $ifd, int $tag): int|float|string|ExifRational|ExifRationalList|ExifNumericList|UInt64|null
     {
         if (!$ifd instanceof Ifd) {
             return null;
@@ -3167,6 +3167,10 @@ final readonly class ExifDocument
         }
 
         if ($value instanceof UInt64) {
+            if (!$value->fitsSignedInt()) {
+                return null;
+            }
+
             return $value->toInt('EXIF integer coercion');
         }
 

--- a/tests/Model/Exif/ExifDocumentTest.php
+++ b/tests/Model/Exif/ExifDocumentTest.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 namespace MagicSunday\ImageMeta\Tests\Model\Exif;
 
 use DateTimeImmutable;
+use MagicSunday\ImageMeta\Core\Util\UInt64;
 use MagicSunday\ImageMeta\Model\Exif\ExifDocument;
 use MagicSunday\ImageMeta\Model\Exif\ExifNumericList;
 use MagicSunday\ImageMeta\Model\Exif\ExifRational;
@@ -438,6 +439,29 @@ final class ExifDocumentTest extends TestCase
         self::assertSame(4096, $docComplete->previewImageLength());
         self::assertSame(6, $docComplete->previewImageCompression());
         self::assertEqualsWithDelta(0.5, $docComplete->previewImageScale(), 1e-6);
+    }
+
+    #[Test]
+    public function previewMetadataIgnoresOffsetsBeyondSupportedRange(): void
+    {
+        $ifd0 = new Ifd([]);
+
+        $offset = UInt64::fromUInt32(0x8000_0000, 0);
+
+        $exifIfd = new Ifd([
+            ExifTag::PREVIEW_IMAGE_START       => new IfdEntry(ExifTag::PREVIEW_IMAGE_START, 16, 1, $offset),
+            ExifTag::PREVIEW_IMAGE_LENGTH      => new IfdEntry(ExifTag::PREVIEW_IMAGE_LENGTH, 4, 1, 4096),
+            ExifTag::PREVIEW_IMAGE_COMPRESSION => new IfdEntry(ExifTag::PREVIEW_IMAGE_COMPRESSION, 3, 1, 6),
+            ExifTag::PREVIEW_IMAGE_SCALE       => new IfdEntry(ExifTag::PREVIEW_IMAGE_SCALE, 5, 1, new ExifRational(1, 2)),
+        ]);
+
+        $document = new ExifDocument($ifd0, $exifIfd, null, null, null);
+
+        self::assertFalse($document->hasPreviewImage());
+        self::assertNull($document->previewImageOffset());
+        self::assertNull($document->previewImageLength());
+        self::assertNull($document->previewImageCompression());
+        self::assertNull($document->previewImageScale());
     }
 
     /**


### PR DESCRIPTION
## Overview
- ensure EXIF preview helpers ignore offsets that exceed the supported integer range
- treat oversized UInt64 values as missing when coercing scalar values

## Details
- bail out of integer coercion when UInt64 values do not fit into PHP's signed range
- allow raw value accessors to surface UInt64 entries and cover the behaviour with a regression test for preview metadata

## Tests
- `composer ci:test:php:unit`

## Risks
- Low; changes only affect preview metadata coercion logic when offsets are out of range.

## Changelog
- n/a

## Closes
- Closes #N/A

------
https://chatgpt.com/codex/tasks/task_e_69009c31b3c88323869925b558a14568