### PR TITLE
Add enum mapping coverage for numeric string inputs

### DIFF
--- a/tests/Value/Enum/EnumMappingTest.php
+++ b/tests/Value/Enum/EnumMappingTest.php
@@ -17,9 +17,12 @@ use MagicSunday\ImageMeta\Value\Enum\ExposureMode;
 use MagicSunday\ImageMeta\Value\Enum\FileSource;
 use MagicSunday\ImageMeta\Value\Enum\GainControl;
 use MagicSunday\ImageMeta\Value\Enum\LightSource;
+use MagicSunday\ImageMeta\Value\Enum\MeteringMode;
+use MagicSunday\ImageMeta\Value\Enum\Orientation;
 use MagicSunday\ImageMeta\Value\Enum\Photometric;
 use MagicSunday\ImageMeta\Value\Enum\PlanarConfiguration;
 use MagicSunday\ImageMeta\Value\Enum\ResolutionUnit;
+use MagicSunday\ImageMeta\Value\Enum\SceneCaptureType;
 use MagicSunday\ImageMeta\Value\Enum\SensingMethod;
 use MagicSunday\ImageMeta\Value\Enum\SubjectDistanceRange;
 use MagicSunday\ImageMeta\Value\Enum\YCbCrPositioning;
@@ -39,9 +42,15 @@ use PHPUnit\Framework\TestCase;
  * @covers \MagicSunday\ImageMeta\Value\Enum\SensingMethod
  * @covers \MagicSunday\ImageMeta\Value\Enum\CompositeImage
  * @covers \MagicSunday\ImageMeta\Value\Enum\LightSource
+ * @covers \MagicSunday\ImageMeta\Value\Enum\Orientation
+ * @covers \MagicSunday\ImageMeta\Value\Enum\MeteringMode
+ * @covers \MagicSunday\ImageMeta\Value\Enum\SceneCaptureType
  */
 final class EnumMappingTest extends TestCase
 {
+    /**
+     * Ensures enums convert canonical integer encodings into typed values.
+     */
     #[Test]
     public function mapsCommonEnumValues(): void
     {
@@ -59,6 +68,9 @@ final class EnumMappingTest extends TestCase
         self::assertSame(LightSource::WARM_WHITE_FLUORESCENT, LightSource::fromExifValue(16));
     }
 
+    /**
+     * Normalises numeric-string payloads emitted by some encoders.
+     */
     #[Test]
     public function normalizesStringInputs(): void
     {
@@ -67,6 +79,22 @@ final class EnumMappingTest extends TestCase
         self::assertSame(LightSource::UNKNOWN, LightSource::fromExifValue('0'));
     }
 
+    /**
+     * Converts camera orientation, metering and scene capture enums when delivered as numeric strings.
+     */
+    #[Test]
+    public function mapsSceneAndMeteringEnumsFromStringPayloads(): void
+    {
+        self::assertSame(Orientation::RIGHT_TOP, Orientation::fromExifValue('6'));
+        self::assertSame(MeteringMode::CENTER_WEIGHTED_AVERAGE, MeteringMode::fromExifValue('2'));
+
+        // Scene capture codes are frequently stored as strings in manufacturer maker notes.
+        self::assertSame(SceneCaptureType::NIGHT_SCENE, SceneCaptureType::fromExifValue('3'));
+    }
+
+    /**
+     * Returns null for empty or non-numeric payloads that cannot be mapped to an enum.
+     */
     #[Test]
     public function returnsNullForEmptyOrNonNumericStrings(): void
     {
@@ -74,9 +102,21 @@ final class EnumMappingTest extends TestCase
         self::assertNull(Compression::fromExifValue('foo'));
     }
 
+    /**
+     * Ignores vendor specific file source values outside of the EXIF specification.
+     */
     #[Test]
     public function ignoresVendorSpecificFileSource(): void
     {
         self::assertNull(FileSource::fromExifValue(0x8000));
+    }
+
+    /**
+     * Rejects orientation codes that fall outside the EXIF defined range.
+     */
+    #[Test]
+    public function returnsNullForOutOfRangeOrientationCodes(): void
+    {
+        self::assertNull(Orientation::fromExifValue(9));
     }
 }


### PR DESCRIPTION
## Summary
- extend the enum mapping tests to cover orientation, metering, and scene capture codes delivered as numeric strings
- document the intent of the enum-mapping tests and verify invalid orientation values are rejected

## Testing
- composer ci:test:php:unit

------
https://chatgpt.com/codex/tasks/task_e_6901c17afa648323bab45bc140bca044