### PR TITLE
docs: clarify MPF document accessor behavior

### DIFF
--- a/src/Parse/Jpeg/JpegExtractor.php
+++ b/src/Parse/Jpeg/JpegExtractor.php
@@ -215,6 +215,13 @@ final class JpegExtractor
         return $this->audioStreams;
     }
 
+    /**
+     * Returns the parsed MPF document or null when it is unavailable.
+     *
+     * Triggers lazy parsing via parseIfNeeded() if the stream has not been processed yet.
+     *
+     * @return MpfDocument|null
+     */
     public function getMpfDocument(): ?MpfDocument
     {
         $this->parseIfNeeded();


### PR DESCRIPTION
## Summary
- document the lazy parsing behaviour of getMpfDocument
- describe that the accessor returns the parsed MPF document or null when absent

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6901b7c2af44832396f661a10272c1b8