### PR TITLE
Fix preview fallback for root IFD

### DIFF
--- a/src/Model/Exif/ExifDocument.php
+++ b/src/Model/Exif/ExifDocument.php
@@ -834,7 +834,7 @@ final readonly class ExifDocument
             $candidates[] = $this->exifIfd;
         }
 
-        foreach ($this->fallbackIfds(includePrimaryThumbnail: false) as $ifd) {
+        foreach ($this->fallbackIfds(includePrimaryThumbnail: false, includeIfd0: true) as $ifd) {
             $candidates[] = $ifd;
         }
 

--- a/tests/Model/Exif/ExifDocumentTest.php
+++ b/tests/Model/Exif/ExifDocumentTest.php
@@ -330,6 +330,35 @@ final class ExifDocumentTest extends TestCase
     }
 
     #[Test]
+    public function previewMetadataFallsBackToRootIfdWhenExifIfdMissing(): void
+    {
+        $ifd0 = new Ifd([
+            ExifTag::PREVIEW_IMAGE_START       => new IfdEntry(ExifTag::PREVIEW_IMAGE_START, 4, 1, 8192),
+            ExifTag::PREVIEW_IMAGE_LENGTH      => new IfdEntry(ExifTag::PREVIEW_IMAGE_LENGTH, 4, 1, 4096),
+            ExifTag::PREVIEW_IMAGE_COMPRESSION => new IfdEntry(
+                ExifTag::PREVIEW_IMAGE_COMPRESSION,
+                3,
+                1,
+                Compression::JPEG_OLD_STYLE->value,
+            ),
+            ExifTag::PREVIEW_IMAGE_SCALE => new IfdEntry(
+                ExifTag::PREVIEW_IMAGE_SCALE,
+                5,
+                1,
+                new ExifRational(1, 4),
+            ),
+        ]);
+
+        $document = new ExifDocument($ifd0, null, null, null, null);
+
+        self::assertTrue($document->hasPreviewImage());
+        self::assertSame(8192, $document->previewImageOffset());
+        self::assertSame(4096, $document->previewImageLength());
+        self::assertSame(Compression::JPEG_OLD_STYLE->value, $document->previewImageCompression());
+        self::assertEqualsWithDelta(0.25, $document->previewImageScale(), 1e-6);
+    }
+
+    #[Test]
     public function previewImageTreatsZeroOffsetsAndLengthsAsMissing(): void
     {
         $ifd0 = new Ifd([]);


### PR DESCRIPTION
## Summary
- include the root IFD when searching for EXIF 3.0 preview descriptors so offsets and lengths survive missing EXIF IFDs
- add coverage that exercises preview fallback logic using a synthetic root-IFD payload

## Testing
- composer ci:test:php:unit

------
https://chatgpt.com/codex/tasks/task_e_69013ea103988323a0f3edb835ac67cd