### PR TITLE
docs: cross reference EXIF specification chapters

### DIFF
--- a/src/Core/ExifCapabilities.php
+++ b/src/Core/ExifCapabilities.php
@@ -18,7 +18,8 @@ use function strlen;
 use function trim;
 
 /**
- * Derives EXIF capability profiles from version identifiers.
+ * Derives EXIF capability profiles from version identifiers defined in
+ * EXIF 2.32 §4.6.8 and EXIF 3.0 §4.6.8 (other tags).
  */
 final class ExifCapabilities
 {

--- a/src/Model/Exif/ExifTag.php
+++ b/src/Model/Exif/ExifTag.php
@@ -16,7 +16,7 @@ namespace MagicSunday\ImageMeta\Model\Exif;
  */
 final readonly class ExifTag
 {
-    // Image file directory (IFD0)
+    // Image file directory (IFD0 — EXIF 2.32 §4.6.2 / EXIF 3.0 §4.6.2)
     /**
      * TIFF 6.0 subfile type bitfield describing the purpose of the image data.
      */
@@ -167,7 +167,7 @@ final readonly class ExifTag
 
     public const int JPEG_INTERCHANGE_FORMAT_LENGTH = 0x0202;
 
-    // EXIF 3.0 preview tags
+    // EXIF 3.0 preview tags (EXIF 3.0 §4.6.12 preview image data)
     public const int PREVIEW_IMAGE_START = 0xC51B;
 
     public const int PREVIEW_IMAGE_LENGTH = 0xC51C;
@@ -202,14 +202,14 @@ final readonly class ExifTag
 
     public const int COPYRIGHT = 0x8298;
 
-    // Pointer tags
+    // Pointer tags (EXIF 2.32 §4.6.2 / EXIF 3.0 §4.6.2 directory structure)
     public const int EXIF_IFD_POINTER = 0x8769;
 
     public const int GPS_IFD_POINTER = 0x8825;
 
     public const int INTEROPERABILITY_IFD_POINTER = 0xA005;
 
-    // EXIF sub IFD
+    // EXIF sub IFD (EXIF 2.32 §4.6.3 / EXIF 3.0 §4.6.3 shooting conditions)
     public const int CFA_REPEAT_PATTERN_DIM = 0x828D;
 
     public const int BATTERY_LEVEL = 0x828F;
@@ -239,7 +239,7 @@ final readonly class ExifTag
 
     public const int PHOTOGRAPHIC_SENSITIVITY = 0x8827;
 
-    // Opto-Electric Conversion Function
+    // Opto-Electric Conversion Function (EXIF 2.32 §4.6.3 / EXIF 3.0 §4.6.3)
     public const int OECF = 0x8828;
 
     public const int INTERLACE = 0x8829;
@@ -435,7 +435,7 @@ final readonly class ExifTag
 
     public const int DEVICE_SETTING_DESCRIPTION = 0xA40B;
 
-    // DNG colour profile tags (EXIF 2.3/3.0)
+    // DNG colour profile tags (EXIF 2.32 §4.6.3 / EXIF 3.0 §4.6.3, DNG extensions)
     /**
      * DNG camera calibration signature string recorded alongside the profile data.
      */
@@ -481,7 +481,7 @@ final readonly class ExifTag
      */
     public const int PROFILE_TONE_CURVE = 0xC6FC;
 
-    // GPS sub IFD (Table 66 – EXIF 3.0)
+    // GPS sub IFD (Table 66 – EXIF 3.0 §4.6.6 / EXIF 2.32 §4.6.6)
     public const int GPS_VERSION_ID = 0x0000;
 
     public const int GPS_LATITUDE_REF = 0x0001;
@@ -606,7 +606,7 @@ final readonly class ExifTag
      */
     public const int METADATA_EDITING_SOFTWARE_LEGACY = 0xE932;
 
-    // Interoperability IFD
+    // Interoperability IFD (EXIF 2.32 §4.6.7 / EXIF 3.0 §4.6.7)
     public const int INTEROPERABILITY_INDEX = 0x0001;
 
     public const int INTEROPERABILITY_VERSION = 0x0002;

--- a/src/Model/Exif/ValueConverters.php
+++ b/src/Model/Exif/ValueConverters.php
@@ -442,7 +442,8 @@ final readonly class ValueConverters
     }
 
     /**
-     * Converts a textual YCbCr subsampling representation into integer pairs.
+     * Converts a textual YCbCr subsampling representation into integer pairs as
+     * described in EXIF 2.32 §4.6.2 / EXIF 3.0 §4.6.2 (image data structure).
      *
      * @return array{0:int,1:int}|null
      */
@@ -468,7 +469,8 @@ final readonly class ValueConverters
     }
 
     /**
-     * Normalises a raw EXIF version byte string into a dotted decimal representation.
+     * Normalises a raw EXIF version byte string into a dotted decimal representation
+     * per EXIF 2.32 §4.6.8 / EXIF 3.0 §4.6.8 (other tags).
      */
     public static function toExifVersion(?string $bytes): ?string
     {
@@ -549,7 +551,8 @@ final readonly class ValueConverters
     }
 
     /**
-     * Normalises EXIF battery level readings to a percentage.
+     * Normalises EXIF battery level readings to a percentage following
+     * EXIF 2.32 §4.6.3 / EXIF 3.0 §4.6.3 (BatteryLevel tag semantics).
      *
      * @param int|float|string|ExifRational|ExifRationalList|ExifNumericList|null $value Raw battery level value.
      */
