### PR TITLE
feat: extend EXIF fallbacks across auxiliary IFDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 - Expanded GPS coverage to include horizontal positioning error and the full destination navigation set from EXIF 2.32 table 66.
 - Introduced dedicated maker note decoders for Apple (`MakerNotes\AppleDecoder`), Canon, Nikon and Sony plus the
   `Curate\Resolver\MakerNotesResolver` convenience helper.
+- Added best-effort EXIF fallbacks that resolve ISO sensitivity, capture timestamps, and user comment encodings from SubIFDs and
+  primary thumbnails, including timezone offsets carried outside the main EXIF directory.
 
 ### Changed
 - Renamed the diagonal field-of-view helper from `fovDeg` to `fovDiagonalDeg`; consumers should switch to the new property name.

--- a/src/Model/Exif/ExifDocument.php
+++ b/src/Model/Exif/ExifDocument.php
@@ -64,6 +64,7 @@ use function strtoupper;
 use function substr;
 use function substr_count;
 use function trim;
+use function spl_object_id;
 
 /**
  * Represents a parsed EXIF payload and exposes convenience accessors.
@@ -1197,6 +1198,24 @@ final readonly class ExifDocument
             }
         }
 
+        $fallbackTags = [
+            ExifTag::STANDARD_OUTPUT_SENSITIVITY,
+            ExifTag::RECOMMENDED_EXPOSURE_INDEX,
+            ExifTag::PHOTOGRAPHIC_SENSITIVITY,
+            ExifTag::ISO_SPEED,
+            ExifTag::ISO_SPEED_RATINGS_LEGACY,
+            ExifTag::EXPOSURE_INDEX,
+        ];
+
+        foreach ($this->fallbackIfds() as $ifd) {
+            foreach ($fallbackTags as $tag) {
+                $value = $this->int($ifd, $tag);
+                if ($value !== null) {
+                    return $value;
+                }
+            }
+        }
+
         return null;
     }
 
@@ -2309,7 +2328,19 @@ final readonly class ExifDocument
      */
     public function offsetTimeOriginal(): ?string
     {
-        return $this->normalizedOffset($this->exifIfd, ExifTag::OFFSET_TIME_ORIGINAL);
+        $offset = $this->normalizedOffset($this->exifIfd, ExifTag::OFFSET_TIME_ORIGINAL);
+        if ($offset !== null) {
+            return $offset;
+        }
+
+        foreach ($this->fallbackIfds() as $ifd) {
+            $candidate = $this->normalizedOffset($ifd, ExifTag::OFFSET_TIME_ORIGINAL);
+            if ($candidate !== null) {
+                return $candidate;
+            }
+        }
+
+        return null;
     }
 
     /**
@@ -2317,7 +2348,19 @@ final readonly class ExifDocument
      */
     public function offsetTimeDigitized(): ?string
     {
-        return $this->normalizedOffset($this->exifIfd, ExifTag::OFFSET_TIME_DIGITIZED);
+        $offset = $this->normalizedOffset($this->exifIfd, ExifTag::OFFSET_TIME_DIGITIZED);
+        if ($offset !== null) {
+            return $offset;
+        }
+
+        foreach ($this->fallbackIfds() as $ifd) {
+            $candidate = $this->normalizedOffset($ifd, ExifTag::OFFSET_TIME_DIGITIZED);
+            if ($candidate !== null) {
+                return $candidate;
+            }
+        }
+
+        return null;
     }
 
     /**
@@ -2325,7 +2368,19 @@ final readonly class ExifDocument
      */
     public function offsetTime(): ?string
     {
-        return $this->normalizedOffset($this->exifIfd, ExifTag::OFFSET_TIME);
+        $offset = $this->normalizedOffset($this->exifIfd, ExifTag::OFFSET_TIME);
+        if ($offset !== null) {
+            return $offset;
+        }
+
+        foreach ($this->fallbackIfds() as $ifd) {
+            $candidate = $this->normalizedOffset($ifd, ExifTag::OFFSET_TIME);
+            if ($candidate !== null) {
+                return $candidate;
+            }
+        }
+
+        return null;
     }
 
     /**
@@ -3199,26 +3254,35 @@ final readonly class ExifDocument
      *
      * @return list<Ifd>
      */
