### PR TITLE
Add coverage for EXIF list value objects

### DIFF
--- a/tests/Model/Exif/ExifNumericListTest.php
+++ b/tests/Model/Exif/ExifNumericListTest.php
@@ -1,0 +1,63 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\ImageMeta\Tests\Model\Exif;
+
+use InvalidArgumentException;
+use MagicSunday\ImageMeta\Core\Util\UInt64;
+use MagicSunday\ImageMeta\Model\Exif\ExifNumericList;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \MagicSunday\ImageMeta\Model\Exif\ExifNumericList
+ */
+#[CoversClass(ExifNumericList::class)]
+final class ExifNumericListTest extends TestCase
+{
+    public function testAcceptsListOfNumericValues(): void
+    {
+        $values = [
+            1,
+            2.5,
+            UInt64::fromInt(3),
+        ];
+
+        $list = new ExifNumericList($values);
+
+        self::assertSame($values, $list->toArray());
+    }
+
+    public function testRejectsNonListInput(): void
+    {
+        $values = [
+            'first' => 1,
+        ];
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Numeric EXIF values must form a list.');
+
+        new ExifNumericList($values);
+    }
+
+    public function testRejectsUnsupportedComponents(): void
+    {
+        $values = [
+            1,
+            'two',
+        ];
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Numeric EXIF lists may only contain integers, floats, or UInt64 values.');
+
+        new ExifNumericList($values);
+    }
+}

--- a/tests/Model/Exif/ExifRationalListTest.php
+++ b/tests/Model/Exif/ExifRationalListTest.php
@@ -1,0 +1,62 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\ImageMeta\Tests\Model\Exif;
+
+use InvalidArgumentException;
+use MagicSunday\ImageMeta\Model\Exif\ExifRational;
+use MagicSunday\ImageMeta\Model\Exif\ExifRationalList;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \MagicSunday\ImageMeta\Model\Exif\ExifRationalList
+ */
+#[CoversClass(ExifRationalList::class)]
+final class ExifRationalListTest extends TestCase
+{
+    public function testAcceptsListOfExifRationalValues(): void
+    {
+        $values = [
+            new ExifRational(1, 2),
+            new ExifRational(3, 4),
+        ];
+
+        $list = new ExifRationalList($values);
+
+        self::assertSame($values, $list->toArray());
+    }
+
+    public function testRejectsNonListInput(): void
+    {
+        $values = [
+            'first' => new ExifRational(1, 2),
+        ];
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Rational EXIF values must form a list.');
+
+        new ExifRationalList($values);
+    }
+
+    public function testRejectsNonExifRationalElements(): void
+    {
+        $values = [
+            new ExifRational(1, 2),
+            42,
+        ];
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Rational EXIF lists may only contain ExifRational instances.');
+
+        new ExifRationalList($values);
+    }
+}


### PR DESCRIPTION
## Overview
- add PHPUnit tests for the EXIF rational list value object
- cover valid and invalid inputs for the EXIF numeric list value object

## Details
- ensure rational list rejects non-sequential arrays and non-ExifRational elements
- verify numeric list accepts int/float/UInt64 values and rejects unsupported types

## Tests
- `composer ci:test:php:unit`

## Risks
- Low

## Changelog
- Added: PHPUnit coverage for EXIF rational and numeric lists

## References
- None


------
https://chatgpt.com/codex/tasks/task_e_690256e8ce688323a944b6cec9c9aab5