### PR TITLE
feat: unify binary read access primitives

### DIFF
--- a/src/Core/ByteReader.php
+++ b/src/Core/ByteReader.php
@@ -17,6 +17,8 @@ use MagicSunday\ImageMeta\Core\Util\Unpack;
 
 use function ord;
 
+use const SEEK_SET;
+
 /**
  * Provides shared unsigned integer read helpers for byte-oriented data sources.
  */
@@ -33,7 +35,7 @@ final readonly class ByteReader
      *
      * @param Closure(int):string      $read    Callback that returns the requested number of bytes.
      * @param Closure():int            $tell    Callback that reports the current cursor position.
-     * @param Closure(int|UInt64):void $seek    Callback that repositions the cursor of the data source.
+     * @param Closure(int|UInt64, int):void $seek    Callback that repositions the cursor of the data source.
      * @param string                   $context Short description used in error messages.
      */
     public function __construct(
@@ -105,8 +107,8 @@ final readonly class ByteReader
     /**
      * Moves the cursor of the underlying data source.
      */
-    public function setPosition(int|UInt64 $offset): void
+    public function setPosition(int|UInt64 $offset, int $whence = SEEK_SET): void
     {
-        ($this->seek)($offset);
+        ($this->seek)($offset, $whence);
     }
 }

--- a/src/Core/Contracts/BinaryReadAccessInterface.php
+++ b/src/Core/Contracts/BinaryReadAccessInterface.php
@@ -1,0 +1,67 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\ImageMeta\Core\Contracts;
+
+use MagicSunday\ImageMeta\Core\Util\UInt64;
+
+use const SEEK_SET;
+
+/**
+ * Defines a unified contract for binary data sources that support random access reads.
+ */
+interface BinaryReadAccessInterface
+{
+    /**
+     * Returns the total number of bytes available from the data source.
+     */
+    public function size(): int;
+
+    /**
+     * Returns the current zero-based cursor position.
+     */
+    public function tell(): int;
+
+    /**
+     * Moves the cursor relative to the provided whence origin.
+     *
+     * @param int|UInt64 $offset Byte offset relative to the origin specified by $whence.
+     * @param int        $whence One of the PHP SEEK_* constants describing the origin.
+     */
+    public function seek(int|UInt64 $offset, int $whence = SEEK_SET): void;
+
+    /**
+     * Reads a fixed number of bytes from the current cursor position.
+     *
+     * @param int|UInt64 $length Number of bytes to read.
+     */
+    public function read(int|UInt64 $length): string;
+
+    /**
+     * Reads an unsigned 8-bit integer from the data source.
+     */
+    public function readU8(): int;
+
+    /**
+     * Reads an unsigned 16-bit big-endian integer from the data source.
+     */
+    public function readU16BE(): int;
+
+    /**
+     * Reads an unsigned 32-bit big-endian integer from the data source.
+     */
+    public function readU32BE(): int;
+
+    /**
+     * Reads an unsigned 64-bit big-endian integer from the data source.
+     */
+    public function readU64BE(): UInt64;
+}

--- a/src/Core/MemoryBuffer.php
+++ b/src/Core/MemoryBuffer.php
@@ -11,8 +11,15 @@ declare(strict_types=1);
 
 namespace MagicSunday\ImageMeta\Core;
 
+use MagicSunday\ImageMeta\Core\ByteReader;
+use MagicSunday\ImageMeta\Core\Contracts\BinaryReadAccessInterface;
+use MagicSunday\ImageMeta\Core\Traits\ReadsBinaryPrimitives;
 use MagicSunday\ImageMeta\Core\Util\UInt64;
 use MagicSunday\ImageMeta\Core\Util\Unpack;
+
+use const SEEK_CUR;
+use const SEEK_END;
+use const SEEK_SET;
 
 use function strlen;
 
@@ -23,8 +30,10 @@ use function strlen;
  * used throughout the project, ensuring that parser code can rely on
  * consistent guard rails even when the input data originates from a string.
  */
