### PR TITLE
M1: Document structured EXIF wrapper deprecations — Curate

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 MagicSunday/ImageMeta provides a streaming metadata parser for JPEG, HEIC and ISO Base Media File Format containers. It unifies EXIF, XMP and QuickTime sources into a common PHP domain model.
 
+## Milestone M1 Goals
+
+- Establish a single value layer without duplicate wrapper APIs.
+- Ensure `StructuredMetadata` exposes raw value objects alongside derived helpers.
+- Track migration progress in `docs/upgrade/m1-single-value-layer.md`.
+
 ## Structured Metadata API
 
 The library exposes a structured and fully typed metadata aggregate via `Metadata::structured()`. The aggregate wraps immutable value objects that hide any tag or container specifics.

--- a/docs/m1-inventory.md
+++ b/docs/m1-inventory.md
@@ -1,0 +1,27 @@
+# Milestone M1 Inventory
+
+This inventory documents every reference to the legacy structured EXIF wrappers and the curated metadata aggregates. It highlights call sites that need to be migrated while converging on a single value layer.
+
+## `MagicSunday\\ImageMeta\\Curate\\Exif\\Structured\\*`
+
+| Wrapper | Location | Purpose |
+| --- | --- | --- |
+| `Camera` | `src/Exif/StructuredExif.php` | Imported and instantiated inside `StructuredExif` to expose EXIF-only camera metadata without cross-container fallbacks. |
+| `Lens` | `src/Exif/StructuredExif.php` | Instantiated by `StructuredExif` to wrap the derived lens value objects. |
+| `Exposure` | `src/Exif/StructuredExif.php` | Created by `StructuredExif` to surface exposure settings alongside derived EV helpers. |
+| `Gps` | `src/Exif/StructuredExif.php` | Provides EXIF-only GPS data for the legacy `StructuredExif` aggregate. |
+| `Image` | `src/Exif/StructuredExif.php` | Supplies image dimension accessors required by the EXIF wrapper. |
+| `Preview` | `src/Exif/StructuredExif.php`, `tests/Support/ExifExpectationAssertions.php` | Used by the API wrapper and expectation helpers to expose thumbnail and preview metadata. |
+
+## `MagicSunday\\ImageMeta\\Curate\\Structured\\*`
+
+| Aggregate | Location | Purpose |
+| --- | --- | --- |
+| `StructuredMetadata` | `src/Curate/StructuredMetadata.php` | Central aggregate composed of curated value objects spanning file, camera, lens, exposure, GPS, sensor, processing, technical and rights metadata. |
+| `CameraMetadata`, `LensMetadata`, `ExposureMetadata`, `GpsMetadata` | `src/Curate/StructuredMetadata.php`, `src/Curate/Exif/ValueFactory.php` | Value-object aggregates assembled by `ValueFactory` and injected into `StructuredMetadata`. |
+| `CaptureMetadata`, `MediaMetadata`, `ProcessingMetadata`, `SensorMetadata`, `TechnicalMetadata`, `RightsMetadata`, `MakerNotesView`, `FileMetadata` | `src/Curate/StructuredMetadata.php`, `src/Curate/Exif/ValueFactory.php` | Additional grouped metadata slices created during curation and exposed through the structured aggregate. |
+
+## `MagicSunday\\ImageMeta\\Convenience\\ExifConvenience::gps()`
+
+* Defined in `src/Convenience/ExifConvenience.php` where it forwards to `ParsedExif::gps()` while retaining EXIF specification references.
+* No external call sites were found during the repository scan, indicating that the helper currently lacks dedicated consumers or tests.

