### PR TITLE
Remove redundant maker note type assertions in decoder tests

### DIFF
--- a/tests/MakerNotes/CanonDecoder/CanonDecoderTest.php
+++ b/tests/MakerNotes/CanonDecoder/CanonDecoderTest.php
@@ -12,7 +12,6 @@ declare(strict_types=1);
 namespace MagicSunday\ImageMeta\Tests\MakerNotes\CanonDecoder;
 
 use MagicSunday\ImageMeta\MakerNotes\CanonDecoder;
-use MagicSunday\ImageMeta\MakerNotes\MakerNotesRecord;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
@@ -37,7 +36,6 @@ final class CanonDecoderTest extends TestCase
 
         $metadata = $decoder->decode($raw, 'Canon', 'Canon EOS R5');
 
-        self::assertInstanceOf(MakerNotesRecord::class, $metadata);
         self::assertSame('Canon', $metadata->vendor());
         self::assertSame(strlen($raw), $metadata->length());
         self::assertSame(sha1($raw), $metadata->sha1());

--- a/tests/MakerNotes/NikonDecoder/NikonDecoderTest.php
+++ b/tests/MakerNotes/NikonDecoder/NikonDecoderTest.php
@@ -11,7 +11,6 @@ declare(strict_types=1);
 
 namespace MagicSunday\ImageMeta\Tests\MakerNotes\NikonDecoder;
 
-use MagicSunday\ImageMeta\MakerNotes\MakerNotesRecord;
 use MagicSunday\ImageMeta\MakerNotes\NikonDecoder;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -37,7 +36,6 @@ final class NikonDecoderTest extends TestCase
 
         $metadata = $decoder->decode($raw, 'Nikon Corporation', 'NIKON Z 8');
 
-        self::assertInstanceOf(MakerNotesRecord::class, $metadata);
         self::assertSame('Nikon', $metadata->vendor());
         self::assertSame(strlen($raw), $metadata->length());
         self::assertSame(sha1($raw), $metadata->sha1());

--- a/tests/MakerNotes/SonyDecoder/SonyDecoderTest.php
+++ b/tests/MakerNotes/SonyDecoder/SonyDecoderTest.php
@@ -11,7 +11,6 @@ declare(strict_types=1);
 
 namespace MagicSunday\ImageMeta\Tests\MakerNotes\SonyDecoder;
 
-use MagicSunday\ImageMeta\MakerNotes\MakerNotesRecord;
 use MagicSunday\ImageMeta\MakerNotes\SonyDecoder;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -37,7 +36,6 @@ final class SonyDecoderTest extends TestCase
 
         $metadata = $decoder->decode($raw, 'Sony', 'ILCE-7RM5');
 
-        self::assertInstanceOf(MakerNotesRecord::class, $metadata);
         self::assertSame('Sony', $metadata->vendor());
         self::assertSame(strlen($raw), $metadata->length());
         self::assertSame(sha1($raw), $metadata->sha1());


### PR DESCRIPTION
## Summary
- drop redundant MakerNotesRecord assertions from the Canon, Nikon, and Sony maker note decoder tests to satisfy PHPStan static analysis

## Testing
- composer ci:test:php:phpstan *(fails: existing violations outside the modified decoder tests)*

------
https://chatgpt.com/codex/tasks/task_e_6902401b2e9c8323bfcaa2609ee65b7a