### PR TITLE
feat(tiff): resolve interop ifd stored in subifds

### DIFF
--- a/src/Parse/Tiff/TiffExifReader.php
+++ b/src/Parse/Tiff/TiffExifReader.php
@@ -602,13 +602,45 @@ final class TiffExifReader
                 continue;
             }
 
+            if ($this->ifdLooksLikeInterop($ifd)) {
+                return $ifd;
+            }
+
             $entry = $ifd->get(ExifTag::INTEROPERABILITY_IFD_POINTER);
             if ($entry instanceof IfdEntry) {
-                return $this->readIfd($this->pointerOffset($entry));
+                $candidate = $this->readIfd($this->pointerOffset($entry));
+
+                if ($this->ifdLooksLikeInterop($candidate)) {
+                    return $candidate;
+                }
+
+                return $candidate;
             }
         }
 
         return null;
+    }
+
+    /**
+     * Determines whether the provided directory contains interoperability tags.
+     */
+    private function ifdLooksLikeInterop(Ifd $ifd): bool
+    {
+        $interopTags = [
+            ExifTag::INTEROPERABILITY_INDEX,
+            ExifTag::INTEROPERABILITY_VERSION,
+            ExifTag::RELATED_IMAGE_FILE_FORMAT,
+            ExifTag::RELATED_IMAGE_WIDTH,
+            ExifTag::RELATED_IMAGE_LENGTH,
+        ];
+
+        foreach ($interopTags as $tag) {
+            if ($ifd->get($tag) instanceof IfdEntry) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/tests/Parse/Tiff/TiffExifReaderTest.php
+++ b/tests/Parse/Tiff/TiffExifReaderTest.php
@@ -292,6 +292,17 @@ final class TiffExifReaderTest extends TestCase
     }
 
     #[Test]
+    public function resolvesInteropStoredDirectlyInSubIfd(): void
+    {
+        $blob      = self::buildClassicInteropInlineSubIfdBlob();
+        $document = (new TiffExifReader())->parseFromBlob($blob);
+
+        self::assertSame('R98', $document->interopIndex());
+        self::assertSame('0100', $document->interopVersion());
+        self::assertSame(2048, $document->relatedImageWidth());
+    }
+
+    #[Test]
     public function parsesLinkedIfdChain(): void
     {
         $blob      = $this->buildClassicLinkedIfdBlob();
@@ -1276,6 +1287,30 @@ final class TiffExifReaderTest extends TestCase
         $interopIfd = pack('v', count($interopEntries)) . implode('', $interopEntries) . pack('V', 0);
 
         return $header . $ifd0 . $subIfd . $interopIfd;
+    }
+
+    private static function buildClassicInteropInlineSubIfdBlob(): string
+    {
+        $header = 'II' . pack('v', 0x002A) . pack('V', 8);
+
+        $ifd0Length   = 2 + 12 + 4;
+        $subIfdOffset = 8 + $ifd0Length;
+
+        $ifd0 = pack('v', 1)
+            . self::packClassicEntry(ExifTag::SUB_IFDS, 4, 1, $subIfdOffset)
+            . pack('V', 0);
+
+        $subIfdEntries = [
+            self::packClassicEntry(ExifTag::INTEROPERABILITY_INDEX, 2, 4, self::inlineAsciiToInt('R98', 4)),
+            self::packClassicEntry(ExifTag::INTEROPERABILITY_VERSION, 2, 4, self::inlineAsciiToInt('0100', 4)),
+            self::packClassicEntry(ExifTag::RELATED_IMAGE_WIDTH, 4, 1, 2048),
+        ];
+
+        $subIfd = pack('v', count($subIfdEntries))
+            . implode('', $subIfdEntries)
+            . pack('V', 0);
+
+        return $header . $ifd0 . $subIfd;
     }
 
     /**


### PR DESCRIPTION
## Summary
- detect interoperability metadata when the SubIFD itself carries interoperability tags
- add coverage to ensure TIFF parsing exposes interop values without an explicit pointer

## Testing
- composer ci:test:php:unit

------
https://chatgpt.com/codex/tasks/task_e_6900a29d6f70832388513a5a0c77b03a