### PR TITLE
test(model): satisfy phpstan in model tests

### DIFF
--- a/tests/Model/Exif/ExifDocumentTest.php
+++ b/tests/Model/Exif/ExifDocumentTest.php
@@ -156,12 +156,54 @@ final class ExifDocumentTest extends TestCase
         self::assertNotNull($capture);
         self::assertSame('2024-05-01T12:34:56.123+02:00', $capture->format(self::ISO_8601_MILLISECONDS));
 
+        /**
+         * @var array{
+         *     lat_ref:?string,
+         *     lat:?float,
+         *     lon_ref:?string,
+         *     lon:?float,
+         *     alt_ref:?int,
+         *     alt:?float,
+         *     version:?string,
+         *     version_raw:?string,
+         *     satellites:?string,
+         *     status:?string,
+         *     measure_mode:?string,
+         *     dop:?float,
+         *     speed_ref:?string,
+         *     speed_ms:?float,
+         *     speed_original_ref:?string,
+         *     speed_original:?float,
+         *     track_ref:?string,
+         *     track:?float,
+         *     img_direction_ref:?string,
+         *     img_direction:?float,
+         *     map_datum:?string,
+         *     dest_lat_ref:?string,
+         *     dest_lat:?float,
+         *     dest_lon_ref:?string,
+         *     dest_lon:?float,
+         *     dest_bearing_ref:?string,
+         *     dest_bearing:?float,
+         *     dest_distance_ref:?string,
+         *     dest_distance_m:?float,
+         *     dest_distance_original_ref:?string,
+         *     dest_distance_original:?float,
+         *     processing_method:?string,
+         *     area_information:?string,
+         *     date:?string,
+         *     date_raw:?string,
+         *     time:?string,
+         *     timestamp:?DateTimeImmutable,
+         *     differential:?int,
+         *     h_positioning_error:?float
+         * } $gps
+         */
         $gps = $doc->gps();
         self::assertEqualsWithDelta(40.441666, $gps['lat'], 0.000001);
         self::assertEqualsWithDelta(79.983333, $gps['lon'], 0.000001);
         self::assertEquals(123.0, $gps['alt']);
         self::assertSame('2.0.0.0', $gps['version']);
-        self::assertArrayHasKey('version_raw', $gps);
         self::assertNull($gps['version_raw']);
     }
 
@@ -1468,7 +1510,6 @@ final class ExifDocumentTest extends TestCase
 
         $vector = $doc->accelerationVector();
         self::assertNotNull($vector);
-        self::assertCount(3, $vector);
         self::assertEqualsWithDelta(0.0, $vector[0], 0.0001);
         self::assertEqualsWithDelta(0.0, $vector[1], 0.0001);
         self::assertEqualsWithDelta(9.8, $vector[2], 0.0001);

--- a/tests/Model/Exif/ExifTagTest.php
+++ b/tests/Model/Exif/ExifTagTest.php
@@ -102,10 +102,6 @@ final class ExifTagTest extends TestCase
             'ARTIST'                         => 0x013B,
             'WHITE_POINT'                    => 0x013E,
             'PRIMARY_CHROMATICITIES'         => 0x013F,
-            'TILE_WIDTH'                    => 0x0142,
-            'TILE_LENGTH'                   => 0x0143,
-            'TILE_OFFSETS'                  => 0x0144,
-            'TILE_BYTE_COUNTS'              => 0x0145,
             'JPEG_INTERCHANGE_FORMAT'        => 0x0201,
             'JPEG_INTERCHANGE_FORMAT_LENGTH' => 0x0202,
             'PREVIEW_IMAGE_START'            => 0xC51B,
@@ -297,7 +293,9 @@ final class ExifTagTest extends TestCase
      */
     public function testHostComputerConstantIsRetained(): void
     {
-        self::assertSame(0x013C, ExifTag::HOST_COMPUTER);
+        $constants = (new ReflectionClass(ExifTag::class))->getConstants();
+
+        self::assertSame(0x013C, $constants['HOST_COMPUTER'] ?? null);
     }
 
     /**
@@ -305,8 +303,10 @@ final class ExifTagTest extends TestCase
      */
     public function testSubfileTypeConstantsMatchSpecification(): void
     {
-        self::assertSame(0x00FE, ExifTag::NEW_SUBFILE_TYPE);
-        self::assertSame(0x00FF, ExifTag::SUBFILE_TYPE);
+        $constants = (new ReflectionClass(ExifTag::class))->getConstants();
+
+        self::assertSame(0x00FE, $constants['NEW_SUBFILE_TYPE'] ?? null);
+        self::assertSame(0x00FF, $constants['SUBFILE_TYPE'] ?? null);
     }
 
     /**
@@ -314,7 +314,12 @@ final class ExifTagTest extends TestCase
      */
     public function testModifyDateAliasMatchesDateTime(): void
     {
-        self::assertSame(ExifTag::DATETIME, ExifTag::MODIFY_DATE);
+        $constants = (new ReflectionClass(ExifTag::class))->getConstants();
+
+        self::assertSame(
+            $constants['DATETIME'] ?? null,
+            $constants['MODIFY_DATE'] ?? null,
+        );
     }
 
     /**
@@ -322,9 +327,11 @@ final class ExifTagTest extends TestCase
      */
     public function testIsoSpeedRatingsLegacyAliasMatchesPhotographicSensitivity(): void
     {
+        $constants = (new ReflectionClass(ExifTag::class))->getConstants();
+
         self::assertSame(
-            ExifTag::PHOTOGRAPHIC_SENSITIVITY,
-            ExifTag::ISO_SPEED_RATINGS_LEGACY
+            $constants['PHOTOGRAPHIC_SENSITIVITY'] ?? null,
+            $constants['ISO_SPEED_RATINGS_LEGACY'] ?? null,
         );
     }
 }

