### PR TITLE
Fix BinaryPlistDecoderTest static assertions

### DIFF
--- a/tests/MakerNotes/Apple/BinaryPlistDecoderTest.php
+++ b/tests/MakerNotes/Apple/BinaryPlistDecoderTest.php
@@ -57,10 +57,10 @@ final class BinaryPlistDecoderTest extends TestCase
         $keyObject = $keyMarker . $key;
 
         $uidLength = strlen($uidBytes);
-        $this->assertGreaterThan(0, $uidLength);
+        self::assertGreaterThan(0, $uidLength);
 
         if ($uidLength > 0x0F) {
-            $this->fail('Test fixture generator does not support UID payloads larger than 15 bytes.');
+            self::fail('Test fixture generator does not support UID payloads larger than 15 bytes.');
         }
 
         $uidMarker = chr(0x80 | ($uidLength - 1));


### PR DESCRIPTION
## Overview
- address PHPStan dynamic static call complaints in the Apple binary plist decoder test helper
- keep the fixture generator aligned with PHPUnit static assertion expectations

## Details
- switch the UID length guard to `self::assertGreaterThan()`
- invoke `self::fail()` instead of the instance helper to satisfy static analysis

## Tests
- [ ] `composer ci:test:php:phpstan` *(fails: outstanding issues in other MakerNotes tests and ValueConverters unrelated to this change; follow-up tasks required)*

## Risks
- low: only adjusts assertion style within an internal test helper

## Changelog
- fix BinaryPlistDecoderTest to call PHPUnit static assertions directly

## References
- n/a

Closes #N/A


------
https://chatgpt.com/codex/tasks/task_e_6902402e5ed8832388219b1868891d04