### PR TITLE
chore: import array_any in TIFF EXIF reader

### DIFF
--- a/src/Parse/Tiff/TiffExifReader.php
+++ b/src/Parse/Tiff/TiffExifReader.php
@@ -30,6 +30,7 @@ use MagicSunday\ImageMeta\Model\Exif\Ifd;
 use MagicSunday\ImageMeta\Model\Exif\IfdEntry;
 use MagicSunday\ImageMeta\Model\Exif\ValueConverters;
 
+use function array_any;
 use function array_slice;
 use function array_values;
 use function chr;


### PR DESCRIPTION
## Overview
- add the missing array_any utility import to the TIFF EXIF reader

## Details
- ensure the function import list stays alphabetically ordered when adding array_any

## Tests
- composer ci:test:php:unit:coverage *(fails: No code coverage driver available in container)*
- composer ci:test:php:phpstan
- composer ci:cgl

## Risks
- Low

## Changelog
- n/a

Closes #N/A

## References
- n/a

------
https://chatgpt.com/codex/tasks/task_e_690256fcd39c83238276f1ecbfd2132e