### PR TITLE
Fix PHPStan issues in test support helpers

### DIFF
--- a/docs/phpstan-follow-up.md
+++ b/docs/phpstan-follow-up.md
@@ -9,3 +9,16 @@ PHPUNIT
 2. Capture the console output and identify every failing test, including file paths and failure messages.
 3. For each failure, implement the necessary fixes in the relevant source or test files while adhering to the repository’s PHP 8.4+ conventions.
 4. Rerun the PHPUnit command until it exits successfully, and document the resolved failures.
+
+## Follow-up tasks
+
+### tests/Support/ExifExpectationAssertions.php
+- [x] Resolve `missingType.iterableValue` for `$expected` parameter at `tests/Support/ExifExpectationAssertions.php:48` by providing explicit array shape annotations recognised by PHPStan.
+- [x] Resolve `method.dynamicName` reported at `tests/Support/ExifExpectationAssertions.php:120` by replacing dynamic EXIF document lookups with typed callables.
+- [x] Resolve `missingType.iterableValue` for `$expected` parameter at `tests/Support/ExifExpectationAssertions.php:205` by documenting the array shape consumed by `assertModelMatches()`.
+
+### tests/Support/GpsTiffBuilder.php
+- [x] Resolve `switch.type` raised at `tests/Support/GpsTiffBuilder.php:88` by constraining the definition modes and removing unreachable branches.
+- [x] Resolve `argument.type` diagnostics at `tests/Support/GpsTiffBuilder.php:89-94` by introducing typed payload definitions and validating mode-specific payloads.
+- [x] Resolve `foreach.nonIterable` at `tests/Support/GpsTiffBuilder.php:103` through explicit rational payload validation.
+- [x] Resolve `offsetAccess.nonOffsetAccessible` and `return.type` at `tests/Support/GpsTiffBuilder.php:157` by asserting unpack results and throwing a `LogicException` when packing fails.

--- a/tests/Support/ExifExpectationAssertions.php
+++ b/tests/Support/ExifExpectationAssertions.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace MagicSunday\ImageMeta\Tests\Support;
 
 use MagicSunday\ImageMeta\Api\ExifDocument as ApiExifDocument;
+use MagicSunday\ImageMeta\Curate\Exif\Structured\Preview as StructuredPreview;
 use MagicSunday\ImageMeta\Model\Exif\ExifDocument as ModelExifDocument;
 use MagicSunday\ImageMeta\Model\Metadata;
-use MagicSunday\ImageMeta\Curate\Exif\Structured\Preview as StructuredPreview;
 use MagicSunday\ImageMeta\Value\Preview as PreviewValue;
 use PHPUnit\Framework\Assert;
 
