### PR TITLE
refactor: remove redundant array_values iteration

### DIFF
--- a/src/Model/Exif/ValueConverters.php
+++ b/src/Model/Exif/ValueConverters.php
@@ -337,7 +337,7 @@ final readonly class ValueConverters
             $values = $rational->values;
         } else {
             $values = [];
-            foreach (array_values($rational) as $component) {
+            foreach ($rational as $component) {
                 if (is_array($component)) {
                     /** @var array<int, int|float|string> $pair */
                     $pair     = array_values($component);
@@ -393,7 +393,7 @@ final readonly class ValueConverters
             $values = $rational->values;
         } else {
             $values = [];
-            foreach (array_values($rational) as $component) {
+            foreach ($rational as $component) {
                 if (is_array($component)) {
                     /** @var array<int, int|float|string> $pair */
                     $pair     = array_values($component);


### PR DESCRIPTION
## Overview
- remove redundant array_values() usage inside foreach loops in the EXIF value converters

## Details
- iterate directly over the provided rational arrays to avoid needless reindexing when keys are unused

## Tests
- not run (not requested)

## Risks
- low

## Changelog
- remove redundant array_values() iteration in EXIF value converters

## References
- n/a

## Closes
- n/a

------
https://chatgpt.com/codex/tasks/task_e_69024e056d688323be9d34e323546692