### PR TITLE
Fix nested ternary operators

### DIFF
--- a/src/Exif/Support/EnumFromIntStringNullable.php
+++ b/src/Exif/Support/EnumFromIntStringNullable.php
@@ -41,7 +41,14 @@ trait EnumFromIntStringNullable
         }
 
         // int|string → int
-        $intValue = is_int($value) ? $value : (is_numeric($value) ? (int) $value : null);
+        if (is_int($value)) {
+            $intValue = $value;
+        } elseif (is_numeric($value)) {
+            $intValue = (int) $value;
+        } else {
+            $intValue = null;
+        }
+
         if ($intValue === null) {
             return null;
         }

--- a/src/Model/Exif/ExifDocument.php
+++ b/src/Model/Exif/ExifDocument.php
@@ -3882,9 +3882,11 @@ final readonly class ExifDocument
         $content           = $hasKnownPrefix ? substr($raw, 8) : $raw;
         $sanitized         = trim($content, "\0 ");
 
-        $resolvedEncoding = $hasKnownPrefix
-            ? ($sanitized === '' ? null : $canonicalEncoding)
-            : $this->inferUserCommentEncoding($content);
+        if ($hasKnownPrefix) {
+            $resolvedEncoding = $sanitized === '' ? null : $canonicalEncoding;
+        } else {
+            $resolvedEncoding = $this->inferUserCommentEncoding($content);
+        }
 
         if ($resolvedEncoding === null) {
             return null;


### PR DESCRIPTION
## Overview
- remove nested ternary usage to satisfy coding guidelines

## Details
- expand `EnumFromIntStringNullable::fromExifValue()` into explicit branching before calling `tryFrom`
- resolve the EXIF user comment encoding with descriptive control flow in `ExifDocument::decodeUserComment`

## Tests
- composer ci:test:php:unit

## Risks
- Low: adjusts control flow for EXIF value normalisation and comment decoding only

## Changelog
- n/a

## References
- None

Closes #N/A

------
https://chatgpt.com/codex/tasks/task_e_69024f93f1c08323904206cb51a241f6