### PR TITLE
docs: clarify Apple supplemental region matching

### DIFF
--- a/src/Curate/Exif/ValueFactory.php
+++ b/src/Curate/Exif/ValueFactory.php
@@ -2062,6 +2062,7 @@ final class ValueFactory
             return [];
         }
 
+        // Collect indices of MWG face regions eligible for supplemental Apple metadata.
         $faceIndices = [];
         foreach ($mwgRegions as $index => $region) {
             if ($region->type === RegionType::FACE) {
@@ -2073,10 +2074,12 @@ final class ValueFactory
             return [];
         }
 
+        // Track face indices still lacking a matched Apple entry.
         $unmatchedIndices = $faceIndices;
         $supplemental     = [];
 
         foreach ($entries as $entry) {
+            // Align geometry-bearing Apple entries with MWG faces based on their shared shape.
             $matchIndex = $this->matchAppleEntryToMwgRegion($mwgRegions, $entry);
             if ($matchIndex === null) {
                 continue;
@@ -2092,6 +2095,7 @@ final class ValueFactory
             $supplemental[$matchIndex] = $this->createSupplementalRegion($baseRegion, $entry);
         }
 
+        // Assign remaining supplemental details to faces even when Apple omitted geometry.
         foreach ($entries as $entry) {
             if ($entry['geometry'] !== null) {
                 continue;


### PR DESCRIPTION
## Summary
- document how supplemental Apple region data is paired with MWG face regions
- explain fallback handling for metadata-only Apple entries without geometry

## Testing
- composer ci:test:php:cgl *(fails: pre-existing coding-style violations across repository)*

------
https://chatgpt.com/codex/tasks/task_e_6901386485c48323b95460c3b61b3e83