-final class MemoryBuffer
+final class MemoryBuffer implements BinaryReadAccessInterface
 {
+    use ReadsBinaryPrimitives;
+
     private readonly ByteReader $byteReader;
 
     /**
@@ -38,8 +47,8 @@ final class MemoryBuffer
         $this->byteReader = new ByteReader(
             read: $this->read(...),
             tell: fn (): int => $this->pos,
-            seek: function (int|UInt64 $offset): void {
-                $this->seekInternal($offset);
+            seek: function (int|UInt64 $offset, int $whence): void {
+                $this->seekInternal($offset, $whence);
             },
             context: 'buffer',
         );
@@ -72,9 +81,9 @@ final class MemoryBuffer
      *
      * @throws BoundsError when the requested offset is outside the buffer
      */
-    public function seek(int|UInt64 $offset): void
+    public function seek(int|UInt64 $offset, int $whence = SEEK_SET): void
     {
-        $this->byteReader->setPosition($offset);
+        $this->seekInternal($offset, $whence);
     }
 
     /**
@@ -91,11 +100,15 @@ final class MemoryBuffer
      */
     public function read(int|UInt64 $length): string
     {
-        $len = $this->normaliseLength($length);
-
-        if ($len === 0) {
+        if ($length instanceof UInt64) {
+            if ($length->isZero()) {
+                return '';
+            }
+        } elseif ($length === 0) {
             return '';
         }
+
+        $len = $this->normaliseLength($length);
 
         $end = $this->pos + $len;
         if ($end > $this->size()) {
@@ -113,16 +126,6 @@ final class MemoryBuffer
     }
 
     /**
-     * Reads an unsigned 8-bit integer from the buffer.
-     *
-     * @return int unsigned 8-bit integer
-     */
-    public function readU8(): int
-    {
-        return $this->byteReader->readU8();
-    }
-
-    /**
      * Reads an unsigned 16-bit integer using little-endian byte order.
      *
      * @return int unsigned 16-bit integer
@@ -133,16 +136,6 @@ final class MemoryBuffer
     }
 
     /**
-     * Reads an unsigned 16-bit integer using big-endian byte order.
-     *
-     * @return int unsigned 16-bit integer
-     */
-    public function readU16BE(): int
-    {
-        return $this->byteReader->readU16BE();
-    }
-
-    /**
      * Reads an unsigned 32-bit integer using little-endian byte order.
      *
      * @return int unsigned 32-bit integer
@@ -150,16 +143,6 @@ final class MemoryBuffer
     public function readU32LE(): int
     {
         return $this->byteReader->unpackInt('V', 4);
-    }
-
-    /**
-     * Reads an unsigned 32-bit integer using big-endian byte order.
-     *
-     * @return int unsigned 32-bit integer
-     */
-    public function readU32BE(): int
-    {
-        return $this->byteReader->readU32BE();
     }
 
     /**
@@ -176,18 +159,23 @@ final class MemoryBuffer
     }
 
     /**
-     * Reads an unsigned 64-bit integer using big-endian byte order.
-     *
-     * @return UInt64 unsigned 64-bit integer
+     * Exposes the ByteReader instance for the shared primitive read trait.
      */
-    public function readU64BE(): UInt64
+    protected function byteReader(): ByteReader
     {
-        return $this->byteReader->readU64BE();
+        return $this->byteReader;
     }
 
-    private function seekInternal(int|UInt64 $offset): void
+    private function seekInternal(int|UInt64 $offset, int $whence): void
     {
-        $this->pos = $this->normaliseOffset($offset, 0, 'MemoryBuffer seek out of range');
+        $target = match ($whence) {
+            SEEK_SET => $this->normaliseOffset($offset, 0, 'MemoryBuffer seek out of range'),
+            SEEK_CUR => $this->normaliseRelativeOffset($offset, $this->pos, 'MemoryBuffer seek out of range'),
+            SEEK_END => $this->normaliseRelativeOffset($offset, $this->size(), 'MemoryBuffer seek out of range'),
+            default   => throw new ParseError('MemoryBuffer invalid seek whence: ' . $whence),
+        };
+
+        $this->pos = $target;
     }
 
     private function normaliseOffset(int|UInt64 $offset, int $length, string $message): int
@@ -207,13 +195,25 @@ final class MemoryBuffer
         return $offset;
     }
 
+    /**
+     * @return positive-int
+     */
     private function normaliseLength(int|UInt64 $length): int
     {
         if ($length instanceof UInt64) {
-            return $this->normaliseUInt64($length, 0, 'MemoryBuffer read length out of range');
+            if ($length->isZero()) {
+                throw new BoundsError('MemoryBuffer read length out of range: ' . $length->toHex());
+            }
+
+            $intValue = $this->normaliseUInt64($length, 0, 'MemoryBuffer read length out of range');
+            if ($intValue <= 0) {
+                throw new BoundsError('MemoryBuffer read length out of range: ' . $length->toHex());
+            }
+
+            return $intValue;
         }
 
-        if ($length < 0) {
+        if ($length <= 0) {
             throw new BoundsError('MemoryBuffer read length out of range: ' . $length);
         }
 
@@ -233,5 +233,31 @@ final class MemoryBuffer
         }
 
         return $intValue;
+    }
+
+    private function normaliseRelativeOffset(int|UInt64 $offset, int $base, string $message): int
+    {
+        $delta = $this->resolveOffsetValue($offset, $message);
+        $target = $base + $delta;
+
+        if ($target < 0 || $target > $this->size()) {
+            throw new BoundsError($message . ': ' . $this->formatOffset($offset));
+        }
+
+        return $target;
+    }
+
+    private function resolveOffsetValue(int|UInt64 $offset, string $message): int
+    {
+        if ($offset instanceof UInt64) {
+            return $offset->toInt($message);
+        }
+
+        return $offset;
+    }
+
+    private function formatOffset(int|UInt64 $offset): string
+    {
+        return $offset instanceof UInt64 ? $offset->toHex() : (string) $offset;
     }
 }

--- a/src/Core/Stream.php
+++ b/src/Core/Stream.php
@@ -11,7 +11,13 @@ declare(strict_types=1);
 
 namespace MagicSunday\ImageMeta\Core;
 
+use MagicSunday\ImageMeta\Core\Contracts\BinaryReadAccessInterface;
+use MagicSunday\ImageMeta\Core\Traits\ReadsBinaryPrimitives;
 use MagicSunday\ImageMeta\Core\Util\UInt64;
+
+use const SEEK_CUR;
+use const SEEK_END;
+use const SEEK_SET;
 
 use function fopen;
 use function fread;
@@ -23,8 +29,10 @@ use function strlen;
 /**
  * Provides a bounds-checked streaming reader over a binary resource handle.
  */
-final class Stream
+final class Stream implements BinaryReadAccessInterface
 {
+    use ReadsBinaryPrimitives;
+
     /** @var resource */
     private $fh;
 
@@ -38,8 +46,6 @@ final class Stream
      * Opens the given path for binary reading and wraps it in a stream instance.
      *
      * @param string $path Absolute or relative file system path to open.
-     *
-     * @return self
      */
     public static function fromPath(string $path): self
     {
@@ -71,8 +77,8 @@ final class Stream
         $this->byteReader = new ByteReader(
             read: $this->read(...),
             tell: fn (): int => $this->pos,
-            seek: function (int|UInt64 $offset): void {
-                $this->seekInternal($offset);
+            seek: function (int|UInt64 $offset, int $whence): void {
+                $this->seekInternal($offset, $whence);
             },
             context: 'stream',
         );
@@ -80,8 +86,6 @@ final class Stream
 
     /**
      * Returns the total size of the underlying data source in bytes.
-     *
-     * @return int
      */
     public function size(): int
     {
@@ -90,8 +94,6 @@ final class Stream
 
     /**
      * Returns the current cursor position relative to the start of the stream.
-     *
-     * @return int
      */
     public function tell(): int
     {
@@ -100,86 +102,43 @@ final class Stream
 
     /**
      * Moves the read cursor to an absolute offset within the stream.
-     *
-     * @param int $offset Absolute zero-based byte offset to seek to.
      */
-    public function seek(int $offset): void
+    public function seek(int|UInt64 $offset, int $whence = SEEK_SET): void
     {
-        $this->byteReader->setPosition($offset);
+        $this->seekInternal($offset, $whence);
     }
 
     /**
      * Reads a fixed number of bytes from the stream, advancing the cursor.
-     *
-     * @param int $length Number of bytes to read.
-     *
-     * @return string
      */
-    public function read(int $length): string
+    public function read(int|UInt64 $length): string
     {
-        if ($length === 0) {
+        if ($length instanceof UInt64) {
+            if ($length->isZero()) {
+                return '';
+            }
+        } elseif ($length === 0) {
             return '';
         }
 
-        if ($length < 0 || $this->pos + $length > $this->size) {
-            throw new BoundsError('read beyond EOF: ' . $this->pos . '+' . $length . ' > ' . $this->size);
+        $len = $this->normaliseLength($length);
+
+        if ($this->pos + $len > $this->size) {
+            throw new BoundsError('read beyond EOF: ' . $this->pos . '+' . $len . ' > ' . $this->size);
         }
 
-        $data = fread($this->fh, $length);
-        if ($data === false || strlen($data) !== $length) {
+        $data = fread($this->fh, $len);
+        if ($data === false || strlen($data) !== $len) {
             throw new ParseError('short read');
         }
 
-        $this->pos += $length;
+        $this->pos += $len;
 
         return $data;
     }
 
     /**
-     * Reads a single unsigned byte from the stream.
-     *
-     * @return int
-     */
-    public function readU8(): int
-    {
-        return $this->byteReader->readU8();
-    }
-
-    /**
-     * Reads an unsigned 16-bit big-endian integer from the stream.
-     *
-     * @return int
-     */
-    public function readU16BE(): int
-    {
-        return $this->byteReader->readU16BE();
-    }
-
-    /**
-     * Reads an unsigned 32-bit big-endian integer from the stream.
-     *
-     * @return int
-     */
-    public function readU32BE(): int
-    {
-        return $this->byteReader->readU32BE();
-    }
-
-    /**
-     * Reads an unsigned 64-bit big-endian integer from the stream.
-     *
-     * @return UInt64
-     */
-    public function readU64BE(): UInt64
-    {
-        return $this->byteReader->readU64BE();
-    }
-
-    /**
      * Creates a bounded view into this stream without copying bytes.
-     *
-     * @param int $offset Starting byte offset for the window.
-     * @param int $length Maximum number of bytes readable from the window.
      */
     public function window(int $offset, int $length): StreamWindow
     {
@@ -191,32 +150,86 @@ final class Stream
     }
 
     /**
-     * Validates and seeks the underlying resource to an absolute offset.
-     *
-     * @param int|UInt64 $offset Absolute byte offset relative to the start of the stream.
-     *
-     * @throws BoundsError If the offset is negative or exceeds the stream size.
-     * @throws ParseError  If the offset cannot be converted to a supported integer range.
+     * Exposes the ByteReader instance for the shared primitive read trait.
      */
-    private function seekInternal(int|UInt64 $offset): void
+    protected function byteReader(): ByteReader
+    {
+        return $this->byteReader;
+    }
+
+    private function seekInternal(int|UInt64 $offset, int $whence): void
+    {
+        $target = match ($whence) {
+            SEEK_SET => $this->normaliseAbsoluteOffset($offset, 'seek out of range'),
+            SEEK_CUR => $this->normaliseRelativeOffset($offset, $this->pos, 'seek out of range'),
+            SEEK_END => $this->normaliseRelativeOffset($offset, $this->size, 'seek out of range'),
+            default   => throw new ParseError('invalid seek whence: ' . $whence),
+        };
+
+        fseek($this->fh, $target);
+        $this->pos = $target;
+    }
+
+    /**
+     * @return positive-int
+     */
+    private function normaliseLength(int|UInt64 $length): int
+    {
+        if ($length instanceof UInt64) {
+            if ($length->isZero()) {
+                throw new BoundsError('stream read length out of range: ' . $length->toHex());
+            }
+
+            $length = $length->toInt('stream read length out of range');
+        }
+
+        if ($length <= 0) {
+            throw new BoundsError('stream read length out of range: ' . $length);
+        }
+
+        return $length;
+    }
+
+    private function normaliseAbsoluteOffset(int|UInt64 $offset, string $message): int
     {
         if ($offset instanceof UInt64) {
             if ($offset->compareInt($this->size) > 0) {
-                throw new BoundsError('seek out of range: ' . $offset->toHex());
+                throw new BoundsError($message . ': ' . $offset->toHex());
             }
 
-            $offsetValue  = $offset->toInt('seek out of range');
-            $messageValue = $offset->toHex();
-        } else {
-            $offsetValue  = $offset;
-            $messageValue = (string) $offset;
+            $offset = $offset->toInt($message);
         }
 
-        if ($offsetValue < 0 || $offsetValue > $this->size) {
-            throw new BoundsError('seek out of range: ' . $messageValue);
+        if ($offset < 0 || $offset > $this->size) {
+            throw new BoundsError($message . ': ' . $this->formatOffset($offset));
         }
 
-        fseek($this->fh, $offsetValue);
-        $this->pos = $offsetValue;
+        return $offset;
+    }
+
+    private function normaliseRelativeOffset(int|UInt64 $offset, int $base, string $message): int
+    {
+        $delta  = $this->resolveOffsetValue($offset, $message);
+        $target = $base + $delta;
+
+        if ($target < 0 || $target > $this->size) {
+            throw new BoundsError($message . ': ' . $this->formatOffset($offset));
+        }
+
+        return $target;
+    }
+
+    private function resolveOffsetValue(int|UInt64 $offset, string $message): int
+    {
+        if ($offset instanceof UInt64) {
+            return $offset->toInt($message);
+        }
+
+        return $offset;
+    }
+
+    private function formatOffset(int|UInt64 $offset): string
+    {
+        return $offset instanceof UInt64 ? $offset->toHex() : (string) $offset;
     }
 }

--- a/src/Core/StreamWindow.php
+++ b/src/Core/StreamWindow.php
@@ -11,23 +11,27 @@ declare(strict_types=1);
 
 namespace MagicSunday\ImageMeta\Core;
 
+use MagicSunday\ImageMeta\Core\Contracts\BinaryReadAccessInterface;
+use MagicSunday\ImageMeta\Core\Traits\ReadsBinaryPrimitives;
 use MagicSunday\ImageMeta\Core\Util\UInt64;
+
+use const SEEK_CUR;
+use const SEEK_END;
+use const SEEK_SET;
 
 /**
  * Represents a bounded view into a parent stream with an independent cursor.
  */
-final class StreamWindow
+final class StreamWindow implements BinaryReadAccessInterface
 {
+    use ReadsBinaryPrimitives;
+
     private int $cursor = 0;
 
     private readonly ByteReader $byteReader;
 
     /**
      * Creates a window that restricts reads to a fixed region of the parent stream.
-     *
-     * @param Stream $base   Underlying stream providing the bytes.
-     * @param int    $offset Start offset within the base stream.
-     * @param int    $length Maximum number of bytes accessible through the window.
      */
     public function __construct(
         private readonly Stream $base,
@@ -37,8 +41,8 @@ final class StreamWindow
         $this->byteReader = new ByteReader(
             read: $this->read(...),
             tell: fn (): int => $this->cursor,
-            seek: function (int|UInt64 $offset): void {
-                $this->seekInternal($offset);
+            seek: function (int|UInt64 $offset, int $whence): void {
+                $this->seekInternal($offset, $whence);
             },
             context: 'window',
         );
@@ -46,8 +50,6 @@ final class StreamWindow
 
     /**
      * Returns the number of bytes exposed through this window.
-     *
-     * @return int
      */
     public function size(): int
     {
@@ -56,8 +58,6 @@ final class StreamWindow
 
     /**
      * Returns the cursor position relative to the start of the window.
-     *
-     * @return int
      */
     public function tell(): int
     {
@@ -66,96 +66,118 @@ final class StreamWindow
 
     /**
      * Repositions the window cursor to an absolute offset inside the window.
-     *
-     * @param int $pos Byte offset relative to the window start.
      */
-    public function seek(int $pos): void
+    public function seek(int|UInt64 $offset, int $whence = SEEK_SET): void
     {
-        $this->byteReader->setPosition($pos);
+        $this->seekInternal($offset, $whence);
     }
 
     /**
      * Reads bytes from the bounded region and advances the cursor.
-     *
-     * @param int $length Number of bytes to read.
-     *
-     * @return string
      */
-    public function read(int $length): string
+    public function read(int|UInt64 $length): string
     {
-        if ($length === 0) {
+        if ($length instanceof UInt64) {
+            if ($length->isZero()) {
+                return '';
+            }
+        } elseif ($length === 0) {
             return '';
         }
 
-        if ($length < 0 || $this->cursor + $length > $this->length) {
+        $len = $this->normaliseLength($length);
+
+        if ($this->cursor + $len > $this->length) {
             throw new BoundsError('window read out of range');
         }
 
-        $this->base->seek($this->offset + $this->cursor);
-        $data = $this->base->read($length);
-        $this->cursor += $length;
+        $this->base->seek($this->offset + $this->cursor, SEEK_SET);
+        $data = $this->base->read($len);
+        $this->cursor += $len;
 
         return $data;
     }
 
     /**
-     * Reads an unsigned byte from the window.
-     *
-     * @return int
+     * Exposes the ByteReader instance for the shared primitive read trait.
      */
-    public function readU8(): int
+    protected function byteReader(): ByteReader
     {
-        return $this->byteReader->readU8();
+        return $this->byteReader;
+    }
+
+    private function seekInternal(int|UInt64 $offset, int $whence): void
+    {
+        $target = match ($whence) {
+            SEEK_SET => $this->normaliseAbsoluteOffset($offset, 'window seek out of range'),
+            SEEK_CUR => $this->normaliseRelativeOffset($offset, $this->cursor, 'window seek out of range'),
+            SEEK_END => $this->normaliseRelativeOffset($offset, $this->length, 'window seek out of range'),
+            default   => throw new ParseError('window invalid seek whence: ' . $whence),
+        };
+
+        $this->cursor = $target;
     }
 
     /**
-     * Reads an unsigned 16-bit big-endian integer from the window.
-     *
-     * @return int
+     * @return positive-int
      */
-    public function readU16BE(): int
+    private function normaliseLength(int|UInt64 $length): int
     {
-        return $this->byteReader->readU16BE();
-    }
+        if ($length instanceof UInt64) {
+            if ($length->isZero()) {
+                throw new BoundsError('window read length out of range: ' . $length->toHex());
+            }
 
-    /**
-     * Reads an unsigned 32-bit big-endian integer from the window.
-     *
-     * @return int
-     */
-    public function readU32BE(): int
-    {
-        return $this->byteReader->readU32BE();
-    }
-
-    /**
-     * Reads an unsigned 64-bit big-endian integer from the window.
-     *
-     * @return UInt64
-     */
-    public function readU64BE(): UInt64
-    {
-        return $this->byteReader->readU64BE();
-    }
-
-    /**
-     * Ensures the window cursor moves to a valid absolute position.
-     *
-     * @param int|UInt64 $pos Absolute byte offset relative to the window start.
-     *
-     * @throws BoundsError If the position is negative or beyond the window length.
-     * @throws ParseError  If the position cannot be converted to a supported integer range.
-     */
-    private function seekInternal(int|UInt64 $pos): void
-    {
-        if ($pos instanceof UInt64) {
-            $pos = $pos->toInt('window seek out of range');
+            $length = $length->toInt('window read length out of range');
         }
 
-        if ($pos < 0 || $pos > $this->length) {
-            throw new BoundsError('window seek out of range');
+        if ($length <= 0) {
+            throw new BoundsError('window read length out of range: ' . $length);
         }
 
-        $this->cursor = $pos;
+        return $length;
+    }
+
+    private function normaliseAbsoluteOffset(int|UInt64 $offset, string $message): int
+    {
+        if ($offset instanceof UInt64) {
+            if ($offset->compareInt($this->length) > 0) {
+                throw new BoundsError($message . ': ' . $offset->toHex());
+            }
+
+            $offset = $offset->toInt($message);
+        }
+
+        if ($offset < 0 || $offset > $this->length) {
+            throw new BoundsError($message . ': ' . $this->formatOffset($offset));
+        }
+
+        return $offset;
+    }
+
+    private function normaliseRelativeOffset(int|UInt64 $offset, int $base, string $message): int
+    {
+        $delta  = $this->resolveOffsetValue($offset, $message);
+        $target = $base + $delta;
+
+        if ($target < 0 || $target > $this->length) {
+            throw new BoundsError($message . ': ' . $this->formatOffset($offset));
+        }
+
+        return $target;
+    }
+
+    private function resolveOffsetValue(int|UInt64 $offset, string $message): int
+    {
+        if ($offset instanceof UInt64) {
+            return $offset->toInt($message);
+        }
+
+        return $offset;
+    }
+
+    private function formatOffset(int|UInt64 $offset): string
+    {
+        return $offset instanceof UInt64 ? $offset->toHex() : (string) $offset;
     }
 }

--- a/src/Core/Traits/ReadsBinaryPrimitives.php
+++ b/src/Core/Traits/ReadsBinaryPrimitives.php
@@ -1,0 +1,46 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\ImageMeta\Core\Traits;
+
+use MagicSunday\ImageMeta\Core\ByteReader;
+use MagicSunday\ImageMeta\Core\Util\UInt64;
+
+/**
+ * Provides shared implementations for reading primitive types from a ByteReader backed source.
+ */
+trait ReadsBinaryPrimitives
+{
+    /**
+     * Returns the byte reader used to access the underlying data source.
+     */
+    abstract protected function byteReader(): ByteReader;
+
+    public function readU8(): int
+    {
+        return $this->byteReader()->readU8();
+    }
+
+    public function readU16BE(): int
+    {
+        return $this->byteReader()->readU16BE();
+    }
+
+    public function readU32BE(): int
+    {
+        return $this->byteReader()->readU32BE();
+    }
+
+    public function readU64BE(): UInt64
+    {
+        return $this->byteReader()->readU64BE();
+    }
+}

--- a/tests/Core/BinaryReadAccessPropertyTest.php
+++ b/tests/Core/BinaryReadAccessPropertyTest.php
@@ -1,0 +1,110 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\ImageMeta\Tests\Core;
+
+use MagicSunday\ImageMeta\Core\Contracts\BinaryReadAccessInterface;
+use MagicSunday\ImageMeta\Core\MemoryBuffer;
+use MagicSunday\ImageMeta\Core\Stream;
+use MagicSunday\ImageMeta\Core\StreamWindow;
+use MagicSunday\ImageMeta\Core\Util\UInt64;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+use function random_bytes;
+use function random_int;
+use function substr;
+
+/**
+ * Property-based regression tests that ensure the binary access implementations stay aligned.
+ */
+final class BinaryReadAccessPropertyTest extends TestCase
+{
+    use CreatesTempStream;
+
+    #[Test]
+    public function testMemoryBufferAndStreamBehaveIdenticallyForRandomPayloads(): void
+    {
+        for ($iteration = 0; $iteration < 25; ++$iteration) {
+            $length  = random_int(64, 256);
+            $payload = random_bytes($length);
+
+            $buffer = new MemoryBuffer($payload);
+            $stream = new Stream($this->createTempStream($payload), $length);
+
+            self::assertSame(
+                $this->consumeReader($buffer),
+                $this->consumeReader($stream),
+            );
+        }
+    }
+
+    #[Test]
+    public function testStreamWindowMatchesBufferViewForRandomSlices(): void
+    {
+        for ($iteration = 0; $iteration < 25; ++$iteration) {
+            $length  = random_int(128, 256);
+            $payload = random_bytes($length);
+
+            $stream = new Stream($this->createTempStream($payload), $length);
+
+            $maxOffset = $length - 64;
+            $offset    = random_int(0, $maxOffset);
+            $minWindow = 64;
+            $maxWindow = $length - $offset;
+            if ($maxWindow < $minWindow) {
+                $maxWindow = $minWindow;
+            }
+
+            $windowLength = $minWindow === $maxWindow ? $minWindow : random_int($minWindow, $maxWindow);
+
+            $window = new StreamWindow($stream, $offset, $windowLength);
+            $buffer = new MemoryBuffer(substr($payload, $offset, $windowLength));
+
+            self::assertSame(
+                $this->consumeReader($buffer),
+                $this->consumeReader($window),
+            );
+        }
+    }
+
+    /**
+     * Collects a selection of read operations to compare different implementations deterministically.
+     *
+     * @return array<int, int|string>
+     */
+    private function consumeReader(BinaryReadAccessInterface $reader): array
+    {
+        $reader->seek(UInt64::fromInt(0), \SEEK_SET);
+
+        $results = [];
+        $results[] = $reader->read(UInt64::fromInt(3));
+        $results[] = $reader->read(2);
+        $results[] = $reader->readU8();
+        $results[] = $reader->readU16BE();
+        $results[] = $reader->readU32BE();
+        $results[] = $reader->readU64BE()->toHex();
+
+        $reader->seek(-4, \SEEK_CUR);
+        $results[] = $reader->read(4);
+
+        $reader->seek(-8, \SEEK_END);
+        $results[] = $reader->read(4);
+
+        $reader->seek(UInt64::fromInt(0), \SEEK_SET);
+        $results[] = $reader->tell();
+
+        $reader->seek(0, \SEEK_END);
+        $results[] = $reader->tell();
+
+        return $results;
+    }
+}


### PR DESCRIPTION
## Overview
- introduce a shared binary read access contract and trait for all core buffers
- update MemoryBuffer, Stream, and StreamWindow to implement the common API and consolidated seek semantics
- cover the new behaviour with property-based tests comparing all implementations

## Details
- add `BinaryReadAccessInterface` and `ReadsBinaryPrimitives` to centralise primitive read helpers
- refactor `MemoryBuffer`, `Stream`, and `StreamWindow` to support whence-aware seeking and reuse the trait implementations
- expand regression coverage with randomised parity tests across buffer, stream, and window readers

## Tests
- `composer ci:test:php:unit`
- `composer ci:test:php:phpstan`

## Risks
- Touches low-level I/O helpers used throughout parsing; regressions would surface broadly if contract mismatches occur

## Changelog
- unify binary read helpers through a dedicated interface and trait
- extend buffer, stream, and window readers with whence-aware seek logic and shared primitive implementations

## References
- n/a

Closes #M1

------
https://chatgpt.com/codex/tasks/task_e_69026cd8d2888323a506c5b58563eccf