### PR TITLE
test: add phpstan expectation annotations for API tests

### DIFF
--- a/tests/Api/ExifDocumentReferenceMatrixTest.php
+++ b/tests/Api/ExifDocumentReferenceMatrixTest.php
@@ -19,10 +19,96 @@ use PHPUnit\Framework\Attributes\DataProviderExternal;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @phpstan-type StructuredExpectation array{
+ *     standards: array{
+ *         exifVersion: ?string,
+ *         profile: ?string,
+ *         flashpixVersion: ?string,
+ *         tiffEpStandardId: array<int|string, mixed>|null,
+ *         tiffEpStandardString: ?string,
+ *     },
+ *     exposure: array{iso: ?int},
+ *     capture: array{
+ *         dateTimeOriginal: ?string,
+ *         offsetTimeOriginal: ?string,
+ *         subSecTimeOriginal: ?string,
+ *     },
+ *     image: array{userComment: ?string, userCommentEncoding: ?string},
+ *     interop: array{
+ *         index: ?string,
+ *         version: ?string,
+ *         fileFormat: ?string,
+ *         width: ?int,
+ *         length: ?int,
+ *     },
+ *     preview: array{
+ *         hasThumbnail: ?bool,
+ *         hasPreview: ?bool,
+ *         previewOffset: ?int,
+ *         previewLength: ?int,
+ *         previewWidth: ?int,
+ *         previewHeight: ?int,
+ *         previewBitDepth: ?int,
+ *         previewCompression: ?int,
+ *         previewCompressionName: ?string,
+ *         previewColorSpace: ?int,
+ *         previewColorSpaceName: ?string,
+ *         previewEncoding: ?string,
+ *         previewMimeType: ?string,
+ *         previewScale: ?float,
+ *     },
+ *     makerNotes: array{vendor: string, length: int, sha1: string, isSafe: ?bool}|null,
+ *     environment: array{temperatureC: ?float, humidityPercent: ?float, pressureHpa: ?float},
+ *     sensor: array{spatialFrequencyResponse: array<int|string, mixed>|null},
+ * }
+ * @phpstan-type ApiExpectation array{
+ *     iso: ?int,
+ *     dateTimeOriginal: ?string,
+ *     userComment: ?string,
+ *     userCommentEncoding: ?string,
+ *     interop: array{
+ *         index: ?string,
+ *         version: ?string,
+ *         fileFormat: ?string,
+ *         width: ?int,
+ *         length: ?int,
+ *     },
+ *     preview: array{
+ *         hasThumbnail: ?bool,
+ *         hasPreview: ?bool,
+ *         previewOffset: ?int,
+ *         previewLength: ?int,
+ *         previewWidth: ?int,
+ *         previewHeight: ?int,
+ *         previewBitDepth: ?int,
+ *         previewCompression: ?int,
+ *         previewCompressionName: ?string,
+ *         previewColorSpace: ?int,
+ *         previewColorSpaceName: ?string,
+ *         previewEncoding: ?string,
+ *         previewMimeType: ?string,
+ *         previewScale: ?float,
+ *     },
+ * }
+ * @phpstan-type ModelExpectation array{
+ *     exifVersion: ?string,
+ *     exifProfile: string,
+ *     flashpixVersion: ?string,
+ *     tiffEpStandardId: array<int|string, mixed>|null,
+ *     tiffEpStandardString: ?string,
+ * }
+ * @method static void assertStructuredMatches(string $fixture, \MagicSunday\ImageMeta\Model\Metadata $metadata, StructuredExpectation $expected)
+ * @method static void assertApiMatches(string $fixture, \MagicSunday\ImageMeta\Api\ExifDocument $document, ApiExpectation $expected)
+ * @method static void assertModelMatches(string $fixture, ?\MagicSunday\ImageMeta\Model\Exif\ExifDocument $document, ModelExpectation $expected)
+ */
 final class ExifDocumentReferenceMatrixTest extends TestCase
 {
     use ExifExpectationAssertions;
 
+    /**
+     * @param ApiExpectation $expectedApi
+     */
     #[Test]
     #[DataProviderExternal(ExifVersionExpectations::class, 'provideApi')]
     public function exposesFallbackMetadataFromReferenceImages(
@@ -35,6 +121,13 @@ final class ExifDocumentReferenceMatrixTest extends TestCase
         $modelDocument = $metadata->exifDoc;
         self::assertNotNull($modelDocument, sprintf('Reference EXIF document missing for %s', $fixture));
 
+        /**
+         * @var array{
+         *     structured: array<string, mixed>,
+         *     api: ApiExpectation,
+         *     model: ModelExpectation,
+         * } $expectation
+         */
         $expectation = ExifVersionExpectations::get($fixture);
         self::assertModelMatches($fixture, $modelDocument, $expectation['model']);
 

--- a/tests/Api/ExifReaderTest.php
+++ b/tests/Api/ExifReaderTest.php
@@ -19,6 +19,89 @@ use MagicSunday\ImageMeta\Value\Enum\Orientation;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @phpstan-type StructuredExpectation array{
+ *     standards: array{
+ *         exifVersion: ?string,
+ *         profile: ?string,
+ *         flashpixVersion: ?string,
+ *         tiffEpStandardId: array<int|string, mixed>|null,
+ *         tiffEpStandardString: ?string,
+ *     },
+ *     exposure: array{iso: ?int},
+ *     capture: array{
+ *         dateTimeOriginal: ?string,
+ *         offsetTimeOriginal: ?string,
+ *         subSecTimeOriginal: ?string,
+ *     },
+ *     image: array{userComment: ?string, userCommentEncoding: ?string},
+ *     interop: array{
+ *         index: ?string,
+ *         version: ?string,
+ *         fileFormat: ?string,
+ *         width: ?int,
+ *         length: ?int,
+ *     },
+ *     preview: array{
+ *         hasThumbnail: ?bool,
+ *         hasPreview: ?bool,
+ *         previewOffset: ?int,
+ *         previewLength: ?int,
+ *         previewWidth: ?int,
+ *         previewHeight: ?int,
+ *         previewBitDepth: ?int,
+ *         previewCompression: ?int,
+ *         previewCompressionName: ?string,
+ *         previewColorSpace: ?int,
+ *         previewColorSpaceName: ?string,
+ *         previewEncoding: ?string,
+ *         previewMimeType: ?string,
+ *         previewScale: ?float,
+ *     },
+ *     makerNotes: array{vendor: string, length: int, sha1: string, isSafe: ?bool}|null,
+ *     environment: array{temperatureC: ?float, humidityPercent: ?float, pressureHpa: ?float},
+ *     sensor: array{spatialFrequencyResponse: array<int|string, mixed>|null},
+ * }
+ * @phpstan-type ApiExpectation array{
+ *     iso: ?int,
+ *     dateTimeOriginal: ?string,
+ *     userComment: ?string,
+ *     userCommentEncoding: ?string,
+ *     interop: array{
+ *         index: ?string,
+ *         version: ?string,
+ *         fileFormat: ?string,
+ *         width: ?int,
+ *         length: ?int,
+ *     },
+ *     preview: array{
+ *         hasThumbnail: ?bool,
+ *         hasPreview: ?bool,
+ *         previewOffset: ?int,
+ *         previewLength: ?int,
+ *         previewWidth: ?int,
+ *         previewHeight: ?int,
+ *         previewBitDepth: ?int,
+ *         previewCompression: ?int,
+ *         previewCompressionName: ?string,
+ *         previewColorSpace: ?int,
+ *         previewColorSpaceName: ?string,
+ *         previewEncoding: ?string,
+ *         previewMimeType: ?string,
+ *         previewScale: ?float,
+ *     },
+ * }
+ * @phpstan-type ModelExpectation array{
+ *     exifVersion: ?string,
+ *     exifProfile: string,
+ *     flashpixVersion: ?string,
+ *     tiffEpStandardId: array<int|string, mixed>|null,
+ *     tiffEpStandardString: ?string,
+ * }
+ * @method static void assertStructuredMatches(string $fixture, \MagicSunday\ImageMeta\Model\Metadata $metadata, StructuredExpectation $expected)
+ * @method static void assertApiMatches(string $fixture, \MagicSunday\ImageMeta\Api\ExifDocument $document, ApiExpectation $expected)
+ * @method static void assertModelMatches(string $fixture, ?\MagicSunday\ImageMeta\Model\Exif\ExifDocument $document, ModelExpectation $expected)
+ */
 final class ExifReaderTest extends TestCase
 {
     use ExifExpectationAssertions;
@@ -85,6 +168,13 @@ final class ExifReaderTest extends TestCase
 
         $document = $reader->read($path);
 
+        /**
+         * @var array{
+         *     structured: array<string, mixed>,
+         *     api: ApiExpectation,
+         *     model: ModelExpectation,
+         * } $expectation
+         */
         $expectation = ExifVersionExpectations::get($fixture);
 
         self::assertModelMatches($fixture, $document->raw(), $expectation['model']);


### PR DESCRIPTION
## Summary
- add explicit PHPStan type aliases for EXIF expectation arrays in API tests
- document expectation payloads passed to shared assertion helpers

## Testing
- `composer ci:test:php:phpstan` *(fails: existing issues outside tests/Api)*

------
https://chatgpt.com/codex/tasks/task_e_69023456bb6083238b719508a2294572