--- a/tests/Model/Exif/ValueConvertersTest.php
+++ b/tests/Model/Exif/ValueConvertersTest.php
@@ -189,7 +189,7 @@ final class ValueConvertersTest extends TestCase
     }
 
     /**
-     * @return iterable<string, array{ExifRational|string, float|null}>
+     * @return iterable<string, array{ExifRational|string|null, float|null}>
      */
     public static function provideApexValues(): iterable
     {
@@ -211,7 +211,7 @@ final class ValueConvertersTest extends TestCase
     }
 
     /**
-     * @return iterable<string, array{ExifRational|string, float|null}>
+     * @return iterable<string, array{ExifRational|string|null, float|null}>
      */
     public static function provideBatteryLevelValues(): iterable
     {
@@ -748,6 +748,7 @@ final class ValueConvertersTest extends TestCase
         self::assertNull(ValueConverters::toExifVersion("\x01\x02\x03\x04"));
 
         $flash = ValueConverters::flashFromShort(0x59);
+        self::assertInstanceOf(FlashInfo::class, $flash);
         self::assertTrue($flash->fired);
         self::assertSame(FlashMode::AUTO, $flash->mode);
         self::assertSame(FlashReturn::NO_STROBE_DETECTION, $flash->returnDetection);

--- a/tests/Model/Metadata/MetadataTest.php
+++ b/tests/Model/Metadata/MetadataTest.php
@@ -175,8 +175,9 @@ final class MetadataTest extends TestCase
 
         self::assertSame('primary-exif-blob', $metadata->exifBlobs[0]);
         self::assertSame('clip-42', $metadata->quickTime?->contentIdentifier());
-        self::assertSame('Fujifilm', $metadata->exifDoc?->cameraMake());
-        self::assertSame('X-T5', $metadata->exifDoc?->cameraModel());
+        self::assertNotNull($metadata->exifDoc);
+        self::assertSame('Fujifilm', $metadata->exifDoc->cameraMake());
+        self::assertSame('X-T5', $metadata->exifDoc->cameraModel());
         self::assertSame(
             '2024-06-01',
             $metadata->xmpDoc?->get('http://ns.adobe.com/photoshop/1.0/', 'DateCreated')

--- a/tests/Model/Xmp/XmpDocumentTest.php
+++ b/tests/Model/Xmp/XmpDocumentTest.php
@@ -57,7 +57,6 @@ XML;
         $subjects = $document->find('subject');
         self::assertIsArray($subjects);
         self::assertSame(['First', 'Second'], $subjects);
-        self::assertContainsOnlyString($subjects);
         self::assertNull($document->get(self::DC_NAMESPACE, 'title'));
     }
 


### PR DESCRIPTION
## Overview
- align model test fixtures with PHPStan's GPS field expectations
- remove redundant assertions and clarify data provider types to improve static analysis precision
- harden flash normalisation checks against null results and avoid nullsafe access on known objects

## Details
- document the full GPS field map in `ExifDocumentTest` and drop redundant vector count assertion
- deduplicate TILE* constants and query `ReflectionClass` in `ExifTagTest` to satisfy PHPStan
- allow nullable inputs in relevant data providers and assert `FlashInfo` instances before dereferencing
- make metadata assertions use non-null `ExifDocument` references and trim redundant XMP string assertions

## Tests
- `.build/bin/phpstan analyse tests/Model --configuration .build/phpstan.neon --memory-limit=-1 --error-format raw`

## Risks
- low; test-only adjustments to satisfy static analysis

## Changelog
- not required (test coverage only)

## References
- n/a

------
https://chatgpt.com/codex/tasks/task_e_6902343c5f908323bd3252487675dd68