### PR TITLE
Fix PHPStan typing across metadata extractors

### DIFF
--- a/src/Model/Mpf/MpfAttributes.php
+++ b/src/Model/Mpf/MpfAttributes.php
@@ -12,11 +12,10 @@ declare(strict_types=1);
 namespace MagicSunday\ImageMeta\Model\Mpf;
 
 /**
- * @phpstan-type MpfRational array{numerator:int, denominator:int}
- * @phpstan-type MpfAttributeValue int|string|list<int>|MpfRational|list<MpfRational>
- */
-/**
  * Represents optional MP Attribute IFD fields describing the image set.
+ *
+ * @phpstan-type MpfRational = array{numerator:int, denominator:int}
+ * @phpstan-type MpfAttributeValue = int|string|list<int>|MpfRational|list<MpfRational>
  */
 final readonly class MpfAttributes
 {

--- a/src/Model/Xmp/XmpDocument.php
+++ b/src/Model/Xmp/XmpDocument.php
@@ -61,10 +61,6 @@ final readonly class XmpDocument
         }
 
         foreach ($value as $element) {
-            if (!is_string($element)) {
-                continue;
-            }
-
             $trimmed = trim($element);
             if ($trimmed !== '') {
                 return $trimmed;

--- a/src/Parse/IsoBmff/IsoBmffExtractor.php
+++ b/src/Parse/IsoBmff/IsoBmffExtractor.php
@@ -47,6 +47,9 @@ use function trim;
  * EXIF 3.0 §4.8 outlines embedding Exif items in ISO BMFF containers through
  * the `Exif` box and item metadata; EXIF 2.32 §4.8 describes the legacy rules
  * retained for backwards compatibility.
+ *
+ * @phpstan-type QuickTimeValue = string|int|float|bool
+ * @phpstan-type QuickTimeKeyMap = array<string, QuickTimeValue>
  */
 final readonly class IsoBmffExtractor
 {
@@ -266,7 +269,7 @@ final readonly class IsoBmffExtractor
      * @param list<string>          $exifBlobs
      * @param list<string>          $xmpBlobs
      * @param array<string, bool>   $xmpHashes
-     * @param array<string, string> $qtKeys
+     * @param QuickTimeKeyMap $qtKeys
      */
     private function parseMoovBox(BoxDescriptor $moov, array &$exifBlobs, array &$xmpBlobs, array &$qtKeys, array &$xmpHashes): void
     {
@@ -286,7 +289,7 @@ final readonly class IsoBmffExtractor
      *
      * @param BoxDescriptor $ftyp Box descriptor representing the file type declaration.
      *
-     * @return array<string, string|int>
+     * @return QuickTimeKeyMap
      */
     private function parseFtyp(BoxDescriptor $ftyp): array
     {
@@ -319,7 +322,7 @@ final readonly class IsoBmffExtractor
      * @param list<string>          $exifBlobs
      * @param list<string>          $xmpBlobs
      * @param array<string, bool>   $xmpHashes
-     * @param array<string, string> $qtKeys
+     * @param QuickTimeKeyMap $qtKeys
      */
     private function parseUdtaBox(BoxDescriptor $udta, array &$exifBlobs, array &$xmpBlobs, array &$qtKeys, array &$xmpHashes): void
     {
@@ -335,7 +338,7 @@ final readonly class IsoBmffExtractor
      *
      * @param BoxDescriptor $trak Box descriptor for the track container.
      *
-     * @return array<string, string|int>
+     * @return QuickTimeKeyMap
      */
     private function parseTrak(BoxDescriptor $trak): array
     {
@@ -666,7 +669,7 @@ final readonly class IsoBmffExtractor
      * @param list<string>          $exifBlobs
      * @param list<string>          $xmpBlobs
      * @param array<string, bool>   $xmpHashes
-     * @param array<string, string> $qtKeys
+     * @param QuickTimeKeyMap $qtKeys
      */
     private function parseMetaBox(BoxDescriptor $meta, array &$exifBlobs, array &$xmpBlobs, array &$qtKeys, array &$xmpHashes): void
     {
@@ -865,11 +868,11 @@ final readonly class IsoBmffExtractor
     }
 
     /**
-     * @param array<string, string>    $existing
+     * @param QuickTimeKeyMap          $existing
      * @param list<array<int, string>> $keysMaps
      * @param list<BoxDescriptor>      $ilstBoxes
      *
-     * @return array<string, string>
+     * @return QuickTimeKeyMap
      */
     private function mergeQuickTimeKeys(array $existing, array $keysMaps, array $ilstBoxes): array
     {
@@ -1213,7 +1216,7 @@ final readonly class IsoBmffExtractor
      * @param BoxDescriptor      $ilst     Box descriptor for the `ilst` container.
      * @param array<int, string> $keyIndex
      *
-     * @return array<string, string>
+     * @return QuickTimeKeyMap
      */
     private function parseIlst(BoxDescriptor $ilst, array $keyIndex): array
     {
@@ -1328,10 +1331,10 @@ final readonly class IsoBmffExtractor
     /**
      * Merges two associative arrays while keeping values from the right-hand side.
      *
-     * @param array<string, string> $left
-     * @param array<string, string> $right
+     * @param QuickTimeKeyMap $left
+     * @param QuickTimeKeyMap $right
      *
-     * @return array<string, string>
+     * @return QuickTimeKeyMap
      */
     private function mergeAssociative(array $left, array $right): array
     {

--- a/src/Parse/Jpeg/JpegExtractor.php
+++ b/src/Parse/Jpeg/JpegExtractor.php
@@ -633,7 +633,8 @@ final class JpegExtractor
             throw new ParseError(sprintf('Audio segment at offset %d has invalid sample rate field', $offset));
         }
 
-        $sampleRate = (int) $sampleRateUnpack['rate'];
+        /** @var array{rate:int} $sampleRateUnpack */
+        $sampleRate = $sampleRateUnpack['rate'];
         $bitDepth   = ord($payload[$signatureLength + 8]);
 
         $sampleCountData = substr($payload, $signatureLength + 9, 4);
@@ -642,7 +643,8 @@ final class JpegExtractor
             throw new ParseError(sprintf('Audio segment at offset %d has invalid sample count field', $offset));
         }
 
-        $sampleCount = (int) $sampleCountUnpack['count'];
+        /** @var array{count:int} $sampleCountUnpack */
+        $sampleCount = $sampleCountUnpack['count'];
         $data        = substr($payload, self::AUDIO_HEADER_LENGTH);
 
         if ($channels === 0 || $channels > 2) {
@@ -684,7 +686,7 @@ final class JpegExtractor
         if ($sampleCount > 0 && $format !== self::AUDIO_FORMAT_IMA_ADPCM) {
             $bytesPerSample = (int) (($bitDepth / 8) * $channels);
             if ($bytesPerSample > 0) {
-                $expectedLength = (int) ($sampleCount * $bytesPerSample);
+                $expectedLength = $sampleCount * $bytesPerSample;
                 if ($expectedLength !== strlen($data)) {
                     throw new ParseError(sprintf('Audio segment at offset %d has inconsistent data length', $offset));
                 }
@@ -742,9 +744,10 @@ final class JpegExtractor
             throw new ParseError(sprintf('Unable to parse FlashPix segment header at offset %d', $offset));
         }
 
-        $streamId = (int) $unpacked['stream'];
-        $sequenceNumber = (int) $unpacked['sequence'];
-        $sequenceCount = (int) $unpacked['count'];
+        /** @var array{stream:int, sequence:int, count:int} $unpacked */
+        $streamId = $unpacked['stream'];
+        $sequenceNumber = $unpacked['sequence'];
+        $sequenceCount = $unpacked['count'];
         $data = substr($payload, $signatureLength + 4);
 
         if ($sequenceNumber === 0 || $sequenceCount === 0 || $sequenceNumber > $sequenceCount) {


### PR DESCRIPTION
## Overview
- align PHPStan type aliases for MPF attributes and QuickTime metadata helpers
- refine JPEG audio parsing annotations and XMP document iteration guards

## Details
- embed MPF attribute type aliases directly on the model to expose them to PHPStan
- add `QuickTimeValue`/`QuickTimeKeyMap` aliases and reuse them across ISO BMFF helper docs
- document unpacked array shapes in `JpegExtractor` audio and FlashPix handlers to avoid mixed casts
- drop redundant runtime string checks in `XmpDocument::string()` now that the parser guarantees string lists

## Tests
- `composer ci:test:php:phpstan` *(fails: existing violations outside the touched classes)*

## Risks
- Low: adjustments are limited to docblocks, type metadata, and defensive checks.

## Changelog
- n/a

## References
- n/a

Closes #N/A

------
https://chatgpt.com/codex/tasks/task_e_690230e105388323a5c5811d8bc8bc4e