### PR TITLE
docs(jpeg): clarify constructor stream phpdoc

### DIFF
--- a/src/Parse/Jpeg/JpegExtractor.php
+++ b/src/Parse/Jpeg/JpegExtractor.php
@@ -125,7 +125,7 @@ final class JpegExtractor
     /**
      * Initialises the extractor with a seekable stream.
      *
-     * @param Stream $stream Stream representing the JPEG binary.
+     * @param Stream $stream Stream representing the JPEG binary stream.
      */
     public function __construct(private readonly Stream $stream)
     {


### PR DESCRIPTION
## Summary
- clarify the JPEG extractor constructor PHPDoc to reference the stream handle

## Testing
- .build/bin/phpunit --configuration .build/phpunit.xml tests/Parse/Jpeg

------
https://chatgpt.com/codex/tasks/task_e_6901bef049488323916749a793453435