### PR TITLE
test: streamline metadata reader phpstan compliance

### DIFF
--- a/tests/MetadataReader/MetadataReaderTest.php
+++ b/tests/MetadataReader/MetadataReaderTest.php
@@ -15,7 +15,6 @@ use MagicSunday\ImageMeta\MakerNotes\MakerNotesRecord;
 use MagicSunday\ImageMeta\MetadataReader;
 use MagicSunday\ImageMeta\Model\Exif\ExifDocument;
 use MagicSunday\ImageMeta\Model\Exif\ExifTag;
-use MagicSunday\ImageMeta\Model\Metadata;
 use MagicSunday\ImageMeta\Model\QuickTimeMeta;
 use MagicSunday\ImageMeta\Model\Xmp\XmpDocument;
 use PHPUnit\Framework\Attributes\Test;
@@ -73,7 +72,6 @@ final class MetadataReaderTest extends TestCase
             @unlink($path);
         }
 
-        self::assertInstanceOf(Metadata::class, $metadata);
         self::assertSame([$tiff], $metadata->exifBlobs);
         self::assertSame([$xmp], $metadata->xmpBlobs);
         self::assertNull($metadata->quickTime);
@@ -189,7 +187,6 @@ final class MetadataReaderTest extends TestCase
             @unlink($path);
         }
 
-        self::assertInstanceOf(Metadata::class, $metadata);
         self::assertSame([$tiff], $metadata->exifBlobs);
         self::assertSame([$xmp], $metadata->xmpBlobs);
         self::assertInstanceOf(QuickTimeMeta::class, $metadata->quickTime);


### PR DESCRIPTION
## Overview
- remove redundant instance assertions in the metadata reader integration test
- satisfy PHPStan by dropping checks that were trivially true because of return types

## Details
- cleared the `staticMethod.alreadyNarrowedType` reports for `tests/MetadataReader/MetadataReaderTest.php` (lines 76 and 192)

## Tests
- `.build/bin/phpstan analyze tests/MetadataReader/MetadataReaderTest.php --configuration .build/phpstan.neon --memory-limit=-1`

## Risks
- Low; assertions remain focused on behaviour instead of redundant type checks.

## Changelog
- n/a

## References
- None


------
https://chatgpt.com/codex/tasks/task_e_69023a95f5c483239519d0160b895c16