### PR TITLE
fix(exif): tighten list generics

### DIFF
--- a/src/Model/Exif/ExifNumericList.php
+++ b/src/Model/Exif/ExifNumericList.php
@@ -13,10 +13,9 @@ namespace MagicSunday\ImageMeta\Model\Exif;
 
 use InvalidArgumentException;
 use MagicSunday\ImageMeta\Core\Util\UInt64;
+use TypeError;
 
 use function array_is_list;
-use function is_float;
-use function is_int;
 
 /**
  * Represents a list of numeric EXIF values.
@@ -29,14 +28,22 @@ final readonly class ExifNumericList
     public array $values;
 
     /**
-     * @param array<int, int|float|UInt64> $values Ordered list of numeric components.
+     * @param list<int|float|UInt64> $values Ordered list of numeric components.
+     *
+     * @phpstan-param array<int, int|float|UInt64> $values Ordered list of numeric components.
+     *
+     * @psalm-param list<int|float|UInt64> $values
      */
     public function __construct(array $values)
     {
         $this->assertList($values);
 
         foreach ($values as $value) {
-            $this->assertNumericComponent($value);
+            try {
+                $this->assertNumericComponent($value);
+            } catch (TypeError $exception) {
+                throw new InvalidArgumentException('Numeric EXIF lists may only contain integers, floats, or UInt64 values.', 0, $exception);
+            }
         }
 
         /** @var list<int|float|UInt64> $values */
@@ -54,7 +61,9 @@ final readonly class ExifNumericList
     }
 
     /**
-     * @param array<int, int|float|UInt64> $values
+     * @param list<int|float|UInt64> $values
+     *
+     * @phpstan-param array<int, int|float|UInt64> $values
      *
      * @phpstan-assert list<int|float|UInt64> $values
      */
@@ -67,12 +76,8 @@ final readonly class ExifNumericList
         throw new InvalidArgumentException('Numeric EXIF values must form a list.');
     }
 
-    private function assertNumericComponent(mixed $value): void
+    private function assertNumericComponent(int|float|UInt64 $value): void
     {
-        if (is_int($value) || is_float($value) || $value instanceof UInt64) {
-            return;
-        }
-
-        throw new InvalidArgumentException('Numeric EXIF lists may only contain integers, floats, or UInt64 values.');
+        // The union type enforces numeric values at the call site. The method body remains intentionally empty.
     }
 }

--- a/src/Model/Exif/ExifRationalList.php
+++ b/src/Model/Exif/ExifRationalList.php
@@ -12,8 +12,10 @@ declare(strict_types=1);
 namespace MagicSunday\ImageMeta\Model\Exif;
 
 use InvalidArgumentException;
+use TypeError;
 
 use function array_is_list;
+use function array_map;
 
 /**
  * Represents a list of rational EXIF values.
@@ -26,7 +28,11 @@ final readonly class ExifRationalList
     public array $values;
 
     /**
-     * @param array<int, mixed> $values Ordered list of rational components.
+     * @param list<ExifRational> $values Ordered list of rational components.
+     *
+     * @phpstan-param array<int, ExifRational> $values Ordered list of rational components.
+     *
+     * @psalm-param list<ExifRational> $values
      *
      * @throws InvalidArgumentException If the provided values are not a sequential list of ExifRational objects.
      */
@@ -36,10 +42,15 @@ final readonly class ExifRationalList
             throw new InvalidArgumentException('Rational EXIF values must form a list.');
         }
 
-        foreach ($values as $value) {
-            if (!$value instanceof ExifRational) {
-                throw new InvalidArgumentException('Rational EXIF lists may only contain ExifRational instances.');
-            }
+        try {
+            $values = array_map(
+                static function (ExifRational $value): ExifRational {
+                    return $value;
+                },
+                $values
+            );
+        } catch (TypeError $exception) {
+            throw new InvalidArgumentException('Rational EXIF lists may only contain ExifRational instances.', 0, $exception);
         }
 
         /** @var list<ExifRational> $values */


### PR DESCRIPTION
## Overview
- improve Exif rational and numeric list constructors to use list-aware generics
- keep runtime validation while exposing stricter Psalm/PHPStan annotations

## Details
- document constructors with `list<>` param annotations and align PHPStan/Psalm tags
- replace manual numeric type checks with union-typed helper that wraps `TypeError` in `InvalidArgumentException`
- normalize rational inputs via typed `array_map` to preserve custom exception semantics

## Tests
- `composer ci:test:php:unit:coverage` *(fails: No code coverage driver available)*
- `composer ci:test:php:phpstan`
- `composer ci:cgl`

## Risks
- Low; only adjusts model validation and docs

## Changelog
- n/a

## References
- n/a

## Closes
- n/a

------
https://chatgpt.com/codex/tasks/task_e_6902568a616483238338965714e0b64c