### PR TITLE
Add BoxDescriptor unit coverage

### DIFF
--- a/tests/Parse/IsoBmff/BoxDescriptorTest.php
+++ b/tests/Parse/IsoBmff/BoxDescriptorTest.php
@@ -1,0 +1,94 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\ImageMeta\Tests\Parse\IsoBmff;
+
+use MagicSunday\ImageMeta\Core\Stream;
+use MagicSunday\ImageMeta\Core\StreamWindow;
+use MagicSunday\ImageMeta\Parse\IsoBmff\BoxDescriptor;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+use function fopen;
+use function fwrite;
+use function rewind;
+use function strlen;
+
+/**
+ * Exercises the ISO BMFF box descriptor value object.
+ *
+ * @covers \MagicSunday\ImageMeta\Parse\IsoBmff\BoxDescriptor
+ */
+final class BoxDescriptorTest extends TestCase
+{
+    #[Test]
+    public function testConstructorAssignsValuesVerbatim(): void
+    {
+        $window = $this->createWindow('0123456789abcdef', 4, 8);
+
+        $descriptor = new BoxDescriptor(
+            type: 'test',
+            size: 32,
+            offset: 4,
+            contentOffset: 12,
+            contentSize: 20,
+            window: $window,
+            userType: 'abcd1234ef567890abcd1234ef567890',
+        );
+
+        self::assertSame('test', $descriptor->type);
+        self::assertSame(32, $descriptor->size);
+        self::assertSame(4, $descriptor->offset);
+        self::assertSame(12, $descriptor->contentOffset);
+        self::assertSame(20, $descriptor->contentSize);
+        self::assertSame($window, $descriptor->window);
+        self::assertSame('abcd1234ef567890abcd1234ef567890', $descriptor->userType);
+    }
+
+    #[Test]
+    public function testDescriptorsDoNotShareStateAccidentally(): void
+    {
+        $windowA = $this->createWindow('abcdefghij', 2, 4);
+        $windowB = $this->createWindow('abcdefghij', 5, 3);
+
+        $first  = new BoxDescriptor('aaaa', 16, 2, 6, 8, $windowA, null);
+        $second = new BoxDescriptor('bbbb', 24, 3, 7, 6, $windowB, '00112233445566778899aabbccddeeff');
+
+        self::assertNotSame($first->window, $second->window);
+        self::assertNotSame($first->type, $second->type);
+        self::assertNotSame($first->size, $second->size);
+        self::assertNotSame($first->offset, $second->offset);
+        self::assertNotSame($first->contentOffset, $second->contentOffset);
+        self::assertNotSame($first->contentSize, $second->contentSize);
+        self::assertNotSame($first->userType, $second->userType);
+    }
+
+    private function createWindow(string $data, int $offset, int $length): StreamWindow
+    {
+        $handle = fopen('php://temp', 'wb+');
+        if ($handle === false) {
+            self::fail('Unable to create temporary stream handle.');
+        }
+
+        $bytesWritten = fwrite($handle, $data);
+        if ($bytesWritten !== strlen($data)) {
+            self::fail('Unable to populate temporary stream data.');
+        }
+
+        if (rewind($handle) === false) {
+            self::fail('Unable to rewind temporary stream handle.');
+        }
+
+        $stream = new Stream($handle, strlen($data));
+
+        return $stream->window($offset, $length);
+    }
+}


### PR DESCRIPTION
## Overview
- add dedicated tests for the ISO BMFF box descriptor value object

## Details
- verify constructor passes through metadata fields and preserves the StreamWindow instance
- cover negative assertions to ensure descriptors created with different parameters do not share state
- provide a guarded StreamWindow factory for tests that simulates bounded payload access

## Tests
- `composer ci:cgl`
- `composer ci:test:php:unit`
- `composer ci:test:php:unit:coverage` *(fails: No code coverage driver available in container)*
- `composer ci:test:php:phpstan`

## Risks
- low; tests only

## Changelog
- n/a (tests only)

Closes #N/A

------
https://chatgpt.com/codex/tasks/task_e_690256bf0a808323b45e2e0e549a67a7