### PR TITLE
Add preview coverage to EXIF fallback matrix

### DIFF
--- a/tests/Acceptance/ExifBackfillMatrixTest.php
+++ b/tests/Acceptance/ExifBackfillMatrixTest.php
@@ -31,7 +31,7 @@ final class ExifBackfillMatrixTest extends TestCase
      * @param string|null            $expectedUserCommentEncoding Expected best-effort user comment encoding or null.
      * @param array{flashpixVersion:string,tiffEpStandardId:?list<int>,tiffEpStandardString:?string} $expectedStandards Expected standards metadata components.
      * @param array<string, int|string|null> $expectedInterop         Expected interoperability metadata components.
-     * @param array<string, int|float|bool|null> $expectedPreview     Expected preview descriptor components.
+     * @param array<string, int|float|bool|string|null> $expectedPreview Expected preview descriptor components.
     */
     #[Test]
     #[DataProvider('provideReferenceImages')]
@@ -105,7 +105,13 @@ final class ExifBackfillMatrixTest extends TestCase
         self::assertSame($expectedPreview['width'], $preview->previewWidth, sprintf('%s: Preview width', $file));
         self::assertSame($expectedPreview['height'], $preview->previewHeight, sprintf('%s: Preview height', $file));
         self::assertSame($expectedPreview['bitDepth'], $preview->previewBitDepth, sprintf('%s: Preview bit depth', $file));
-        self::assertSame($expectedPreview['compression'], $preview->previewCompression?->value, sprintf('%s: Preview compression', $file));
+        self::assertSame(
+            $expectedPreview['compression'],
+            $preview->previewCompression?->value,
+            sprintf('%s: Preview compression', $file),
+        );
+        self::assertSame($expectedPreview['encoding'], $preview->previewEncoding, sprintf('%s: Preview encoding', $file));
+        self::assertSame($expectedPreview['mimeType'], $preview->previewMimeType, sprintf('%s: Preview mime type', $file));
         if ($expectedPreview['scale'] === null) {
             self::assertNull($preview->previewScale, sprintf('%s: Preview scale', $file));
         } else {
@@ -160,6 +166,8 @@ final class ExifBackfillMatrixTest extends TestCase
                 'bitDepth' => null,
                 'compression' => null,
                 'scale' => null,
+                'encoding' => null,
+                'mimeType' => null,
             ],
         ];
 
@@ -190,6 +198,8 @@ final class ExifBackfillMatrixTest extends TestCase
                 'bitDepth' => null,
                 'compression' => null,
                 'scale' => null,
+                'encoding' => null,
+                'mimeType' => null,
             ],
         ];
 
@@ -220,6 +230,8 @@ final class ExifBackfillMatrixTest extends TestCase
                 'bitDepth' => null,
                 'compression' => null,
                 'scale' => null,
+                'encoding' => null,
+                'mimeType' => null,
             ],
         ];
 
@@ -250,6 +262,8 @@ final class ExifBackfillMatrixTest extends TestCase
                 'bitDepth' => null,
                 'compression' => null,
                 'scale' => null,
+                'encoding' => null,
+                'mimeType' => null,
             ],
         ];
 
@@ -280,6 +294,8 @@ final class ExifBackfillMatrixTest extends TestCase
                 'bitDepth' => null,
                 'compression' => null,
                 'scale' => null,
+                'encoding' => null,
+                'mimeType' => null,
             ],
         ];
 
@@ -310,6 +326,8 @@ final class ExifBackfillMatrixTest extends TestCase
                 'bitDepth' => null,
                 'compression' => null,
                 'scale' => null,
+                'encoding' => null,
+                'mimeType' => null,
             ],
         ];
 
@@ -340,6 +358,8 @@ final class ExifBackfillMatrixTest extends TestCase
                 'bitDepth' => null,
                 'compression' => null,
                 'scale' => null,
+                'encoding' => null,
+                'mimeType' => null,
             ],
         ];
 
@@ -370,6 +390,8 @@ final class ExifBackfillMatrixTest extends TestCase
                 'bitDepth' => null,
                 'compression' => null,
                 'scale' => null,
+                'encoding' => null,
+                'mimeType' => null,
             ],
         ];
 
@@ -400,6 +422,8 @@ final class ExifBackfillMatrixTest extends TestCase
                 'bitDepth' => 8,
                 'compression' => Compression::JPEG_OLD_STYLE->value,
                 'scale' => 0.5,
+                'encoding' => null,
+                'mimeType' => null,
             ],
         ];
     }

