### PR TITLE
docs(exif): clarify sfr and oecf docblocks

### DIFF
--- a/src/Model/Exif/ValueConverters.php
+++ b/src/Model/Exif/ValueConverters.php
@@ -909,7 +909,8 @@ final readonly class ValueConverters
 
     /**
      * Decodes the spatial frequency response payload as defined by
-     * EXIF 2.32 §4.6.3 / EXIF 3.0 §4.6.3 figure 14.
+     * EXIF 3.0 §4.6.3 (figure 14) and the legacy layout retained in
+     * EXIF 2.32 §4.6.3.
      *
      * @param string|null $payload Raw UNDEFINED payload captured from the EXIF tag.
      *
@@ -922,7 +923,7 @@ final readonly class ValueConverters
 
     /**
      * Decodes the opto-electronic conversion function payload as defined by
-     * EXIF 2.32 §4.6.3 / EXIF 3.0 §4.6.3 table 15.
+     * EXIF 3.0 §4.6.3 (table 15) and the earlier EXIF 2.32 §4.6.3 layout.
      *
      * @param string|null $payload Raw UNDEFINED payload captured from the EXIF tag.
      *


### PR DESCRIPTION
## Summary
- reference the explicit EXIF 3.0 section and matrix figure for the spatial frequency response helper
- note the legacy EXIF 2.32 section that still applies to older payloads
- do the same for the OECF helper, pointing at the published table number

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6901d095b954832388d068082c7025bc