### PR TITLE
docs: clarify structured exif constructor mappings

### DIFF
--- a/src/Api/ExifDocument.php
+++ b/src/Api/ExifDocument.php
@@ -53,6 +53,14 @@ final class ExifDocument
 
     private readonly InteropValue $interop;
 
+    /**
+     * Creates the structured EXIF view by aggregating the curated value objects extracted from the parser.
+     *
+     * @param ModelExifDocument|null $document              Parsed EXIF document that provides the raw value objects.
+     * @param int|null               $fallbackWidth         Pixel width used when the EXIF image width tag is not available.
+     * @param int|null               $fallbackHeight        Pixel height used when the EXIF image height tag is not available.
+     * @param int|null               $fallbackBitsPerSample Bit depth to fall back to when the EXIF component depth is missing.
+     */
     public function __construct(
         ?ModelExifDocument $document,
         ?int $fallbackWidth = null,
@@ -76,6 +84,7 @@ final class ExifDocument
             relatedImageLength: $document?->relatedImageLength(),
         );
 
+        // Build structured view models that expose the curated EXIF metadata slices.
         $this->camera   = new StructuredCamera($cameraValue);
         $this->lens     = new StructuredLens($lensValue, $derived);
         $this->exposure = new StructuredExposure($exposureValue, $derived);

--- a/src/Curate/Exif/Structured/Camera.php
+++ b/src/Curate/Exif/Structured/Camera.php
@@ -34,6 +34,11 @@ final readonly class Camera
 
     public ?SensingMethod $sensingMethod;
 
+    /**
+     * @param CameraValue $camera Raw camera value object produced by the parser with unmodified EXIF fields. The mapped
+     *                            properties expose the textual identifiers as-is while keeping enum wrappers for file
+     *                            source and sensing method.
+     */
     public function __construct(CameraValue $camera)
     {
         $this->make          = $camera->make;

--- a/src/Curate/Exif/Structured/Exposure.php
+++ b/src/Curate/Exif/Structured/Exposure.php
@@ -72,6 +72,10 @@ final readonly class Exposure
 
     public ?float $ev100;
 
+    /**
+     * @param ExposureValue $exposure Raw exposure value object with EXIF shutter, aperture and metering metadata.
+     * @param Derived       $derived  Derived optics helper providing calculated EV100 and related exposure math.
+     */
     public function __construct(ExposureValue $exposure, Derived $derived)
     {
         $this->iso              = $exposure->iso;
@@ -95,6 +99,7 @@ final readonly class Exposure
         $this->isoLatitudeZzz   = $exposure->isoLatitudeZzz;
         $this->exposureIndex    = $exposure->exposureIndex;
         $this->flashEnergy      = $exposure->flashEnergy;
+        // EV100 stems from the derived helper and expresses exposure at ISO 100 regardless of the recorded ISO.
         $this->ev100            = $derived->ev100;
     }
 }

--- a/src/Curate/Exif/Structured/Gps.php
+++ b/src/Curate/Exif/Structured/Gps.php
@@ -90,8 +90,12 @@ final readonly class Gps
 
     public ?float $horizontalPositioningError;
 
+    /**
+     * @param GpsValue $gps Raw GPS value object containing the EXIF coordinates and references plus already parsed time data.
+     */
     public function __construct(GpsValue $gps)
     {
+        // Wrap EXIF coordinate values with their hemisphere reference so that signed decimal degrees stay consistent.
         $this->latitude                = $gps->latitude !== null ? new GpsCoordinate($gps->latitude, $gps->latitudeRef) : null;
         $this->longitude               = $gps->longitude !== null ? new GpsCoordinate($gps->longitude, $gps->longitudeRef) : null;
         $this->altitude                = $gps->altitude;

--- a/src/Curate/Exif/Structured/Image.php
+++ b/src/Curate/Exif/Structured/Image.php
@@ -53,6 +53,9 @@ final readonly class Image
 
     public ?string $userCommentEncoding;
 
+    /**
+     * @param ImageValue $image Raw image value object sourced directly from EXIF, already normalised for enums and lists.
+     */
     public function __construct(ImageValue $image)
     {
         $this->width                   = $image->width;

--- a/src/Curate/Exif/Structured/Lens.php
+++ b/src/Curate/Exif/Structured/Lens.php
@@ -46,6 +46,10 @@ final readonly class Lens
 
     public ?float $fieldOfViewDiagonal;
 
+    /**
+     * @param LensValue $lens    Raw lens value object with EXIF optical information such as make, model and focal lengths.
+     * @param Derived   $derived Derived helper supplying computed crop factor, hyperfocal distance and FOV values.
+     */
     public function __construct(LensValue $lens, Derived $derived)
     {
         $this->make                  = $lens->lensMake;
@@ -54,6 +58,7 @@ final readonly class Lens
         $this->focalLength           = $lens->focalLengthMm;
         $this->maximumAperture       = $lens->maxApertureFNumber;
         $this->specification         = $lens->lensSpecification;
+        // Fill missing EXIF equivalent focal length with the derived 35mm calculation for downstream consumers.
         $this->equivalent35mm        = $lens->focalLengthIn35mm ?? $derived->focalLength35mm;
         $this->cropFactor            = $derived->cropFactor;
         $this->hyperfocalDistance    = $derived->hyperfocalM;

--- a/src/Curate/Exif/Structured/Preview.php
+++ b/src/Curate/Exif/Structured/Preview.php
@@ -44,6 +44,9 @@ final readonly class Preview
 
     public ?int $previewLength;
 
+    /**
+     * @param PreviewValue $preview Raw preview value object describing embedded thumbnails and previews from EXIF.
+     */
     public function __construct(PreviewValue $preview)
     {
         $this->hasThumbnail      = $preview->hasThumbnail;


### PR DESCRIPTION
## Summary
- document ExifDocument constructor fallbacks and structured aggregation
- add phpdoc notes for each structured EXIF view constructor and highlight derived mappings
- annotate non-obvious transformations for GPS coordinates and derived exposure or focal length values

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_6901b2ccd85c8323bf2cb682b052fb5a