### PR TITLE
Expand EXIF fixtures to cover raw model metadata

### DIFF
--- a/tests/Acceptance/ExifBackfillMatrixTest.php
+++ b/tests/Acceptance/ExifBackfillMatrixTest.php
@@ -29,6 +29,7 @@ final class ExifBackfillMatrixTest extends TestCase
         string $fixture,
         array $expectedStructured,
         array $expectedApi,
+        array $expectedModel,
     ): void {
         $metadata = (new MetadataReader())->read(ExifVersionExpectations::path($fixture));
 
@@ -36,5 +37,7 @@ final class ExifBackfillMatrixTest extends TestCase
 
         $document = new ApiExifDocument($metadata->exifDoc);
         self::assertApiMatches($fixture, $document, $expectedApi);
+
+        self::assertModelMatches($fixture, $metadata->exifDoc, $expectedModel);
     }
 }

--- a/tests/Api/ExifDocumentReferenceMatrixTest.php
+++ b/tests/Api/ExifDocumentReferenceMatrixTest.php
@@ -35,6 +35,9 @@ final class ExifDocumentReferenceMatrixTest extends TestCase
         $modelDocument = $metadata->exifDoc;
         self::assertNotNull($modelDocument, sprintf('Reference EXIF document missing for %s', $fixture));
 
+        $expectation = ExifVersionExpectations::get($fixture);
+        self::assertModelMatches($fixture, $modelDocument, $expectation['model']);
+
         $document = new ApiExifDocument($modelDocument);
 
         self::assertSame($modelDocument, $document->raw(), sprintf('%s: Raw document reference', $fixture));

--- a/tests/Api/ExifReaderTest.php
+++ b/tests/Api/ExifReaderTest.php
@@ -87,6 +87,7 @@ final class ExifReaderTest extends TestCase
 
         $expectation = ExifVersionExpectations::get($fixture);
 
+        self::assertModelMatches($fixture, $document->raw(), $expectation['model']);
         self::assertApiMatches($fixture, $document, $expectation['api']);
     }
 

--- a/tests/Fixtures/Images/ExifVersions/expectations.json
+++ b/tests/Fixtures/Images/ExifVersions/expectations.json
@@ -70,6 +70,13 @@
                 "previewMimeType": null,
                 "previewScale": null
             }
+        },
+        "model": {
+            "exifVersion": "1.00",
+            "exifProfile": "1.0",
+            "flashpixVersion": "1.00",
+            "tiffEpStandardId": null,
+            "tiffEpStandardString": null
         }
     },
     "exif-1-1.jpg": {
@@ -143,6 +150,13 @@
                 "previewMimeType": null,
                 "previewScale": null
             }
+        },
+        "model": {
+            "exifVersion": "1.10",
+            "exifProfile": "1.1",
+            "flashpixVersion": "1.00",
+            "tiffEpStandardId": null,
+            "tiffEpStandardString": null
         }
     },
     "exif-2-1.jpg": {
@@ -216,6 +230,13 @@
                 "previewMimeType": null,
                 "previewScale": null
             }
+        },
+        "model": {
+            "exifVersion": "2.10",
+            "exifProfile": "2.1",
+            "flashpixVersion": "1.00",
+            "tiffEpStandardId": null,
+            "tiffEpStandardString": null
         }
     },
     "exif-2-2.jpg": {
@@ -289,6 +310,13 @@
                 "previewMimeType": null,
                 "previewScale": null
             }
+        },
+        "model": {
+            "exifVersion": "2.20",
+            "exifProfile": "2.2",
+            "flashpixVersion": "1.00",
+            "tiffEpStandardId": null,
+            "tiffEpStandardString": null
         }
     },
     "exif-2-21.jpg": {
@@ -362,6 +390,13 @@
                 "previewMimeType": null,
                 "previewScale": null
             }
