### PR TITLE
Rename length parameter in stream read methods

### DIFF
--- a/src/Core/Stream.php
+++ b/src/Core/Stream.php
@@ -111,26 +111,26 @@ final class Stream
     /**
      * Reads a fixed number of bytes from the stream, advancing the cursor.
      *
-     * @param int $len Number of bytes to read.
+     * @param int $length Number of bytes to read.
      *
      * @return string
      */
-    public function read(int $len): string
+    public function read(int $length): string
     {
-        if ($len === 0) {
+        if ($length === 0) {
             return '';
         }
 
-        if ($len < 0 || $this->pos + $len > $this->size) {
-            throw new BoundsError('read beyond EOF: ' . $this->pos . '+' . $len . ' > ' . $this->size);
+        if ($length < 0 || $this->pos + $length > $this->size) {
+            throw new BoundsError('read beyond EOF: ' . $this->pos . '+' . $length . ' > ' . $this->size);
         }
 
-        $data = fread($this->fh, $len);
-        if ($data === false || strlen($data) !== $len) {
+        $data = fread($this->fh, $length);
+        if ($data === false || strlen($data) !== $length) {
             throw new ParseError('short read');
         }
 
-        $this->pos += $len;
+        $this->pos += $length;
 
         return $data;
     }

--- a/src/Core/StreamWindow.php
+++ b/src/Core/StreamWindow.php
@@ -77,23 +77,23 @@ final class StreamWindow
     /**
      * Reads bytes from the bounded region and advances the cursor.
      *
-     * @param int $len Number of bytes to read.
+     * @param int $length Number of bytes to read.
      *
      * @return string
      */
-    public function read(int $len): string
+    public function read(int $length): string
     {
-        if ($len === 0) {
+        if ($length === 0) {
             return '';
         }
 
-        if ($len < 0 || $this->cursor + $len > $this->length) {
+        if ($length < 0 || $this->cursor + $length > $this->length) {
             throw new BoundsError('window read out of range');
         }
 
         $this->base->seek($this->offset + $this->cursor);
-        $data = $this->base->read($len);
-        $this->cursor += $len;
+        $data = $this->base->read($length);
+        $this->cursor += $length;
 
         return $data;
     }


### PR DESCRIPTION
## Summary
- rename the `$len` parameter to `$length` in `Stream::read`
- mirror the parameter rename in `StreamWindow::read`
- update the accompanying docblocks to reflect the new name

## Testing
- composer ci:test:php:phpstan *(fails: existing 450 errors in baseline)*
- composer ci:test:php:unit


------
https://chatgpt.com/codex/tasks/task_e_6901b2bbe6748323bc895130c465b66b