### PR TITLE
docs: document ByteReader constructor and UInt64 helpers

### DIFF
--- a/src/Core/ByteReader.php
+++ b/src/Core/ByteReader.php
@@ -28,6 +28,14 @@ final class ByteReader
 
     private readonly Closure $seek;
 
+    /**
+     * Creates a reader backed by callbacks that operate on an external data source.
+     *
+     * @param callable(int):string      $read    Callback that returns the requested number of bytes.
+     * @param callable():int            $tell    Callback that reports the current cursor position.
+     * @param callable(int|UInt64):void $seek    Callback that repositions the cursor of the data source.
+     * @param string                    $context Short description used in error messages.
+     */
     public function __construct(
         callable $read,
         callable $tell,

--- a/src/Core/Util/UInt64.php
+++ b/src/Core/Util/UInt64.php
@@ -26,6 +26,14 @@ final class UInt64
 
     private const int UINT32_BASE = 4_294_967_296;
 
+    /**
+     * Builds an unsigned 64-bit value from two unsigned 32-bit halves.
+     *
+     * @param int $hi Most significant 32-bit component.
+     * @param int $lo Least significant 32-bit component.
+     *
+     * @throws ParseError When either component falls outside the unsigned 32-bit range.
+     */
     public function __construct(
         private readonly int $hi,
         private readonly int $lo,
@@ -125,6 +133,8 @@ final class UInt64
      * @param int $value The value to add; must be zero or positive.
      *
      * @return self New instance representing the sum.
+     *
+     * @throws ParseError When attempting to add a negative integer.
      */
     public function addSmall(int $value): self
     {
@@ -163,6 +173,8 @@ final class UInt64
      * @param string $context Description used for the exception message when out of range.
      *
      * @return int Signed integer representation of the value.
+     *
+     * @throws ParseError When the value cannot be represented as a signed integer on this platform.
      */
     public function toInt(string $context): int
     {


### PR DESCRIPTION
## Summary
- add constructor PHPDoc to `ByteReader` detailing callback signatures and context metadata
- expand `UInt64` documentation to describe constructor requirements and exception behaviour

## Testing
- ./.build/bin/php-cs-fixer fix --config .build/.php-cs-fixer.dist.php src/Core/ByteReader.php src/Core/Util/UInt64.php

------
https://chatgpt.com/codex/tasks/task_e_6901b7c0a07c832399e6200d09883459