### PR TITLE
Narrow BinaryPlistEncoder type unions

### DIFF
--- a/tests/MakerNotes/Apple/AppleDecoderKeyedArchiveTest.php
+++ b/tests/MakerNotes/Apple/AppleDecoderKeyedArchiveTest.php
@@ -132,7 +132,10 @@ final class BinaryPlistEncoder
      */
     private array $nodes = [];
 
-    public function encode(mixed $value): string
+    /**
+     * @param array<array-key, array|bool|float|int|string|null>|bool|float|int|string|null $value
+     */
+    public function encode(array|bool|float|int|string|null $value): string
     {
         $this->nodes = [];
 
@@ -184,7 +187,10 @@ final class BinaryPlistEncoder
         return $header . $objects . $offsetTable . $trailer;
     }
 
-    private function collect(mixed $value): int
+    /**
+     * @param array<array-key, array|bool|float|int|string|null>|bool|float|int|string|null $value
+     */
+    private function collect(array|bool|float|int|string|null $value): int
     {
         if ($value === null) {
             return $this->addNode(new BinaryPlistNode('null', null));


### PR DESCRIPTION
## Overview
- narrow the BinaryPlistEncoder parameter types to the concrete values handled in the Apple keyed archive fixture

## Details
- replace mixed parameters with array|bool|float|int|string|null unions and update PHPDocs so recursive calls keep the narrowed value type

## Tests
- composer ci:test:php:unit

## Risks
- low

## Changelog
- Narrow BinaryPlistEncoder encode/collect parameter unions in the Apple keyed archive fixture.

Closes #N/A

------
https://chatgpt.com/codex/tasks/task_e_69022ad4e1488323ac14dd3486abe694