### PR TITLE
Fix SemanticStyle QuickTime test construction

### DIFF
--- a/tests/MakerNotes/Apple/Support/SemanticStyleTest.php
+++ b/tests/MakerNotes/Apple/Support/SemanticStyleTest.php
@@ -7,17 +7,16 @@ namespace MagicSunday\ImageMeta\Tests\MakerNotes\Apple\Support;
 use MagicSunday\ImageMeta\MakerNotes\Apple\Support\SemanticStyle;
 use MagicSunday\ImageMeta\Model\QuickTimeMeta;
 use PHPUnit\Framework\TestCase;
+use ReflectionClass;
 
 final class SemanticStyleTest extends TestCase
 {
     public function testFromQuickTimeParsesModernStructure(): void
     {
-        $meta = new QuickTimeMeta([
-            'SemanticStyle' => [
-                '_0' => 'Vivid',
-                '_2' => 0.15,
-                '_3' => ['value' => '0.25'],
-            ],
+        $meta = $this->quickTimeMeta([
+            '_0' => 'Vivid',
+            '_2' => 0.15,
+            '_3' => ['value' => '0.25'],
         ]);
 
         self::assertSame(['Vivid', 0.15, 0.25], SemanticStyle::fromQuickTime($meta));
@@ -41,5 +40,23 @@ final class SemanticStyleTest extends TestCase
     public function testFromValueReturnsNullWhenNoComponents(): void
     {
         self::assertNull(SemanticStyle::fromValue(['values' => []]));
+    }
+
+    /**
+     * Creates a QuickTime metadata container populated with the supplied semantic style payload.
+     *
+     * @param array<int|string, mixed> $semanticStyle
+     */
+    private function quickTimeMeta(array $semanticStyle): QuickTimeMeta
+    {
+        $reflector = new ReflectionClass(QuickTimeMeta::class);
+
+        /** @var QuickTimeMeta $meta */
+        $meta = $reflector->newInstanceWithoutConstructor();
+        $property = $reflector->getProperty('keys');
+        $property->setAccessible(true);
+        $property->setValue($meta, ['SemanticStyle' => $semanticStyle]);
+
+        return $meta;
     }
 }


### PR DESCRIPTION
## Overview
- fix the SemanticStyle QuickTime metadata test setup to comply with QuickTimeMeta constructor constraints

## Details
- add a helper that instantiates QuickTimeMeta via reflection with a semantic-style payload
- reuse the helper inside the modern structure test case to avoid nested array literals in the constructor call

## Tests
- `composer ci:test:php:phpstan` *(fails: pre-existing 47 errors across ValueConverters and Apple decoder tests)*

## Risks
- Low; changes confined to a PHPUnit test helper.

## Changelog
- Adjusted SemanticStyle QuickTime test fixture creation.

## References
- n/a

Closes #N/A

------
https://chatgpt.com/codex/tasks/task_e_6902417b4ebc8323af875f6a7a7ac274