### PR TITLE
test(acceptance): add array shape docs for expectation matrices

### DIFF
--- a/tests/Acceptance/ExifBackfillMatrixTest.php
+++ b/tests/Acceptance/ExifBackfillMatrixTest.php
@@ -19,10 +19,109 @@ use PHPUnit\Framework\Attributes\DataProviderExternal;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @phpstan-type StructuredExpectation array{
+ *     standards: array{
+ *         exifVersion: string|null,
+ *         profile: string|null,
+ *         flashpixVersion: string|null,
+ *         tiffEpStandardId: array<int, int>|null,
+ *         tiffEpStandardString: string|null,
+ *     },
+ *     exposure: array{iso: int|null},
+ *     capture: array{
+ *         dateTimeOriginal: string|null,
+ *         offsetTimeOriginal: string|null,
+ *         subSecTimeOriginal: string|null,
+ *     },
+ *     image: array{
+ *         userComment: string|null,
+ *         userCommentEncoding: string|null,
+ *     },
+ *     interop: array{
+ *         index: string|null,
+ *         version: string|null,
+ *         fileFormat: string|null,
+ *         width: int|null,
+ *         length: int|null,
+ *     },
+ *     preview: array{
+ *         hasThumbnail: bool|null,
+ *         hasPreview: bool|null,
+ *         previewOffset: int|null,
+ *         previewLength: int|null,
+ *         previewWidth: int|null,
+ *         previewHeight: int|null,
+ *         previewBitDepth: int|null,
+ *         previewCompression: int|null,
+ *         previewCompressionName: string|null,
+ *         previewColorSpace: int|null,
+ *         previewColorSpaceName: string|null,
+ *         previewEncoding: string|null,
+ *         previewMimeType: string|null,
+ *         previewScale: float|null,
+ *     },
+ *     makerNotes: array{
+ *         vendor: string,
+ *         length: int,
+ *         sha1: string,
+ *         isSafe: bool|null,
+ *     }|null,
+ *     environment: array{
+ *         temperatureC: float|null,
+ *         humidityPercent: float|null,
+ *         pressureHpa: float|null,
+ *     },
+ *     sensor: array{
+ *         spatialFrequencyResponse: array<array-key, mixed>|null,
+ *     },
+ * }
+ * @phpstan-type ApiExpectation array{
+ *     iso: int|null,
+ *     dateTimeOriginal: string|null,
+ *     userComment: string|null,
+ *     userCommentEncoding: string|null,
+ *     interop: array{
+ *         index: string|null,
+ *         version: string|null,
+ *         fileFormat: string|null,
+ *         width: int|null,
+ *         length: int|null,
+ *     },
+ *     preview: array{
+ *         hasThumbnail: bool|null,
+ *         hasPreview: bool|null,
+ *         previewOffset: int|null,
+ *         previewLength: int|null,
+ *         previewWidth: int|null,
+ *         previewHeight: int|null,
+ *         previewBitDepth: int|null,
+ *         previewCompression: int|null,
+ *         previewCompressionName: string|null,
+ *         previewColorSpace: int|null,
+ *         previewColorSpaceName: string|null,
+ *         previewEncoding: string|null,
+ *         previewMimeType: string|null,
+ *         previewScale: float|null,
+ *     },
+ * }
+ * @phpstan-type ModelExpectation array{
+ *     exifVersion: string|null,
+ *     exifProfile: string,
+ *     flashpixVersion: string|null,
+ *     tiffEpStandardId: array<int, int>|null,
+ *     tiffEpStandardString: string|null,
+ * }
+ */
 final class ExifBackfillMatrixTest extends TestCase
 {
     use ExifExpectationAssertions;
 
+    /**
+     * @param StructuredExpectation $expectedStructured
+     * @param ApiExpectation        $expectedApi
+     * @param ModelExpectation      $expectedModel
+     */
     #[Test]
     #[DataProviderExternal(ExifVersionExpectations::class, 'provideAll')]
     public function extractsFallbackMetadataFromReferenceImages(

--- a/tests/Acceptance/ExifVersionMatrixTest.php
+++ b/tests/Acceptance/ExifVersionMatrixTest.php
@@ -18,10 +18,16 @@ use PHPUnit\Framework\Attributes\DataProviderExternal;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @phpstan-import-type StructuredExpectation from ExifBackfillMatrixTest
+ */
 final class ExifVersionMatrixTest extends TestCase
 {
     use ExifExpectationAssertions;
 
+    /**
+     * @param StructuredExpectation $expectedStructured
+     */
     #[Test]
     #[DataProviderExternal(ExifVersionExpectations::class, 'provideStructured')]
     public function matchesStructuredExpectations(string $fixture, array $expectedStructured): void


### PR DESCRIPTION
## Summary
- document the structured, API, and model expectation array shapes used by the acceptance matrix tests
- import the shared structured expectation shape in the EXIF version acceptance test
- annotate data provider payloads so PHPStan can verify the expectation types

## Testing
- .build/bin/phpstan analyse tests/Acceptance --configuration .build/phpstan.neon --memory-limit=-1

------
https://chatgpt.com/codex/tasks/task_e_69023aaab8f083238bb1cb170adda85a