-    private function fallbackIfds(): array
+    private function fallbackIfds(bool $includePrimaryThumbnail = true): array
     {
         $ifds = [];
+        $seen = [];
+
+        $append = static function (?Ifd $candidate) use (&$ifds, &$seen): void {
+            if (!$candidate instanceof Ifd) {
+                return;
+            }
+
+            $id = spl_object_id($candidate);
+            if (isset($seen[$id])) {
+                return;
+            }
+
+            $seen[$id] = true;
+            $ifds[]    = $candidate;
+        };
+
+        if ($includePrimaryThumbnail) {
+            $append($this->ifd1);
+        }
 
         foreach ($this->subIfds as $ifd) {
-            if ($ifd instanceof Ifd) {
-                $ifds[] = $ifd;
-            }
+            $append($ifd);
         }
 
         foreach ($this->subsequentIfds as $ifd) {
-            if (!$ifd instanceof Ifd) {
-                continue;
-            }
-
-            if ($this->ifd1 instanceof Ifd && $ifd === $this->ifd1) {
-                continue;
-            }
-
-            $ifds[] = $ifd;
+            $append($ifd);
         }
 
         return $ifds;

--- a/tests/Model/Exif/ExifDocumentTest.php
+++ b/tests/Model/Exif/ExifDocumentTest.php
@@ -39,6 +39,7 @@ use function iconv;
 use function pack;
 use function strlen;
 use function substr;
+use function str_pad;
 
 /**
  * @covers \MagicSunday\ImageMeta\Model\Exif\ExifDocument
@@ -1967,6 +1968,75 @@ final class ExifDocumentTest extends TestCase
         $doc = new ExifDocument(new Ifd([]), null, null, null, null, null, [], [256 => $subIfd]);
 
         self::assertSame(640, $doc->isoBestEffort());
+    }
+
+    #[Test]
+    public function isoFallsBackToSubIfdsWhenPrimaryTagsAreMissing(): void
+    {
+        $subIfd = new Ifd([
+            ExifTag::PHOTOGRAPHIC_SENSITIVITY => new IfdEntry(
+                ExifTag::PHOTOGRAPHIC_SENSITIVITY,
+                3,
+                1,
+                512,
+            ),
+        ]);
+
+        $doc = new ExifDocument(new Ifd([]), null, null, null, null, null, [], [1024 => $subIfd]);
+
+        self::assertSame(512, $doc->iso());
+        self::assertSame(512, $doc->isoBestEffort());
+    }
+
+    #[Test]
+    public function isoFallsBackToThumbnailIfdWhenAvailable(): void
+    {
+        $ifd1 = new Ifd([
+            ExifTag::PHOTOGRAPHIC_SENSITIVITY => new IfdEntry(
+                ExifTag::PHOTOGRAPHIC_SENSITIVITY,
+                3,
+                1,
+                1600,
+            ),
+        ]);
+
+        $doc = new ExifDocument(new Ifd([]), null, null, null, $ifd1, null, [$ifd1], []);
+
+        self::assertSame(1600, $doc->iso());
+        self::assertSame(1600, $doc->isoBestEffort());
+    }
+
+    #[Test]
+    public function dateTimeOriginalFallsBackToThumbnailIfdMetadata(): void
+    {
+        $ifd1 = new Ifd([
+            ExifTag::DATETIME_ORIGINAL    => new IfdEntry(ExifTag::DATETIME_ORIGINAL, 2, 1, '2024:05:06 07:08:09'),
+            ExifTag::OFFSET_TIME_ORIGINAL => new IfdEntry(ExifTag::OFFSET_TIME_ORIGINAL, 2, 1, '+02:00'),
+        ]);
+
+        $doc = new ExifDocument(new Ifd([]), null, null, null, $ifd1, null, [$ifd1], []);
+
+        self::assertSame('2024:05:06 07:08:09', $doc->dateTimeOriginalRaw());
+
+        $dateTime = $doc->dateTimeOriginalBestEffort();
+        self::assertNotNull($dateTime);
+        self::assertSame('2024-05-06T07:08:09+02:00', $dateTime->format(DATE_ATOM));
+    }
+
+    #[Test]
+    public function userCommentEncodingFallsBackToThumbnailIfd(): void
+    {
+        $comment = str_pad('ASCII', 8, "\0") . 'Fallback comment';
+
+        $ifd1 = new Ifd([
+            ExifTag::USER_COMMENT => new IfdEntry(ExifTag::USER_COMMENT, 7, 1, $comment),
+        ]);
+
+        $doc = new ExifDocument(new Ifd([]), null, null, null, $ifd1, null, [$ifd1], []);
+
+        self::assertSame('Fallback comment', $doc->userComment());
+        self::assertSame('ASCII', $doc->userCommentEncoding());
+        self::assertSame('ASCII', $doc->userCommentEncodingBestEffort());
     }
 
     /**


### PR DESCRIPTION
## Summary
- expand `ExifDocument::iso()` to inspect auxiliary IFDs before giving up on ISO backfills
- resolve EXIF timezone offsets, capture timestamps, and user comment metadata from thumbnail and SubIFDs with deduplicated traversal
- cover the new fallbacks with unit tests and document the behaviour in the changelog

## Testing
- composer ci:test:php:unit
- composer ci:test:php:phpstan *(fails: repository currently reports 411 existing errors)*

------
https://chatgpt.com/codex/tasks/task_e_690119982ed48323938240d0b82020f7