### PR TITLE
feat: extend EXIF fallback coverage for capture metadata

### DIFF
--- a/src/Model/Exif/ExifDocument.php
+++ b/src/Model/Exif/ExifDocument.php
@@ -1295,7 +1295,7 @@ final readonly class ExifDocument
             ExifTag::EXPOSURE_INDEX,
         ];
 
-        foreach ($this->fallbackIfds() as $ifd) {
+        foreach ($this->fallbackIfds(includeIfd0: true) as $ifd) {
             foreach ($fallbackTags as $tag) {
                 $value = $this->int($ifd, $tag);
                 if ($value !== null) {
@@ -2230,7 +2230,7 @@ final readonly class ExifDocument
             return $value;
         }
 
-        foreach ($this->fallbackIfds() as $ifd) {
+        foreach ($this->fallbackIfds(includeIfd0: true) as $ifd) {
             $candidate = $this->str($ifd, ExifTag::DATETIME_ORIGINAL);
             if ($candidate !== null) {
                 return $candidate;
@@ -2301,7 +2301,7 @@ final readonly class ExifDocument
             return $value;
         }
 
-        foreach ($this->fallbackIfds() as $ifd) {
+        foreach ($this->fallbackIfds(includeIfd0: true) as $ifd) {
             $candidate = $this->str($ifd, ExifTag::DATETIME_DIGITIZED);
             if ($candidate !== null) {
                 return $candidate;
@@ -2421,7 +2421,7 @@ final readonly class ExifDocument
             return $offset;
         }
 
-        foreach ($this->fallbackIfds() as $ifd) {
+        foreach ($this->fallbackIfds(includeIfd0: true) as $ifd) {
             $candidate = $this->normalizedOffset($ifd, ExifTag::OFFSET_TIME_ORIGINAL);
             if ($candidate !== null) {
                 return $candidate;
@@ -2441,7 +2441,7 @@ final readonly class ExifDocument
             return $offset;
         }
 
-        foreach ($this->fallbackIfds() as $ifd) {
+        foreach ($this->fallbackIfds(includeIfd0: true) as $ifd) {
             $candidate = $this->normalizedOffset($ifd, ExifTag::OFFSET_TIME_DIGITIZED);
             if ($candidate !== null) {
                 return $candidate;
@@ -2461,7 +2461,7 @@ final readonly class ExifDocument
             return $offset;
         }
 
-        foreach ($this->fallbackIfds() as $ifd) {
+        foreach ($this->fallbackIfds(includeIfd0: true) as $ifd) {
             $candidate = $this->normalizedOffset($ifd, ExifTag::OFFSET_TIME);
             if ($candidate !== null) {
                 return $candidate;
@@ -3340,9 +3340,12 @@ final readonly class ExifDocument
     /**
      * Provides the fallback IFDs consulted when primary metadata is absent.
      *
+     * @param bool $includePrimaryThumbnail When true the primary thumbnail (IFD1) is considered.
+     * @param bool $includeIfd0             When true the root directory (IFD0) is appended as a last resort.
+     *
      * @return list<Ifd>
      */
-    private function fallbackIfds(bool $includePrimaryThumbnail = true): array
+    private function fallbackIfds(bool $includePrimaryThumbnail = true, bool $includeIfd0 = false): array
     {
         $ifds = [];
         $seen = [];
@@ -3371,6 +3374,10 @@ final readonly class ExifDocument
 
         foreach ($this->subsequentIfds as $ifd) {
             $append($ifd);
+        }
+
+        if ($includeIfd0) {
+            $append($this->ifd0);
         }
 
         return $ifds;
@@ -3460,7 +3467,7 @@ final readonly class ExifDocument
             return $raw;
         }
 
-        foreach ($this->fallbackIfds() as $ifd) {
+        foreach ($this->fallbackIfds(includeIfd0: true) as $ifd) {
             $candidate = $this->rawString($ifd, ExifTag::USER_COMMENT);
             if ($candidate !== null) {
                 return $candidate;

--- a/tests/Model/Exif/ExifDocumentTest.php
+++ b/tests/Model/Exif/ExifDocumentTest.php
@@ -21,6 +21,7 @@ use MagicSunday\ImageMeta\Model\Exif\ExifTag;
 use MagicSunday\ImageMeta\Model\Exif\Ifd;
 use MagicSunday\ImageMeta\Model\Exif\IfdEntry;
 use MagicSunday\ImageMeta\Model\Exif\ValueConverters;
+use MagicSunday\ImageMeta\Parse\Tiff\TiffConst;
 use MagicSunday\ImageMeta\Parse\Tiff\TiffExifReader;
 use MagicSunday\ImageMeta\Tests\Support\GpsTiffBuilder;
 use MagicSunday\ImageMeta\Value\Enum\CfaPatternColor;
@@ -533,6 +534,27 @@ final class ExifDocumentTest extends TestCase
         $parsed = $doc->dateTimeOriginal();
         self::assertInstanceOf(DateTimeImmutable::class, $parsed);
         self::assertSame('2020-05-06T07:08:09+00:00', $parsed->format(DATE_ATOM));
+    }
+
+    #[Test]
+    public function dateTimeOriginalRawFallsBackToIfd0WhenExifTagMissing(): void
+    {
+        $ifd0 = new Ifd([
+            ExifTag::DATETIME_ORIGINAL => new IfdEntry(
+                ExifTag::DATETIME_ORIGINAL,
+                TiffConst::TYPE_ASCII,
+                1,
+                '2001:02:03 04:05:06',
+            ),
+        ]);
+
+        $doc = new ExifDocument($ifd0, new Ifd([]), null, null, null);
+
+        self::assertSame('2001:02:03 04:05:06', $doc->dateTimeOriginalRaw());
+
+        $resolved = $doc->dateTimeOriginal();
+        self::assertInstanceOf(DateTimeImmutable::class, $resolved);
+        self::assertSame('2001-02-03T04:05:06+00:00', $resolved->format(DATE_ATOM));
     }
 
     #[Test]
@@ -1421,6 +1443,21 @@ final class ExifDocumentTest extends TestCase
         $magnitude = $doc->accelerationMs2();
         self::assertNotNull($magnitude);
         self::assertEqualsWithDelta(9.8, $magnitude, 0.0001);
+    }
+
+    #[Test]
+    public function userCommentFallsBackToIfd0WhenExifEntryMissing(): void
+    {
+        $payload = "ASCII\0\0\0Legacy fallback\0";
+
+        $ifd0 = new Ifd([
+            ExifTag::USER_COMMENT => new IfdEntry(ExifTag::USER_COMMENT, 7, 1, $payload),
+        ]);
+
+        $doc = new ExifDocument($ifd0, new Ifd([]), null, null, null);
+
+        self::assertSame('Legacy fallback', $doc->userComment());
+        self::assertSame('ASCII', $doc->userCommentEncodingBestEffort());
     }
 
     /**


### PR DESCRIPTION
## Summary
- widen the fallback search to include IFD0 when resolving ISO values, date/time tags, offsets, and user comments while keeping preview lookups unchanged
- add unit coverage confirming DateTimeOriginal and user comment data can be sourced from IFD0 when EXIF directories are missing

## Testing
- composer ci:test:php:unit

------
https://chatgpt.com/codex/tasks/task_e_69013a5de93883238263f35a60d6e0c4