### PR TITLE
fix: silence phpstan warnings for Exif list negative tests

### DIFF
--- a/tests/Model/Exif/ExifNumericListTest.php
+++ b/tests/Model/Exif/ExifNumericListTest.php
@@ -47,6 +47,7 @@ final class ExifNumericListTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Numeric EXIF values must form a list.');
 
+        // @phpstan-ignore-next-line: associative array passed intentionally to assert runtime validation.
         new ExifNumericList($values);
     }
 
@@ -60,6 +61,7 @@ final class ExifNumericListTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Numeric EXIF lists may only contain integers, floats, or UInt64 values.');
 
+        // @phpstan-ignore-next-line: string element passed intentionally to assert runtime validation.
         new ExifNumericList($values);
     }
 }

--- a/tests/Model/Exif/ExifRationalListTest.php
+++ b/tests/Model/Exif/ExifRationalListTest.php
@@ -46,6 +46,7 @@ final class ExifRationalListTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Rational EXIF values must form a list.');
 
+        // @phpstan-ignore-next-line: associative array passed intentionally to assert runtime validation.
         new ExifRationalList($values);
     }
 
@@ -59,6 +60,7 @@ final class ExifRationalListTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Rational EXIF lists may only contain ExifRational instances.');
 
+        // @phpstan-ignore-next-line: scalar element passed intentionally to assert runtime validation.
         new ExifRationalList($values);
     }
 }


### PR DESCRIPTION
## Overview
* silence phpstan argument type warnings triggered by negative test fixtures
* keep the runtime coverage by documenting the intentional misuse

## Details
* add `@phpstan-ignore-next-line` annotations before the invalid constructor invocations used to assert error paths

## Tests
* `composer ci:test:php:phpstan`

## Risks
* Low – limited to phpstan annotations inside test cases

## Changelog
* n/a

## References
* n/a

## Closes
* Closes #N/A

------
https://chatgpt.com/codex/tasks/task_e_69026b0ea2e483239919cd549d664dd3