### PR TITLE
Fix resource handling in FormatDetector tests

### DIFF
--- a/tests/Detect/FormatDetector/FormatDetectorTest.php
+++ b/tests/Detect/FormatDetector/FormatDetectorTest.php
@@ -104,9 +104,22 @@ final class FormatDetectorTest extends TestCase
     private function createStream(string $bytes): Stream
     {
         $handle = fopen('php://temp', 'w+b');
-        fwrite($handle, $bytes);
-        rewind($handle);
 
-        return new Stream($handle, strlen($bytes));
+        if ($handle === false) {
+            self::fail('Unable to create temporary stream resource.');
+        }
+
+        $length = strlen($bytes);
+        $written = fwrite($handle, $bytes);
+
+        if ($written === false || $written !== $length) {
+            self::fail('Unable to write bytes to temporary stream resource.');
+        }
+
+        if (rewind($handle) === false) {
+            self::fail('Unable to rewind temporary stream resource.');
+        }
+
+        return new Stream($handle, $length);
     }
 }


### PR DESCRIPTION
## Overview
- ensure the FormatDetector tests open in-memory streams safely for PHPStan

## Details
- guard temporary stream creation, writing, and rewinding to guarantee resource types

## Tests
- `composer ci:test:php:phpstan` *(fails: existing repository-wide PHPStan issues outside tests/Detect)*
- `.build/bin/phpstan analyse tests/Detect --configuration .build/phpstan.neon`

## Risks
- Low

## Changelog
- n/a

## References
- None

Closes #N/A

------
https://chatgpt.com/codex/tasks/task_e_690234361b548323853e8b790985d7bb