### PR TITLE
fix: remove coverage constraint on gps builder

### DIFF
--- a/tests/Model/Exif/ExifDocumentTest.php
+++ b/tests/Model/Exif/ExifDocumentTest.php
@@ -62,7 +62,6 @@ use function substr;
 #[UsesClass(IfdEntry::class)]
 #[UsesClass(ValueConverters::class)]
 #[UsesClass(TiffExifReader::class)]
-#[UsesClass(GpsTiffBuilder::class)]
 #[UsesClass(ExifNumericList::class)]
 #[UsesClass(ExifCapabilities::class)]
 #[UsesClass(UInt64::class)]


### PR DESCRIPTION
## Overview
* remove the PHPUnit coverage metadata entry that pointed at the test support GPS TIFF builder

## Details
* drop the `#[UsesClass]` annotation for `GpsTiffBuilder` so that the coverage filter (limited to `src/`) no longer fails during the run

## Tests
* `composer ci:test:php:unit`

## Risks
* Low

## Changelog
* n/a

## References
* n/a

Closes #N/A

------
https://chatgpt.com/codex/tasks/task_e_69026a1272048323bdeb9ab03d9bac7a