### PR TITLE
M#: Harden Exif coverage validation — Tests/Spec

### DIFF
--- a/tests/Spec/ExifCoverageTest.php
+++ b/tests/Spec/ExifCoverageTest.php
@@ -22,7 +22,7 @@ final class ExifCoverageTest extends TestCase
     public function testCoverageMapMatchesImplementation(): void
     {
         $map = $this->loadCoverageMap(__DIR__ . '/../../resources/exif-map.yaml');
-        $this->assertNotSame([], $map, 'Coverage map must not be empty.');
+        self::assertNotSame([], $map, 'Coverage map must not be empty.');
 
         $tagMethods = $this->collectTagUsage();
         $tagMetadata = $this->collectTagMetadata();
@@ -44,10 +44,12 @@ final class ExifCoverageTest extends TestCase
         $unknownTypes = [];
         foreach ($map as $tag => $entry) {
             self::assertArrayHasKey('ifd', $entry, sprintf('Entry for %s must define the ifd field.', $tag));
-            self::assertContains($entry['ifd'], $allowedIfds, sprintf('Entry for %s references an unknown IFD "%s".', $tag, (string) $entry['ifd']));
+            self::assertIsString($entry['ifd'], sprintf('Entry for %s must provide the ifd field as string.', $tag));
+            self::assertContains($entry['ifd'], $allowedIfds, sprintf('Entry for %s references an unknown IFD "%s".', $tag, $entry['ifd']));
 
             self::assertArrayHasKey('type', $entry, sprintf('Entry for %s must define the type field.', $tag));
-            $type = (string) $entry['type'];
+            self::assertIsString($entry['type'], sprintf('Entry for %s must provide the type field as string.', $tag));
+            $type = $entry['type'];
             if ($type !== 'auto') {
                 $typeConst = 'TYPE_' . strtoupper($type);
                 if (!defined(TiffConst::class . '::' . $typeConst)) {
@@ -56,11 +58,13 @@ final class ExifCoverageTest extends TestCase
             }
 
             self::assertArrayHasKey('minVersion', $entry, sprintf('Entry for %s must define the minVersion field.', $tag));
-            $minVersion = (string) $entry['minVersion'];
+            self::assertIsString($entry['minVersion'], sprintf('Entry for %s must provide the minVersion field as string.', $tag));
+            $minVersion = $entry['minVersion'];
             self::assertMatchesRegularExpression('/^[0-9]+\.[0-9]+$/', $minVersion, sprintf('Entry for %s has invalid minVersion "%s".', $tag, $minVersion));
 
             if (isset($entry['maxVersion'])) {
-                $maxVersion = (string) $entry['maxVersion'];
+                self::assertIsString($entry['maxVersion'], sprintf('Entry for %s must provide the maxVersion field as string.', $tag));
+                $maxVersion = $entry['maxVersion'];
                 self::assertMatchesRegularExpression('/^[0-9]+\.[0-9]+$/', $maxVersion, sprintf('Entry for %s has invalid maxVersion "%s".', $tag, $maxVersion));
             }
 
@@ -70,15 +74,24 @@ final class ExifCoverageTest extends TestCase
             }
 
             self::assertArrayHasKey('voGetter', $entry, sprintf('Entry for %s must define the voGetter field.', $tag));
-            $getters = $entry['voGetter'];
-            if (!is_array($getters)) {
-                $getters = [$getters];
+            $rawGetters = $entry['voGetter'];
+            $getters = [];
+
+            if (is_array($rawGetters)) {
+                foreach ($rawGetters as $getter) {
+                    self::assertIsString($getter, sprintf('Getter entry for %s must be a string.', $tag));
+                    $getters[] = $getter;
+                }
+            } elseif (is_string($rawGetters)) {
+                $getters[] = $rawGetters;
+            } else {
+                self::fail(sprintf('Entry for %s must define voGetter as string or list of strings.', $tag));
             }
 
             self::assertNotSame([], $getters, sprintf('Entry for %s must list at least one voGetter.', $tag));
 
+            /** @var list<string> $getters */
             foreach ($getters as $getter) {
-                self::assertIsString($getter, sprintf('Getter entry for %s must be a string.', $tag));
                 $this->assertValidGetterPath($getter, $structuredReflection, $knownParsedMethods);
             }
 
@@ -90,17 +103,32 @@ final class ExifCoverageTest extends TestCase
         // Ensure there are no dangling entries pointing to methods that no longer exist.
         $danglingEntries = [];
         foreach ($map as $tag => $entry) {
-            $getters = $entry['voGetter'];
-            if (!is_array($getters)) {
-                $getters = [$getters];
+            $rawGetters = $entry['voGetter'];
+            $getters = [];
+
+            if (is_array($rawGetters)) {
+                foreach ($rawGetters as $getter) {
+                    if (!is_string($getter)) {
+                        $danglingEntries[$tag] = $getter;
+                        continue;
+                    }
+
+                    $getters[] = $getter;
+                }
+            } elseif (is_string($rawGetters)) {
+                $getters[] = $rawGetters;
+            } else {
+                continue;
             }
 
+            /** @var list<string> $getters */
             foreach ($getters as $getter) {
-                $segments = explode('.', (string) $getter);
-                if ($segments === []) {
+                if ($getter === '') {
                     $danglingEntries[$tag] = $getter;
                     continue;
                 }
+
+                $segments = explode('.', $getter);
 
                 if ($segments[0] !== 'raw') {
                     continue;
@@ -177,14 +205,15 @@ final class ExifCoverageTest extends TestCase
     /**
      * Ensures that a getter path can be resolved via StructuredExif.
      *
+     * @param ReflectionClass<StructuredExif> $structuredReflection
      * @param array<string, bool> $knownParsedMethods
      */
     private function assertValidGetterPath(string $path, ReflectionClass $structuredReflection, array $knownParsedMethods): void
     {
+        self::assertNotSame('', $path, 'Getter path must not be empty.');
+        $currentClass = new ReflectionClass($structuredReflection->getName());
         $segments = explode('.', $path);
-        self::assertNotSame([], $segments, sprintf('Getter path "%s" is empty.', $path));
 
-        $currentClass = $structuredReflection;
         foreach ($segments as $index => $segment) {
             self::assertTrue($currentClass->hasMethod($segment), sprintf('Method "%s" not found on %s for getter "%s".', $segment, $currentClass->getName(), $path));
             $method = $currentClass->getMethod($segment);
@@ -298,7 +327,7 @@ final class ExifCoverageTest extends TestCase
         ksort($tagMethods);
         $result = [];
         foreach ($tagMethods as $tag => $methods) {
-            $result[$tag] = array_values(array_keys($methods));
+            $result[$tag] = array_keys($methods);
         }
 
         return $result;
@@ -359,14 +388,15 @@ final class ExifCoverageTest extends TestCase
                 continue;
             }
 
-            if (preg_match('/public const int ([A-Z0-9_]+) = [^;]+;(.*)/', $line, $matches)) {
+            if (preg_match('/public const int ([A-Z0-9_]+) = [^;]+;(.*)/', $line, $matches) === 1) {
                 $name = $matches[1];
-                $inlineComment = $matches[2] ?? '';
+                $inlineComment = $matches[2];
                 $commentText = $docBuffer . ' ' . $inlineComment;
                 $docBuffer = '';
 
-                preg_match_all('/EXIF\s+([0-9]+(?:\.[0-9]+)?)/i', $commentText, $versionMatches);
-                $versions = $versionMatches[1] ?? [];
+                $versionMatches = [];
+                $versionMatchCount = preg_match_all('/EXIF\s+([0-9]+(?:\.[0-9]+)?)/i', $commentText, $versionMatches);
+                $versions = ($versionMatchCount === false || $versionMatchCount === 0) ? [] : $versionMatches[1];
                 $normalizedVersions = [];
                 foreach ($versions as $version) {
                     $clean = rtrim($version, '.');


### PR DESCRIPTION
## Summary
Tighten the EXIF coverage spec to satisfy PHPStan by validating map entries as strings and rejecting malformed getter definitions.

**Issue/Milestone:** Closes #N/A • Milestone M#
**Scope (allowed files only):** `tests/Spec/ExifCoverageTest.php`
**Non-Goals:** Changes outside the EXIF coverage test harness.

---

## Implementation Notes
- Runtime: PHP 8.4, `declare(strict_types=1);`, PSR-12.
- **Streaming only** (Core\\Stream/StreamWindow) — keine Ganzdatei-Reads.
- Keine externen Binaries/Extensions; **kein** `exif_read_data()`.
- Value Objects (chainable) nur für EXIF-Ausgabe; kein Rendering.
- **Enums** für gängige Kodierungen genutzt/ergänzt (Encoding/Endianness/IFD/XMP/...).
- **Spec-References** im Code ergänzt/aktualisiert (siehe „References“).

---

## Always Checklist (must be green)
**Composer-Tasks (deine CI-Skripte):**
- [ ] Lint: `composer ci:test:php:lint`
- [ ] PHPStan: `composer ci:test:php:phpstan`
- [ ] Rector (dry-run): `composer ci:test:php:rector`
- [ ] Coding-Style: `composer ci::cgl`
- [ ] PHPUnit: `composer ci:test:php:unit`
- [ ] Coverage ≥ **90 %**: `composer ci:test:php:unit:coverage`
- [ ] JSCPD (Duplikate = 0): `composer ci:test:php:cpd`
- [ ] Sammellauf: `composer ci:test` (sollte grün sein; enthält Lint, PHPStan, Rector-Dry-Run, CS-Dry-Run, Unit)

**Inhaltliche/Code-Guidelines:**
- [ ] **Keine** `mixed`-Signaturen • **kein** `empty()` • **keine** verschachtelten Ternaries
- [ ] Fully-qualified native functions (`\\strlen`, `\\count`, …) und sinnvolle `use`-Imports
- [ ] **Keine** dynamischen Aufrufe statischer Methoden
- [ ] Sinnvolle **Interfaces** verwendet (wo Verträge sinnvoll sind)
- [ ] Typisierte Klassenkonstanten; redundante Casts/Default-Argumente entfernt
- [ ] Klassen als `readonly`, wo passend; keine redundanten `readonly`-Mods
- [ ] **Eine Klasse je Datei** • Test-Namespaces spiegeln `src/`-Struktur
- [ ] Englische PHPDocs & englische Inline-Kommentare an komplexen Stellen
- [ ] Sinnvolle Namen für Variablen/Konstanten; Magic Numbers/Strings vermieden
- [ ] `array_find` / `array_any` / `array_all` gezielt statt trivialer `foreach` verwendet (wo es die Lesbarkeit verbessert)

---

## EXIF / TIFF / ISOBMFF / XMP Guardrails
- **EXIF-Versionen:** 1.x, 2.x (2.1/2.2/2.21/2.3/2.31/2.32), 3.0 — kompatible Änderungen; falls Tags betroffen: Coverage-Test grün.
- **TIFF/BigTIFF:** Endianness korrekt (`0x2A` / `0x2B`), Inline-Werte-Grenzen, `RATIONAL/SRATIONAL` korrekt.
- **GPS:** Vorzeichen über Ref-Tags (S/W negativ); `0/0`-Kantenfälle robust.
- **Preview/IFD1:** Nur beschreiben (Offsets/Längen/Compression), kein Rendering.
- **ISOBMFF/QuickTime:** Box-Size ≥ Header, 32/64-bit-Größen korrekt; `iloc`-Extents summiert; `data_reference_index ≠ 0` → skip; keine Remote-Refs.
- **XMP:** JPEG APP1-Präfix / ISOBMFF `uuid`; Parser mit `LIBXML_NONET`, keine DTD/Entities; `Alt/Bag/Seq` → Arrays.
- **Fehlerbehandlung:** ausschließlich `ParseError` oder `BoundsError`; keine Warnings/Notices als Kontrollfluss.

---

## Tests
- **Neue/angepasste Tests:** Hardened `tests/Spec/ExifCoverageTest` assertions to guard type expectations.
- **Negative Cases:** Added failure paths for malformed getter definitions in the map.
- **Fixtures/Streams:** No new fixtures required.

---

### Agent Updates
- Validates EXIF coverage entries with explicit string checks to keep PHPStan satisfied.
- `composer ci:test:php:phpstan` still fails on pre-existing issues in unrelated modules; see discussion for context.

## M# Sweep — Verify compliance for this milestone
Bitte **alles** verifizieren und kurz die Ergebnisse notieren:
- [ ] `composer ci:test` **grün** (Lint, PHPStan, Rector-Dry-Run, CS-Dry-Run, Unit)
- [ ] `composer ci:test:php:cpd` **0 Duplikate** (JSCPD, Konfig: `.build/.jscpd.json`)
- [ ] `composer ci:test:php:unit:coverage` **≥ 90 %**
- [ ] **ExifCoverageTest** (falls vorhanden): 0 fehlende Tags/Getters (gegen `resources/exif-map.yaml`)
- [ ] Für **jede** Klasse existiert ein Test (Namespace-Spiegelung)

---

## Breaking Changes / Risk / Rollback
- **Breaking changes:** None.
- **Risiken:** Minimal; test-only tightening of assertions.
- **Rollback-Plan:** Revert commit `test(exif): harden coverage map validation`.

---

## Changelog
- test(exif): harden coverage map validation checks in `ExifCoverageTest`.

---

## References (Specs & Docs)
- EXIF 3.0 §… ; ggf. EXIF 2.32 §… ; EXIF 2.31 §…
- TIFF 6.0 §…
- ISOBMFF/QuickTime §…
- XMP (Adobe XMP Packet) §…

Docs im Repo:
- `docs/EXIF-210.pdf`, `docs/EXIF-220.pdf`, `docs/EXIF-230.pdf`, `docs/EXIF-231.pdf`, `docs/EXIF-232.pdf`, `docs/EXIF-300.pdf`
- `docs/TIFF6.pdf`

---

## Review Roles (tick what you covered)
- [ ] Planner (Scope/Non-Goals/Guardrails definiert)
- [ ] Spec Writer (AC/Tests präzisiert)
- [ ] Test Agent (RED zuerst)
- [ ] Implementer (GREEN minimal & im Datei-Scope)
- [ ] Static/QA (Stan/CS/Rector/JSCPD clean)
- [ ] Security (Bounds, Offsets, XML-Flags)
- [ ] Reviewer (Minimalität, DX, Spec-Refs, Enums)
- [ ] Release (PR-Text, Labels, Milestone, „Closes #…“)


------
https://chatgpt.com/codex/tasks/task_e_69038d8b36288323814764bc2204d39d