### PR TITLE
fix: replace foreach scans with array_any

### DIFF
--- a/src/MakerNotes/Apple/AppleMakerNotesMapper.php
+++ b/src/MakerNotes/Apple/AppleMakerNotesMapper.php
@@ -17,6 +17,7 @@ use MagicSunday\ImageMeta\MakerNotes\AppleMetadata;
 use MagicSunday\ImageMeta\MakerNotes\MakerNotesRecord;
 use MagicSunday\ImageMeta\Model\QuickTimeMeta;
 
+use function array_any;
 use function array_key_exists;
 use function get_object_vars;
 use function is_array;
@@ -273,29 +274,24 @@ final class AppleMakerNotesMapper
      */
     private function hasAppleData(AppleMakerNotes $apple): bool
     {
-        foreach (get_object_vars($apple) as $key => $value) {
-            if ($key === 'flags') {
-                if ($value !== []) {
-                    return true;
-                }
+        $values = get_object_vars($apple);
 
-                continue;
-            }
-
-            if (is_array($value)) {
-                if ($value !== []) {
-                    return true;
-                }
-
-                continue;
-            }
-
-            if ($value !== null) {
-                return true;
-            }
+        if (array_key_exists('flags', $values) && $values['flags'] !== []) {
+            return true;
         }
 
-        return false;
+        unset($values['flags']);
+
+        return array_any(
+            $values,
+            static function ($value): bool {
+                if (is_array($value)) {
+                    return $value !== [];
+                }
+
+                return $value !== null;
+            },
+        );
     }
 
     /**

--- a/src/Model/Exif/ExifDocument.php
+++ b/src/Model/Exif/ExifDocument.php
@@ -44,6 +44,7 @@ use MagicSunday\ImageMeta\Value\Enum\WhiteBalance;
 use MagicSunday\ImageMeta\Value\Enum\YCbCrPositioning;
 
 use function abs;
+use function array_any;
 use function array_key_exists;
 use function array_map;
 use function count;
@@ -804,11 +805,14 @@ final readonly class ExifDocument
             return $context['length'] > 0;
         }
 
-        foreach ($this->previewCandidateIfds() as $ifd) {
-            if ($ifd->get(ExifTag::PREVIEW_IMAGE_START) instanceof IfdEntry
-                || $ifd->get(ExifTag::PREVIEW_IMAGE_LENGTH) instanceof IfdEntry) {
-                return false;
-            }
+        if (array_any(
+            $this->previewCandidateIfds(),
+            static function (Ifd $ifd): bool {
+                return $ifd->get(ExifTag::PREVIEW_IMAGE_START) instanceof IfdEntry
+                    || $ifd->get(ExifTag::PREVIEW_IMAGE_LENGTH) instanceof IfdEntry;
+            },
+        )) {
+            return false;
         }
 
         $otherPreviewTags = [
@@ -822,12 +826,16 @@ final readonly class ExifDocument
             ExifTag::PREVIEW_IMAGE_COLOR_SPACE,
         ];
 
-        foreach ($this->previewCandidateIfds() as $ifd) {
-            foreach ($otherPreviewTags as $tag) {
-                if ($ifd->get($tag) instanceof IfdEntry) {
-                    return false;
-                }
-            }
+        if (array_any(
+            $this->previewCandidateIfds(),
+            static function (Ifd $ifd) use ($otherPreviewTags): bool {
+                return array_any(
+                    $otherPreviewTags,
+                    static fn (int $tag): bool => $ifd->get($tag) instanceof IfdEntry,
+                );
+            },
+        )) {
+            return false;
         }
 
         return null;


### PR DESCRIPTION
## Overview
- replace manual foreach scans that only detect populated values with array_any()
- keep behaviour identical while leaning on PHP 8.4 helpers

## Details
- update Apple maker note detection to collect object vars once and defer emptiness checks to array_any()
- collapse EXIF preview tag lookups into array_any() predicates to avoid nested foreach loops

## Tests
- composer ci:test:php:unit

## Risks
- Low; refactors conditional scans without altering data normalisation logic.

## Changelog
- Not user facing.

## References
- EXIF 3.0 §4.6.12

Closes: n/a

------
https://chatgpt.com/codex/tasks/task_e_69024e83bd388323944c1a56d35d95c4