### PR TITLE
test(apple): tighten mapper tests

### DIFF
--- a/tests/MakerNotes/Apple/AppleMakerNotesMapperTest.php
+++ b/tests/MakerNotes/Apple/AppleMakerNotesMapperTest.php
@@ -89,21 +89,24 @@ final class AppleMakerNotesMapperTest extends TestCase
 
         $mapper   = new AppleMakerNotesMapper();
         $mapped   = $mapper->map($makerNotes, $quickTime);
-        $apple    = $mapped?->apple();
+
+        self::assertNotNull($mapped);
+
+        $apple = $mapped->apple();
 
         self::assertNotSame($makerNotes, $mapped);
-        self::assertSame('Apple', $mapped?->vendor());
-        self::assertSame(128, $mapped?->length());
-        self::assertSame(str_repeat('1', 40), $mapped?->sha1());
+        self::assertSame('Apple', $mapped->vendor());
+        self::assertSame(128, $mapped->length());
+        self::assertSame(str_repeat('1', 40), $mapped->sha1());
 
         self::assertInstanceOf(AppleMakerNotes::class, $apple);
-        self::assertSame('maker-note', $apple?->contentIdentifier);
-        self::assertSame('Maker Camera', $apple?->cameraType);
-        self::assertSame([1.1, 1.2, 1.3], $apple?->hdrGain);
-        self::assertSame('MakerPreset', $apple?->semanticStylePreset);
-        self::assertSame('Portrait', $apple?->imageCaptureType);
-        self::assertSame('Maker', $apple?->oisMode);
-        self::assertSame('maker-burst', $apple?->burstUuid);
+        self::assertSame('maker-note', $apple->contentIdentifier);
+        self::assertSame('Maker Camera', $apple->cameraType);
+        self::assertSame([1.1, 1.2, 1.3], $apple->hdrGain);
+        self::assertSame('MakerPreset', $apple->semanticStylePreset);
+        self::assertSame('Portrait', $apple->imageCaptureType);
+        self::assertSame('Maker', $apple->oisMode);
+        self::assertSame('maker-burst', $apple->burstUuid);
     }
 
     #[Test]
@@ -167,29 +170,33 @@ final class AppleMakerNotesMapperTest extends TestCase
 
         $mapper = new AppleMakerNotesMapper();
         $mapped = $mapper->map($makerNotes, $quickTime);
-        $apple  = $mapped?->apple();
 
-        self::assertSame('qt-content', $apple?->contentIdentifier);
-        self::assertSame('Quick Camera', $apple?->cameraType);
-        self::assertSame([0.9, 1.0, 1.1], $apple?->hdrGain);
-        self::assertSame(1.25, $apple?->hdrHeadroom);
-        self::assertSame(9.5, $apple?->snr);
-        self::assertSame(0.45, $apple?->focusPosition);
-        self::assertSame(2, $apple?->livePhotoIndex);
-        self::assertSame(6100, $apple?->colorTemperature);
-        self::assertSame('QuickPreset', $apple?->semanticStylePreset);
-        self::assertSame([0.2, 0.1, -0.3], $apple?->accelerationVector);
-        self::assertSame('qt-request', $apple?->imageCaptureRequestId);
-        self::assertSame('Medium', $apple?->qualityHint);
-        self::assertSame('1.1', $apple?->makerNoteVersion);
-        self::assertSame('HDR2', $apple?->hdrImageType);
-        self::assertSame([0.5, 1.8], $apple?->focusDistanceRange);
-        self::assertSame('3', $apple?->oisMode);
-        self::assertSame('Night Mode', $apple?->imageCaptureType);
-        self::assertSame('qt-unique', $apple?->imageUniqueId);
-        self::assertSame('qt-photo', $apple?->photoIdentifier);
-        self::assertSame(1.2, $apple?->afMeasuredDepth);
-        self::assertSame(0.6, $apple?->afConfidence);
+        self::assertNotNull($mapped);
+
+        $apple = $mapped->apple();
+
+        self::assertInstanceOf(AppleMakerNotes::class, $apple);
+        self::assertSame('qt-content', $apple->contentIdentifier);
+        self::assertSame('Quick Camera', $apple->cameraType);
+        self::assertSame([0.9, 1.0, 1.1], $apple->hdrGain);
+        self::assertSame(1.25, $apple->hdrHeadroom);
+        self::assertSame(9.5, $apple->snr);
+        self::assertSame(0.45, $apple->focusPosition);
+        self::assertSame(2, $apple->livePhotoIndex);
+        self::assertSame(6100, $apple->colorTemperature);
+        self::assertSame('QuickPreset', $apple->semanticStylePreset);
+        self::assertSame([0.2, 0.1, -0.3], $apple->accelerationVector);
+        self::assertSame('qt-request', $apple->imageCaptureRequestId);
+        self::assertSame('Medium', $apple->qualityHint);
+        self::assertSame('1.1', $apple->makerNoteVersion);
+        self::assertSame('HDR2', $apple->hdrImageType);
+        self::assertSame([0.5, 1.8], $apple->focusDistanceRange);
+        self::assertSame('3', $apple->oisMode);
+        self::assertSame('Night Mode', $apple->imageCaptureType);
+        self::assertSame('qt-unique', $apple->imageUniqueId);
+        self::assertSame('qt-photo', $apple->photoIdentifier);
+        self::assertSame(1.2, $apple->afMeasuredDepth);
+        self::assertSame(0.6, $apple->afConfidence);
     }
 
     #[Test]
@@ -204,6 +211,7 @@ final class AppleMakerNotesMapperTest extends TestCase
         $mapper = new AppleMakerNotesMapper();
         $mapped = $mapper->map(null, $quickTime);
 
+        self::assertNotNull($mapped);
         self::assertInstanceOf(MakerNotesRecord::class, $mapped);
         self::assertSame('Apple', $mapped->vendor());
         self::assertSame(0, $mapped->length());
@@ -255,7 +263,12 @@ final class AppleMakerNotesMapperTest extends TestCase
         $mapper = new AppleMakerNotesMapper();
         $mapped = $mapper->map($makerNotes, $quickTime);
 
-        $flags = $mapped?->apple()?->flags ?? [];
+        self::assertNotNull($mapped);
+
+        $apple = $mapped->apple();
+        self::assertInstanceOf(AppleMakerNotes::class, $apple);
+
+        $flags = $apple->flags;
         self::assertSame(true, $flags['nightMode']);
         self::assertSame(false, $flags['hdrEnabled']);
         self::assertSame(true, $flags['hdrAuto']);


### PR DESCRIPTION
## Overview
- ensure Apple maker note mapper tests assert on non-null records before dereferencing
- replace nullsafe property access with strict assertions for Apple maker notes data

## Details
- add explicit `assertNotNull` guards ahead of Apple maker note assertions
- require real `AppleMakerNotes` instances prior to checking mapped fields and flags

## Testing
- `composer ci:test:php:phpstan` *(fails: existing project-wide PHPStan violations outside the Apple mapper tests)*

## Risks
- Low: test-only changes that tighten existing assertions.

## Changelog
- n/a (tests only)

## References
- n/a

Closes #N/A

------
https://chatgpt.com/codex/tasks/task_e_69023d6ca9608323903491db6e04f0d4