### PR TITLE
fix: remove redundant casts in UInt64 utility

### DIFF
--- a/src/Core/Util/UInt64.php
+++ b/src/Core/Util/UInt64.php
@@ -59,7 +59,7 @@ final class UInt64
             throw new ParseError('Cannot create UInt64 from a negative integer.');
         }
 
-        $hi = (int) intdiv($value, self::UINT32_BASE);
+        $hi = intdiv($value, self::UINT32_BASE);
         $lo = $value & self::UINT32_MASK;
 
         return new self($hi, $lo);
@@ -182,7 +182,7 @@ final class UInt64
             throw new ParseError(sprintf('%s exceeds supported integer range.', $context));
         }
 
-        return (int) (($this->hi * self::UINT32_BASE) + $this->lo);
+        return ($this->hi * self::UINT32_BASE) + $this->lo;
     }
 
     /**


### PR DESCRIPTION
## Overview
- address PHPStan warnings about redundant integer casts in the UInt64 helper

## Details
- rely on the native integer result of `intdiv()` for the high 32-bit component
- return the combined signed integer without superfluous casting after range checks

## Tests
- `.build/bin/phpstan analyse src/Core/Util/UInt64.php --configuration .build/phpstan.neon --memory-limit=-1`

## Risks
- Low; touches only the UInt64 conversion helpers.

## Changelog
- n/a

## References
- None

## Closes
- Closes #N/A

------
https://chatgpt.com/codex/tasks/task_e_69022d4fee188323b13723542cb5ecf4