### PR TITLE
fix(exif): harden numeric list validation

### DIFF
--- a/src/Model/Exif/ExifNumericList.php
+++ b/src/Model/Exif/ExifNumericList.php
@@ -29,20 +29,14 @@ final readonly class ExifNumericList
     public array $values;
 
     /**
-     * @param list<int|float|UInt64> $values Ordered list of numeric components.
+     * @param array<int, int|float|UInt64> $values Ordered list of numeric components.
      */
     public function __construct(array $values)
     {
-        if (!array_is_list($values)) {
-            throw new InvalidArgumentException('Numeric EXIF values must form a list.');
-        }
+        self::assertList($values);
 
         foreach ($values as $value) {
-            if (is_int($value) || is_float($value) || $value instanceof UInt64) {
-                continue;
-            }
-
-            throw new InvalidArgumentException('Numeric EXIF lists may only contain integers, floats, or UInt64 values.');
+            self::assertNumericComponent($value);
         }
 
         /** @var list<int|float|UInt64> $values */
@@ -57,5 +51,28 @@ final readonly class ExifNumericList
     public function toArray(): array
     {
         return $this->values;
+    }
+
+    /**
+     * @param array<int, int|float|UInt64> $values
+     *
+     * @phpstan-assert list<int|float|UInt64> $values
+     */
+    private static function assertList(array $values): void
+    {
+        if (array_is_list($values)) {
+            return;
+        }
+
+        throw new InvalidArgumentException('Numeric EXIF values must form a list.');
+    }
+
+    private static function assertNumericComponent(mixed $value): void
+    {
+        if (is_int($value) || is_float($value) || $value instanceof UInt64) {
+            return;
+        }
+
+        throw new InvalidArgumentException('Numeric EXIF lists may only contain integers, floats, or UInt64 values.');
     }
 }


### PR DESCRIPTION
## Overview
- tighten `ExifNumericList` validation to satisfy PHPStan checks without weakening runtime safeguards

## Details
- replace inline invariants with dedicated assertion helpers that raise consistent exceptions
- annotate assertions with `@phpstan-assert` to refine list types after validation

## Tests
- `composer ci:test:php:phpstan` *(fails: pre-existing repository-wide PHPStan violations outside `ExifNumericList`)*

## Risks
- low: refactor keeps existing validation behaviour while improving static analysis precision

## Changelog
- n/a (internal QA improvement)

## References
- n/a

Closes: n/a

------
https://chatgpt.com/codex/tasks/task_e_69023ac6dcd0832396dbf29eb82cd51f