### PR TITLE
docs(jpeg): cite mpf app2 segment chapter

### DIFF
--- a/src/Parse/Jpeg/JpegExtractor.php
+++ b/src/Parse/Jpeg/JpegExtractor.php
@@ -56,6 +56,10 @@ final class JpegExtractor
 
     private const string ICC_SIGNATURE = "ICC_PROFILE\0";
 
+    /**
+     * Signature identifying MP Index payloads inside APP2 markers
+     * (EXIF 3.0 §4.6.4 / EXIF 2.32 §4.6.4).
+     */
     private const string MPF_SIGNATURE = "MPF\0";
 
     /**
@@ -701,6 +705,9 @@ final class JpegExtractor
 
     /**
      * Collects MPF APP2 segments to be parsed after the marker scan completes.
+     *
+     * EXIF 3.0 §4.6.4 specifies that Multi-Picture Format data resides in APP2
+     * markers, retaining the layout published in EXIF 2.32 §4.6.4.
      */
     private function handleMpfSegment(string $payload, int $offset): void
     {


### PR DESCRIPTION
## Overview
- document the EXIF requirements for MPF APP2 handling in the JPEG extractor

## Details
- annotate the MPF APP2 signature constant with EXIF 3.0 §4.6.4 / EXIF 2.32 §4.6.4
- extend the MPF segment collector docblock with matching spec references

## Tests
- not run (documentation-only change)

## Risks
- Low

## Changelog
- n/a

## References
- EXIF 3.0 §4.6.4
- EXIF 2.32 §4.6.4

Closes #N/A

------
https://chatgpt.com/codex/tasks/task_e_6901ddea809083238507106c5c2f5a1d