--- a/docs/upgrade/m1-single-value-layer.md
+++ b/docs/upgrade/m1-single-value-layer.md
@@ -1,0 +1,35 @@
+# Milestone M1 Upgrade Notes — Single Value Layer
+
+Milestone M1 introduces a single structured metadata layer backed by immutable value objects. The EXIF-only wrapper classes under `MagicSunday\ImageMeta\Curate\Exif\Structured` remain functional for the current release but are marked as internal deprecations to guide integrators towards the curated aggregates.
+
+## Impacted APIs
+
+The following classes are tagged with `@deprecated` and will be removed after Milestone M1:
+
+- `MagicSunday\ImageMeta\Curate\Exif\Structured\Camera`
+- `MagicSunday\ImageMeta\Curate\Exif\Structured\Lens`
+- `MagicSunday\ImageMeta\Curate\Exif\Structured\Exposure`
+- `MagicSunday\ImageMeta\Curate\Exif\Structured\Gps`
+- `MagicSunday\ImageMeta\Curate\Exif\Structured\Image`
+- `MagicSunday\ImageMeta\Curate\Exif\Structured\Preview`
+
+`MagicSunday\ImageMeta\Exif\StructuredExif` continues to expose these wrappers so existing integrations remain operational during the transition.
+
+## Migration Guidance
+
+1. Prefer `Metadata::structured()` which returns `MagicSunday\ImageMeta\Curate\Structured\StructuredMetadata`.
+2. Access curated value objects directly, for example:
+   ```php
+   $metadata = (new MetadataReader())->read($path)->structured();
+   $metadata->camera->device->model;
+   $metadata->lens->optics->equivalent35mm();
+   $metadata->media->image->width;
+   $metadata->gps->coordinates->latitude?->toFloat();
+   ```
+3. For preview information, use `$metadata->media->preview` instead of the deprecated `Structured\Preview` wrapper.
+
+## Deprecation Mechanics
+
+- Deprecations are expressed via PHPDoc `@deprecated` annotations with internal wording to avoid accidental public API promotion.
+- No runtime triggers are emitted; consumers must rely on static analysis or IDE inspections.
+- Removal is scheduled after Milestone M1 once library consumers confirm migration to the curated aggregates.

