### PR TITLE
docs: align parseIfNeeded EXIF citations

### DIFF
--- a/src/Parse/Jpeg/JpegExtractor.php
+++ b/src/Parse/Jpeg/JpegExtractor.php
@@ -296,7 +296,11 @@ final class JpegExtractor
     }
 
     /**
-     * Lazily scans the JPEG structure the first time metadata is requested.
+     * Lazily scans the JPEG structure on first access to collect metadata APP markers.
+     *
+     * EXIF 3.0 §4.7.1-§4.7.3 require APP1/APP2 metadata segments to reside between the
+     * SOI and the first SOS marker while excluding restart and TEM markers from carrying
+     * payloads; EXIF 2.32 §4.7.1-§4.7.3 preserve the same ordering and marker constraints.
      */
     private function parseIfNeeded(): void
     {
@@ -338,11 +342,11 @@ final class JpegExtractor
             }
 
             if ($marker === Marker::SOS) {
-                break; // stop scanning metadata when scan data begins
+                break; // EXIF 3.0 §4.7.1 and EXIF 2.32 §4.7.1 restrict metadata APP markers to precede the first SOS.
             }
 
             if ($marker === Marker::TEM || ($marker >= Marker::RST_FIRST && $marker <= Marker::RST_LAST)) {
-                continue; // markers without payload
+                continue; // EXIF 3.0 §4.7.1 and EXIF 2.32 §4.7.1 treat restart and TEM markers as non-payload markers.
             }
 
             $isAppSegment  = $marker >= Marker::APP_FIRST && $marker <= Marker::APP_LAST;


### PR DESCRIPTION
# Overview
- clarify the JPEG parser documentation around APP metadata scanning
- cite the EXIF 3.0 and 2.32 clauses that bound APP1/APP2 placement and marker handling

# Details
- expand the `parseIfNeeded` PHPDoc to note the APP1/APP2 ordering rules and restart/TEM exclusions from the EXIF spec
- update inline comments to reference the same EXIF 3.0 §4.7.1 and EXIF 2.32 §4.7.1 guidance when halting before SOS or skipping restart markers

# Tests
- `composer ci:test:php:unit:coverage` *(fails: No code coverage driver available)*
- `composer ci:test:php:phpstan`
- `composer ci:cgl`

# Risks
- Low: documentation-only change

# Changelog
- n/a

# References
- EXIF 3.0 §4.7.1-§4.7.3
- EXIF 2.32 §4.7.1-§4.7.3

# Closes
- n/a

------
https://chatgpt.com/codex/tasks/task_e_690256ab64608323915bfd0e79f95f0e