### PR TITLE
fix: rename ByteReader cursor accessors to avoid property conflict

### DIFF
--- a/src/Core/ByteReader.php
+++ b/src/Core/ByteReader.php
@@ -97,7 +97,7 @@ final readonly class ByteReader
     /**
      * Returns the current cursor position of the underlying data source.
      */
-    public function tell(): int
+    public function getPosition(): int
     {
         return ($this->tell)();
     }
@@ -105,7 +105,7 @@ final readonly class ByteReader
     /**
      * Moves the cursor of the underlying data source.
      */
-    public function seek(int|UInt64 $offset): void
+    public function setPosition(int|UInt64 $offset): void
     {
         ($this->seek)($offset);
     }

--- a/src/Core/MemoryBuffer.php
+++ b/src/Core/MemoryBuffer.php
@@ -62,7 +62,7 @@ final class MemoryBuffer
      */
     public function tell(): int
     {
-        return $this->byteReader->tell();
+        return $this->byteReader->getPosition();
     }
 
     /**
@@ -74,7 +74,7 @@ final class MemoryBuffer
      */
     public function seek(int|UInt64 $offset): void
     {
-        $this->byteReader->seek($offset);
+        $this->byteReader->setPosition($offset);
     }
 
     /**

--- a/src/Core/Stream.php
+++ b/src/Core/Stream.php
@@ -95,7 +95,7 @@ final class Stream
      */
     public function tell(): int
     {
-        return $this->byteReader->tell();
+        return $this->byteReader->getPosition();
     }
 
     /**
@@ -105,7 +105,7 @@ final class Stream
      */
     public function seek(int $offset): void
     {
-        $this->byteReader->seek($offset);
+        $this->byteReader->setPosition($offset);
     }
 
     /**

--- a/src/Core/StreamWindow.php
+++ b/src/Core/StreamWindow.php
@@ -61,7 +61,7 @@ final class StreamWindow
      */
     public function tell(): int
     {
-        return $this->byteReader->tell();
+        return $this->byteReader->getPosition();
     }
 
     /**
@@ -71,7 +71,7 @@ final class StreamWindow
      */
     public function seek(int $pos): void
     {
-        $this->byteReader->seek($pos);
+        $this->byteReader->setPosition($pos);
     }
 
     /**


### PR DESCRIPTION
## Overview
- rename the ByteReader cursor accessors to avoid name collisions with its internal closures
- update stream, window, and memory buffer wrappers to use the new accessor names

## Details
- replace `tell()`/`seek()` on `ByteReader` with `getPosition()`/`setPosition()` while keeping external API stable
- delegate `Stream`, `StreamWindow`, and `MemoryBuffer` cursor helpers to the renamed methods

## Tests
- `composer ci:test:php:unit`

## Risks
- Low: method renames are internal to core abstractions and covered by unit tests

## Changelog
- fix(core): rename byte reader cursor helpers to avoid closure name clash

## References
- n/a

Closes #N/A

------
https://chatgpt.com/codex/tasks/task_e_69024f7bb4288323914e1e967567092c