### PR TITLE
Refactor: use array_find for lookup loops

### DIFF
--- a/src/MakerNotes/AppleDecoder.php
+++ b/src/MakerNotes/AppleDecoder.php
@@ -19,6 +19,7 @@ use MagicSunday\ImageMeta\MakerNotes\Apple\KeyedArchiveUnarchiver;
 use MagicSunday\ImageMeta\MakerNotes\Apple\Support\SemanticStyle;
 use MagicSunday\ImageMeta\Value\RunTime;
 
+use function array_find;
 use function array_flip;
 use function array_is_list;
 use function array_key_exists;
@@ -568,13 +569,10 @@ final class AppleDecoder implements MakerNotesDecoderInterface
      */
     private function firstExistingKey(array $dictionary, string ...$keys): ?string
     {
-        foreach ($keys as $key) {
-            if (array_key_exists($key, $dictionary)) {
-                return $key;
-            }
-        }
-
-        return null;
+        return array_find(
+            $keys,
+            static fn (string $key): bool => array_key_exists($key, $dictionary),
+        );
     }
 
     /**

--- a/src/Model/Exif/ExifDocument.php
+++ b/src/Model/Exif/ExifDocument.php
@@ -44,6 +44,7 @@ use MagicSunday\ImageMeta\Value\Enum\WhiteBalance;
 use MagicSunday\ImageMeta\Value\Enum\YCbCrPositioning;
 
 use function abs;
+use function array_find;
 use function array_key_exists;
 use function array_map;
 use function count;
@@ -804,11 +805,16 @@ final readonly class ExifDocument
             return $context['length'] > 0;
         }
 
-        foreach ($this->previewCandidateIfds() as $ifd) {
-            if ($ifd->get(ExifTag::PREVIEW_IMAGE_START) instanceof IfdEntry
-                || $ifd->get(ExifTag::PREVIEW_IMAGE_LENGTH) instanceof IfdEntry) {
-                return false;
-            }
+        $candidates = $this->previewCandidateIfds();
+
+        $startOrLengthIfd = array_find(
+            $candidates,
+            static fn (Ifd $ifd): bool => $ifd->get(ExifTag::PREVIEW_IMAGE_START) instanceof IfdEntry
+                || $ifd->get(ExifTag::PREVIEW_IMAGE_LENGTH) instanceof IfdEntry,
+        );
+
+        if ($startOrLengthIfd !== null) {
+            return false;
         }
 
         $otherPreviewTags = [
@@ -822,12 +828,16 @@ final readonly class ExifDocument
             ExifTag::PREVIEW_IMAGE_COLOR_SPACE,
         ];
 
-        foreach ($this->previewCandidateIfds() as $ifd) {
-            foreach ($otherPreviewTags as $tag) {
-                if ($ifd->get($tag) instanceof IfdEntry) {
-                    return false;
-                }
-            }
+        $otherPreviewIfd = array_find(
+            $candidates,
+            fn (Ifd $ifd): bool => array_find(
+                $otherPreviewTags,
+                static fn ($tag): bool => $ifd->get($tag) instanceof IfdEntry,
+            ) !== null,
+        );
+
+        if ($otherPreviewIfd !== null) {
+            return false;
         }
 
         return null;

--- a/src/Model/QuickTimeMeta.php
+++ b/src/Model/QuickTimeMeta.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace MagicSunday\ImageMeta\Model;
 
+use function array_find;
 use function array_key_exists;
 use function is_bool;
 use function is_float;
@@ -230,13 +231,12 @@ final readonly class QuickTimeMeta
     {
         $candidates = self::KEY_ALIASES[$key] ?? [$key];
 
-        foreach ($candidates as $candidate) {
-            if (array_key_exists($candidate, $this->keys)) {
-                return $this->keys[$candidate];
-            }
-        }
+        $candidate = array_find(
+            $candidates,
+            fn (string $candidate): bool => array_key_exists($candidate, $this->keys),
+        );
 
-        return null;
+        return $candidate === null ? null : $this->keys[$candidate];
     }
 
     /**


### PR DESCRIPTION
## Overview
- replace simple foreach search loops with array_find() now that PHP 8.4 is available
- keep behaviour unchanged while improving readability in QuickTime, EXIF, and Apple maker note helpers

## Details
- update QuickTime metadata lookup to resolve the first matching alias via array_find()
- streamline Apple keyed-archive key detection with array_find()
- collapse EXIF preview detection loops into array_find() queries shared across candidate IFDs

## Tests
- `composer ci:test:php:unit`
- `composer ci:test:php:phpstan` *(fails: BitMaskTest assertions flagged as already-narrowed in existing baseline)*

## Risks
- Low; changes only adjust lookup helpers to rely on array_find() while preserving existing conditions

## Changelog
- n/a

## References
- n/a

Closes #N/A

------
https://chatgpt.com/codex/tasks/task_e_69024eae1e748323a1c2465da88c2fb5