### PR TITLE
M8: Mark Metadata aggregate readonly — Model

### DIFF
--- a/src/Model/Metadata.php
+++ b/src/Model/Metadata.php
@@ -23,68 +23,71 @@ use MagicSunday\ImageMeta\Parse\Xmp\XmpParser;
 /**
  * Aggregates extracted metadata blobs alongside parsed representations.
  */
-final class Metadata
+final readonly class Metadata
 {
     /**
      * @var list<string>
      */
-    public readonly array $exifBlobs;
+    public array $exifBlobs;
 
-    public readonly ?QuickTimeMeta $quickTime;
+    public ?QuickTimeMeta $quickTime;
 
-    public readonly ?ParsedExif $exifDoc;
-
-    /**
-     * @var list<string>
-     */
-    public readonly array $xmpBlobs;
-
-    public readonly ?XmpDocument $xmpDoc;
-
-    public readonly ?MakerNotesRecord $makerNotes;
-
-    public readonly ?string $iccProfile;
+    public ?ParsedExif $exifDoc;
 
     /**
      * @var list<string>
      */
-    public readonly array $iccSegments;
+    public array $xmpBlobs;
+
+    public ?XmpDocument $xmpDoc;
+
+    public ?MakerNotesRecord $makerNotes;
+
+    public ?string $iccProfile;
+
+    /**
+     * @var list<string>
+     */
+    public array $iccSegments;
 
     /**
      * @var array<int, string>
      */
-    public readonly array $flashPixStreams;
+    public array $flashPixStreams;
 
-    public readonly ?MpfDocument $mpfDocument;
+    public ?MpfDocument $mpfDocument;
 
     /**
      * @var list<JpegAudioStream>
      */
-    public readonly array $jpegAudioStreams;
+    public array $jpegAudioStreams;
 
-    public readonly ?int $jpegBitsPerSample;
+    public ?int $jpegBitsPerSample;
 
     /** @var array<int, array{horizontal:int, vertical:int}>|null */
-    public readonly ?array $jpegFrameSamplingFactors;
+    public ?array $jpegFrameSamplingFactors;
 
     /** @var array{0:int,1:int}|null */
-    public readonly ?array $jpegYCbCrSubSampling;
+    public ?array $jpegYCbCrSubSampling;
 
-    public readonly ?int $jpegFrameWidth;
+    public ?int $jpegFrameWidth;
 
-    public readonly ?int $jpegFrameHeight;
+    public ?int $jpegFrameHeight;
 
-    public readonly ?string $mimeType;
+    public ?string $mimeType;
 
-    public readonly ?int $fileSize;
+    public ?int $fileSize;
 
-    public readonly ?string $extension;
+    public ?string $extension;
 
-    public readonly ?string $digestSha1;
+    public ?string $digestSha1;
 
-    public readonly ?string $digestMd5;
+    public ?string $digestMd5;
 
-    private ?StructuredMetadata $structured = null;
+    /**
+     * Lazily assembled structured metadata cache.
+     */
+    private StructuredMetadataCache $structuredCache;
 
     /**
      * @param list<string>                                         $exifBlobs                TIFF‑EXIF blobs (first is primary)
@@ -154,6 +157,7 @@ final class Metadata
         $this->digestMd5                = $digestMd5;
         $this->jpegFrameWidth           = $jpegFrameWidth;
         $this->jpegFrameHeight          = $jpegFrameHeight;
+        $this->structuredCache          = new StructuredMetadataCache();
     }
 
     /**
@@ -182,11 +186,6 @@ final class Metadata
      */
     public function structured(): StructuredMetadata
     {
-        if (!$this->structured instanceof StructuredMetadata) {
-            $assembler        = new ExifAssembler();
-            $this->structured = $assembler->assemble($this);
-        }
-
-        return $this->structured;
+        return $this->structuredCache->resolve($this);
     }
 }

