### PR TITLE
fix(core): prefer first-class callables in byte reader

### DIFF
--- a/src/Core/ByteReader.php
+++ b/src/Core/ByteReader.php
@@ -31,20 +31,20 @@ final readonly class ByteReader
     /**
      * Creates a reader backed by callbacks that operate on an external data source.
      *
-     * @param callable(int):string      $read    Callback that returns the requested number of bytes.
-     * @param callable():int            $tell    Callback that reports the current cursor position.
-     * @param callable(int|UInt64):void $seek    Callback that repositions the cursor of the data source.
+     * @param Closure(int):string      $read    Callback that returns the requested number of bytes.
+     * @param Closure():int            $tell    Callback that reports the current cursor position.
+     * @param Closure(int|UInt64):void $seek    Callback that repositions the cursor of the data source.
      * @param string                    $context Short description used in error messages.
      */
     public function __construct(
-        callable $read,
-        callable $tell,
-        callable $seek,
+        Closure $read,
+        Closure $tell,
+        Closure $seek,
         private string $context,
     ) {
-        $this->read = Closure::fromCallable($read);
-        $this->tell = Closure::fromCallable($tell);
-        $this->seek = Closure::fromCallable($seek);
+        $this->read = $read;
+        $this->tell = $tell;
+        $this->seek = $seek;
     }
 
     /**


### PR DESCRIPTION
## Overview
- switch the `ByteReader` constructor to accept closure-typed callbacks directly
- remove intermediate `Closure::fromCallable()` usage now that all call sites pass first-class callables

## Details
- adjust the phpdoc annotations to match the new `Closure` parameter types
- keep the stored callbacks untouched so invocations remain unchanged

## Tests
- `composer ci:test:php:unit`

## Risks
- low: constructor signature narrows to closures already used by all callers

## Changelog
- fix: use closure-typed callbacks in `ByteReader`

## References
- n/a (no spec chapters affected)

Closes #N/A


------
https://chatgpt.com/codex/tasks/task_e_69024e586bc883238172353c5c927e74