### PR TITLE
docs: align GPSInfo spec citation

### DIFF
--- a/src/Api/ExifDocument.php
+++ b/src/Api/ExifDocument.php
@@ -443,7 +443,8 @@ final class ExifDocument
          *     differential:?int,
          *     h_positioning_error:?float
          * } $gpsValues */
-        // ModelExifDocument::gps() returns a normalized array of EXIF GPSInfo tags (EXIF 2.31 §4.6.6).
+        // ModelExifDocument::gps() returns a normalized array of EXIF GPSInfo tags
+        // (EXIF 3.0 §4.6.8; EXIF 2.32 §4.6.8 retains the same tag catalogue).
         $gpsValues = $document->gps();
 
         return new GpsValue(


### PR DESCRIPTION
## Overview
- update the GPS accessor comment to cite the current EXIF specification numbering

## Details
- switch the inline reference from EXIF 2.31 §4.6.6 to EXIF 3.0 §4.6.8 and note that EXIF 2.32 §4.6.8 retains the same tag list

## Testing
- not run (comment-only change)

## Risks
- low: documentation-only change

## References
- EXIF 3.0 §4.6.8
- EXIF 2.32 §4.6.8

------
https://chatgpt.com/codex/tasks/task_e_6901ddf20c3c8323ae77ef55ac1fb832