+        },
+        "model": {
+            "exifVersion": "2.21",
+            "exifProfile": "2.21",
+            "flashpixVersion": "1.00",
+            "tiffEpStandardId": null,
+            "tiffEpStandardString": null
         }
     },
     "exif-2-3.jpg": {
@@ -440,6 +475,18 @@
                 "previewMimeType": null,
                 "previewScale": null
             }
+        },
+        "model": {
+            "exifVersion": "2.30",
+            "exifProfile": "2.3",
+            "flashpixVersion": "1.00",
+            "tiffEpStandardId": [
+                2,
+                0,
+                0,
+                0
+            ],
+            "tiffEpStandardString": "2.0.0.0"
         }
     },
     "exif-2-31.jpg": {
@@ -518,6 +565,18 @@
                 "previewMimeType": null,
                 "previewScale": null
             }
+        },
+        "model": {
+            "exifVersion": "2.31",
+            "exifProfile": "2.31",
+            "flashpixVersion": "1.00",
+            "tiffEpStandardId": [
+                2,
+                0,
+                0,
+                1
+            ],
+            "tiffEpStandardString": "2.0.0.1"
         }
     },
     "exif-2-32.jpg": {
@@ -596,6 +655,18 @@
                 "previewMimeType": null,
                 "previewScale": null
             }
+        },
+        "model": {
+            "exifVersion": "2.32",
+            "exifProfile": "2.32",
+            "flashpixVersion": "1.00",
+            "tiffEpStandardId": [
+                2,
+                0,
+                0,
+                2
+            ],
+            "tiffEpStandardString": "2.0.0.2"
         }
     },
     "exif-3-0.jpg": {
@@ -675,6 +746,19 @@
                 "previewMimeType": null,
                 "previewScale": 0.5
             }
+        },
+        "model": {
+            "exifVersion": "3.00",
+            "exifProfile": "3.0",
+            "flashpixVersion": "1.00",
+            "tiffEpStandardId": [
+                48,
+                49,
+                48,
+                48,
+                0
+            ],
+            "tiffEpStandardString": "0100"
         }
     }
 }

--- a/tests/Support/ExifExpectationAssertions.php
+++ b/tests/Support/ExifExpectationAssertions.php
@@ -6,6 +6,7 @@ namespace MagicSunday\ImageMeta\Tests\Support;
 
 use MagicSunday\ImageMeta\Api\ExifDocument as ApiExifDocument;
 use MagicSunday\ImageMeta\Curate\StructuredMetadata;
+use MagicSunday\ImageMeta\Model\Exif\ExifDocument as ModelExifDocument;
 use MagicSunday\ImageMeta\Curate\Exif\Structured\Preview as StructuredPreview;
 use MagicSunday\ImageMeta\Value\Preview as PreviewValue;
 use PHPUnit\Framework\Assert;
@@ -128,6 +129,26 @@ trait ExifExpectationAssertions
         Assert::assertSame($expectedInterop['length'], $interop->relatedImageLength, sprintf('%s: API Interop length', $fixture));
 
         self::assertPreviewMatches($fixture, $expected['preview'], $document->preview());
+    }
+
+    /**
+     * @param array{
+     *     exifVersion:?string,
+     *     exifProfile:string,
+     *     flashpixVersion:?string,
+     *     tiffEpStandardId:?array,
+     *     tiffEpStandardString:?string,
+     * } $expected
+     */
+    private static function assertModelMatches(string $fixture, ?ModelExifDocument $document, array $expected): void
+    {
+        Assert::assertNotNull($document, sprintf('%s: Raw EXIF document', $fixture));
+
+        Assert::assertSame($expected['exifVersion'], $document->exifVersion(), sprintf('%s: Raw EXIF version', $fixture));
+        Assert::assertSame($expected['exifProfile'], $document->exifProfile(), sprintf('%s: Raw EXIF profile', $fixture));
+        Assert::assertSame($expected['flashpixVersion'], $document->flashpixVersion(), sprintf('%s: Raw FlashPix version', $fixture));
+        Assert::assertSame($expected['tiffEpStandardId'], $document->tiffEpStandardId(), sprintf('%s: Raw TIFF/EP standard id', $fixture));
+        Assert::assertSame($expected['tiffEpStandardString'], $document->tiffEpStandardIdString(), sprintf('%s: Raw TIFF/EP standard string', $fixture));
     }
 
     /**

--- a/tests/Support/ExifVersionExpectations.php
+++ b/tests/Support/ExifVersionExpectations.php
@@ -17,7 +17,7 @@ final class ExifVersionExpectations
     private const string EXPECTATIONS_FILE = self::FIXTURE_DIR . '/expectations.json';
 
     /**
-     * @var array<string, array{structured: array<string, mixed>, api: array<string, mixed>}>|null
+     * @var array<string, array{structured: array<string, mixed>, api: array<string, mixed>, model: array<string, mixed>}>|null
      */
     private static ?array $cache = null;
 
