### PR TITLE
refactor(jpeg): tighten MPF rational helper types

### DIFF
--- a/src/Parse/Jpeg/MpfParser.php
+++ b/src/Parse/Jpeg/MpfParser.php
@@ -455,7 +455,7 @@ final class MpfParser
      */
     private function rationalListValue(int|string|array|null $value): ?array
     {
-        if ($value === null) {
+        if (!is_array($value)) {
             return null;
         }
 
@@ -471,16 +471,12 @@ final class MpfParser
     }
 
     /**
-     * @param mixed $value
+     * @param array<int|string, mixed> $value
      *
      * @phpstan-assert-if-true array{numerator:int, denominator:int} $value
      */
-    private function isRational(mixed $value): bool
+    private function isRational(array $value): bool
     {
-        if (!is_array($value)) {
-            return false;
-        }
-
         if (!array_key_exists('numerator', $value) || !array_key_exists('denominator', $value)) {
             return false;
         }
@@ -489,17 +485,20 @@ final class MpfParser
     }
 
     /**
-     * @param mixed $value
+     * @param array<int|string, mixed> $value
      *
      * @phpstan-assert-if-true list<array{numerator:int, denominator:int}> $value
      */
-    private function isRationalList(mixed $value): bool
+    private function isRationalList(array $value): bool
     {
-        if (!is_array($value) || !array_is_list($value)) {
+        if (!array_is_list($value)) {
             return false;
         }
 
-        return array_all($value, $this->isRational(...));
+        return array_all(
+            $value,
+            fn (mixed $item): bool => is_array($item) && $this->isRational($item),
+        );
     }
 
     private function readU16(MemoryBuffer $buffer, Endian $endian): int


### PR DESCRIPTION
## Overview
- guard MPF rational list parsing against non-array values before shape assertions
- narrow helper signatures to typed arrays to improve static analysis certainty

## Details
- ensure `rationalListValue` short-circuits when encountering non-array inputs
- replace `mixed` parameter hints in `isRational`/`isRationalList` with array types and update PHPStan assertions
- harden rational list validation by checking element types before invoking the rational assertion helper

## Tests
- `composer ci:test:php:unit:coverage` *(fails: no code coverage driver available)*
- `composer ci:test:php:phpstan`
- `composer ci:cgl`

## Risks
- Low: refactor limits input types and may surface previously-silent type mismatches.

## Changelog
- tighten MPF rational helper typing and validation

## References
- None (no EXIF chapter updates required)

Closes #N/A

------
https://chatgpt.com/codex/tasks/task_e_6902568bb0248323b1186db70900f8d7