--- a/src/Curate/Exif/Structured/Camera.php
+++ b/src/Curate/Exif/Structured/Camera.php
@@ -17,6 +17,9 @@ use MagicSunday\ImageMeta\Value\Enum\SensingMethod;
 
 /**
  * Provides EXIF backed camera metadata without container fallbacks.
+ *
+ * @deprecated Internal bridging wrapper scheduled for removal after Milestone M1.
+ *             Use MagicSunday\ImageMeta\Curate\Structured\CameraMetadata instead.
  */
 final readonly class Camera
 {

--- a/src/Curate/Exif/Structured/Exposure.php
+++ b/src/Curate/Exif/Structured/Exposure.php
@@ -25,6 +25,9 @@ use MagicSunday\ImageMeta\Value\FlashInfo;
 
 /**
  * Captures EXIF exposure values alongside derived exposure metrics.
+ *
+ * @deprecated Internal bridging wrapper scheduled for removal after Milestone M1.
+ *             Use MagicSunday\ImageMeta\Curate\Structured\ExposureMetadata instead.
  */
 final readonly class Exposure
 {

--- a/src/Curate/Exif/Structured/Gps.php
+++ b/src/Curate/Exif/Structured/Gps.php
@@ -17,6 +17,9 @@ use MagicSunday\ImageMeta\Value\Gps as GpsValue;
 
 /**
  * Offers EXIF GPS metadata without external augmentation.
+ *
+ * @deprecated Internal bridging wrapper scheduled for removal after Milestone M1.
+ *             Use MagicSunday\ImageMeta\Curate\Structured\GpsMetadata instead.
  */
 final readonly class Gps
 {

--- a/src/Curate/Exif/Structured/Image.php
+++ b/src/Curate/Exif/Structured/Image.php
@@ -17,6 +17,9 @@ use MagicSunday\ImageMeta\Value\Image as ImageValue;
 
 /**
  * Holds EXIF image attributes without QuickTime fallbacks.
+ *
+ * @deprecated Internal bridging wrapper scheduled for removal after Milestone M1.
+ *             Use MagicSunday\ImageMeta\Curate\Structured\MediaMetadata for curated image data.
  */
 final readonly class Image
 {

--- a/src/Curate/Exif/Structured/Lens.php
+++ b/src/Curate/Exif/Structured/Lens.php
@@ -16,6 +16,9 @@ use MagicSunday\ImageMeta\Value\Lens as LensValue;
 
 /**
  * Represents EXIF lens metadata enriched with derived optical metrics.
+ *
+ * @deprecated Internal bridging wrapper scheduled for removal after Milestone M1.
+ *             Use MagicSunday\ImageMeta\Curate\Structured\LensMetadata instead.
  */
 final readonly class Lens
 {

--- a/src/Curate/Exif/Structured/Preview.php
+++ b/src/Curate/Exif/Structured/Preview.php
@@ -17,6 +17,9 @@ use MagicSunday\ImageMeta\Value\Preview as PreviewValue;
 
 /**
  * Indicates the availability of previews and thumbnails from EXIF.
+ *
+ * @deprecated Internal bridging wrapper scheduled for removal after Milestone M1.
+ *             Use MagicSunday\ImageMeta\Curate\Structured\MediaMetadata for preview data.
  */
 final readonly class Preview
 {

--- a/src/Exif/StructuredExif.php
+++ b/src/Exif/StructuredExif.php
@@ -35,6 +35,10 @@ use MagicSunday\ImageMeta\Value\Standards;
 
 /**
  * Provides an EXIF-only structured view derived from a parsed document.
+ *
+ * This legacy aggregate bridges the deprecated structured EXIF wrappers until
+ * the single value layer migration completes. Prefer {@see \MagicSunday\ImageMeta\Curate\StructuredMetadata}
+ * for new integrations.
  */
 final readonly class StructuredExif
 {


### PR DESCRIPTION
<!--
PR-Titel-Empfehlung:
M#: <kurze Beschreibung> — <Bereich>
Beispiel: M1: Unify binary readers — Core/Stream
-->

## Summary
- Documented the M1 inventory, guardrails and deprecation pathway for the structured EXIF wrappers.

**Issue/Milestone:** Closes #0 • Milestone M1
**Scope (allowed files only):** README.md; docs/m1-inventory.md; docs/upgrade/m1-single-value-layer.md; src/Curate/Exif/Structured/*; src/Exif/StructuredExif.php
**Non-Goals:** No parser logic or runtime behavioural changes.

---

## Implementation Notes
- Runtime: PHP 8.4, `declare(strict_types=1);`, PSR-12.
- **Streaming only** (Core\Stream/StreamWindow) — keine Ganzdatei-Reads.
- Keine externen Binaries/Extensions; **kein** `exif_read_data()`.
- Value Objects (chainable) nur für EXIF-Ausgabe; kein Rendering.
- **Enums** für gängige Kodierungen genutzt/ergänzt (Encoding/Endianness/IFD/XMP/...).
- **Spec-References** im Code ergänzt/aktualisiert (siehe „References“).

---

## Always Checklist (must be green)
**Composer-Tasks (deine CI-Skripte):**
- [ ] Lint: `composer ci:test:php:lint`
- [ ] PHPStan: `composer ci:test:php:phpstan`
- [ ] Rector (dry-run): `composer ci:test:php:rector`
- [ ] Coding-Style: `composer ci::cgl`
- [ ] PHPUnit: `composer ci:test:php:unit`
- [ ] Coverage ≥ **90 %**: `composer ci:test:php:unit:coverage`
- [ ] JSCPD (Duplikate = 0): `composer ci:test:php:cpd`
- [ ] Sammellauf: `composer ci:test` (sollte grün sein; enthält Lint, PHPStan, Rector-Dry-Run, CS-Dry-Run, Unit)

**Inhaltliche/Code-Guidelines:**
- [ ] **Keine** `mixed`-Signaturen • **kein** `empty()` • **keine** verschachtelten Ternaries
- [ ] Fully-qualified native functions (`\strlen`, `\count`, …) und sinnvolle `use`-Imports
- [ ] **Keine** dynamischen Aufrufe statischer Methoden
- [ ] Sinnvolle **Interfaces** verwendet (wo Verträge sinnvoll sind)
- [ ] Typisierte Klassenkonstanten; redundante Casts/Default-Argumente entfernt
- [ ] Klassen als `readonly`, wo passend; keine redundanten `readonly`-Mods
- [ ] **Eine Klasse je Datei** • Test-Namespaces spiegeln `src/`-Struktur
- [ ] Englische PHPDocs & englische Inline-Kommentare an komplexen Stellen
- [ ] Sinnvolle Namen für Variablen/Konstanten; Magic Numbers/Strings vermieden
- [ ] `array_find` / `array_any` / `array_all` gezielt statt trivialer `foreach` verwendet (wo es die Lesbarkeit verbessert)

---

## EXIF / TIFF / ISOBMFF / XMP Guardrails
- **EXIF-Versionen:** 1.x, 2.x (2.1/2.2/2.21/2.3/2.31/2.32), 3.0 — kompatible Änderungen; falls Tags betroffen: Coverage-Test grün.
- **TIFF/BigTIFF:** Endianness korrekt (`0x2A` / `0x2B`), Inline-Werte-Grenzen, `RATIONAL/SRATIONAL` korrekt.
- **GPS:** Vorzeichen über Ref-Tags (S/W negativ); `0/0`-Kantenfälle robust.
- **Preview/IFD1:** Nur beschreiben (Offsets/Längen/Compression), kein Rendering.
- **ISOBMFF/QuickTime:** Box-Size ≥ Header, 32/64-bit-Größen korrekt; `iloc`-Extents summiert; `data_reference_index ≠ 0` → skip; keine Remote-Refs.
- **XMP:** JPEG APP1-Präfix / ISOBMFF `uuid`; Parser mit `LIBXML_NONET`, keine DTD/Entities; `Alt/Bag/Seq` → Arrays.
- **Fehlerbehandlung:** ausschließlich `ParseError` oder `BoundsError`; keine Warnings/Notices als Kontrollfluss.

---

## Tests
- **Neue/angepasste Tests:** Not applicable — documentation and annotations only.
- **Negative Cases:** Not applicable.
- **Fixtures/Streams:** Not applicable.

---

## Milestone M1 Addendum
- Documented repository-wide references for legacy structured EXIF wrappers and convenience helpers in `docs/m1-inventory.md`.
- Captured single value layer objectives in the README and outlined upgrade guidance in `docs/upgrade/m1-single-value-layer.md`.
- Flagged the legacy structured EXIF wrapper classes with internal `@deprecated` annotations while clarifying their bridging role.

## M# Sweep — Verify compliance for this milestone
Bitte **alles** verifizieren und kurz die Ergebnisse notieren:
- [ ] `composer ci:test` **grün** (Lint, PHPStan, Rector-Dry-Run, CS-Dry-Run, Unit)
- [ ] `composer ci:test:php:cpd` **0 Duplikate** (JSCPD, Konfig: `.build/.jscpd.json`)
- [ ] `composer ci:test:php:unit:coverage` **≥ 90 %**
- [ ] **ExifCoverageTest** (falls vorhanden): 0 fehlende Tags/Getters (gegen `resources/exif-map.yaml`)
- [ ] Für **jede** Klasse existiert ein Test (Namespace-Spiegelung)

---

## Breaking Changes / Risk / Rollback
- **Breaking changes:** <!-- falls ja: welche und warum notwendig -->
- **Risiken:** <!-- Parser-Sensitivität, Performance, Abhängigkeiten -->
- **Rollback-Plan:** <!-- einfache Revert-Strategie / Feature-Flag falls nötig -->

---

## Changelog
- chore: document structured EXIF wrapper deprecations and migration aids.

---

## References (Specs & Docs)
Not applicable — documentation update.
- EXIF 3.0 §… ; ggf. EXIF 2.32 §… ; EXIF 2.31 §…
- TIFF 6.0 §…
- ISOBMFF/QuickTime §…
- XMP (Adobe XMP Packet) §…

Docs im Repo:
- `docs/EXIF-210.pdf`, `docs/EXIF-220.pdf`, `docs/EXIF-230.pdf`, `docs/EXIF-231.pdf`, `docs/EXIF-232.pdf`, `docs/EXIF-300.pdf`
- `docs/TIFF6.pdf`

---

## Review Roles (tick what you covered)
- [x] Planner (Scope/Non-Goals/Guardrails definiert)
- [ ] Spec Writer (AC/Tests präzisiert)
- [ ] Test Agent (RED zuerst)
- [x] Implementer (GREEN minimal & im Datei-Scope)
- [ ] Static/QA (Stan/CS/Rector/JSCPD clean)
- [ ] Security (Bounds, Offsets, XML-Flags)
- [ ] Reviewer (Minimalität, DX, Spec-Refs, Enums)
- [x] Release (PR-Text, Labels, Milestone, „Closes #…“)


------
https://chatgpt.com/codex/tasks/task_e_690476f135d4832383fdd2612961b19c