### PR TITLE
test: add coverage for TiffConst constants

### DIFF
--- a/tests/Parse/Tiff/TiffConstTest.php
+++ b/tests/Parse/Tiff/TiffConstTest.php
@@ -1,0 +1,65 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\ImageMeta\Tests\Parse\Tiff;
+
+use MagicSunday\ImageMeta\Parse\Tiff\TiffConst;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+
+/**
+ * Ensures TIFF shared constants keep their specification-backed numeric values.
+ */
+final class TiffConstTest extends TestCase
+{
+    /**
+     * Provides each public constant defined by {@see TiffConst} alongside its expected numeric value.
+     *
+     * @return iterable<string, array{string, int}>
+     */
+    public static function constantProvider(): iterable
+    {
+        yield 'magic classic' => ['MAGIC_CLASSIC', 0x002A];
+        yield 'magic big' => ['MAGIC_BIG', 0x002B];
+        yield 'type byte' => ['TYPE_BYTE', 1];
+        yield 'type ascii' => ['TYPE_ASCII', 2];
+        yield 'type short' => ['TYPE_SHORT', 3];
+        yield 'type long' => ['TYPE_LONG', 4];
+        yield 'type rational' => ['TYPE_RATIONAL', 5];
+        yield 'type sbyte' => ['TYPE_SBYTE', 6];
+        yield 'type undefined' => ['TYPE_UNDEFINED', 7];
+        yield 'type sshort' => ['TYPE_SSHORT', 8];
+        yield 'type slong' => ['TYPE_SLONG', 9];
+        yield 'type srational' => ['TYPE_SRATIONAL', 10];
+        yield 'type float' => ['TYPE_FLOAT', 11];
+        yield 'type double' => ['TYPE_DOUBLE', 12];
+        yield 'type ifd' => ['TYPE_IFD', 13];
+        yield 'type long8' => ['TYPE_LONG8', 16];
+        yield 'type slong8' => ['TYPE_SLONG8', 17];
+        yield 'type ifd8' => ['TYPE_IFD8', 18];
+    }
+
+    #[Test]
+    #[DataProvider('constantProvider')]
+    public function itExposesExpectedConstantValues(string $constantName, int $expectedValue): void
+    {
+        $reflection  = new ReflectionClass(TiffConst::class);
+        $actualValue = $reflection->getConstant($constantName);
+
+        self::assertSame(
+            $expectedValue,
+            $actualValue,
+            "TiffConst::{$constantName} must remain {$expectedValue}."
+        );
+    }
+}


### PR DESCRIPTION
## Overview
- add a PHPUnit regression test to ensure every public TiffConst value stays in sync with the TIFF/EXIF specifications

## Details
- enumerate the expected TIFF magic identifiers and data type codes via a PHPUnit data provider
- assert each constant retains the specification-backed numeric value

## Tests
- composer ci:test:php:unit:coverage *(fails: No code coverage driver available)*
- composer ci:test:php:phpstan
- composer ci:cgl

## Risks
- Low

## Changelog
- Added a regression test covering MagicSunday\\ImageMeta\\Parse\\Tiff\\TiffConst constant values

## References
- None

Closes #N/A

------
https://chatgpt.com/codex/tasks/task_e_690256cb089883238d8c6c33e801a943