### PR TITLE
M9: Replace search loops with array helpers — MakerNotes/Model

### DIFF
--- a/src/MakerNotes/Apple/Support/SemanticStyle.php
+++ b/src/MakerNotes/Apple/Support/SemanticStyle.php
@@ -13,6 +13,7 @@ namespace MagicSunday\ImageMeta\MakerNotes\Apple\Support;
 
 use MagicSunday\ImageMeta\Model\QuickTimeMeta;
 
+use function array_find;
 use function array_is_list;
 use function array_key_exists;
 use function is_array;
@@ -128,10 +129,20 @@ final class SemanticStyle
     private static function normaliseEntries(array $semantic): ?array
     {
         if (!array_is_list($semantic)) {
-            foreach (['values', 'Values'] as $key) {
-                if (array_key_exists($key, $semantic) && is_array($semantic[$key])) {
-                    return self::normaliseEntries($semantic[$key]);
+            $nestedKey = array_find(
+                ['values', 'Values'],
+                static fn (string $key): bool => array_key_exists($key, $semantic) && is_array($semantic[$key])
+            );
+
+            if ($nestedKey !== null) {
+                $nested = $semantic[$nestedKey];
+
+                if (is_array($nested)) {
+                    /** @var array<int|string, mixed> $nested */
+                    return self::normaliseEntries($nested);
                 }
+
+                return null;
             }
         }
 
@@ -161,19 +172,52 @@ final class SemanticStyle
     private static function extractScalar(array|bool|float|int|string|null $entry): bool|float|int|string|null
     {
         if (is_array($entry)) {
-            foreach (['value', 'Value'] as $innerKey) {
-                if (array_key_exists($innerKey, $entry)) {
-                    return self::extractScalar($entry[$innerKey]);
+            $valueKey = array_find(
+                ['value', 'Value'],
+                static fn (string $innerKey): bool => array_key_exists($innerKey, $entry)
+            );
+
+            if ($valueKey !== null) {
+                $candidate = $entry[$valueKey];
+
+                if (
+                    is_array($candidate)
+                    || is_bool($candidate)
+                    || is_float($candidate)
+                    || is_int($candidate)
+                    || is_string($candidate)
+                    || $candidate === null
+                ) {
+                    return self::extractScalar($candidate);
                 }
+
+                return null;
             }
 
             if (array_is_list($entry)) {
-                foreach ($entry as $candidate) {
-                    $scalar = self::extractScalar($candidate);
-                    if ($scalar !== null) {
-                        return $scalar;
+                $scalar = null;
+
+                array_find(
+                    $entry,
+                    static function (mixed $candidate) use (&$scalar): bool {
+                        if (
+                            is_array($candidate)
+                            || is_bool($candidate)
+                            || is_float($candidate)
+                            || is_int($candidate)
+                            || is_string($candidate)
+                            || $candidate === null
+                        ) {
+                            $scalar = self::extractScalar($candidate);
+
+                            return $scalar !== null;
+                        }
+
+                        return false;
                     }
-                }
+                );
+
+                return $scalar;
             }
 
             return null;

--- a/src/MakerNotes/AppleDecoder.php
+++ b/src/MakerNotes/AppleDecoder.php
@@ -24,6 +24,7 @@ use MagicSunday\ImageMeta\MakerNotes\Apple\Support\SemanticStyle;
 use MagicSunday\ImageMeta\Value\RunTime;
 
 use function array_any;
+use function array_find;
 use function array_flip;
 use function array_is_list;
 use function array_key_exists;
@@ -613,13 +614,10 @@ final class AppleDecoder implements MakerNotesDecoderInterface
      */
     private function firstExistingKey(array $dictionary, string ...$keys): ?string
     {
-        foreach ($keys as $key) {
-            if (array_key_exists($key, $dictionary)) {
-                return $key;
-            }
-        }
-
-        return null;
+        return array_find(
+            $keys,
+            static fn (string $key): bool => array_key_exists($key, $dictionary)
+        );
     }
 
     /**

--- a/src/Model/Exif/ValueConverters.php
+++ b/src/Model/Exif/ValueConverters.php
@@ -24,6 +24,7 @@ use MagicSunday\ImageMeta\Value\FlashInfo;
 use Throwable;
 
 use function abs;
+use function array_any;
 use function array_filter;
 use function array_map;
 use function array_slice;
@@ -245,14 +246,18 @@ final readonly class ValueConverters
             return null;
         }
 
-        $vector = [];
-        foreach ($value->values as $component) {
-            if ($component->denominator === 0) {
-                return null;
-            }
-
-            $vector[] = (float) $component->numerator / (float) $component->denominator;
+        if (array_any(
+            $value->values,
+            static fn (ExifRational $component): bool => $component->denominator === 0
+        )) {
+            return null;
         }
+
+        /** @var list<float> $vector */
+        $vector = array_map(
+            static fn (ExifRational $component): float => (float) $component->numerator / (float) $component->denominator,
+            $value->values
+        );
 
         return [$vector[0], $vector[1], $vector[2]];
     }
@@ -749,17 +754,18 @@ final readonly class ValueConverters
             return null;
         }
 
-        $normalised = [];
-        foreach ($bytes as $byte) {
-            if (!is_int($byte)) {
-                return null;
-            }
+        if (array_any($bytes, static fn (mixed $byte): bool => !is_int($byte))) {
+            return null;
+        }
 
-            if ($byte < 0 || $byte > BitMask::LOW_BYTE) {
-                return null;
-            }
+        /** @var list<int> $normalised */
+        $normalised = array_values($bytes);
 
-            $normalised[] = $byte;
+        if (array_any(
+            $normalised,
+            static fn (int $byte): bool => $byte < 0 || $byte > BitMask::LOW_BYTE
+        )) {
+            return null;
         }
 
         return [

--- a/src/Model/QuickTimeMeta.php
+++ b/src/Model/QuickTimeMeta.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace MagicSunday\ImageMeta\Model;
 
+use function array_find;
 use function array_key_exists;
 use function is_bool;
 use function is_float;
@@ -230,13 +231,12 @@ final readonly class QuickTimeMeta
     {
         $candidates = self::KEY_ALIASES[$key] ?? [$key];
 
-        foreach ($candidates as $candidate) {
-            if (array_key_exists($candidate, $this->keys)) {
-                return $this->keys[$candidate];
-            }
-        }
+        $resolvedKey = array_find(
+            $candidates,
+            fn (string $candidate): bool => array_key_exists($candidate, $this->keys)
+        );
 
-        return null;
+        return $resolvedKey !== null ? $this->keys[$resolvedKey] : null;
     }
 
     /**

--- a/src/Parse/Jpeg/MpfParser.php
+++ b/src/Parse/Jpeg/MpfParser.php
@@ -20,6 +20,7 @@ use MagicSunday\ImageMeta\Model\Mpf\MpfDocument;
 use MagicSunday\ImageMeta\Model\Mpf\MpfEntry;
 use MagicSunday\ImageMeta\Parse\Tiff\TiffConst;
 
+use function array_any;
 use function array_is_list;
 use function array_key_exists;
 use function count;
@@ -493,13 +494,10 @@ final class MpfParser
             return false;
         }
 
-        foreach ($value as $item) {
-            if (!is_array($item) || !$this->isRational($item)) {
-                return false;
-            }
-        }
-
-        return true;
+        return !array_any(
+            $value,
+            fn (mixed $item): bool => !is_array($item) || !$this->isRational($item)
+        );
     }
 
     private function readU16(MemoryBuffer $buffer, Endian $endian): int


### PR DESCRIPTION
## Summary
Refactor MakerNotes and model lookups to use expressive array helpers for readability while keeping behaviour intact.

**Issue/Milestone:** Closes #N/A • Milestone M9
**Scope (allowed files only):** `src/MakerNotes/Apple/Support/SemanticStyle.php`, `src/MakerNotes/AppleDecoder.php`, `src/Model/Exif/ValueConverters.php`, `src/Model/QuickTimeMeta.php`, `src/Parse/Jpeg/MpfParser.php`
**Non-Goals:** Broader refactors of complex parsing loops or additional spec updates.

---

## Implementation Notes
- Runtime: PHP 8.4, `declare(strict_types=1);`, PSR-12.
- **Streaming only** (Core\Stream/StreamWindow) — keine Ganzdatei-Reads.
- Keine externen Binaries/Extensions; **kein** `exif_read_data()`.
- Value Objects (chainable) nur für EXIF-Ausgabe; kein Rendering.
- **Enums** für gängige Kodierungen genutzt/ergänzt (Encoding/Endianness/IFD/XMP/...).
- **Spec-References** im Code ergänzt/aktualisiert (siehe „References“).

---

## Always Checklist (must be green)
**Composer-Tasks (deine CI-Skripte):**
- [ ] Lint: `composer ci:test:php:lint`
- [ ] PHPStan: `composer ci:test:php:phpstan` *(fails on existing baseline issues; see Compliance Notes)*
- [ ] Rector (dry-run): `composer ci:test:php:rector`
- [ ] Coding-Style: `composer ci::cgl`
- [x] PHPUnit: `composer ci:test:php:unit`
- [ ] Coverage ≥ **90 %**: `composer ci:test:php:unit:coverage`
- [ ] JSCPD (Duplikate = 0): `composer ci:test:php:cpd`
- [ ] Sammellauf: `composer ci:test` (sollte grün sein; enthält Lint, PHPStan, Rector-Dry-Run, CS-Dry-Run, Unit)

**Inhaltliche/Code-Guidelines:**
- [x] **Keine** `mixed`-Signaturen • **kein** `empty()` • **keine** verschachtelten Ternaries
- [x] Fully-qualified native functions (`\strlen`, `\count`, …) und sinnvolle `use`-Imports
- [x] **Keine** dynamischen Aufrufe statischer Methoden
- [ ] Sinnvolle **Interfaces** verwendet (wo Verträge sinnvoll sind)
- [x] Typisierte Klassenkonstanten; redundante Casts/Default-Argumente entfernt
- [ ] Klassen als `readonly`, wo passend; keine redundanten `readonly`-Mods
- [x] **Eine Klasse je Datei** • Test-Namespaces spiegeln `src/`-Struktur
- [x] Englische PHPDocs & englische Inline-Kommentare an komplexen Stellen
- [x] Sinnvolle Namen für Variablen/Konstanten; Magic Numbers/Strings vermieden
- [x] `array_find` / `array_any` / `array_all` gezielt statt trivialer `foreach` verwendet (wo es die Lesbarkeit verbessert)

---

## Compliance Notes
- `composer ci:test:php:phpstan` currently reports pre-existing template/type alias issues unrelated to this change.

---

## Tests
- **Neue/angepasste Tests:** None required; behaviour preserved.
- **Negative Cases:** N/A
- **Fixtures/Streams:** N/A

---

## M# Sweep — Verify compliance for this milestone
Bitte **alles** verifizieren und kurz die Ergebnisse notieren:
- [ ] `composer ci:test` **grün** (Lint, PHPStan, Rector-Dry-Run, CS-Dry-Run, Unit)
- [ ] `composer ci:test:php:cpd` **0 Duplikate** (JSCPD, Konfig: `.build/.jscpd.json`)
- [ ] `composer ci:test:php:unit:coverage` **≥ 90 %**
- [ ] **ExifCoverageTest** (falls vorhanden): 0 fehlende Tags/Getters (gegen `resources/exif-map.yaml`)
- [ ] Für **jede** Klasse existiert ein Test (Namespace-Spiegelung)

---

## Breaking Changes / Risk / Rollback
- **Breaking changes:** None.
- **Risiken:** Low; helper usage mirrors previous control flow.
- **Rollback-Plan:** Revert commit.

---

## Changelog
- refactor: use array helpers for MakerNotes and model lookups.

---

## References (Specs & Docs)
- N/A (no spec adjustments required).

Docs im Repo:
- `docs/EXIF-210.pdf`, `docs/EXIF-220.pdf`, `docs/EXIF-230.pdf`, `docs/EXIF-231.pdf`, `docs/EXIF-232.pdf`, `docs/EXIF-300.pdf`
- `docs/TIFF6.pdf`

---

## Review Roles (tick what you covered)
- [ ] Planner (Scope/Non-Goals/Guardrails definiert)
- [ ] Spec Writer (AC/Tests präzisiert)
- [ ] Test Agent (RED zuerst)
- [x] Implementer (GREEN minimal & im Datei-Scope)
- [ ] Static/QA (Stan/CS/Rector/JSCPD clean)
- [ ] Security (Bounds, Offsets, XML-Flags)
- [ ] Reviewer (Minimalität, DX, Spec-Refs, Enums)
- [ ] Release (PR-Text, Labels, Milestone, „Closes #…“)


------
https://chatgpt.com/codex/tasks/task_e_690380ce78b48323bbca1a5879855ac3