@@ -605,7 +608,8 @@ final readonly class ValueConverters
     }
 
     /**
-     * Converts the maker note safety flag into a boolean representation.
+     * Converts the maker note safety flag into a boolean representation per
+     * EXIF 2.32 §4.6.8 / EXIF 3.0 §4.6.8 (MakerNoteSafety).
      *
      * @param ExifNumericList|int|float|string|null $value Raw maker note safety value.
      */
@@ -900,7 +904,8 @@ final readonly class ValueConverters
     }
 
     /**
-     * Decodes the spatial frequency response payload as defined by EXIF figure 14.
+     * Decodes the spatial frequency response payload as defined by
+     * EXIF 2.32 §4.6.3 / EXIF 3.0 §4.6.3 figure 14.
      *
      * @param string|null $payload Raw UNDEFINED payload captured from the EXIF tag.
      *
@@ -912,7 +917,8 @@ final readonly class ValueConverters
     }
 
     /**
-     * Decodes the opto-electronic conversion function payload as defined by EXIF table 15.
+     * Decodes the opto-electronic conversion function payload as defined by
+     * EXIF 2.32 §4.6.3 / EXIF 3.0 §4.6.3 table 15.
      *
      * @param string|null $payload Raw UNDEFINED payload captured from the EXIF tag.
      *
@@ -1212,7 +1218,8 @@ final readonly class ValueConverters
     }
 
     /**
-     * Converts the EXIF flash bit field into a typed value object.
+     * Converts the EXIF flash bit field into a typed value object per
+     * EXIF 2.32 §4.6.4 / EXIF 3.0 §4.6.4 (Flash tag bit layout).
      *
      * @param ExifScalar $value Flash tag value representation.
      */
@@ -1254,7 +1261,8 @@ final readonly class ValueConverters
     }
 
     /**
-     * Normalises EXIF offset time values to a canonical "+HH:MM" representation.
+     * Normalises EXIF offset time values to a canonical "+HH:MM" representation
+     * per EXIF 2.32 §4.6.3 / EXIF 3.0 §4.6.3 (OffsetTime tags).
      *
      * @param int|float|string|ExifRational|ExifRationalList|null $value The raw offset value.
      */

