### PR TITLE
docs: clarify ExifReader documentation

### DIFF
--- a/src/Api/ExifReader.php
+++ b/src/Api/ExifReader.php
@@ -25,11 +25,22 @@ final class ExifReader
 {
     private readonly TiffExifReader $tiffReader;
 
+    /**
+     * Allows injecting a custom TIFF EXIF reader instance, e.g. for sharing caches in
+     * higher-level code, while falling back to the default reader when none is provided.
+     */
     public function __construct(?TiffExifReader $tiffReader = null)
     {
         $this->tiffReader = $tiffReader ?? new TiffExifReader();
     }
 
+    /**
+     * Reads EXIF metadata from JPEG and ISO-BMFF (e.g. HEIC, MOV, MP4) containers.
+     *
+     * @param string $path Absolute or relative path to the media file that should be parsed.
+     *
+     * @return ExifDocument Value object with parsed EXIF data and fallback image attributes.
+     */
     public function read(string $path): ExifDocument
     {
         $stream = Stream::fromPath($path);
@@ -43,12 +54,16 @@ final class ExifReader
         if ($type === ContainerType::JPEG) {
             $jpeg                  = new JpegExtractor($stream);
             $exifBlobs             = $jpeg->extractExifBlobs();
+            // JPEG frames expose dimensions and bit depth, so we capture them as fallbacks
+            // when EXIF data omits these values.
             $fallbackWidth         = $jpeg->getFrameWidth();
             $fallbackHeight        = $jpeg->getFrameHeight();
             $fallbackBitsPerSample = $jpeg->getFrameSamplePrecision();
         } else {
             $isoExtractor = new IsoBmffExtractor($stream);
             [$exifBlobs]  = $isoExtractor->extract();
+            // ISO-BMFF containers can store multiple items with varying characteristics,
+            // therefore we keep the fallback values null and rely on the parsed EXIF data.
         }
 
         $document = null;


### PR DESCRIPTION
## Summary
- describe the optional TIFF reader dependency on the ExifReader constructor
- document the supported containers and return value of ExifReader::read
- explain fallback handling for JPEG and ISO-BMFF streams with inline comments

## Testing
- not run (documentation-only change)

------
https://chatgpt.com/codex/tasks/task_e_6901b2cbea84832392cf5e22fe6a1d9e