--- a/tests/Api/ExifDocumentReferenceMatrixTest.php
+++ b/tests/Api/ExifDocumentReferenceMatrixTest.php
@@ -97,7 +97,18 @@ final class ExifDocumentReferenceMatrixTest extends TestCase
     }
 
     /**
-     * @param array{hasPreview:?bool,offset:?int,length:?int,width:?int,height:?int,bitDepth:?int,compression:?int,scale:?float|null} $expected
+     * @param array{
+     *     hasPreview:?bool,
+     *     offset:?int,
+     *     length:?int,
+     *     width:?int,
+     *     height:?int,
+     *     bitDepth:?int,
+     *     compression:?int,
+     *     scale:?float|null,
+     *     encoding:?string,
+     *     mimeType:?string,
+     * } $expected
      */
     private function assertPreviewDescriptor(string $file, array $expected, StructuredPreview $preview): void
     {
@@ -107,6 +118,8 @@ final class ExifDocumentReferenceMatrixTest extends TestCase
         self::assertSame($expected['width'], $preview->previewWidth, sprintf('%s: Preview width', $file));
         self::assertSame($expected['height'], $preview->previewHeight, sprintf('%s: Preview height', $file));
         self::assertSame($expected['bitDepth'], $preview->previewBitDepth, sprintf('%s: Preview bit depth', $file));
+        self::assertSame($expected['encoding'], $preview->previewEncoding, sprintf('%s: Preview encoding', $file));
+        self::assertSame($expected['mimeType'], $preview->previewMimeType, sprintf('%s: Preview mime type', $file));
 
         if ($expected['compression'] === null) {
             self::assertNull($preview->previewCompression, sprintf('%s: Preview compression', $file));

--- a/tests/Api/ExifReaderTest.php
+++ b/tests/Api/ExifReaderTest.php
@@ -13,6 +13,7 @@ namespace MagicSunday\ImageMeta\Tests\Api;
 
 use MagicSunday\ImageMeta\Api\ExifReader;
 use MagicSunday\ImageMeta\Value\Enum\ColorSpace;
+use MagicSunday\ImageMeta\Value\Enum\Compression;
 use MagicSunday\ImageMeta\Value\Enum\Orientation;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -70,6 +71,42 @@ final class ExifReaderTest extends TestCase
         self::assertNull($preview->previewScale);
         self::assertNull($preview->previewOffset);
         self::assertNull($preview->previewLength);
+    }
+
+    #[Test]
+    public function readsPreviewAndInteropMetadataFromExif30Image(): void
+    {
+        $reader = new ExifReader();
+        $path   = __DIR__ . '/../Fixtures/Images/ExifVersions/exif-3-0.jpg';
+
+        $document = $reader->read($path);
+
+        self::assertTrue($document->hasData());
+        self::assertSame(300, $document->iso());
+        self::assertSame('2028-09-10T11:12:13+00:00', $document->dateTimeOriginal()?->format(DATE_ATOM));
+        self::assertSame('Preview 3.0 comment', $document->userComment());
+        self::assertSame('ASCII', $document->userCommentEncoding());
+
+        $interop = $document->interop();
+        self::assertSame('R98', $interop->index);
+        self::assertSame('0100', $interop->version);
+        self::assertSame('JPEG', $interop->relatedImageFileFormat);
+        self::assertSame(4000, $interop->relatedImageWidth);
+        self::assertSame(3000, $interop->relatedImageLength);
+
+        $preview = $document->preview();
+        self::assertTrue($preview->hasPreview);
+        self::assertSame(16384, $preview->previewOffset);
+        self::assertSame(8192, $preview->previewLength);
+        self::assertSame(1600, $preview->previewWidth);
+        self::assertSame(900, $preview->previewHeight);
+        self::assertSame(8, $preview->previewBitDepth);
+        self::assertNull($preview->previewEncoding);
+        self::assertNull($preview->previewMimeType);
+        self::assertInstanceOf(Compression::class, $preview->previewCompression);
+        self::assertSame(Compression::JPEG_OLD_STYLE, $preview->previewCompression);
+        self::assertNotNull($preview->previewScale);
+        self::assertEqualsWithDelta(0.5, $preview->previewScale, 1e-6);
     }
 
     #[Test]


### PR DESCRIPTION
## Summary
- extend the EXIF fallback acceptance matrix to assert preview descriptor fields across the reference images
- mirror the preview assertions in the API reference matrix helper
- add an ExifReader integration test that exercises EXIF 3.0 preview and interoperability accessors

## Testing
- composer ci:test:php:unit

------
https://chatgpt.com/codex/tasks/task_e_6901b2af00108323b911e7207ee1d126