### PR TITLE
test: guard temporary stream fixtures in core tests

### DIFF
--- a/tests/Core/BoundsError/BoundsErrorTest.php
+++ b/tests/Core/BoundsError/BoundsErrorTest.php
@@ -14,12 +14,10 @@ namespace MagicSunday\ImageMeta\Tests\Core\BoundsError;
 use MagicSunday\ImageMeta\Core\BoundsError;
 use MagicSunday\ImageMeta\Core\MemoryBuffer;
 use MagicSunday\ImageMeta\Core\Stream;
+use MagicSunday\ImageMeta\Tests\Core\CreatesTempStream;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
-use function fopen;
-use function fwrite;
-use function rewind;
 use function strlen;
 
 /**
@@ -27,6 +25,8 @@ use function strlen;
  */
 final class BoundsErrorTest extends TestCase
 {
+    use CreatesTempStream;
+
     /**
      * Attempts to read beyond the declared stream length to ensure the guard throws a descriptive BoundsError.
      */
@@ -35,11 +35,7 @@ final class BoundsErrorTest extends TestCase
     {
         $payload = 'meta';
 
-        $fh = fopen('php://temp', 'r+b');
-        fwrite($fh, $payload);
-        rewind($fh);
-
-        $stream = new Stream($fh, strlen($payload));
+        $stream = new Stream($this->createTempStream($payload), strlen($payload));
 
         $stream->read(4);
 

--- a/tests/Core/CreatesTempStream.php
+++ b/tests/Core/CreatesTempStream.php
@@ -1,0 +1,52 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\ImageMeta\Tests\Core;
+
+use PHPUnit\Framework\Assert;
+use function fopen;
+use function fwrite;
+use function rewind;
+use function strlen;
+
+/**
+ * Helper for creating temporary in-memory streams populated with fixture payloads.
+ */
+trait CreatesTempStream
+{
+    /**
+     * Creates a temporary stream populated with the provided payload.
+     *
+     * @param string $payload Bytes that should be written to the stream.
+     *
+     * @return resource Writable stream resource positioned at the beginning of the payload.
+     */
+    private function createTempStream(string $payload)
+    {
+        $handle = fopen('php://temp', 'r+b');
+
+        if ($handle === false) {
+            Assert::fail('Unable to create temporary stream.');
+        }
+
+        $written = fwrite($handle, $payload);
+
+        if ($written === false || $written !== strlen($payload)) {
+            Assert::fail('Unable to populate temporary stream.');
+        }
+
+        if (rewind($handle) === false) {
+            Assert::fail('Unable to rewind temporary stream.');
+        }
+
+        return $handle;
+    }
+}

--- a/tests/Core/ParseError/ParseErrorTest.php
+++ b/tests/Core/ParseError/ParseErrorTest.php
@@ -13,13 +13,11 @@ namespace MagicSunday\ImageMeta\Tests\Core\ParseError;
 
 use MagicSunday\ImageMeta\Core\ParseError;
 use MagicSunday\ImageMeta\Core\Stream;
+use MagicSunday\ImageMeta\Tests\Core\CreatesTempStream;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
-use function fopen;
-use function fwrite;
 use function restore_error_handler;
-use function rewind;
 use function set_error_handler;
 use function str_contains;
 use function sys_get_temp_dir;
@@ -30,17 +28,15 @@ use function uniqid;
  */
 final class ParseErrorTest extends TestCase
 {
+    use CreatesTempStream;
+
     /**
      * Declares a stream size larger than the written payload to force a short read ParseError.
      */
     #[Test]
     public function testStreamReadThrowsParseErrorOnShortRead(): void
     {
-        $fh = fopen('php://temp', 'r+b');
-        fwrite($fh, 'A');
-        rewind($fh);
-
-        $stream = new Stream($fh, 2);
+        $stream = new Stream($this->createTempStream('A'), 2);
 
         $this->expectException(ParseError::class);
         $this->expectExceptionMessage('short read');

--- a/tests/Core/Stream/StreamTest.php
+++ b/tests/Core/Stream/StreamTest.php
@@ -13,13 +13,11 @@ namespace MagicSunday\ImageMeta\Tests\Core\Stream;
 
 use MagicSunday\ImageMeta\Core\BoundsError;
 use MagicSunday\ImageMeta\Core\Stream;
+use MagicSunday\ImageMeta\Tests\Core\CreatesTempStream;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
-use function fopen;
-use function fwrite;
 use function pack;
-use function rewind;
 use function strlen;
 
 /**
@@ -27,6 +25,8 @@ use function strlen;
  */
 final class StreamTest extends TestCase
 {
+    use CreatesTempStream;
+
     /**
      * Ensures sequential big-endian integer reads advance the cursor as expected.
      */
@@ -37,11 +37,7 @@ final class StreamTest extends TestCase
             . pack('N', 0x10203040)
             . pack('N2', 0x01234567, 0x89ABCDEF);
 
-        $fh = fopen('php://temp', 'r+b');
-        fwrite($fh, $payload);
-        rewind($fh);
-
-        $stream = new Stream($fh, strlen($payload));
+        $stream = new Stream($this->createTempStream($payload), strlen($payload));
 
         self::assertSame(0, $stream->tell());
         self::assertSame(0xBEEF, $stream->readU16BE());
@@ -60,11 +56,7 @@ final class StreamTest extends TestCase
     {
         $payload = 'MagicSunday';
 
-        $fh = fopen('php://temp', 'r+b');
-        fwrite($fh, $payload);
-        rewind($fh);
-
-        $stream = new Stream($fh, strlen($payload));
+        $stream = new Stream($this->createTempStream($payload), strlen($payload));
 
         $chunk = $stream->read(5);
 
@@ -84,11 +76,7 @@ final class StreamTest extends TestCase
     {
         $payload = 'Image';
 
-        $fh = fopen('php://temp', 'r+b');
-        fwrite($fh, $payload);
-        rewind($fh);
-
-        $stream = new Stream($fh, strlen($payload));
+        $stream = new Stream($this->createTempStream($payload), strlen($payload));
 
         $stream->read(5);
 
@@ -104,11 +92,7 @@ final class StreamTest extends TestCase
     {
         $payload = 'Meta';
 
-        $fh = fopen('php://temp', 'r+b');
-        fwrite($fh, $payload);
-        rewind($fh);
-
-        $stream = new Stream($fh, strlen($payload));
+        $stream = new Stream($this->createTempStream($payload), strlen($payload));
 
         $this->expectException(BoundsError::class);
         $stream->seek(8);

--- a/tests/Core/StreamWindow/StreamWindowTest.php
+++ b/tests/Core/StreamWindow/StreamWindowTest.php
@@ -14,13 +14,11 @@ namespace MagicSunday\ImageMeta\Tests\Core\StreamWindow;
 use MagicSunday\ImageMeta\Core\BoundsError;
 use MagicSunday\ImageMeta\Core\Stream;
 use MagicSunday\ImageMeta\Core\StreamWindow;
+use MagicSunday\ImageMeta\Tests\Core\CreatesTempStream;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
-use function fopen;
-use function fwrite;
 use function pack;
-use function rewind;
 use function strlen;
 
 /**
@@ -28,6 +26,8 @@ use function strlen;
  */
 final class StreamWindowTest extends TestCase
 {
+    use CreatesTempStream;
+
     /**
      * Verifies that the window reports its configured length and initial cursor position.
      */
@@ -137,10 +137,6 @@ final class StreamWindowTest extends TestCase
      */
     private function createStream(string $payload): Stream
     {
-        $handle = fopen('php://temp', 'r+b');
-        fwrite($handle, $payload);
-        rewind($handle);
-
-        return new Stream($handle, strlen($payload));
+        return new Stream($this->createTempStream($payload), strlen($payload));
     }
 }


### PR DESCRIPTION
## Overview
- add a reusable helper that guarantees tmp streams are writable before test usage
- adopt the helper across core stream-oriented tests to satisfy PHPStan resource assertions

## Details
- introduce `CreatesTempStream` trait that validates stream creation, population, and rewinding
- update BoundsError, ParseError, Stream, and StreamWindow tests to consume the helper instead of raw handles

## Tests
- `composer ci:test:php:phpstan -- --error-format=raw | grep "tests/Core" -n`

## Risks
- Low: test-only adjustments

## Changelog
- n/a

## References
- n/a

Closes #N/A

------
https://chatgpt.com/codex/tasks/task_e_69023444bf688323b5d07cca0ca78915