### PR TITLE
test: assert Apple flag mask results are arrays

### DIFF
--- a/tests/MakerNotes/Apple/AppleDecoderFlagMaskTest.php
+++ b/tests/MakerNotes/Apple/AppleDecoderFlagMaskTest.php
@@ -36,6 +36,7 @@ final class AppleDecoderFlagMaskTest extends TestCase
         ];
 
         $result = $method->invoke($decoder, $dictionary);
+        self::assertIsArray($result);
         ksort($result);
 
         $expected = [
@@ -66,6 +67,7 @@ final class AppleDecoderFlagMaskTest extends TestCase
         ];
 
         $result = $method->invoke($decoder, $dictionary);
+        self::assertIsArray($result);
         ksort($result);
 
         $expected = [


### PR DESCRIPTION
## Overview
- harden the Apple decoder flag mask tests for static analysis

## Details
- assert that the reflection result is an array before sorting in each flag mask scenario

## Tests
- .build/bin/phpstan analyze --configuration .build/phpstan.neon tests/MakerNotes/Apple/AppleDecoderFlagMaskTest.php

## Risks
- Low

## Changelog
- n/a

## References
- n/a

Closes: N/A

------
https://chatgpt.com/codex/tasks/task_e_69023d7ec8808323a96ba97118270614