### PR TITLE
feat(exif): add fallback getters and interop wiring

### DIFF
--- a/src/Api/ExifDocument.php
+++ b/src/Api/ExifDocument.php
@@ -124,6 +124,26 @@ final class ExifDocument
         return $this->interop;
     }
 
+    public function iso(): ?int
+    {
+        return $this->raw?->isoBestEffort();
+    }
+
+    public function dateTimeOriginal(): ?DateTimeImmutable
+    {
+        return $this->raw?->dateTimeOriginalBestEffort();
+    }
+
+    public function userComment(): ?string
+    {
+        return $this->raw?->userComment();
+    }
+
+    public function userCommentEncoding(): ?string
+    {
+        return $this->raw?->userCommentEncodingBestEffort();
+    }
+
     public function hasData(): bool
     {
         return $this->raw instanceof ModelExifDocument;

--- a/src/Parse/Tiff/TiffExifReader.php
+++ b/src/Parse/Tiff/TiffExifReader.php
@@ -152,6 +152,13 @@ final class TiffExifReader
     private array $ifdCache = [];
 
     /**
+     * Tracks pointer offsets that have already been inspected while resolving interoperability IFDs.
+     *
+     * @var array<int, bool>
+     */
+    private array $interopVisitedOffsets = [];
+
+    /**
      * Parses an EXIF TIFF blob into a structured document model.
      *
      * @param string        $tiffBlob           Raw TIFF data including headers.
@@ -165,10 +172,11 @@ final class TiffExifReader
         $this->buf->seek(0);
         $this->blobSize = UInt64::fromInt($this->buf->size());
 
-        $this->makerNoteRaw      = null;
-        $this->subIfds           = [];
-        $this->ifdCache          = [];
-        $this->bigTiffOffsetSize = 8;
+        $this->makerNoteRaw           = null;
+        $this->subIfds                = [];
+        $this->ifdCache               = [];
+        $this->bigTiffOffsetSize      = 8;
+        $this->interopVisitedOffsets = [];
 
         // byte order
         $boSig    = $this->buf->read(2);
@@ -597,6 +605,8 @@ final class TiffExifReader
      */
     private function locateInteropIfd(?Ifd ...$ifds): ?Ifd
     {
+        $deferred = [];
+
         foreach ($ifds as $ifd) {
             if (!$ifd instanceof Ifd) {
                 continue;
@@ -607,14 +617,31 @@ final class TiffExifReader
             }
 
             $entry = $ifd->get(ExifTag::INTEROPERABILITY_IFD_POINTER);
-            if ($entry instanceof IfdEntry) {
-                $candidate = $this->readIfd($this->pointerOffset($entry));
+            if (!$entry instanceof IfdEntry) {
+                continue;
+            }
 
-                if ($this->ifdLooksLikeInterop($candidate)) {
-                    return $candidate;
-                }
+            $offset = $this->pointerOffset($entry);
+            if (isset($this->interopVisitedOffsets[$offset])) {
+                continue;
+            }
 
+            $this->interopVisitedOffsets[$offset] = true;
+
+            $candidate = $this->readIfd($offset);
+
+            if ($this->ifdLooksLikeInterop($candidate)) {
                 return $candidate;
+            }
+
+            $deferred[] = $candidate;
+        }
+
+        if ($deferred !== []) {
+            $resolved = $this->locateInteropIfd(...$deferred);
+
+            if ($resolved instanceof Ifd) {
+                return $resolved;
             }
         }
 

--- a/tests/Acceptance/ExifFallbacksTest.php
+++ b/tests/Acceptance/ExifFallbacksTest.php
@@ -1,0 +1,46 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\ImageMeta\Tests\Acceptance;
+
+use MagicSunday\ImageMeta\MetadataReader;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class ExifFallbacksTest extends TestCase
+{
+    private const SAMPLE = __DIR__ . '/../../test-images/Images/gps_exif_example.jpg';
+
+    #[Test]
+    public function readsBestEffortExposureAndTemporalData(): void
+    {
+        $structured = (new MetadataReader())
+            ->read(self::SAMPLE)
+            ->structured();
+
+        self::assertSame(80, $structured->exposure->iso);
+        self::assertSame(
+            '2011-12-06T11:08:37+00:00',
+            $structured->capture->temporal->original?->format(DATE_ATOM),
+        );
+        self::assertSame(
+            '400 N Michigan Ave, Chicago, IL 60611, USA',
+            $structured->media->image->userComment,
+        );
+        self::assertSame('ASCII', $structured->media->image->userCommentEncoding);
+
+        $interop = $structured->technical->interop;
+        self::assertSame('R98', $interop->index);
+        self::assertSame('0100', $interop->version);
+        self::assertSame(4000, $interop->relatedImageWidth);
+        self::assertSame(3000, $interop->relatedImageLength);
+    }
+}

--- a/tests/Api/ExifDocumentFallbackTest.php
+++ b/tests/Api/ExifDocumentFallbackTest.php
@@ -58,11 +58,42 @@ final class ExifDocumentFallbackTest extends TestCase
         self::assertNotNull($bestEffortOriginal);
         self::assertSame('2024-05-06T07:08:09+02:00', $bestEffortOriginal->format(DATE_ATOM));
 
+        $apiOriginal = $apiDocument->dateTimeOriginal();
+        self::assertNotNull($apiOriginal);
+        self::assertSame('2024-05-06T07:08:09+02:00', $apiOriginal->format(DATE_ATOM));
+
+        self::assertSame(400, $apiDocument->iso());
+
         $exposure = $apiDocument->exposure();
         self::assertSame(400, $exposure->iso);
 
         $image = $apiDocument->image();
         self::assertSame('Shot with ND filter', $image->userComment);
         self::assertSame('ASCII', $image->userCommentEncoding);
+
+        self::assertSame('Shot with ND filter', $apiDocument->userComment());
+        self::assertSame('ASCII', $apiDocument->userCommentEncoding());
+    }
+
+    #[Test]
+    public function previewMetadataRequiresValidDescriptor(): void
+    {
+        $ifd0 = new Ifd([]);
+
+        $exifIfd = new Ifd([
+            ExifTag::PREVIEW_IMAGE_COMPRESSION => new IfdEntry(ExifTag::PREVIEW_IMAGE_COMPRESSION, 3, 1, 6),
+            ExifTag::PREVIEW_IMAGE_SCALE       => new IfdEntry(
+                ExifTag::PREVIEW_IMAGE_SCALE,
+                5,
+                1,
+                new ExifRational(1, 2),
+            ),
+        ]);
+
+        $apiDocument = new ApiExifDocument(new ModelExifDocument($ifd0, $exifIfd, null, null, null));
+
+        $preview = $apiDocument->preview();
+        self::assertNull($preview->previewCompression);
+        self::assertNull($preview->previewScale);
     }
 }

--- a/tests/Parse/Tiff/TiffExifReaderTest.php
+++ b/tests/Parse/Tiff/TiffExifReaderTest.php
@@ -303,6 +303,16 @@ final class TiffExifReaderTest extends TestCase
     }
 
     #[Test]