@@ -50,20 +50,24 @@ final class ExifVersionExpectations
     }
 
     /**
-     * @return iterable<string, array{string, array<string, mixed>, array<string, mixed>}> Data provider payload for both
-     *                                                                                     structured and API expectations.
+     * @return iterable<string, array{string, array<string, mixed>, array<string, mixed>, array<string, mixed>}> Data provider
+     *                                                                                                          payload for
+     *                                                                                                          structured,
+     *                                                                                                          API and raw
+     *                                                                                                          model
+     *                                                                                                          expectations.
      */
     public static function provideAll(): iterable
     {
         foreach (self::all() as $fixture => $expectation) {
-            yield $fixture => [$fixture, $expectation['structured'], $expectation['api']];
+            yield $fixture => [$fixture, $expectation['structured'], $expectation['api'], $expectation['model']];
         }
     }
 
     /**
-     * Returns the structured and API expectations for a given fixture.
+     * Returns the structured, API and model expectations for a given fixture.
      *
-     * @return array{structured: array<string, mixed>, api: array<string, mixed>}
+     * @return array{structured: array<string, mixed>, api: array<string, mixed>, model: array<string, mixed>}
      */
     public static function get(string $fixture): array
     {
@@ -77,7 +81,7 @@ final class ExifVersionExpectations
     }
 
     /**
-     * @return array<string, array{structured: array<string, mixed>, api: array<string, mixed>}> Cached expectations.
+     * @return array<string, array{structured: array<string, mixed>, api: array<string, mixed>, model: array<string, mixed>}> Cached expectations.
      */
     private static function all(): array
     {
@@ -90,7 +94,7 @@ final class ExifVersionExpectations
             throw new RuntimeException(sprintf('Unable to read EXIF expectations from %s', self::EXPECTATIONS_FILE));
         }
 
-        /** @var array<string, array{structured: array<string, mixed>, api: array<string, mixed>}> $data */
+        /** @var array<string, array{structured: array<string, mixed>, api: array<string, mixed>, model: array<string, mixed>}> $data */
         $data = json_decode($json, true, 512, JSON_THROW_ON_ERROR);
 
         self::$cache = $data;


### PR DESCRIPTION
## Overview
- add raw EXIF model expectations for each reference JPEG fixture
- extend shared test assertions to validate the parsed EXIF document metadata
- exercise the new expectations across acceptance and API matrix tests

## Details
- enriched `expectations.json` with model-level `exifVersion`, profile, FlashPix version and TIFF/EP identifiers for every EXIF sample
- updated `ExifExpectationAssertions` with a raw-model assertion helper and wired it into the matrix-style PHPUnit suites
- refreshed the fixtures helper to expose the new expectations in all relevant data providers

## Tests
- `composer ci:test:php:unit`

## Risks
- Low: assertions only, touching test fixtures and helpers.

## Changelog
- Extend EXIF sample fixtures and assertions to cover raw document metadata.

## References
- EXIF 3.0 §4

Closes #N/A

------
https://chatgpt.com/codex/tasks/task_e_6901fd15629c8323a03a6b61cd9dcdaa