### PR TITLE
docs: reference EXIF spec chapters for flash and ISO helpers

### DIFF
--- a/src/Convenience/ExifConvenience.php
+++ b/src/Convenience/ExifConvenience.php
@@ -169,6 +169,8 @@ final class ExifConvenience
 
     /**
      * Resolves ISO sensitivity using the EXIF 3.x sensitivity type priority rules.
+     *
+     * EXIF 3.0 §4.6.3 formalises the SensitivityType-driven priority order retained from EXIF 2.32 §4.6.3.
      */
     private static function isoFromSensitivityType(ExifDocument $doc): ?int
     {
@@ -243,6 +245,7 @@ final class ExifConvenience
      */
     private static function sensitivityTagPriority(int $type): array
     {
+        // Mapping derived from the EXIF SensitivityType table (EXIF 2.32 §4.6.3 / EXIF 3.0 §4.6.3).
         return match ($type) {
             1       => [ExifTag::STANDARD_OUTPUT_SENSITIVITY],
             2       => [ExifTag::RECOMMENDED_EXPOSURE_INDEX],

--- a/src/Value/Enum/FlashFunction.php
+++ b/src/Value/Enum/FlashFunction.php
@@ -14,7 +14,7 @@ namespace MagicSunday\ImageMeta\Value\Enum;
 use MagicSunday\ImageMeta\Exif\Support\EnumFromIntStringNullable;
 
 /**
- * Describes whether the flash function is present on the camera.
+ * Describes whether the flash function is present on the camera (EXIF 2.32 §4.6.4 / EXIF 3.0 §4.6.4).
  */
 enum FlashFunction: int
 {

--- a/src/Value/Enum/FlashMode.php
+++ b/src/Value/Enum/FlashMode.php
@@ -14,7 +14,7 @@ namespace MagicSunday\ImageMeta\Value\Enum;
 use MagicSunday\ImageMeta\Exif\Support\EnumFromIntStringNullable;
 
 /**
- * Enumerates the flash mode encoded inside the EXIF Flash tag.
+ * Enumerates the flash mode encoded inside the EXIF Flash tag (EXIF 2.32 §4.6.4 / EXIF 3.0 §4.6.4).
  */
 enum FlashMode: int
 {

--- a/src/Value/Enum/FlashReturn.php
+++ b/src/Value/Enum/FlashReturn.php
@@ -14,7 +14,7 @@ namespace MagicSunday\ImageMeta\Value\Enum;
 use MagicSunday\ImageMeta\Exif\Support\EnumFromIntStringNullable;
 
 /**
- * Indicates the strobe return detection status encoded in the EXIF Flash tag.
+ * Indicates the strobe return detection status encoded in the EXIF Flash tag (EXIF 2.32 §4.6.4 / EXIF 3.0 §4.6.4).
  */
 enum FlashReturn: int
 {

--- a/src/Value/ExifFlash.php
+++ b/src/Value/ExifFlash.php
@@ -49,6 +49,7 @@ final class ExifFlash
 
         $flashBits = is_int($value) ? $value : (int) $value;
 
+        // EXIF 2.32 §4.6.4 and EXIF 3.0 §4.6.4 define the Flash tag bit layout decoded below.
         // Extract the grouped bit fields encoded within the EXIF Flash tag.
         $returnBits   = ($flashBits >> self::RETURN_SHIFT) & self::TWO_BIT_MASK;
         $modeBits     = ($flashBits >> self::MODE_SHIFT) & self::TWO_BIT_MASK;


### PR DESCRIPTION
## Summary
- document the EXIF Flash helpers with their corresponding EXIF 2.32 and 3.0 chapter references
- cross-reference the SensitivityType priority handling with the EXIF 2.32/3.0 chapter covering ISO resolution

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6901c77b2ed48323a410c41c8e64b2e4