### PR TITLE
fix: guard rational list construction

### DIFF
--- a/src/Model/Exif/ExifRationalList.php
+++ b/src/Model/Exif/ExifRationalList.php
@@ -26,7 +26,9 @@ final readonly class ExifRationalList
     public array $values;
 
     /**
-     * @param list<ExifRational> $values Ordered list of rational components.
+     * @param array<int, mixed> $values Ordered list of rational components.
+     *
+     * @throws InvalidArgumentException If the provided values are not a sequential list of ExifRational objects.
      */
     public function __construct(array $values)
     {


### PR DESCRIPTION
# Overview
- relax the static analysis expectations for `ExifRationalList` construction
- keep the runtime validation that only `ExifRational` instances are stored in the list

# Details
- widen the constructor parameter phpdoc to `array<int, mixed>` so PHPStan no longer treats the list-checks as redundant
- document the thrown `InvalidArgumentException` for invalid inputs while preserving the existing guards

# Tests
- `composer ci:test:php:phpstan` *(fails: existing repo-wide PHPStan issues outside this change)*

# Risks
- Low; the value object retains its validation and public API.

# Changelog
- n/a

# References
- None

------
https://chatgpt.com/codex/tasks/task_e_69023acd1ae883238e59197bee1231fd