### PR TITLE
Refactor XMP list finalization to use array_filter

### DIFF
--- a/src/Parse/Xmp/XmpParser.php
+++ b/src/Parse/Xmp/XmpParser.php
@@ -14,7 +14,9 @@ namespace MagicSunday\ImageMeta\Parse\Xmp;
 use MagicSunday\ImageMeta\Model\Xmp\XmpDocument;
 use XMLReader;
 
+use function array_filter;
 use function array_key_exists;
+use function array_values;
 use function is_array;
 use function sprintf;
 use function trim;
@@ -142,12 +144,10 @@ final class XmpParser
      */
     private function finalizeValue(array $items, string $text): array|string|null
     {
-        $filtered = [];
-        foreach ($items as $value) {
-            if ($value !== '') {
-                $filtered[] = $value;
-            }
-        }
+        $filtered = array_values(array_filter(
+            $items,
+            static fn (string $value): bool => $value !== '',
+        ));
 
         if ($filtered !== []) {
             return $filtered;


### PR DESCRIPTION
## Overview
- streamline the XMP container value finalization logic by replacing the manual loop with `array_filter`

## Details
- use `array_values(array_filter(...))` to drop empty list items while preserving list semantics
- import the global helpers explicitly to keep the namespace header consistent

## Tests
- `composer ci:test:php:unit`

## Risks
- Low: affects only XMP container value finalization

## Changelog
- Refactor XMP parser container handling to rely on `array_filter`

Closes #N/A

## References
- n/a

------
https://chatgpt.com/codex/tasks/task_e_69024e708ba483238dbb3fb7d54baa2c