@@ -17,32 +17,61 @@ use PHPUnit\Framework\Assert;
 trait ExifExpectationAssertions
 {
     /**
-     * @param Metadata $metadata
      * @param array{
-     *     standards: array{exifVersion:?string, profile:?string, flashpixVersion:?string, tiffEpStandardId:?array, tiffEpStandardString:?string},
-     *     exposure: array{iso:?int},
-     *     capture: array{dateTimeOriginal:?string, offsetTimeOriginal:?string, subSecTimeOriginal:?string},
-     *     image: array{userComment:?string, userCommentEncoding:?string},
-     *     interop: array{index:?string, version:?string, fileFormat:?string, width:?int, length:?int},
-     *     preview: array{
-     *         hasThumbnail:?bool,
-     *         hasPreview:?bool,
-     *         previewOffset:?int,
-     *         previewLength:?int,
-     *         previewWidth:?int,
-     *         previewHeight:?int,
-     *         previewBitDepth:?int,
-     *         previewCompression:?int,
-     *         previewCompressionName:?string,
-     *         previewColorSpace:?int,
-     *         previewColorSpaceName:?string,
-     *         previewEncoding:?string,
-     *         previewMimeType:?string,
-     *         previewScale:?float,
+     *     standards: array{
+     *         exifVersion: string|null,
+     *         profile: string|null,
+     *         flashpixVersion: string|null,
+     *         tiffEpStandardId: array<int, int>|null,
+     *         tiffEpStandardString: string|null,
      *     },
-     *     makerNotes:?array{vendor:string,length:int,sha1:string,isSafe:?bool},
-     *     environment: array{temperatureC:?float, humidityPercent:?float, pressureHpa:?float},
-     *     sensor: array{spatialFrequencyResponse:?array},
+     *     exposure: array{iso: int|null},
+     *     capture: array{
+     *         dateTimeOriginal: string|null,
+     *         offsetTimeOriginal: string|null,
+     *         subSecTimeOriginal: string|null,
+     *     },
+     *     image: array{
+     *         userComment: string|null,
+     *         userCommentEncoding: string|null,
+     *     },
+     *     interop: array{
+     *         index: string|null,
+     *         version: string|null,
+     *         fileFormat: string|null,
+     *         width: int|null,
+     *         length: int|null,
+     *     },
+     *     preview: array{
+     *         hasThumbnail: bool|null,
+     *         hasPreview: bool|null,
+     *         previewOffset: int|null,
+     *         previewLength: int|null,
+     *         previewWidth: int|null,
+     *         previewHeight: int|null,
+     *         previewBitDepth: int|null,
+     *         previewCompression: int|null,
+     *         previewCompressionName: string|null,
+     *         previewColorSpace: int|null,
+     *         previewColorSpaceName: string|null,
+     *         previewEncoding: string|null,
+     *         previewMimeType: string|null,
+     *         previewScale: float|null,
+     *     },
+     *     makerNotes: array{
+     *         vendor: string,
+     *         length: int,
+     *         sha1: string,
+     *         isSafe: bool|null,
+     *     }|null,
+     *     environment: array{
+     *         temperatureC: float|null,
+     *         humidityPercent: float|null,
+     *         pressureHpa: float|null,
+     *     },
+     *     sensor: array{
+     *         spatialFrequencyResponse: array<array-key, mixed>|null,
+     *     },
      * } $expected
      */
     private static function assertStructuredMatches(string $fixture, Metadata $metadata, array $expected): void
@@ -109,15 +138,16 @@ trait ExifExpectationAssertions
 
         $expectedEnv = $expected['environment'];
         $raw = $metadata->exifDoc;
+        /** @var array<string, callable(ModelExifDocument): ?float> $environmentMatchers */
         $environmentMatchers = [
-            'temperatureC'    => 'temperatureCelsius',
-            'humidityPercent' => 'humidityPercent',
-            'pressureHpa'     => 'pressureHPa',
+            'temperatureC'    => static fn (ModelExifDocument $document): ?float => $document->temperatureCelsius(),
+            'humidityPercent' => static fn (ModelExifDocument $document): ?float => $document->humidityPercent(),
+            'pressureHpa'     => static fn (ModelExifDocument $document): ?float => $document->pressureHPa(),
         ];
 
-        foreach ($environmentMatchers as $key => $method) {
+        foreach ($environmentMatchers as $key => $resolver) {
             $expectedValue = $expectedEnv[$key];
-            $actualValue   = $raw?->$method();
+            $actualValue   = $raw !== null ? $resolver($raw) : null;
 
             if ($expectedValue === null) {
                 Assert::assertNull($actualValue, sprintf('%s: %s', $fixture, ucfirst($key)));
@@ -142,26 +172,32 @@ trait ExifExpectationAssertions
 
     /**
      * @param array{
-     *     iso:?int,
-     *     dateTimeOriginal:?string,
-     *     userComment:?string,
-     *     userCommentEncoding:?string,
-     *     interop: array{index:?string, version:?string, fileFormat:?string, width:?int, length:?int},
+     *     iso: int|null,
+     *     dateTimeOriginal: string|null,
+     *     userComment: string|null,
+     *     userCommentEncoding: string|null,
+     *     interop: array{
+     *         index: string|null,
+     *         version: string|null,
+     *         fileFormat: string|null,
+     *         width: int|null,
+     *         length: int|null,
+     *     },
      *     preview: array{
-     *         hasThumbnail:?bool,
-     *         hasPreview:?bool,
-     *         previewOffset:?int,
-     *         previewLength:?int,
-     *         previewWidth:?int,
-     *         previewHeight:?int,
-     *         previewBitDepth:?int,
-     *         previewCompression:?int,
-     *         previewCompressionName:?string,
-     *         previewColorSpace:?int,
-     *         previewColorSpaceName:?string,
-     *         previewEncoding:?string,
-     *         previewMimeType:?string,
-     *         previewScale:?float,
+     *         hasThumbnail: bool|null,
+     *         hasPreview: bool|null,
+     *         previewOffset: int|null,
+     *         previewLength: int|null,
+     *         previewWidth: int|null,
+     *         previewHeight: int|null,
+     *         previewBitDepth: int|null,
+     *         previewCompression: int|null,
+     *         previewCompressionName: string|null,
+     *         previewColorSpace: int|null,
+     *         previewColorSpaceName: string|null,
+     *         previewEncoding: string|null,
+     *         previewMimeType: string|null,
+     *         previewScale: float|null,
      *     },
      * } $expected
      */
@@ -195,11 +231,11 @@ trait ExifExpectationAssertions
 
     /**
      * @param array{
-     *     exifVersion:?string,
-     *     exifProfile:string,
-     *     flashpixVersion:?string,
-     *     tiffEpStandardId:?array,
-     *     tiffEpStandardString:?string,
+     *     exifVersion: string|null,
+     *     exifProfile: string,
+     *     flashpixVersion: string|null,
+     *     tiffEpStandardId: array<int, int>|null,
+     *     tiffEpStandardString: string|null,
      * } $expected
      */
     private static function assertModelMatches(string $fixture, ?ModelExifDocument $document, array $expected): void
@@ -215,20 +251,20 @@ trait ExifExpectationAssertions
 
     /**
      * @param array{
-     *     hasThumbnail:?bool,
-     *     hasPreview:?bool,
-     *     previewOffset:?int,
-     *     previewLength:?int,
-     *     previewWidth:?int,
-     *     previewHeight:?int,
-     *     previewBitDepth:?int,
-     *     previewCompression:?int,
-     *     previewCompressionName:?string,
-     *     previewColorSpace:?int,
-     *     previewColorSpaceName:?string,
-     *     previewEncoding:?string,
-     *     previewMimeType:?string,
-     *     previewScale:?float,
+     *     hasThumbnail: bool|null,
+     *     hasPreview: bool|null,
+     *     previewOffset: int|null,
+     *     previewLength: int|null,
+     *     previewWidth: int|null,
+     *     previewHeight: int|null,
+     *     previewBitDepth: int|null,
+     *     previewCompression: int|null,
+     *     previewCompressionName: string|null,
+     *     previewColorSpace: int|null,
+     *     previewColorSpaceName: string|null,
+     *     previewEncoding: string|null,
+     *     previewMimeType: string|null,
+     *     previewScale: float|null,
      * } $expected
      */
     private static function assertPreviewMatches(string $fixture, array $expected, PreviewValue|StructuredPreview $preview): void

--- a/tests/Support/GpsTiffBuilder.php
+++ b/tests/Support/GpsTiffBuilder.php
@@ -11,10 +11,13 @@ declare(strict_types=1);
 
 namespace MagicSunday\ImageMeta\Tests\Support;
 
+use LogicException;
 use MagicSunday\ImageMeta\Model\Exif\ExifTag;
 
 use function array_map;
 use function array_pad;
+use function chr;
+use function implode;
 use function ord;
 use function pack;
 use function str_split;
@@ -23,6 +26,11 @@ use function unpack;
 
 /**
  * Builds synthetic Classic TIFF payloads containing EXIF GPS metadata for integration tests.
+ *
+ * @phpstan-type GpsStringDefinition = array{tag: int, type: int, count: positive-int, mode: 'string', payload: string}
+ * @phpstan-type GpsRationalDefinition = array{tag: int, type: int, count: positive-int, mode: 'rationals', payload: list<array{numerator: int, denominator: int}>}
+ * @phpstan-type GpsInlineDefinition = array{tag: int, type: int, count: positive-int, mode: 'inline', payload: int}
+ * @phpstan-type GpsDefinition = GpsStringDefinition|GpsRationalDefinition|GpsInlineDefinition
  */
 final class GpsTiffBuilder
 {
@@ -41,33 +49,9 @@ final class GpsTiffBuilder
             . self::packClassicEntry(ExifTag::GPS_IFD_POINTER, 4, 1, $gpsIfdOffset)
             . pack('V', 0);
 
-        $definitions = [
-            [ExifTag::GPS_VERSION_ID, 2, 9, 'string', '3.0.0.0' . chr(0)],
-            [ExifTag::GPS_LATITUDE_REF, 2, 2, 'string', "N\0"],
-            [ExifTag::GPS_LATITUDE, 5, 3, 'rationals', [[51, 1], [30, 1], [0, 1]]],
-            [ExifTag::GPS_LONGITUDE_REF, 2, 2, 'string', "E\0"],
-            [ExifTag::GPS_LONGITUDE, 5, 3, 'rationals', [[8, 1], [30, 1], [0, 1]]],
-            [ExifTag::GPS_ALTITUDE_REF, 1, 1, 'inline', 0],
-            [ExifTag::GPS_ALTITUDE, 5, 1, 'rationals', [[150, 1]]],
-            [ExifTag::GPS_TIME_STAMP, 5, 3, 'rationals', [[12, 1], [34, 1], [56789, 1000]]],
-            [ExifTag::GPS_DATE_STAMP, 2, 11, 'string', "2024:05:06\0"],
-            [ExifTag::GPS_SPEED_REF, 2, 2, 'string', "K\0"],
-            [ExifTag::GPS_SPEED, 5, 1, 'rationals', [[72000, 1000]]],
-            [ExifTag::GPS_TRACK_REF, 2, 2, 'string', "T\0"],
-            [ExifTag::GPS_TRACK, 5, 1, 'rationals', [[450, 1]]],
-            [ExifTag::GPS_IMG_DIRECTION_REF, 2, 2, 'string', "M\0"],
-            [ExifTag::GPS_IMG_DIRECTION, 5, 1, 'rationals', [[405, 1]]],
-            [ExifTag::GPS_DEST_LATITUDE_REF, 2, 2, 'string', "N\0"],
-            [ExifTag::GPS_DEST_LATITUDE, 5, 3, 'rationals', [[41, 1], [0, 1], [0, 1]]],
-            [ExifTag::GPS_DEST_LONGITUDE_REF, 2, 2, 'string', "E\0"],
-            [ExifTag::GPS_DEST_LONGITUDE, 5, 3, 'rationals', [[8, 1], [30, 1], [0, 1]]],
-            [ExifTag::GPS_DEST_BEARING_REF, 2, 2, 'string', "T\0"],
-            [ExifTag::GPS_DEST_BEARING, 5, 1, 'rationals', [[765, 1]]],
-            [ExifTag::GPS_DEST_DISTANCE_REF, 2, 2, 'string', "K\0"],
-            [ExifTag::GPS_DEST_DISTANCE, 5, 1, 'rationals', [[42, 1]]],
-            [ExifTag::GPS_DIFFERENTIAL, 3, 1, 'inline', 2],
-            [ExifTag::GPS_H_POSITIONING_ERROR, 5, 1, 'rationals', [[15, 10]]],
-        ];
+        $definitions = self::gpsDefinitions();
+        /** @var list<GpsDefinition> $definitions */
+        $definitions = $definitions;
 
         $gpsEntryCount = count($definitions);
         $gpsIfdSize    = 2 + ($gpsEntryCount * 12) + 4;
@@ -83,13 +67,22 @@ final class GpsTiffBuilder
             return $offset;
         };
 
-        foreach ($definitions as [$tag, $type, $count, $mode, $payload]) {
+        foreach ($definitions as $definition) {
+            /** @var GpsDefinition $definition */
+            $definition = $definition;
+
+            $tag = $definition['tag'];
+            $type = $definition['type'];
+            $count = $definition['count'];
+            $mode = $definition['mode'];
+            $payload = $definition['payload'];
+
             switch ($mode) {
-                case 'bytes':
-                    $value        = self::inlineBytes($payload);
-                    $gpsEntries[] = self::packClassicEntry($tag, $type, $count, $value);
-                    break;
                 case 'string':
+                    if (!is_string($payload)) {
+                        throw new LogicException('String payload expected.');
+                    }
+
                     if (strlen($payload) <= 4) {
                         $gpsEntries[] = self::packClassicEntry($tag, $type, $count, self::inlineString($payload));
                         break;
@@ -99,16 +92,25 @@ final class GpsTiffBuilder
                     $gpsEntries[] = self::packClassicEntry($tag, $type, $count, $offset);
                     break;
                 case 'rationals':
+                    if (!is_array($payload)) {
+                        throw new LogicException('Rational payload expected.');
+                    }
+
+                    /** @var list<array{numerator: int, denominator: int}> $payload */
                     $buffer = '';
-                    foreach ($payload as [$numerator, $denominator]) {
-                        $buffer .= self::packRational($numerator, $denominator);
+                    foreach ($payload as $components) {
+                        $buffer .= self::packRational($components['numerator'], $components['denominator']);
                     }
 
                     $offset       = $addData($buffer);
                     $gpsEntries[] = self::packClassicEntry($tag, $type, $count, $offset);
                     break;
                 case 'inline':
-                    $gpsEntries[] = self::packClassicEntry($tag, $type, $count, (int) $payload);
+                    if (!is_int($payload)) {
+                        throw new LogicException('Inline payload expected to be integer.');
+                    }
+
+                    $gpsEntries[] = self::packClassicEntry($tag, $type, $count, $payload);
                     break;
             }
         }
@@ -116,6 +118,125 @@ final class GpsTiffBuilder
         $gpsIfd = pack('v', $gpsEntryCount) . implode('', $gpsEntries) . pack('V', 0);
 
         return $header . $ifd0 . $gpsIfd . $gpsData;
+    }
+
+    /**
+     * @phpstan-return list<GpsDefinition>
+     */
+    private static function gpsDefinitions(): array
+    {
+        return [
+            self::stringDefinition(ExifTag::GPS_VERSION_ID, 2, 9, '3.0.0.0' . chr(0)),
+            self::stringDefinition(ExifTag::GPS_LATITUDE_REF, 2, 2, "N\0"),
+            self::rationalDefinition(ExifTag::GPS_LATITUDE, 5, 3, [
+                ['numerator' => 51, 'denominator' => 1],
+                ['numerator' => 30, 'denominator' => 1],
+                ['numerator' => 0, 'denominator' => 1],
+            ]),
+            self::stringDefinition(ExifTag::GPS_LONGITUDE_REF, 2, 2, "E\0"),
+            self::rationalDefinition(ExifTag::GPS_LONGITUDE, 5, 3, [
+                ['numerator' => 8, 'denominator' => 1],
+                ['numerator' => 30, 'denominator' => 1],
+                ['numerator' => 0, 'denominator' => 1],
+            ]),
+            self::inlineDefinition(ExifTag::GPS_ALTITUDE_REF, 1, 1, 0),
+            self::rationalDefinition(ExifTag::GPS_ALTITUDE, 5, 1, [
+                ['numerator' => 150, 'denominator' => 1],
+            ]),
+            self::rationalDefinition(ExifTag::GPS_TIME_STAMP, 5, 3, [
+                ['numerator' => 12, 'denominator' => 1],
+                ['numerator' => 34, 'denominator' => 1],
+                ['numerator' => 56789, 'denominator' => 1000],
+            ]),
+            self::stringDefinition(ExifTag::GPS_DATE_STAMP, 2, 11, "2024:05:06\0"),
+            self::stringDefinition(ExifTag::GPS_SPEED_REF, 2, 2, "K\0"),
+            self::rationalDefinition(ExifTag::GPS_SPEED, 5, 1, [
+                ['numerator' => 72000, 'denominator' => 1000],
+            ]),
+            self::stringDefinition(ExifTag::GPS_TRACK_REF, 2, 2, "T\0"),
+            self::rationalDefinition(ExifTag::GPS_TRACK, 5, 1, [
+                ['numerator' => 450, 'denominator' => 1],
+            ]),
+            self::stringDefinition(ExifTag::GPS_IMG_DIRECTION_REF, 2, 2, "M\0"),
+            self::rationalDefinition(ExifTag::GPS_IMG_DIRECTION, 5, 1, [
+                ['numerator' => 405, 'denominator' => 1],
+            ]),
+            self::stringDefinition(ExifTag::GPS_DEST_LATITUDE_REF, 2, 2, "N\0"),
+            self::rationalDefinition(ExifTag::GPS_DEST_LATITUDE, 5, 3, [
+                ['numerator' => 41, 'denominator' => 1],
+                ['numerator' => 0, 'denominator' => 1],
+                ['numerator' => 0, 'denominator' => 1],
+            ]),
+            self::stringDefinition(ExifTag::GPS_DEST_LONGITUDE_REF, 2, 2, "E\0"),
+            self::rationalDefinition(ExifTag::GPS_DEST_LONGITUDE, 5, 3, [
+                ['numerator' => 8, 'denominator' => 1],
+                ['numerator' => 30, 'denominator' => 1],
+                ['numerator' => 0, 'denominator' => 1],
+            ]),
+            self::stringDefinition(ExifTag::GPS_DEST_BEARING_REF, 2, 2, "T\0"),
+            self::rationalDefinition(ExifTag::GPS_DEST_BEARING, 5, 1, [
+                ['numerator' => 765, 'denominator' => 1],
+            ]),
+            self::stringDefinition(ExifTag::GPS_DEST_DISTANCE_REF, 2, 2, "K\0"),
+            self::rationalDefinition(ExifTag::GPS_DEST_DISTANCE, 5, 1, [
+                ['numerator' => 42, 'denominator' => 1],
+            ]),
+            self::inlineDefinition(ExifTag::GPS_DIFFERENTIAL, 3, 1, 2),
+            self::rationalDefinition(ExifTag::GPS_H_POSITIONING_ERROR, 5, 1, [
+                ['numerator' => 15, 'denominator' => 10],
+            ]),
+        ];
+    }
+
+    /**
+     * @phpstan-param positive-int $count
+     * @param list<array{numerator: int, denominator: int}> $payload
+     *
+     * @phpstan-return GpsRationalDefinition
+     */
+    private static function rationalDefinition(int $tag, int $type, int $count, array $payload): array
+    {
+        return [
+            'tag'     => $tag,
+            'type'    => $type,
+            'count'   => $count,
+            'mode'    => 'rationals',
+            'payload' => $payload,
+        ];
+    }
+
+    /**
+     * @phpstan-param positive-int $count
+     * @param string $payload
+     *
+     * @phpstan-return GpsStringDefinition
+     */
+    private static function stringDefinition(int $tag, int $type, int $count, string $payload): array
+    {
+        return [
+            'tag'     => $tag,
+            'type'    => $type,
+            'count'   => $count,
+            'mode'    => 'string',
+            'payload' => $payload,
+        ];
+    }
+
+    /**
+     * @phpstan-param positive-int $count
+     * @param int $payload
+     *
+     * @phpstan-return GpsInlineDefinition
+     */
+    private static function inlineDefinition(int $tag, int $type, int $count, int $payload): array
+    {
+        return [
+            'tag'     => $tag,
+            'type'    => $type,
+            'count'   => $count,
+            'mode'    => 'inline',
+            'payload' => $payload,
+        ];
     }
 
     /**
@@ -142,18 +263,29 @@ final class GpsTiffBuilder
      */
     private static function inlineString(string $value): int
     {
-        return self::inlineBytes(array_map(ord(...), str_split($value)));
+        /** @var list<int<0, 255>> $bytes */
+        $bytes = array_map(ord(...), str_split($value));
+
+        return self::inlineBytes($bytes);
     }
 
     /**
      * Converts up to four bytes into an inline DWORD representation.
      *
-     * @param array<int> $bytes
+     * @param list<int<0, 255>> $bytes
      */
     private static function inlineBytes(array $bytes): int
     {
         $bytes = array_pad($bytes, 4, 0);
+        /** @var list<int<0, 255>> $bytes */
+        $bytes = $bytes;
 
-        return unpack('V', pack('C4', $bytes[0], $bytes[1], $bytes[2], $bytes[3]))[1];
+        $packed = unpack('V', pack('C4', $bytes[0], $bytes[1], $bytes[2], $bytes[3]));
+        if ($packed === false) {
+            throw new LogicException('Unable to unpack inline bytes.');
+        }
+
+        /** @var array<int, int> $packed */
+        return $packed[1];
     }
 }


### PR DESCRIPTION
## Summary
- tighten the array shape documentation in ExifExpectationAssertions to satisfy PHPStan
- refactor GpsTiffBuilder definitions to use typed helper factories and runtime guards
- record resolved PHPStan diagnostics for the support utilities in docs/phpstan-follow-up.md

## Testing
- .build/bin/phpstan analyse --configuration .build/phpstan.neon tests/Support/ExifExpectationAssertions.php tests/Support/GpsTiffBuilder.php

------
https://chatgpt.com/codex/tasks/task_e_690233ed667883238b2b7c0e0c99ebad