### PR TITLE
Fix PHPStan warnings in Apple maker note tests

### DIFF
--- a/tests/MakerNotes/AppleDecoder/AppleDecoderTest.php
+++ b/tests/MakerNotes/AppleDecoder/AppleDecoderTest.php
@@ -57,8 +57,6 @@ final class AppleDecoderTest extends TestCase
 
         $metadata = $decoder->decode($raw, 'Apple', 'iPhone');
 
-        self::assertInstanceOf(MakerNotesRecord::class, $metadata);
-
         $apple = $metadata->apple();
         self::assertInstanceOf(AppleMakerNotes::class, $apple);
         self::assertSame('archived-photo-uuid', $apple->contentIdentifier);
@@ -96,8 +94,6 @@ final class AppleDecoderTest extends TestCase
 
         $metadata = $decoder->decode($raw, 'Apple', 'iPhone');
 
-        self::assertInstanceOf(MakerNotesRecord::class, $metadata);
-
         $apple = $metadata->apple();
         self::assertInstanceOf(AppleMakerNotes::class, $apple);
         self::assertSame('archived-photo-uuid', $apple->contentIdentifier);
@@ -132,8 +128,6 @@ final class AppleDecoderTest extends TestCase
         $decoder = new AppleDecoder();
 
         $metadata = $decoder->decode($raw, 'Apple', 'iPhone');
-
-        self::assertInstanceOf(MakerNotesRecord::class, $metadata);
         self::assertSame('Apple', $metadata->vendor());
         self::assertSame(strlen($raw), $metadata->length());
         self::assertSame(sha1($raw), $metadata->sha1());
@@ -167,8 +161,6 @@ final class AppleDecoderTest extends TestCase
 
         $metadata = $decoder->decode($raw, 'Apple', 'iPhone');
 
-        self::assertInstanceOf(MakerNotesRecord::class, $metadata);
-
         $apple = $metadata->apple();
         self::assertInstanceOf(AppleMakerNotes::class, $apple);
         self::assertSame('padded', $apple->contentIdentifier);
@@ -183,8 +175,6 @@ final class AppleDecoderTest extends TestCase
         $decoder = new AppleDecoder();
 
         $metadata = $decoder->decode($raw, 'Apple', 'iPhone');
-
-        self::assertInstanceOf(MakerNotesRecord::class, $metadata);
 
         $apple = $metadata->apple();
         self::assertInstanceOf(AppleMakerNotes::class, $apple);
@@ -213,8 +203,6 @@ final class AppleDecoderTest extends TestCase
 
         $metadata = $decoder->decode($raw, 'Apple', 'iPhone');
 
-        self::assertInstanceOf(MakerNotesRecord::class, $metadata);
-
         $apple = $metadata->apple();
         self::assertInstanceOf(AppleMakerNotes::class, $apple);
         self::assertSame(2, $apple->livePhotoIndex);
@@ -227,8 +215,6 @@ final class AppleDecoderTest extends TestCase
         $decoder = new AppleDecoder();
 
         $metadata = $decoder->decode($raw, 'Apple', 'iPhone');
-
-        self::assertInstanceOf(MakerNotesRecord::class, $metadata);
 
         $apple = $metadata->apple();
         self::assertInstanceOf(AppleMakerNotes::class, $apple);
@@ -273,6 +259,9 @@ final class AppleDecoderTest extends TestCase
         self::assertEqualsWithDelta(0.8, $notes->afConfidence, 1e-12);
     }
 
+    /**
+     * @param array<int, int>|array{values: list<int>}|int $makerNoteVersion
+     */
     #[Test]
     #[DataProvider('makerNoteVersionProvider')]
     public function buildAppleMakerNotesNormalisesMakerNoteVersionFromIntegers(array|int $makerNoteVersion, string $expected): void
@@ -395,7 +384,7 @@ final class AppleDecoderTest extends TestCase
     }
 
     /**
-     * @return iterable<int, array{int, string}>
+     * @return iterable<string, array{int, string}>
      */
     public static function hdrImageTypeProvider(): iterable
     {
@@ -425,7 +414,7 @@ final class AppleDecoderTest extends TestCase
     }
 
     /**
-     * @return iterable<int, array{int, string}>
+     * @return iterable<string, array{int, string}>
      */
     public static function imageCaptureTypeProvider(): iterable
     {
@@ -452,8 +441,6 @@ final class AppleDecoderTest extends TestCase
         $decoder = new AppleDecoder();
 
         $metadata = $decoder->decode($raw, 'Apple', 'iPhone');
-
-        self::assertInstanceOf(MakerNotesRecord::class, $metadata);
         $apple = $metadata->apple();
         self::assertInstanceOf(AppleMakerNotes::class, $apple);
         self::assertSame('textual', $apple->contentIdentifier);
@@ -539,11 +526,12 @@ final class AppleDecoderTest extends TestCase
         self::assertInstanceOf(AppleMakerNotes::class, $notes);
         self::assertSame(1200, $notes->livePhotoIndex);
         self::assertEqualsWithDelta(2.0, $notes->livePhotoTime, 1e-12);
-        self::assertInstanceOf(RunTime::class, $notes->runTime);
-        self::assertSame(2, $notes->runTime?->epoch);
-        self::assertSame(600, $notes->runTime?->timescale);
-        self::assertSame(1500, $notes->runTime?->value);
-        self::assertSame(5, $notes->runTime?->flags);
+        $runTime = $notes->runTime;
+        self::assertInstanceOf(RunTime::class, $runTime);
+        self::assertSame(2, $runTime->epoch);
+        self::assertSame(600, $runTime->timescale);
+        self::assertSame(1500, $runTime->value);
+        self::assertSame(5, $runTime->flags);
     }
 
     #[Test]
@@ -629,8 +617,6 @@ final class AppleDecoderTest extends TestCase
         $decoder = new AppleDecoder();
 
         $metadata = $decoder->decode('Apple iOS' . str_repeat("\x00", 32), 'Apple', 'iPhone');
-
-        self::assertInstanceOf(MakerNotesRecord::class, $metadata);
         self::assertNull($metadata->apple());
     }
 


### PR DESCRIPTION
## Overview
- align the Apple maker note decoder tests with PHPStan expectations

## Details
- drop redundant `MakerNotesRecord` type assertions and rely on the decoder return type
- document the maker note version data provider input shape and declare string keys for generator-based providers
- assert `RunTime` fields via a local variable to avoid nullsafe access on guaranteed instances

## Tests
- `composer ci:test:php:phpstan` *(fails: outstanding violations in other modules)*
- `.build/bin/phpstan analyse tests/MakerNotes/AppleDecoder/AppleDecoderTest.php`

## Risks
- Low; test-only updates

## Changelog
- n/a (tests only)

## References
- None

Closes: n/a

------
https://chatgpt.com/codex/tasks/task_e_69023cce0da483238c1573a65356435b