### PR TITLE
refactor: replace mixed usage in MPF parser and EXIF types

### DIFF
--- a/src/Model/Exif/ExifNumericList.php
+++ b/src/Model/Exif/ExifNumericList.php
@@ -29,7 +29,7 @@ final readonly class ExifNumericList
     public array $values;
 
     /**
-     * @param array<int|string, mixed> $values Ordered list of numeric components.
+     * @param list<int|float|UInt64> $values Ordered list of numeric components.
      */
     public function __construct(array $values)
     {
@@ -52,7 +52,7 @@ final readonly class ExifNumericList
     /**
      * Returns the list of numeric values as a plain array.
      *
-     * @return list<int|float>
+     * @return list<int|float|UInt64>
      */
     public function toArray(): array
     {

--- a/src/Model/Exif/ExifRationalList.php
+++ b/src/Model/Exif/ExifRationalList.php
@@ -26,7 +26,7 @@ final readonly class ExifRationalList
     public array $values;
 
     /**
-     * @param array<int|string, mixed> $values Ordered list of rational components.
+     * @param list<ExifRational> $values Ordered list of rational components.
      */
     public function __construct(array $values)
     {

--- a/src/Model/Exif/ValueConverters.php
+++ b/src/Model/Exif/ValueConverters.php
@@ -11,6 +11,10 @@ declare(strict_types=1);
 
 namespace MagicSunday\ImageMeta\Model\Exif;
 
+/**
+ * @phpstan-type RationalComponent array<int, int|float|string>
+ * @phpstan-type RationalLike array<int, RationalComponent|ExifRational|int|float|string>
+ */
 use BackedEnum;
 use DateTimeImmutable;
 use DateTimeZone;
@@ -268,7 +272,8 @@ final readonly class ValueConverters
     /**
      * Converts a rational pair into a white point array.
      *
-     * @param array<int, mixed>|ExifRationalList|ExifNumericList|null $rational
+     * @param array<int, int|float|string|array<int, int|float|string>>|ExifRationalList|ExifNumericList|null $rational
+     * @phpstan-param RationalLike|ExifRationalList|ExifNumericList|null $rational
      *
      * @return array{0:float,1:float}|null
      */
@@ -319,7 +324,8 @@ final readonly class ValueConverters
     /**
      * Converts rational chromaticity pairs into a flat float array.
      *
-     * @param array<int, mixed>|ExifRationalList|ExifNumericList|null $rational
+     * @param array<int, int|float|string|array<int, int|float|string>>|ExifRationalList|ExifNumericList|null $rational
+     * @phpstan-param RationalLike|ExifRationalList|ExifNumericList|null $rational
      *
      * @return array{0:float,1:float,2:float,3:float,4:float,5:float}|null
      */
@@ -374,7 +380,8 @@ final readonly class ValueConverters
     /**
      * Serialises a DNG matrix or CFA pattern into a reproducible string representation.
      *
-     * @param array<int, mixed>|ExifRationalList|ExifNumericList|null $matrix
+     * @param array<int, int|float|string|array<int, int|float|string>>|ExifRationalList|ExifNumericList|null $matrix
+     * @phpstan-param RationalLike|ExifRationalList|ExifNumericList|null $matrix
      */
     public static function dngMatrixToString(ExifRationalList|ExifNumericList|array|null $matrix): ?string
     {

--- a/src/Model/Mpf/MpfAttributes.php
+++ b/src/Model/Mpf/MpfAttributes.php
@@ -12,6 +12,10 @@ declare(strict_types=1);
 namespace MagicSunday\ImageMeta\Model\Mpf;
 
 /**
+ * @phpstan-type MpfRational array{numerator:int, denominator:int}
+ * @phpstan-type MpfAttributeValue int|string|list<int>|MpfRational|list<MpfRational>
+ */
+/**
  * Represents optional MP Attribute IFD fields describing the image set.
  */
 final readonly class MpfAttributes
@@ -22,14 +26,18 @@ final readonly class MpfAttributes
      * @param int|null    $individualImageNumber  Sequence number of the current image within the set.
      * @param list<array{numerator:int, denominator:int}>|null $panoramaAngle Optional panorama angle rational values.
      * @param list<array{numerator:int, denominator:int}>|null $panoramaAxis  Optional panorama axis rational values.
-     * @param array<int, mixed> $additionalTags   Remaining MP attribute tags retained in raw form.
+     * @param array<int, int|string|array> $additionalTags   Remaining MP attribute tags retained in raw form.
+     * @phpstan-param array<int, MpfAttributeValue> $additionalTags   Remaining MP attribute tags retained in raw form.
      */
     public function __construct(
         public ?string $imageUidList,
         public ?int $totalFrames,
         public ?int $individualImageNumber,
+        /** @var list<array{numerator:int, denominator:int}>|null */
         public ?array $panoramaAngle,
+        /** @var list<array{numerator:int, denominator:int}>|null */
         public ?array $panoramaAxis,
+        /** @var array<int, MpfAttributeValue> */
         public array $additionalTags,
     ) {
     }

--- a/src/Parse/Jpeg/MpfParser.php
+++ b/src/Parse/Jpeg/MpfParser.php
@@ -28,6 +28,10 @@ use function strlen;
 use function substr;
 
 /**
+ * @phpstan-type MpfRational array{numerator:int, denominator:int}
+ * @phpstan-type MpfDecodedValue int|string|list<int>|MpfRational|list<MpfRational>
+ */
+/**
  * Parses MPF payloads carried in JPEG APP2 segments.
  */
 final class MpfParser
@@ -133,7 +137,8 @@ final class MpfParser
     /**
      * Parses a TIFF IFD structure from the buffer.
      *
-     * @return array{0: array<int, mixed>, 1: int}
+     * @return array{0: array<int, int|string|array>, 1: int}
+     * @phpstan-return array{0: array<int, MpfDecodedValue>, 1: int}
      */
     private function readIfd(MemoryBuffer $buffer, Endian $endian, int $offset): array
     {
@@ -205,8 +210,10 @@ final class MpfParser
 
     /**
      * Decodes the raw value bytes using the specified TIFF field type.
+     *
+     * @phpstan-return MpfDecodedValue
      */
-    private function decodeValue(int $type, int $componentCount, string $data, Endian $endian): mixed
+    private function decodeValue(int $type, int $componentCount, string $data, Endian $endian): int|string|array
     {
         $values = [];
         $buf    = new MemoryBuffer($data);
@@ -358,8 +365,11 @@ final class MpfParser
 
     /**
      * Converts arbitrary decoded value into an integer when possible.
+     *
+     * @param int|string|array|null $value
+     * @phpstan-param MpfDecodedValue|null $value
      */
-    private function intValue(mixed $value): ?int
+    private function intValue(int|string|array|null $value): ?int
     {
         if (is_int($value)) {
             return $value;
@@ -370,8 +380,11 @@ final class MpfParser
 
     /**
      * Converts the decoded value into a trimmed string when appropriate.
+     *
+     * @param int|string|array|null $value
+     * @phpstan-param MpfDecodedValue|null $value
      */
-    private function stringValue(mixed $value): ?string
+    private function stringValue(int|string|array|null $value): ?string
     {
         if (!is_string($value)) {
             return null;

--- a/tests/Model/Exif/ValueConvertersTest.php
+++ b/tests/Model/Exif/ValueConvertersTest.php
@@ -97,17 +97,17 @@ final class ValueConvertersTest extends TestCase
     /**
      * Ensures invalid values cannot be converted and return null instead.
      *
-     * @param mixed $value The invalid rational input to convert.
+     * @param ExifRational|ExifNumericList|string|null $value The invalid rational input to convert.
      */
     #[Test]
     #[DataProvider('provideInvalidInputs')]
-    public function returnsNullForInvalidRationalInputs(mixed $value): void
+    public function returnsNullForInvalidRationalInputs(ExifRational|ExifNumericList|string|null $value): void
     {
         self::assertNull(ValueConverters::rationalToFloat($value));
     }
 
     /**
-     * @return iterable<string, array{mixed}>
+     * @return iterable<string, array{ExifRational|ExifNumericList|string|null}>
      */
     public static function provideInvalidInputs(): iterable
     {
@@ -118,12 +118,12 @@ final class ValueConvertersTest extends TestCase
     }
 
     /**
-     * @param mixed      $value    The APEX encoded value.
+     * @param ExifRational|string $value    The APEX encoded value.
      * @param float|null $expected The expected f-number.
      */
     #[Test]
     #[DataProvider('provideApexValues')]
-    public function convertsApexValuesToFNumber(mixed $value, ?float $expected): void
+    public function convertsApexValuesToFNumber(ExifRational|string $value, ?float $expected): void
     {
         $result = ValueConverters::apexToFNumber($value);
 
@@ -189,7 +189,7 @@ final class ValueConvertersTest extends TestCase
     }
 
     /**
-     * @return iterable<string, array{mixed, float|null}>
+     * @return iterable<string, array{ExifRational|string, float|null}>
      */
     public static function provideApexValues(): iterable
     {
@@ -200,18 +200,18 @@ final class ValueConvertersTest extends TestCase
     }
 
     /**
-     * @param mixed      $value    Raw battery level value.
+     * @param ExifRational|string|null $value    Raw battery level value.
      * @param float|null $expected Normalised percentage value.
      */
     #[Test]
     #[DataProvider('provideBatteryLevelValues')]
-    public function normalisesBatteryLevelToPercent(mixed $value, ?float $expected): void
+    public function normalisesBatteryLevelToPercent(ExifRational|string|null $value, ?float $expected): void
     {
         self::assertSame($expected, ValueConverters::batteryLevelToPercent($value));
     }
 
     /**
-     * @return iterable<string, array{mixed, float|null}>
+     * @return iterable<string, array{ExifRational|string, float|null}>
      */
     public static function provideBatteryLevelValues(): iterable
     {
@@ -228,12 +228,12 @@ final class ValueConvertersTest extends TestCase
 
     /**
      * @param string|null $ref      The speed reference.
-     * @param mixed       $value    The raw speed value.
+     * @param ExifRational|string $value    The raw speed value.
      * @param float|null  $expected The expected metres per second.
      */
     #[Test]
     #[DataProvider('provideGpsSpeedValues')]
-    public function convertsGpsSpeedToMetresPerSecond(?string $ref, mixed $value, ?float $expected): void
+    public function convertsGpsSpeedToMetresPerSecond(?string $ref, ExifRational|string $value, ?float $expected): void
     {
         $result = ValueConverters::gpsSpeedToMs($ref, $value);
 
@@ -248,7 +248,7 @@ final class ValueConvertersTest extends TestCase
     }
 
     /**
-     * @return iterable<string, array{string|null, mixed, float|null}>
+     * @return iterable<string, array{string|null, ExifRational|string, float|null}>
      */
     public static function provideGpsSpeedValues(): iterable
     {
@@ -288,18 +288,18 @@ final class ValueConvertersTest extends TestCase
     }
 
     /**
-     * @param mixed       $value    The raw offset representation.
+     * @param int|float|string|ExifRational|ExifRationalList|null $value    The raw offset representation.
      * @param string|null $expected The expected canonical offset string.
      */
     #[Test]
     #[DataProvider('provideOffsetStrings')]
-    public function normalisesOffsetStrings(mixed $value, ?string $expected): void
+    public function normalisesOffsetStrings(int|float|string|ExifRational|ExifRationalList|null $value, ?string $expected): void
     {
         self::assertSame($expected, ValueConverters::parseOffsetString($value));
     }
 
     /**
-     * @return iterable<string, array{mixed, string|null}>
+     * @return iterable<string, array{int|float|string|ExifRational|ExifRationalList|null, string|null}>
      */
     public static function provideOffsetStrings(): iterable
     {
@@ -314,18 +314,18 @@ final class ValueConvertersTest extends TestCase
     }
 
     /**
-     * @param mixed    $value    The raw offset value.
+     * @param int|float|string|ExifRational|ExifRationalList|null $value    The raw offset value.
      * @param int|null $expected Expected minutes from UTC.
      */
     #[Test]
     #[DataProvider('provideOffsetMinutes')]
-    public function convertsOffsetToMinutes(mixed $value, ?int $expected): void
+    public function convertsOffsetToMinutes(int|float|string|ExifRational|ExifRationalList|null $value, ?int $expected): void
     {
         self::assertSame($expected, ValueConverters::offsetToMinutes($value));
     }
 
     /**
-     * @return iterable<string, array{mixed, int|null}>
+     * @return iterable<string, array{int|float|string|ExifRational|ExifRationalList|null, int|null}>
      */
     public static function provideOffsetMinutes(): iterable
     {


### PR DESCRIPTION
## Summary
- replace remaining mixed signatures in the MPF parser with explicit unions and phpstan type aliases
- narrow EXIF list constructors and converter annotations to describe concrete numeric and rational payloads
- update EXIF value converter tests to use the refined input unions

## Testing
- composer ci:test:php:unit

------
https://chatgpt.com/codex/tasks/task_e_6901b0869fd88323b07a26698996714c