### PR TITLE
test: resolve phpstan warnings in Apple mapper tests

### DIFF
--- a/tests/MakerNotes/Apple/AppleMakerNotesMapperTest.php
+++ b/tests/MakerNotes/Apple/AppleMakerNotesMapperTest.php
@@ -212,7 +212,6 @@ final class AppleMakerNotesMapperTest extends TestCase
         $mapped = $mapper->map(null, $quickTime);
 
         self::assertNotNull($mapped);
-        self::assertInstanceOf(MakerNotesRecord::class, $mapped);
         self::assertSame('Apple', $mapped->vendor());
         self::assertSame(0, $mapped->length());
         self::assertSame(str_repeat('0', 40), $mapped->sha1());
@@ -269,8 +268,8 @@ final class AppleMakerNotesMapperTest extends TestCase
         self::assertInstanceOf(AppleMakerNotes::class, $apple);
 
         $flags = $apple->flags;
-        self::assertSame(true, $flags['nightMode']);
-        self::assertSame(false, $flags['hdrEnabled']);
-        self::assertSame(true, $flags['hdrAuto']);
+        self::assertTrue($flags['nightMode']);
+        self::assertFalse($flags['hdrEnabled']);
+        self::assertTrue($flags['hdrAuto']);
     }
 }


### PR DESCRIPTION
## Overview
- address PHPStan findings in the Apple maker-notes mapper test suite
- ensure PHPUnit assertions conform to static analysis expectations

## Details
- drop redundant `assertInstanceOf` call that PHPStan proved always true
- swap equality assertions for dedicated truthiness helpers to satisfy phpstan-phpunit rules

## Tests
- `.build/bin/phpstan analyse tests/MakerNotes/Apple/AppleMakerNotesMapperTest.php --configuration .build/phpstan.neon`

## Risks
- Low: changes only touch PHPUnit assertions

## Changelog
- n/a

## References
- n/a

Closes #N/A

------
https://chatgpt.com/codex/tasks/task_e_6902402873e48323b4d4c80d4275e9a4