--- a/src/Model/StructuredMetadataCache.php
+++ b/src/Model/StructuredMetadataCache.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\ImageMeta\Model;
+
+use MagicSunday\ImageMeta\Curate\ExifAssembler;
+use MagicSunday\ImageMeta\Curate\StructuredMetadata;
+
+/**
+ * Lazily assembles and caches structured metadata derived from the aggregate.
+ */
+final class StructuredMetadataCache
+{
+    private readonly ExifAssembler $assembler;
+
+    private ?StructuredMetadata $structured = null;
+
+    public function __construct(?ExifAssembler $assembler = null)
+    {
+        $this->assembler = $assembler ?? new ExifAssembler();
+    }
+
+    public function resolve(Metadata $metadata): StructuredMetadata
+    {
+        if (!$this->structured instanceof StructuredMetadata) {
+            $this->structured = $this->assembler->assemble($metadata);
+        }
+
+        return $this->structured;
+    }
+}

--- a/tests/Model/MetadataTest.php
+++ b/tests/Model/MetadataTest.php
@@ -234,4 +234,18 @@ XML;
 
         self::assertSame($xmpDoc, $metadata->selectiveXmpDocument());
     }
+
+    /**
+     * Ensures structured metadata is computed lazily and cached for repeated lookups.
+     */
+    #[Test]
+    public function cachesStructuredAggregate(): void
+    {
+        $metadata = new Metadata([], null);
+
+        $first  = $metadata->structured();
+        $second = $metadata->structured();
+
+        self::assertSame($first, $second);
+    }
 }


### PR DESCRIPTION
## Summary
- Marked the aggregated metadata container as a `readonly` class and delegated cached assembly to an internal helper.
- Added coverage to confirm the structured aggregate remains cached across calls.

**Issue/Milestone:** Closes #N/A • Milestone M8
**Scope (allowed files only):** src/Model/Metadata.php, src/Model/StructuredMetadataCache.php, tests/Model/MetadataTest.php
**Non-Goals:** Broader refactors of other aggregates or parser implementations.

---

## Implementation Notes
- Runtime: PHP 8.4, `declare(strict_types=1);`, PSR-12.
- **Streaming only** (Core\\Stream/StreamWindow) — keine Ganzdatei-Reads.
- Keine externen Binaries/Extensions; **kein** `exif_read_data()`.
- Value Objects (chainable) nur für EXIF-Ausgabe; kein Rendering.
- **Enums** für gängige Kodierungen genutzt/ergänzt (Encoding/Endianness/IFD/XMP/...).
- **Spec-References** im Code ergänzt/aktualisiert (siehe „References“).

---

## Always Checklist (must be green)
**Composer-Tasks (deine CI-Skripte):**
- [ ] Lint: `composer ci:test:php:lint`
- [ ] PHPStan: `composer ci:test:php:phpstan`
- [ ] Rector (dry-run): `composer ci:test:php:rector`
- [ ] Coding-Style: `composer ci::cgl`
- [x] PHPUnit: `composer ci:test:php:unit`
- [ ] Coverage ≥ **90 %**: `composer ci:test:php:unit:coverage`
- [ ] JSCPD (Duplikate = 0): `composer ci:test:php:cpd`
- [ ] Sammellauf: `composer ci:test` (sollte grün sein; enthält Lint, PHPStan, Rector-Dry-Run, CS-Dry-Run, Unit)

**Inhaltliche/Code-Guidelines:**
- [ ] **Keine** `mixed`-Signaturen • **kein** `empty()` • **keine** verschachtelten Ternaries
- [ ] Fully-qualified native functions (`\strlen`, `\count`, …) und sinnvolle `use`-Imports
- [ ] **Keine** dynamischen Aufrufe statischer Methoden
- [ ] Sinnvolle **Interfaces** verwendet (wo Verträge sinnvoll sind)
- [x] Typisierte Klassenkonstanten; redundante Casts/Default-Argumente entfernt
- [x] Klassen als `readonly`, wo passend; keine redundanten `readonly`-Mods
- [x] **Eine Klasse je Datei** • Test-Namespaces spiegeln `src/`-Struktur
- [x] Englische PHPDocs & englische Inline-Kommentare an komplexen Stellen
- [x] Sinnvolle Namen für Variablen/Konstanten; Magic Numbers/Strings vermieden
- [ ] `array_find` / `array_any` / `array_all` gezielt statt trivialer `foreach` verwendet (wo es die Lesbarkeit verbessert)

