### PR TITLE
docs(core): clarify exif capability version phpdoc

### DIFF
--- a/src/Core/ExifCapabilities.php
+++ b/src/Core/ExifCapabilities.php
@@ -23,7 +23,12 @@ use function trim;
 final class ExifCapabilities
 {
     /**
-     * Maps a raw or normalised EXIF version string to the capability profile identifier.
+     * Normalises vendor provided EXIF version identifiers to known capability profile codes.
+     * Trims whitespace, removes trailing null bytes and maps digit-only fallbacks so unusual
+     * encodings still yield the canonical profile.
+     *
+     * @param ?string $exifVersion Raw EXIF version string as read from metadata, possibly null or padded.
+     * @return string Canonical capability profile identifier or "unknown" when normalisation fails.
      */
     public static function fromVersion(?string $exifVersion): string
     {


### PR DESCRIPTION
## Summary
- document the normalisation logic performed by ExifCapabilities::fromVersion
- add explicit @param and @return annotations for the EXIF version mapping helper

## Testing
- composer ci:test:php:phpstan *(fails: existing repository issues surfaced above)*
- composer ci:test:php:unit

------
https://chatgpt.com/codex/tasks/task_e_6901b2be06cc832389be8971a008e54b