+    public function skipsInvalidInteropPointerTargets(): void
+    {
+        $blob      = self::buildClassicInteropPointerWithSubIfdFallbackBlob();
+        $document = (new TiffExifReader())->parseFromBlob($blob);
+
+        self::assertSame('R98', $document->interopIndex());
+        self::assertSame('0100', $document->interopVersion());
+    }
+
+    #[Test]
     public function parsesLinkedIfdChain(): void
     {
         $blob      = $this->buildClassicLinkedIfdBlob();
@@ -1311,6 +1321,43 @@ final class TiffExifReaderTest extends TestCase
             . pack('V', 0);
 
         return $header . $ifd0 . $subIfd;
+    }
+
+    /**
+     * Builds a Classic TIFF blob where the EXIF pointer is stale but the SubIFD provides interoperability tags.
+     */
+    private static function buildClassicInteropPointerWithSubIfdFallbackBlob(): string
+    {
+        $header = 'II' . pack('v', 0x002A) . pack('V', 8);
+
+        $ifd0Length    = 2 + (2 * 12) + 4;
+        $exifOffset    = 8 + $ifd0Length;
+        $exifLength    = 2 + 12 + 4;
+        $invalidOffset = $exifOffset + $exifLength;
+        $invalidLength = 2 + 12 + 4;
+        $subIfdOffset  = $invalidOffset + $invalidLength;
+
+        $ifd0 = pack('v', 2)
+            . self::packClassicEntry(ExifTag::EXIF_IFD_POINTER, 4, 1, $exifOffset)
+            . self::packClassicEntry(ExifTag::SUB_IFDS, 4, 1, $subIfdOffset)
+            . pack('V', 0);
+
+        $exifIfd = pack('v', 1)
+            . self::packClassicEntry(ExifTag::INTEROPERABILITY_IFD_POINTER, 4, 1, $invalidOffset)
+            . pack('V', 0);
+
+        $invalidIfd = pack('v', 1)
+            . self::packClassicEntry(ExifTag::ORIENTATION, 3, 1, 1)
+            . pack('V', 0);
+
+        $interopEntries = [
+            self::packClassicEntry(ExifTag::INTEROPERABILITY_INDEX, 2, 4, self::inlineAsciiToInt('R98', 4)),
+            self::packClassicEntry(ExifTag::INTEROPERABILITY_VERSION, 2, 4, self::inlineAsciiToInt('0100', 4)),
+        ];
+
+        $subIfd = pack('v', count($interopEntries)) . implode('', $interopEntries) . pack('V', 0);
+
+        return $header . $ifd0 . $exifIfd . $invalidIfd . $subIfd;
     }
 
     /**


### PR DESCRIPTION
## Summary
- expose best-effort ISO, capture timestamp, and user comment encoding getters on the API façade
- guard interoperability discovery against stale pointers and cover the fallback search paths
- exercise fallback extraction on a real-world JPEG to ensure ISO, comment, and interop data surface correctly

## Testing
- composer ci:test:php:unit
- composer ci:test:php:phpstan

------
https://chatgpt.com/codex/tasks/task_e_6900afbca4348323b38fd0c9f744fdbf