--- a/src/Value/Enum/CfaPatternColor.php
+++ b/src/Value/Enum/CfaPatternColor.php
@@ -14,7 +14,8 @@ namespace MagicSunday\ImageMeta\Value\Enum;
 use MagicSunday\ImageMeta\Exif\Support\EnumFromIntStringNullable;
 
 /**
- * Enumerates the colour components referenced by the CFA pattern tag.
+ * Enumerates the colour components referenced by the CFA pattern tag per
+ * EXIF 2.32 §4.6.2 and EXIF 3.0 §4.6.2 (image data structure).
  */
 enum CfaPatternColor: int
 {

--- a/src/Value/Enum/ColorSpace.php
+++ b/src/Value/Enum/ColorSpace.php
@@ -14,7 +14,8 @@ namespace MagicSunday\ImageMeta\Value\Enum;
 use MagicSunday\ImageMeta\Exif\Support\EnumFromIntStringNullable;
 
 /**
- * Represents the image colour space information.
+ * Represents the image colour space information defined in
+ * EXIF 2.32 §4.6.3 and EXIF 3.0 §4.6.3 (shooting conditions).
  */
 enum ColorSpace: int
 {

--- a/src/Value/Enum/CompositeImage.php
+++ b/src/Value/Enum/CompositeImage.php
@@ -14,7 +14,8 @@ namespace MagicSunday\ImageMeta\Value\Enum;
 use MagicSunday\ImageMeta\Exif\Support\EnumFromIntStringNullable;
 
 /**
- * Enumerates EXIF composite image classifications.
+ * Enumerates EXIF composite image classifications introduced in
+ * EXIF 2.32 §4.6.3 and maintained in EXIF 3.0 §4.6.3 (shooting conditions).
  */
 enum CompositeImage: int
 {

--- a/src/Value/Enum/Compression.php
+++ b/src/Value/Enum/Compression.php
@@ -14,7 +14,9 @@ namespace MagicSunday\ImageMeta\Value\Enum;
 use MagicSunday\ImageMeta\Exif\Support\EnumFromIntStringNullable;
 
 /**
- * Enumerates TIFF/EXIF compression schemes.
+ * Enumerates TIFF/EXIF compression schemes catalogued in
+ * EXIF 2.32 §4.6.2 and EXIF 3.0 §4.6.2 (image data structure),
+ * which reference TIFF 6.0 §8 for baseline definitions.
  */
 enum Compression: int
 {

--- a/src/Value/Enum/Contrast.php
+++ b/src/Value/Enum/Contrast.php
@@ -14,7 +14,8 @@ namespace MagicSunday\ImageMeta\Value\Enum;
 use MagicSunday\ImageMeta\Exif\Support\EnumFromIntStringNullable;
 
 /**
- * Enumerates in-camera contrast processing levels.
+ * Enumerates in-camera contrast processing levels defined in
+ * EXIF 2.32 §4.6.3 and EXIF 3.0 §4.6.3 (shooting conditions).
  */
 enum Contrast: int
 {

--- a/src/Value/Enum/CustomRendered.php
+++ b/src/Value/Enum/CustomRendered.php
@@ -14,7 +14,8 @@ namespace MagicSunday\ImageMeta\Value\Enum;
 use MagicSunday\ImageMeta\Exif\Support\EnumFromIntStringNullable;
 
 /**
- * Enumerates EXIF custom rendered values.
+ * Enumerates EXIF custom rendered values listed in
+ * EXIF 2.32 §4.6.3 and EXIF 3.0 §4.6.3 (shooting conditions).
  */
 enum CustomRendered: int
 {

--- a/src/Value/Enum/DngProfileGainTableTag.php
+++ b/src/Value/Enum/DngProfileGainTableTag.php
@@ -14,7 +14,8 @@ namespace MagicSunday\ImageMeta\Value\Enum;
 use MagicSunday\ImageMeta\Exif\Support\EnumFromIntStringNullable;
 
 /**
- * Enumerates the DNG profile gain table related tags.
+ * Enumerates the DNG profile gain table related tags covered by
+ * EXIF 2.32 §4.6.3 and EXIF 3.0 §4.6.3 (shooting conditions, DNG extensions).
  */
 enum DngProfileGainTableTag: int
 {

--- a/src/Value/Enum/ExposureMode.php
+++ b/src/Value/Enum/ExposureMode.php
@@ -14,7 +14,9 @@ namespace MagicSunday\ImageMeta\Value\Enum;
 use MagicSunday\ImageMeta\Exif\Support\EnumFromIntStringNullable;
 
 /**
- * Enumerates camera exposure mode settings.
+ * Enumerates camera exposure mode settings defined in
+ * EXIF 2.32 §4.6.3 and EXIF 3.0 §4.6.3 (tags relating to
+ * shooting conditions).
  */
 enum ExposureMode: int
 {

--- a/src/Value/Enum/ExposureProgram.php
+++ b/src/Value/Enum/ExposureProgram.php
@@ -14,7 +14,9 @@ namespace MagicSunday\ImageMeta\Value\Enum;
 use MagicSunday\ImageMeta\Exif\Support\EnumFromIntStringNullable;
 
 /**
- * Describes the camera's exposure program.
+ * Describes the camera's exposure program according to
+ * EXIF 2.32 §4.6.3 and EXIF 3.0 §4.6.3 (tags relating to
+ * shooting conditions).
  */
 enum ExposureProgram: int
 {

--- a/src/Value/Enum/FileSource.php
+++ b/src/Value/Enum/FileSource.php
@@ -14,7 +14,8 @@ namespace MagicSunday\ImageMeta\Value\Enum;
 use MagicSunday\ImageMeta\Exif\Support\EnumFromIntStringNullable;
 
 /**
- * Enumerates EXIF 3.0 image acquisition sources.
+ * Enumerates EXIF image acquisition sources listed in
+ * EXIF 2.32 §4.6.3 and EXIF 3.0 §4.6.3 (shooting conditions).
  */
 enum FileSource: int
 {

--- a/src/Value/Enum/GainControl.php
+++ b/src/Value/Enum/GainControl.php
@@ -14,7 +14,8 @@ namespace MagicSunday\ImageMeta\Value\Enum;
 use MagicSunday\ImageMeta\Exif\Support\EnumFromIntStringNullable;
 
 /**
- * Enumerates gain control adjustments performed by the camera.
+ * Enumerates gain control adjustments performed by the camera per
+ * EXIF 2.32 §4.6.3 and EXIF 3.0 §4.6.3 (shooting conditions).
  */
 enum GainControl: int
 {

--- a/src/Value/Enum/IccRenderingIntent.php
+++ b/src/Value/Enum/IccRenderingIntent.php
@@ -14,7 +14,8 @@ namespace MagicSunday\ImageMeta\Value\Enum;
 use MagicSunday\ImageMeta\Exif\Support\EnumFromIntStringNullable;
 
 /**
- * Enumerates the rendering intents defined by the ICC specification.
+ * Enumerates the rendering intents defined by the ICC specification and
+ * referenced by EXIF 2.32 §4.6.3 / EXIF 3.0 §4.6.3 for embedded ICC profiles.
  */
 enum IccRenderingIntent: int
 {

--- a/src/Value/Enum/LightSource.php
+++ b/src/Value/Enum/LightSource.php
@@ -14,7 +14,8 @@ namespace MagicSunday\ImageMeta\Value\Enum;
 use MagicSunday\ImageMeta\Exif\Support\EnumFromIntStringNullable;
 
 /**
- * Enumerates light source identifiers as defined by EXIF.
+ * Enumerates light source identifiers as defined in
+ * EXIF 2.32 §4.6.3 and EXIF 3.0 §4.6.3 (shooting conditions).
  */
 enum LightSource: int
 {

--- a/src/Value/Enum/MeteringMode.php
+++ b/src/Value/Enum/MeteringMode.php
@@ -14,7 +14,8 @@ namespace MagicSunday\ImageMeta\Value\Enum;
 use MagicSunday\ImageMeta\Exif\Support\EnumFromIntStringNullable;
 
 /**
- * Defines the metering mode used to determine exposure.
+ * Defines the metering mode used to determine exposure as listed in
+ * EXIF 2.32 §4.6.3 and EXIF 3.0 §4.6.3 (shooting conditions).
  */
 enum MeteringMode: int
 {

--- a/src/Value/Enum/Orientation.php
+++ b/src/Value/Enum/Orientation.php
@@ -14,7 +14,8 @@ namespace MagicSunday\ImageMeta\Value\Enum;
 use MagicSunday\ImageMeta\Exif\Support\EnumFromIntStringNullable;
 
 /**
- * Enumerates the known EXIF orientation values.
+ * Enumerates the known EXIF orientation values as described in
+ * EXIF 2.32 §4.6.2 and EXIF 3.0 §4.6.2 (image data structure).
  */
 enum Orientation: int
 {

--- a/src/Value/Enum/Photometric.php
+++ b/src/Value/Enum/Photometric.php
@@ -14,7 +14,9 @@ namespace MagicSunday\ImageMeta\Value\Enum;
 use MagicSunday\ImageMeta\Exif\Support\EnumFromIntStringNullable;
 
 /**
- * Enumerates TIFF/EXIF photometric interpretations defined in EXIF 3.0.
+ * Enumerates TIFF/EXIF photometric interpretations defined in
+ * EXIF 2.32 §4.6.2 and EXIF 3.0 §4.6.2 (image data structure),
+ * which in turn reference TIFF 6.0 §8 for the numeric assignments.
  */
 enum Photometric: int
 {

--- a/src/Value/Enum/PlanarConfiguration.php
+++ b/src/Value/Enum/PlanarConfiguration.php
@@ -14,7 +14,9 @@ namespace MagicSunday\ImageMeta\Value\Enum;
 use MagicSunday\ImageMeta\Exif\Support\EnumFromIntStringNullable;
 
 /**
- * Enumerates TIFF planar configuration options.
+ * Enumerates TIFF planar configuration options described in
+ * EXIF 2.32 §4.6.2 and EXIF 3.0 §4.6.2 (image data structure),
+ * reflecting the TIFF 6.0 §8 PlanarConfiguration field.
  */
 enum PlanarConfiguration: int
 {

--- a/src/Value/Enum/ResolutionUnit.php
+++ b/src/Value/Enum/ResolutionUnit.php
@@ -14,7 +14,8 @@ namespace MagicSunday\ImageMeta\Value\Enum;
 use MagicSunday\ImageMeta\Exif\Support\EnumFromIntStringNullable;
 
 /**
- * Enumerates resolution units for X/Y resolution tags.
+ * Enumerates resolution units for X/Y resolution tags per
+ * EXIF 2.32 §4.6.2 and EXIF 3.0 §4.6.2 (image data structure).
  */
 enum ResolutionUnit: int
 {

--- a/src/Value/Enum/Saturation.php
+++ b/src/Value/Enum/Saturation.php
@@ -14,7 +14,8 @@ namespace MagicSunday\ImageMeta\Value\Enum;
 use MagicSunday\ImageMeta\Exif\Support\EnumFromIntStringNullable;
 
 /**
- * Enumerates in-camera saturation processing levels.
+ * Enumerates in-camera saturation processing levels specified in
+ * EXIF 2.32 §4.6.3 and EXIF 3.0 §4.6.3 (shooting conditions).
  */
 enum Saturation: int
 {

--- a/src/Value/Enum/SceneCaptureType.php
+++ b/src/Value/Enum/SceneCaptureType.php
@@ -14,7 +14,8 @@ namespace MagicSunday\ImageMeta\Value\Enum;
 use MagicSunday\ImageMeta\Exif\Support\EnumFromIntStringNullable;
 
 /**
- * Enumerates known EXIF scene capture type values.
+ * Enumerates known EXIF scene capture type values per
+ * EXIF 2.32 §4.6.3 and EXIF 3.0 §4.6.3 (shooting conditions).
  */
 enum SceneCaptureType: int
 {

--- a/src/Value/Enum/SceneType.php
+++ b/src/Value/Enum/SceneType.php
@@ -14,7 +14,8 @@ namespace MagicSunday\ImageMeta\Value\Enum;
 use MagicSunday\ImageMeta\Exif\Support\EnumFromIntStringNullable;
 
 /**
- * Enumerates EXIF scene types.
+ * Enumerates EXIF scene types defined in
+ * EXIF 2.32 §4.6.3 and EXIF 3.0 §4.6.3 (shooting conditions).
  */
 enum SceneType: int
 {

--- a/src/Value/Enum/SensingMethod.php
+++ b/src/Value/Enum/SensingMethod.php
@@ -14,7 +14,8 @@ namespace MagicSunday\ImageMeta\Value\Enum;
 use MagicSunday\ImageMeta\Exif\Support\EnumFromIntStringNullable;
 
 /**
- * Enumerates image sensor sampling methods.
+ * Enumerates image sensor sampling methods specified in
+ * EXIF 2.32 §4.6.3 and EXIF 3.0 §4.6.3 (shooting conditions).
  */
 enum SensingMethod: int
 {

--- a/src/Value/Enum/Sharpness.php
+++ b/src/Value/Enum/Sharpness.php
@@ -14,7 +14,8 @@ namespace MagicSunday\ImageMeta\Value\Enum;
 use MagicSunday\ImageMeta\Exif\Support\EnumFromIntStringNullable;
 
 /**
- * Enumerates in-camera sharpness processing levels.
+ * Enumerates in-camera sharpness processing levels captured in
+ * EXIF 2.32 §4.6.3 and EXIF 3.0 §4.6.3 (shooting conditions).
  */
 enum Sharpness: int
 {

--- a/src/Value/Enum/SubjectDistanceRange.php
+++ b/src/Value/Enum/SubjectDistanceRange.php
@@ -14,7 +14,8 @@ namespace MagicSunday\ImageMeta\Value\Enum;
 use MagicSunday\ImageMeta\Exif\Support\EnumFromIntStringNullable;
 
 /**
- * Enumerates subject distance range classifications.
+ * Enumerates subject distance range classifications documented in
+ * EXIF 2.32 §4.6.3 and EXIF 3.0 §4.6.3 (shooting conditions).
  */
 enum SubjectDistanceRange: int
 {

--- a/src/Value/Enum/WhiteBalance.php
+++ b/src/Value/Enum/WhiteBalance.php
@@ -14,7 +14,8 @@ namespace MagicSunday\ImageMeta\Value\Enum;
 use MagicSunday\ImageMeta\Exif\Support\EnumFromIntStringNullable;
 
 /**
- * Enumerates the white balance modes recorded by EXIF.
+ * Enumerates the white balance modes recorded by EXIF per
+ * EXIF 2.32 §4.6.3 and EXIF 3.0 §4.6.3 (shooting conditions).
  */
 enum WhiteBalance: int
 {

--- a/src/Value/Enum/YCbCrPositioning.php
+++ b/src/Value/Enum/YCbCrPositioning.php
@@ -14,7 +14,8 @@ namespace MagicSunday\ImageMeta\Value\Enum;
 use MagicSunday\ImageMeta\Exif\Support\EnumFromIntStringNullable;
 
 /**
- * Enumerates chroma positioning relative to luma samples in YCbCr images.
+ * Enumerates chroma positioning relative to luma samples in YCbCr images
+ * as defined by EXIF 2.32 §4.6.2 and EXIF 3.0 §4.6.2 (image data structure).
  */
 enum YCbCrPositioning: int
 {


### PR DESCRIPTION
## Summary
- add explicit EXIF 2.32/3.0 chapter references to enum docblocks for shooting and image-structure tags
- annotate grouped EXIF tag definitions and helper utilities with the relevant specification sections
- clarify helper documentation to point to the matching EXIF tables and figures for complex payloads

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6901ca21739883239737d552eb8362bf