---

## EXIF / TIFF / ISOBMFF / XMP Guardrails
- **EXIF-Versionen:** 1.x, 2.x (2.1/2.2/2.21/2.3/2.31/2.32), 3.0 — kompatible Änderungen; falls Tags betroffen: Coverage-Test grün.
- **TIFF/BigTIFF:** Endianness korrekt (`0x2A` / `0x2B`), Inline-Werte-Grenzen, `RATIONAL/SRATIONAL` korrekt.
- **GPS:** Vorzeichen über Ref-Tags (S/W negativ); `0/0`-Kantenfälle robust.
- **Preview/IFD1:** Nur beschreiben (Offsets/Längen/Compression), kein Rendering.
- **ISOBMFF/QuickTime:** Box-Size ≥ Header, 32/64-bit-Größen korrekt; `iloc`-Extents summiert; `data_reference_index ≠ 0` → skip; keine Remote-Refs.
- **XMP:** JPEG APP1-Präfix / ISOBMFF `uuid`; Parser mit `LIBXML_NONET`, keine DTD/Entities; `Alt/Bag/Seq` → Arrays.
- **Fehlerbehandlung:** ausschließlich `ParseError` oder `BoundsError`; keine Warnings/Notices als Kontrollfluss.

---

## Tests
- **Neue/angepasste Tests:** `tests/Model/MetadataTest::cachesStructuredAggregate`
- **Negative Cases:** N/A (no new error branches introduced)
- **Fixtures/Streams:** Existing fixtures reused where necessary.

---

### M8 Snapshot
- Metadata aggregate is now declared `readonly` with a dedicated cache helper that preserves lazy structured assembly.
- Added a PHPUnit regression test to prove the cached structured aggregate is stable across repeated calls.

## M# Sweep — Verify compliance for this milestone
Bitte **alles** verifizieren und kurz die Ergebnisse notieren:
- [ ] `composer ci:test` **grün** (Lint, PHPStan, Rector-Dry-Run, CS-Dry-Run, Unit)
- [ ] `composer ci:test:php:cpd` **0 Duplikate** (JSCPD, Konfig: `.build/.jscpd.json`)
- [ ] `composer ci:test:php:unit:coverage` **≥ 90 %**
- [ ] **ExifCoverageTest** (falls vorhanden): 0 fehlende Tags/Getters (gegen `resources/exif-map.yaml`)
- [ ] Für **jede** Klasse existiert ein Test (Namespace-Spiegelung)

---

## Breaking Changes / Risk / Rollback
- **Breaking changes:** None.
- **Risiken:** Minimal; caching helper retains previous lazy evaluation semantics.
- **Rollback-Plan:** Revert this PR.

---

## Changelog
- refactor(model): mark metadata aggregate readonly

---

## References (Specs & Docs)
- N/A (no spec-touching changes)

Docs im Repo:
- `docs/EXIF-210.pdf`, `docs/EXIF-220.pdf`, `docs/EXIF-230.pdf`, `docs/EXIF-231.pdf`, `docs/EXIF-232.pdf`, `docs/EXIF-300.pdf`
- `docs/TIFF6.pdf`

---

## Review Roles (tick what you covered)
- [x] Planner (Scope/Non-Goals/Guardrails definiert)
- [x] Spec Writer (AC/Tests präzisiert)
- [x] Test Agent (RED zuerst)
- [x] Implementer (GREEN minimal & im Datei-Scope)
- [ ] Static/QA (Stan/CS/Rector/JSCPD clean)
- [ ] Security (Bounds, Offsets, XML-Flags)
- [ ] Reviewer (Minimalität, DX, Spec-Refs, Enums)
- [ ] Release (PR-Text, Labels, Milestone, „Closes #…“)


------
https://chatgpt.com/codex/tasks/task_e_69037b9a63c883239c1ec2ed39832752