### PR TITLE
fix(exif): retain primary IFDs for profile lookup

### DIFF
--- a/src/Model/Exif/ExifDocument.php
+++ b/src/Model/Exif/ExifDocument.php
@@ -2869,7 +2869,9 @@ final readonly class ExifDocument
             }
         }
 
-        $sources = $this->subsequentIfds;
+        foreach ($this->subsequentIfds as $ifd) {
+            $sources[] = $ifd;
+        }
 
         foreach ($this->subIfds as $ifd) {
             $sources[] = $ifd;


### PR DESCRIPTION
## Overview
- ensure `ExifDocument::profileSourceIfds()` retains the initially collected IFDs

## Details
- append subsequent and SubIFDs instead of overwriting the base list so profile detection sees every candidate

## Tests
- not run (not requested)

## Risks
- low: change only touches aggregation of IFD references

## Changelog
- retain primary IFDs when building the profile source list

## References
- n/a

Closes #0

------
https://chatgpt.com/codex/tasks/task_e_69024da898b88323887c682474256f5e