### PR TITLE
test: tighten acceptance expectation array typing

### DIFF
--- a/tests/Acceptance/ExifBackfillMatrixTest.php
+++ b/tests/Acceptance/ExifBackfillMatrixTest.php
@@ -19,10 +19,20 @@ use PHPUnit\Framework\Attributes\DataProviderExternal;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @phpstan-import-type StructuredExpectations from \MagicSunday\ImageMeta\Tests\Support\ExifExpectationAssertions
+ * @phpstan-import-type ApiExpectations from \MagicSunday\ImageMeta\Tests\Support\ExifExpectationAssertions
+ * @phpstan-import-type ModelExpectations from \MagicSunday\ImageMeta\Tests\Support\ExifExpectationAssertions
+ */
 final class ExifBackfillMatrixTest extends TestCase
 {
     use ExifExpectationAssertions;
 
+    /**
+     * @phpstan-param StructuredExpectations $expectedStructured
+     * @phpstan-param ApiExpectations        $expectedApi
+     * @phpstan-param ModelExpectations      $expectedModel
+     */
     #[Test]
     #[DataProviderExternal(ExifVersionExpectations::class, 'provideAll')]
     public function extractsFallbackMetadataFromReferenceImages(

--- a/tests/Acceptance/ExifVersionMatrixTest.php
+++ b/tests/Acceptance/ExifVersionMatrixTest.php
@@ -18,10 +18,16 @@ use PHPUnit\Framework\Attributes\DataProviderExternal;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @phpstan-import-type StructuredExpectations from \MagicSunday\ImageMeta\Tests\Support\ExifExpectationAssertions
+ */
 final class ExifVersionMatrixTest extends TestCase
 {
     use ExifExpectationAssertions;
 
+    /**
+     * @phpstan-param StructuredExpectations $expectedStructured
+     */
     #[Test]
     #[DataProviderExternal(ExifVersionExpectations::class, 'provideStructured')]
     public function matchesStructuredExpectations(string $fixture, array $expectedStructured): void

--- a/tests/Support/ExifExpectationAssertions.php
+++ b/tests/Support/ExifExpectationAssertions.php
@@ -13,37 +13,86 @@ use PHPUnit\Framework\Assert;
 
 /**
  * Shared assertions for verifying EXIF expectation matrices.
+ *
+ * @phpstan-type StructuredExpectations array{
+ *     standards: array{
+ *         exifVersion: ?string,
+ *         profile: ?string,
+ *         flashpixVersion: ?string,
+ *         tiffEpStandardId: list<int>|null,
+ *         tiffEpStandardString: ?string,
+ *     },
+ *     exposure: array{iso: ?int},
+ *     capture: array{
+ *         dateTimeOriginal: ?string,
+ *         offsetTimeOriginal: ?string,
+ *         subSecTimeOriginal: ?string,
+ *     },
+ *     image: array{
+ *         userComment: ?string,
+ *         userCommentEncoding: ?string,
+ *     },
+ *     interop: array{
+ *         index: ?string,
+ *         version: ?string,
+ *         fileFormat: ?string,
+ *         width: ?int,
+ *         length: ?int,
+ *     },
+ *     preview: PreviewExpectations,
+ *     makerNotes: ?array{vendor: string, length: int, sha1: string, isSafe: ?bool},
+ *     environment: array{
+ *         temperatureC: ?float,
+ *         humidityPercent: ?float,
+ *         pressureHpa: ?float,
+ *     },
+ *     sensor: array{spatialFrequencyResponse: array<string, mixed>|null},
+ * }
+ *
+ * @phpstan-type ApiExpectations array{
+ *     iso: ?int,
+ *     dateTimeOriginal: ?string,
+ *     userComment: ?string,
+ *     userCommentEncoding: ?string,
+ *     interop: array{
+ *         index: ?string,
+ *         version: ?string,
+ *         fileFormat: ?string,
+ *         width: ?int,
+ *         length: ?int,
+ *     },
+ *     preview: PreviewExpectations,
+ * }
+ *
+ * @phpstan-type ModelExpectations array{
+ *     exifVersion: ?string,
+ *     exifProfile: string,
+ *     flashpixVersion: ?string,
+ *     tiffEpStandardId: list<int>|null,
+ *     tiffEpStandardString: ?string,
+ * }
+ *
+ * @phpstan-type PreviewExpectations array{
+ *     hasThumbnail: ?bool,
+ *     hasPreview: ?bool,
+ *     previewOffset: ?int,
+ *     previewLength: ?int,
+ *     previewWidth: ?int,
+ *     previewHeight: ?int,
+ *     previewBitDepth: ?int,
+ *     previewCompression: ?int,
+ *     previewCompressionName: ?string,
+ *     previewColorSpace: ?int,
+ *     previewColorSpaceName: ?string,
+ *     previewEncoding: ?string,
+ *     previewMimeType: ?string,
+ *     previewScale: ?float,
+ * }
  */
 trait ExifExpectationAssertions
 {
     /**
-     * @param Metadata $metadata
-     * @param array{
-     *     standards: array{exifVersion:?string, profile:?string, flashpixVersion:?string, tiffEpStandardId:?array, tiffEpStandardString:?string},
-     *     exposure: array{iso:?int},
-     *     capture: array{dateTimeOriginal:?string, offsetTimeOriginal:?string, subSecTimeOriginal:?string},
-     *     image: array{userComment:?string, userCommentEncoding:?string},
-     *     interop: array{index:?string, version:?string, fileFormat:?string, width:?int, length:?int},
-     *     preview: array{
-     *         hasThumbnail:?bool,
-     *         hasPreview:?bool,
-     *         previewOffset:?int,
-     *         previewLength:?int,
-     *         previewWidth:?int,
-     *         previewHeight:?int,
-     *         previewBitDepth:?int,
-     *         previewCompression:?int,
-     *         previewCompressionName:?string,
-     *         previewColorSpace:?int,
-     *         previewColorSpaceName:?string,
-     *         previewEncoding:?string,
-     *         previewMimeType:?string,
-     *         previewScale:?float,
-     *     },
-     *     makerNotes:?array{vendor:string,length:int,sha1:string,isSafe:?bool},
-     *     environment: array{temperatureC:?float, humidityPercent:?float, pressureHpa:?float},
-     *     sensor: array{spatialFrequencyResponse:?array},
-     * } $expected
+     * @phpstan-param StructuredExpectations $expected
      */
     private static function assertStructuredMatches(string $fixture, Metadata $metadata, array $expected): void
     {
@@ -109,29 +158,7 @@ trait ExifExpectationAssertions
 
         $expectedEnv = $expected['environment'];
         $raw = $metadata->exifDoc;
-        $environmentMatchers = [
-            'temperatureC'    => 'temperatureCelsius',
-            'humidityPercent' => 'humidityPercent',
-            'pressureHpa'     => 'pressureHPa',
-        ];
-
-        foreach ($environmentMatchers as $key => $method) {
-            $expectedValue = $expectedEnv[$key];
-            $actualValue   = $raw?->$method();
-
-            if ($expectedValue === null) {
-                Assert::assertNull($actualValue, sprintf('%s: %s', $fixture, ucfirst($key)));
-                continue;
-            }
-
-            Assert::assertNotNull($actualValue, sprintf('%s: %s presence', $fixture, ucfirst($key)));
-            Assert::assertEqualsWithDelta(
-                $expectedValue,
-                $actualValue,
-                1e-6,
-                sprintf('%s: %s value', $fixture, ucfirst($key)),
-            );
-        }
+        self::assertEnvironmentMatches($fixture, $expectedEnv, $raw);
 
         Assert::assertSame(
             $expected['sensor']['spatialFrequencyResponse'],
@@ -141,29 +168,7 @@ trait ExifExpectationAssertions
     }
 
     /**
-     * @param array{
-     *     iso:?int,
-     *     dateTimeOriginal:?string,
-     *     userComment:?string,
-     *     userCommentEncoding:?string,
-     *     interop: array{index:?string, version:?string, fileFormat:?string, width:?int, length:?int},
-     *     preview: array{
-     *         hasThumbnail:?bool,
-     *         hasPreview:?bool,
-     *         previewOffset:?int,
-     *         previewLength:?int,
-     *         previewWidth:?int,
-     *         previewHeight:?int,
-     *         previewBitDepth:?int,
-     *         previewCompression:?int,
-     *         previewCompressionName:?string,
-     *         previewColorSpace:?int,
-     *         previewColorSpaceName:?string,
-     *         previewEncoding:?string,
-     *         previewMimeType:?string,
-     *         previewScale:?float,
-     *     },
-     * } $expected
+     * @phpstan-param ApiExpectations $expected
      */
     private static function assertApiMatches(string $fixture, ApiExifDocument $document, array $expected): void
     {
@@ -194,13 +199,7 @@ trait ExifExpectationAssertions
     }
 
     /**
-     * @param array{
-     *     exifVersion:?string,
-     *     exifProfile:string,
-     *     flashpixVersion:?string,
-     *     tiffEpStandardId:?array,
-     *     tiffEpStandardString:?string,
-     * } $expected
+     * @phpstan-param ModelExpectations $expected
      */
     private static function assertModelMatches(string $fixture, ?ModelExifDocument $document, array $expected): void
     {
@@ -214,22 +213,7 @@ trait ExifExpectationAssertions
     }
 
     /**
-     * @param array{
-     *     hasThumbnail:?bool,
-     *     hasPreview:?bool,
-     *     previewOffset:?int,
-     *     previewLength:?int,
-     *     previewWidth:?int,
-     *     previewHeight:?int,
-     *     previewBitDepth:?int,
-     *     previewCompression:?int,
-     *     previewCompressionName:?string,
-     *     previewColorSpace:?int,
-     *     previewColorSpaceName:?string,
-     *     previewEncoding:?string,
-     *     previewMimeType:?string,
-     *     previewScale:?float,
-     * } $expected
+     * @phpstan-param PreviewExpectations $expected
      */
     private static function assertPreviewMatches(string $fixture, array $expected, PreviewValue|StructuredPreview $preview): void
     {
@@ -266,5 +250,31 @@ trait ExifExpectationAssertions
             Assert::assertNotNull($preview->previewScale, sprintf('%s: Preview scale', $fixture));
             Assert::assertEqualsWithDelta($expected['previewScale'], $preview->previewScale, 1e-6, sprintf('%s: Preview scale value', $fixture));
         }
+    }
+
+    /**
+     * @phpstan-param array{temperatureC: ?float, humidityPercent: ?float, pressureHpa: ?float} $expected
+     */
+    private static function assertEnvironmentMatches(string $fixture, array $expected, ?ModelExifDocument $document): void
+    {
+        $actualTemperature = $document?->temperatureCelsius();
+        $actualHumidity    = $document?->humidityPercent();
+        $actualPressure    = $document?->pressureHPa();
+
+        self::assertOptionalFloat($fixture, 'TemperatureC', $expected['temperatureC'], $actualTemperature);
+        self::assertOptionalFloat($fixture, 'HumidityPercent', $expected['humidityPercent'], $actualHumidity);
+        self::assertOptionalFloat($fixture, 'PressureHpa', $expected['pressureHpa'], $actualPressure);
+    }
+
+    private static function assertOptionalFloat(string $fixture, string $label, ?float $expected, ?float $actual): void
+    {
+        if ($expected === null) {
+            Assert::assertNull($actual, sprintf('%s: %s', $fixture, $label));
+
+            return;
+        }
+
+        Assert::assertNotNull($actual, sprintf('%s: %s presence', $fixture, $label));
+        Assert::assertEqualsWithDelta($expected, $actual, 1e-6, sprintf('%s: %s value', $fixture, $label));
     }
 }

--- a/tests/Support/ExifVersionExpectations.php
+++ b/tests/Support/ExifVersionExpectations.php
@@ -9,6 +9,15 @@ use RuntimeException;
 
 /**
  * Provides access to the EXIF version matrix expectations shared across tests.
+ *
+ * @phpstan-import-type StructuredExpectations from ExifExpectationAssertions
+ * @phpstan-import-type ApiExpectations from ExifExpectationAssertions
+ * @phpstan-import-type ModelExpectations from ExifExpectationAssertions
+ * @phpstan-type AllExpectations array{
+ *     structured: StructuredExpectations,
+ *     api: ApiExpectations,
+ *     model: ModelExpectations,
+ * }
  */
 final class ExifVersionExpectations
 {
@@ -17,7 +26,7 @@ final class ExifVersionExpectations
     private const string EXPECTATIONS_FILE = self::FIXTURE_DIR . '/expectations.json';
 
     /**
-     * @var array<string, array{structured: array<string, mixed>, api: array<string, mixed>, model: array<string, mixed>}>|null
+     * @var array<string, AllExpectations>|null
      */
     private static ?array $cache = null;
 
@@ -30,7 +39,7 @@ final class ExifVersionExpectations
     }
 
     /**
-     * @return iterable<string, array{string, array<string, mixed>}> Data provider payload for structured expectations.
+     * @return iterable<string, array{string, StructuredExpectations}> Data provider payload for structured expectations.
      */
     public static function provideStructured(): iterable
     {
@@ -40,7 +49,7 @@ final class ExifVersionExpectations
     }
 
     /**
-     * @return iterable<string, array{string, array<string, mixed>}> Data provider payload for API expectations.
+     * @return iterable<string, array{string, ApiExpectations}> Data provider payload for API expectations.
      */
     public static function provideApi(): iterable
     {
@@ -50,7 +59,7 @@ final class ExifVersionExpectations
     }
 
     /**
-     * @return iterable<string, array{string, array<string, mixed>, array<string, mixed>, array<string, mixed>}> Data provider
+     * @return iterable<string, array{string, StructuredExpectations, ApiExpectations, ModelExpectations}> Data provider
      *                                                                                                          payload for
      *                                                                                                          structured,
      *                                                                                                          API and raw
@@ -67,7 +76,7 @@ final class ExifVersionExpectations
     /**
      * Returns the structured, API and model expectations for a given fixture.
      *
-     * @return array{structured: array<string, mixed>, api: array<string, mixed>, model: array<string, mixed>}
+     * @return AllExpectations
      */
     public static function get(string $fixture): array
     {
@@ -81,7 +90,7 @@ final class ExifVersionExpectations
     }
 
     /**
-     * @return array<string, array{structured: array<string, mixed>, api: array<string, mixed>, model: array<string, mixed>}> Cached expectations.
+     * @return array<string, AllExpectations> Cached expectations.
      */
     private static function all(): array
     {
@@ -94,7 +103,7 @@ final class ExifVersionExpectations
             throw new RuntimeException(sprintf('Unable to read EXIF expectations from %s', self::EXPECTATIONS_FILE));
         }
 
-        /** @var array<string, array{structured: array<string, mixed>, api: array<string, mixed>, model: array<string, mixed>}> $data */
+        /** @var array<string, AllExpectations> $data */
         $data = json_decode($json, true, 512, JSON_THROW_ON_ERROR);
 
         self::$cache = $data;


### PR DESCRIPTION
## Summary
- define reusable PHPStan type aliases for EXIF expectation payloads shared by the acceptance suite
- annotate acceptance matrix tests with imported expectation types to satisfy strict array generics
- replace dynamic EXIF environment lookups with explicit helper assertions to eliminate variable method calls

## Testing
- composer ci:test:php:phpstan *(fails: existing repo-wide PHPStan violations outside acceptance scope)*
- .build/bin/phpstan analyze --configuration .build/phpstan.neon --no-progress tests/Acceptance tests/Support/ExifExpectationAssertions.php tests/Support/ExifVersionExpectations.php


------
https://chatgpt.com/codex/tasks/task_e_6902345076b88323b6eb24232fbb2c88