### PR TITLE
chore: import array_any helper in Apple decoder

### DIFF
--- a/src/MakerNotes/AppleDecoder.php
+++ b/src/MakerNotes/AppleDecoder.php
@@ -19,6 +19,7 @@ use MagicSunday\ImageMeta\MakerNotes\Apple\KeyedArchiveUnarchiver;
 use MagicSunday\ImageMeta\MakerNotes\Apple\Support\SemanticStyle;
 use MagicSunday\ImageMeta\Value\RunTime;
 
+use function array_any;
 use function array_flip;
 use function array_is_list;
 use function array_key_exists;


### PR DESCRIPTION
## Summary
- import the array_any() function in AppleDecoder so the helper is properly qualified

## Testing
- composer ci:test:php:unit:coverage *(fails: No code coverage driver available)*
- composer ci:test:php:phpstan
- composer ci:cgl

------
https://chatgpt.com/codex/tasks/task_e_690256fcafb483238d65e35383ef4e60