### PR TITLE
Fix handling of optional EXIF dependencies

### DIFF
--- a/src/Api/ExifReader.php
+++ b/src/Api/ExifReader.php
@@ -25,14 +25,17 @@ use MagicSunday\ImageMeta\Parse\Tiff\TiffExifReader;
  */
 final readonly class ExifReader
 {
+    private TiffExifReader $tiffReader;
+
     /**
      * @param TiffExifReader|null $tiffReader Optional TIFF EXIF reader reused across calls.
      *
      * Providing a custom reader allows sharing caches or maker-notes registries in higher-level
      * code while defaulting to a new reader instance when no dependency is supplied.
      */
-    public function __construct(private ?TiffExifReader $tiffReader = new TiffExifReader())
+    public function __construct(?TiffExifReader $tiffReader = null)
     {
+        $this->tiffReader = $tiffReader ?? new TiffExifReader();
     }
 
     /**

--- a/src/Curate/ExifAssembler.php
+++ b/src/Curate/ExifAssembler.php
@@ -19,8 +19,11 @@ use MagicSunday\ImageMeta\Model\Metadata;
  */
 final readonly class ExifAssembler
 {
-    public function __construct(private ?ValueFactory $valueFactory = new ValueFactory())
+    private ValueFactory $valueFactory;
+
+    public function __construct(?ValueFactory $valueFactory = null)
     {
+        $this->valueFactory = $valueFactory ?? new ValueFactory();
     }
 
     /**

--- a/src/Model/Exif/ExifDocument.php
+++ b/src/Model/Exif/ExifDocument.php
@@ -834,16 +834,6 @@ final readonly class ExifDocument
     }
 
     /**
-     * Returns the resolved preview descriptor when both offset and length are valid.
-     *
-     * @return array{ifd:Ifd,offset:int,length:int}|null
-     */
-    private function previewContext(): ?array
-    {
-        return $this->previewContext;
-    }
-
-    /**
      * @return list<Ifd>
      *
      * EXIF 3.0 §4.6.12 permits preview tags inside the Exif IFD or auxiliary SubIFDs, so


### PR DESCRIPTION
## Overview
- ensure `ExifReader` always has a TIFF reader instance before parsing blobs
- guard the `ExifAssembler` factory dependency to avoid nullable lookups
- remove the unused `ExifDocument::previewContext()` helper flagged by static analysis

## Details
- instantiate a default `TiffExifReader` when the facade is constructed without one
- instantiate a default `ValueFactory` when no factory is provided to the assembler
- drop the redundant private preview helper to silence PHPStan

## Tests
- `composer ci:test:php:phpstan`

## Risks
- Low; only adjusts optional dependency wiring and deletes an unused helper.

## Changelog
- Fix optional EXIF dependency initialisation within the public API and curator layers.

## References
- None

Closes #N/A

------
https://chatgpt.com/codex/tasks/task_e_6902488022248323849636d00b907f63