### PR TITLE
Update enum docblocks with EXIF references

### DIFF
--- a/src/Value/Enum/CfaPatternColor.php
+++ b/src/Value/Enum/CfaPatternColor.php
@@ -14,8 +14,9 @@ namespace MagicSunday\ImageMeta\Value\Enum;
 use MagicSunday\ImageMeta\Exif\Support\EnumFromIntStringNullable;
 
 /**
- * Enumerates the colour components referenced by the CFA pattern tag per
- * EXIF 2.32 §4.6.2 and EXIF 3.0 §4.6.2 (image data structure).
+ * Enumerates the colour component codes used by the CFA pattern tag in EXIF 3.0
+ * §4.6.2 (image data structure), retaining the definitions introduced in EXIF
+ * 2.32 §4.6.2.
  */
 enum CfaPatternColor: int
 {

--- a/src/Value/Enum/ColorSpace.php
+++ b/src/Value/Enum/ColorSpace.php
@@ -14,8 +14,9 @@ namespace MagicSunday\ImageMeta\Value\Enum;
 use MagicSunday\ImageMeta\Exif\Support\EnumFromIntStringNullable;
 
 /**
- * Represents the image colour space information defined in
- * EXIF 2.32 §4.6.3 and EXIF 3.0 §4.6.3 (shooting conditions).
+ * Represents the colour space encodings described for the ColorSpace tag in
+ * EXIF 3.0 §4.6.3 (tags relating to shooting conditions), carried over from
+ * the EXIF 2.32 §4.6.3 definitions.
  */
 enum ColorSpace: int
 {

--- a/src/Value/Enum/CompositeImage.php
+++ b/src/Value/Enum/CompositeImage.php
@@ -14,8 +14,9 @@ namespace MagicSunday\ImageMeta\Value\Enum;
 use MagicSunday\ImageMeta\Exif\Support\EnumFromIntStringNullable;
 
 /**
- * Enumerates EXIF composite image classifications introduced in
- * EXIF 2.32 §4.6.3 and maintained in EXIF 3.0 §4.6.3 (shooting conditions).
+ * Enumerates the composite image classifications defined for the CompositeImage
+ * tag in EXIF 3.0 §4.6.3 (shooting conditions), continuing the set introduced
+ * in EXIF 2.32 §4.6.3.
  */
 enum CompositeImage: int
 {

--- a/src/Value/Enum/Compression.php
+++ b/src/Value/Enum/Compression.php
@@ -14,9 +14,9 @@ namespace MagicSunday\ImageMeta\Value\Enum;
 use MagicSunday\ImageMeta\Exif\Support\EnumFromIntStringNullable;
 
 /**
- * Enumerates TIFF/EXIF compression schemes catalogued in
- * EXIF 2.32 §4.6.2 and EXIF 3.0 §4.6.2 (image data structure),
- * which reference TIFF 6.0 §8 for baseline definitions.
+ * Enumerates the TIFF/EXIF compression schemes recorded for the Compression tag
+ * in EXIF 3.0 §4.6.2 (image data structure), preserving the mapping defined in
+ * EXIF 2.32 §4.6.2 and the baseline assignments from TIFF 6.0 §8.
  */
 enum Compression: int
 {

--- a/src/Value/Enum/Contrast.php
+++ b/src/Value/Enum/Contrast.php
@@ -14,8 +14,9 @@ namespace MagicSunday\ImageMeta\Value\Enum;
 use MagicSunday\ImageMeta\Exif\Support\EnumFromIntStringNullable;
 
 /**
- * Enumerates in-camera contrast processing levels defined in
- * EXIF 2.32 §4.6.3 and EXIF 3.0 §4.6.3 (shooting conditions).
+ * Enumerates the in-camera contrast processing levels described for the
+ * Contrast tag in EXIF 3.0 §4.6.3 (shooting conditions), consistent with EXIF
+ * 2.32 §4.6.3.
  */
 enum Contrast: int
 {

--- a/src/Value/Enum/CustomRendered.php
+++ b/src/Value/Enum/CustomRendered.php
@@ -14,8 +14,8 @@ namespace MagicSunday\ImageMeta\Value\Enum;
 use MagicSunday\ImageMeta\Exif\Support\EnumFromIntStringNullable;
 
 /**
- * Enumerates EXIF custom rendered values listed in
- * EXIF 2.32 §4.6.3 and EXIF 3.0 §4.6.3 (shooting conditions).
+ * Enumerates the CustomRendered tag values documented in EXIF 3.0 §4.6.3
+ * (shooting conditions) with the same semantics as EXIF 2.32 §4.6.3.
  */
 enum CustomRendered: int
 {

--- a/src/Value/Enum/DngProfileGainTableTag.php
+++ b/src/Value/Enum/DngProfileGainTableTag.php
@@ -14,8 +14,9 @@ namespace MagicSunday\ImageMeta\Value\Enum;
 use MagicSunday\ImageMeta\Exif\Support\EnumFromIntStringNullable;
 
 /**
- * Enumerates the DNG profile gain table related tags covered by
- * EXIF 2.32 §4.6.3 and EXIF 3.0 §4.6.3 (shooting conditions, DNG extensions).
+ * Enumerates the DNG profile gain table related tags referenced in EXIF 3.0
+ * §4.6.3 (shooting conditions, DNG extensions), retaining the identifiers from
+ * EXIF 2.32 §4.6.3.
  */
 enum DngProfileGainTableTag: int
 {

--- a/src/Value/Enum/ExposureMode.php
+++ b/src/Value/Enum/ExposureMode.php
@@ -14,9 +14,9 @@ namespace MagicSunday\ImageMeta\Value\Enum;
 use MagicSunday\ImageMeta\Exif\Support\EnumFromIntStringNullable;
 
 /**
- * Enumerates camera exposure mode settings defined in
- * EXIF 2.32 §4.6.3 and EXIF 3.0 §4.6.3 (tags relating to
- * shooting conditions).
+ * Enumerates the camera exposure mode settings listed for the ExposureMode tag
+ * in EXIF 3.0 §4.6.3 (tags relating to shooting conditions), unchanged from
+ * the EXIF 2.32 §4.6.3 definitions.
  */
 enum ExposureMode: int
 {

--- a/src/Value/Enum/ExposureProgram.php
+++ b/src/Value/Enum/ExposureProgram.php
@@ -14,9 +14,9 @@ namespace MagicSunday\ImageMeta\Value\Enum;
 use MagicSunday\ImageMeta\Exif\Support\EnumFromIntStringNullable;
 
 /**
- * Describes the camera's exposure program according to
- * EXIF 2.32 §4.6.3 and EXIF 3.0 §4.6.3 (tags relating to
- * shooting conditions).
+ * Describes the exposure program encodings defined for the ExposureProgram tag
+ * in EXIF 3.0 §4.6.3 (shooting conditions), matching the EXIF 2.32 §4.6.3
+ * assignments.
  */
 enum ExposureProgram: int
 {

--- a/src/Value/Enum/FileSource.php
+++ b/src/Value/Enum/FileSource.php
@@ -14,8 +14,9 @@ namespace MagicSunday\ImageMeta\Value\Enum;
 use MagicSunday\ImageMeta\Exif\Support\EnumFromIntStringNullable;
 
 /**
- * Enumerates EXIF image acquisition sources listed in
- * EXIF 2.32 §4.6.3 and EXIF 3.0 §4.6.3 (shooting conditions).
+ * Enumerates the image acquisition sources recorded by the FileSource tag in
+ * EXIF 3.0 §4.6.3 (shooting conditions), preserving the list from EXIF 2.32
+ * §4.6.3.
  */
 enum FileSource: int
 {

--- a/src/Value/Enum/FlashFunction.php
+++ b/src/Value/Enum/FlashFunction.php
@@ -14,7 +14,8 @@ namespace MagicSunday\ImageMeta\Value\Enum;
 use MagicSunday\ImageMeta\Exif\Support\EnumFromIntStringNullable;
 
 /**
- * Describes whether the flash function is present on the camera (EXIF 2.32 §4.6.4 / EXIF 3.0 §4.6.4).
+ * Describes whether the flash function is present on the camera as specified in
+ * EXIF 3.0 §4.6.4 (flash information), consistent with EXIF 2.32 §4.6.4.
  */
 enum FlashFunction: int
 {

--- a/src/Value/Enum/FlashMode.php
+++ b/src/Value/Enum/FlashMode.php
@@ -14,7 +14,9 @@ namespace MagicSunday\ImageMeta\Value\Enum;
 use MagicSunday\ImageMeta\Exif\Support\EnumFromIntStringNullable;
 
 /**
- * Enumerates the flash mode encoded inside the EXIF Flash tag (EXIF 2.32 §4.6.4 / EXIF 3.0 §4.6.4).
+ * Enumerates the flash mode bits carried in the Flash tag according to EXIF 3.0
+ * §4.6.4 (flash information), keeping the interpretations from EXIF 2.32
+ * §4.6.4.
  */
 enum FlashMode: int
 {

--- a/src/Value/Enum/FlashReturn.php
+++ b/src/Value/Enum/FlashReturn.php
@@ -14,7 +14,8 @@ namespace MagicSunday\ImageMeta\Value\Enum;
 use MagicSunday\ImageMeta\Exif\Support\EnumFromIntStringNullable;
 
 /**
- * Indicates the strobe return detection status encoded in the EXIF Flash tag (EXIF 2.32 §4.6.4 / EXIF 3.0 §4.6.4).
+ * Indicates the strobe return detection status encoded in the Flash tag per
+ * EXIF 3.0 §4.6.4 (flash information), unchanged from EXIF 2.32 §4.6.4.
  */
 enum FlashReturn: int
 {

--- a/src/Value/Enum/GainControl.php
+++ b/src/Value/Enum/GainControl.php
@@ -14,8 +14,8 @@ namespace MagicSunday\ImageMeta\Value\Enum;
 use MagicSunday\ImageMeta\Exif\Support\EnumFromIntStringNullable;
 
 /**
- * Enumerates gain control adjustments performed by the camera per
- * EXIF 2.32 §4.6.3 and EXIF 3.0 §4.6.3 (shooting conditions).
+ * Enumerates the gain control adjustments described for the GainControl tag in
+ * EXIF 3.0 §4.6.3 (shooting conditions), mirroring EXIF 2.32 §4.6.3.
  */
 enum GainControl: int
 {

--- a/src/Value/Enum/IccRenderingIntent.php
+++ b/src/Value/Enum/IccRenderingIntent.php
@@ -14,8 +14,9 @@ namespace MagicSunday\ImageMeta\Value\Enum;
 use MagicSunday\ImageMeta\Exif\Support\EnumFromIntStringNullable;
 
 /**
- * Enumerates the rendering intents defined by the ICC specification and
- * referenced by EXIF 2.32 §4.6.3 / EXIF 3.0 §4.6.3 for embedded ICC profiles.
+ * Enumerates the ICC rendering intents referenced by EXIF 3.0 §4.6.3 (shooting
+ * conditions) for embedded profiles, matching the guidance from EXIF 2.32
+ * §4.6.3.
  */
 enum IccRenderingIntent: int
 {

--- a/src/Value/Enum/LightSource.php
+++ b/src/Value/Enum/LightSource.php
@@ -14,8 +14,9 @@ namespace MagicSunday\ImageMeta\Value\Enum;
 use MagicSunday\ImageMeta\Exif\Support\EnumFromIntStringNullable;
 
 /**
- * Enumerates light source identifiers as defined in
- * EXIF 2.32 §4.6.3 and EXIF 3.0 §4.6.3 (shooting conditions).
+ * Enumerates the light source identifiers assigned to the LightSource tag in
+ * EXIF 3.0 §4.6.3 (shooting conditions), retaining the catalogue from EXIF
+ * 2.32 §4.6.3.
  */
 enum LightSource: int
 {

--- a/src/Value/Enum/MeteringMode.php
+++ b/src/Value/Enum/MeteringMode.php
@@ -14,8 +14,8 @@ namespace MagicSunday\ImageMeta\Value\Enum;
 use MagicSunday\ImageMeta\Exif\Support\EnumFromIntStringNullable;
 
 /**
- * Defines the metering mode used to determine exposure as listed in
- * EXIF 2.32 §4.6.3 and EXIF 3.0 §4.6.3 (shooting conditions).
+ * Defines the metering modes listed for the MeteringMode tag in EXIF 3.0
+ * §4.6.3 (shooting conditions), carried over from EXIF 2.32 §4.6.3.
  */
 enum MeteringMode: int
 {

--- a/src/Value/Enum/Orientation.php
+++ b/src/Value/Enum/Orientation.php
@@ -14,8 +14,8 @@ namespace MagicSunday\ImageMeta\Value\Enum;
 use MagicSunday\ImageMeta\Exif\Support\EnumFromIntStringNullable;
 
 /**
- * Enumerates the known EXIF orientation values as described in
- * EXIF 2.32 §4.6.2 and EXIF 3.0 §4.6.2 (image data structure).
+ * Enumerates the orientation values defined for the Orientation tag in EXIF
+ * 3.0 §4.6.2 (image data structure), inherited from EXIF 2.32 §4.6.2.
  */
 enum Orientation: int
 {

--- a/src/Value/Enum/Photometric.php
+++ b/src/Value/Enum/Photometric.php
@@ -14,9 +14,9 @@ namespace MagicSunday\ImageMeta\Value\Enum;
 use MagicSunday\ImageMeta\Exif\Support\EnumFromIntStringNullable;
 
 /**
- * Enumerates TIFF/EXIF photometric interpretations defined in
- * EXIF 2.32 §4.6.2 and EXIF 3.0 §4.6.2 (image data structure),
- * which in turn reference TIFF 6.0 §8 for the numeric assignments.
+ * Enumerates the photometric interpretations listed for the
+ * PhotometricInterpretation tag in EXIF 3.0 §4.6.2 (image data structure),
+ * aligning with EXIF 2.32 §4.6.2 and the TIFF 6.0 §8 definitions.
  */
 enum Photometric: int
 {

--- a/src/Value/Enum/PlanarConfiguration.php
+++ b/src/Value/Enum/PlanarConfiguration.php
@@ -14,9 +14,9 @@ namespace MagicSunday\ImageMeta\Value\Enum;
 use MagicSunday\ImageMeta\Exif\Support\EnumFromIntStringNullable;
 
 /**
- * Enumerates TIFF planar configuration options described in
- * EXIF 2.32 §4.6.2 and EXIF 3.0 §4.6.2 (image data structure),
- * reflecting the TIFF 6.0 §8 PlanarConfiguration field.
+ * Enumerates the planar configuration options for the PlanarConfiguration tag
+ * in EXIF 3.0 §4.6.2 (image data structure), following the mappings from EXIF
+ * 2.32 §4.6.2 and TIFF 6.0 §8.
  */
 enum PlanarConfiguration: int
 {

--- a/src/Value/Enum/ResolutionUnit.php
+++ b/src/Value/Enum/ResolutionUnit.php
@@ -14,8 +14,9 @@ namespace MagicSunday\ImageMeta\Value\Enum;
 use MagicSunday\ImageMeta\Exif\Support\EnumFromIntStringNullable;
 
 /**
- * Enumerates resolution units for X/Y resolution tags per
- * EXIF 2.32 §4.6.2 and EXIF 3.0 §4.6.2 (image data structure).
+ * Enumerates the resolution units recorded by the XResolution/YResolution tags
+ * in EXIF 3.0 §4.6.2 (image data structure), continuing the EXIF 2.32 §4.6.2
+ * set.
  */
 enum ResolutionUnit: int
 {

--- a/src/Value/Enum/Saturation.php
+++ b/src/Value/Enum/Saturation.php
@@ -14,8 +14,9 @@ namespace MagicSunday\ImageMeta\Value\Enum;
 use MagicSunday\ImageMeta\Exif\Support\EnumFromIntStringNullable;
 
 /**
- * Enumerates in-camera saturation processing levels specified in
- * EXIF 2.32 §4.6.3 and EXIF 3.0 §4.6.3 (shooting conditions).
+ * Enumerates the saturation processing levels associated with the Saturation
+ * tag in EXIF 3.0 §4.6.3 (shooting conditions), identical to EXIF 2.32
+ * §4.6.3.
  */
 enum Saturation: int
 {

--- a/src/Value/Enum/SceneCaptureType.php
+++ b/src/Value/Enum/SceneCaptureType.php
@@ -14,8 +14,9 @@ namespace MagicSunday\ImageMeta\Value\Enum;
 use MagicSunday\ImageMeta\Exif\Support\EnumFromIntStringNullable;
 
 /**
- * Enumerates known EXIF scene capture type values per
- * EXIF 2.32 §4.6.3 and EXIF 3.0 §4.6.3 (shooting conditions).
+ * Enumerates the scene capture classifications defined for the SceneCaptureType
+ * tag in EXIF 3.0 §4.6.3 (shooting conditions), unchanged from EXIF 2.32
+ * §4.6.3.
  */
 enum SceneCaptureType: int
 {

--- a/src/Value/Enum/SceneType.php
+++ b/src/Value/Enum/SceneType.php
@@ -14,8 +14,8 @@ namespace MagicSunday\ImageMeta\Value\Enum;
 use MagicSunday\ImageMeta\Exif\Support\EnumFromIntStringNullable;
 
 /**
- * Enumerates EXIF scene types defined in
- * EXIF 2.32 §4.6.3 and EXIF 3.0 §4.6.3 (shooting conditions).
+ * Enumerates the scene type encodings recorded by the SceneType tag in EXIF
+ * 3.0 §4.6.3 (shooting conditions), preserving the EXIF 2.32 §4.6.3 meaning.
  */
 enum SceneType: int
 {

--- a/src/Value/Enum/SensingMethod.php
+++ b/src/Value/Enum/SensingMethod.php
@@ -14,8 +14,8 @@ namespace MagicSunday\ImageMeta\Value\Enum;
 use MagicSunday\ImageMeta\Exif\Support\EnumFromIntStringNullable;
 
 /**
- * Enumerates image sensor sampling methods specified in
- * EXIF 2.32 §4.6.3 and EXIF 3.0 §4.6.3 (shooting conditions).
+ * Enumerates the sensor sampling methods recognised by the SensingMethod tag in
+ * EXIF 3.0 §4.6.3 (shooting conditions), matching the EXIF 2.32 §4.6.3 list.
  */
 enum SensingMethod: int
 {

--- a/src/Value/Enum/Sharpness.php
+++ b/src/Value/Enum/Sharpness.php
@@ -14,8 +14,8 @@ namespace MagicSunday\ImageMeta\Value\Enum;
 use MagicSunday\ImageMeta\Exif\Support\EnumFromIntStringNullable;
 
 /**
- * Enumerates in-camera sharpness processing levels captured in
- * EXIF 2.32 §4.6.3 and EXIF 3.0 §4.6.3 (shooting conditions).
+ * Enumerates the sharpness processing levels described for the Sharpness tag in
+ * EXIF 3.0 §4.6.3 (shooting conditions), consistent with EXIF 2.32 §4.6.3.
  */
 enum Sharpness: int
 {

--- a/src/Value/Enum/SubjectDistanceRange.php
+++ b/src/Value/Enum/SubjectDistanceRange.php
@@ -14,8 +14,9 @@ namespace MagicSunday\ImageMeta\Value\Enum;
 use MagicSunday\ImageMeta\Exif\Support\EnumFromIntStringNullable;
 
 /**
- * Enumerates subject distance range classifications documented in
- * EXIF 2.32 §4.6.3 and EXIF 3.0 §4.6.3 (shooting conditions).
+ * Enumerates the subject distance range classifications assigned to the
+ * SubjectDistanceRange tag in EXIF 3.0 §4.6.3 (shooting conditions), retained
+ * from EXIF 2.32 §4.6.3.
  */
 enum SubjectDistanceRange: int
 {

--- a/src/Value/Enum/WhiteBalance.php
+++ b/src/Value/Enum/WhiteBalance.php
@@ -14,8 +14,8 @@ namespace MagicSunday\ImageMeta\Value\Enum;
 use MagicSunday\ImageMeta\Exif\Support\EnumFromIntStringNullable;
 
 /**
- * Enumerates the white balance modes recorded by EXIF per
- * EXIF 2.32 §4.6.3 and EXIF 3.0 §4.6.3 (shooting conditions).
+ * Enumerates the white balance modes reported by the WhiteBalance tag in EXIF
+ * 3.0 §4.6.3 (shooting conditions), reflecting the EXIF 2.32 §4.6.3 options.
  */
 enum WhiteBalance: int
 {

--- a/src/Value/Enum/YCbCrPositioning.php
+++ b/src/Value/Enum/YCbCrPositioning.php
@@ -14,8 +14,9 @@ namespace MagicSunday\ImageMeta\Value\Enum;
 use MagicSunday\ImageMeta\Exif\Support\EnumFromIntStringNullable;
 
 /**
- * Enumerates chroma positioning relative to luma samples in YCbCr images
- * as defined by EXIF 2.32 §4.6.2 and EXIF 3.0 §4.6.2 (image data structure).
+ * Enumerates the chroma positioning choices defined for the YCbCrPositioning
+ * tag in EXIF 3.0 §4.6.2 (image data structure), continuing the EXIF 2.32
+ * §4.6.2 mapping.
  */
 enum YCbCrPositioning: int
 {


### PR DESCRIPTION
## Summary
- document EXIF 3.0 §4.6.3 references for shooting-condition enums alongside their EXIF 2.32 sections
- add EXIF 3.0 §4.6.2 citations for image data-structure enums while noting the legacy EXIF 2.32 and TIFF mappings
- note EXIF 3.0 §4.6.4 coverage for flash-related enums and the DNG extension tag guidance

## Testing
- not run (doc-only change)

------
https://chatgpt.com/codex/tasks/task_e_6901d0962eb883238d60284ec930d520