### PR TITLE
feat(convenience): format value objects for display

### DIFF
--- a/src/Convenience/CaptureDateResolver.php
+++ b/src/Convenience/CaptureDateResolver.php
@@ -12,9 +12,11 @@ declare(strict_types=1);
 namespace MagicSunday\ImageMeta\Convenience;
 
 use DateTimeImmutable;
-use MagicSunday\ImageMeta\Model\Exif\ParsedExif;
 use MagicSunday\ImageMeta\Model\Metadata;
 use MagicSunday\ImageMeta\Model\Xmp\XmpDocument;
+use MagicSunday\ImageMeta\Value\Capture;
+use MagicSunday\ImageMeta\Value\Gps;
+use MagicSunday\ImageMeta\Value\Temporal;
 use Throwable;
 
 use function is_array;
@@ -24,37 +26,38 @@ use function trim;
 
 /**
  * Resolves the best available capture timestamp for an image asset.
- *
- * The resolver prefers EXIF information as it typically offers the most
- * accurate capture metadata, but it can fall back to XMP when EXIF data is
- * missing or incomplete.
  */
 final class CaptureDateResolver
 {
     /**
      * Determines the most precise capture timestamp contained in the metadata.
-     *
-     * @param Metadata $metadata structured metadata extracted from the asset
-     *
-     * @return DateTimeImmutable|null a normalised timestamp or null when no usable
-     *                                value is available
      */
     public static function bestCaptureDateTime(Metadata $metadata): ?DateTimeImmutable
     {
-        if ($metadata->exifDoc instanceof ParsedExif) {
-            $dateTime = ExifConvenience::captureDateTime($metadata->exifDoc);
+        $structured = $metadata->structured();
 
-            if ($dateTime instanceof DateTimeImmutable) {
-                return $dateTime;
-            }
+        $capture   = $structured->capture->details;
+        $temporal  = $structured->capture->temporal;
+        $gps       = $structured->gps->gps();
+
+        $candidate = self::captureDate($capture)
+            ?? self::temporalFallback($temporal)
+            ?? self::gpsFallback($gps);
+
+        if ($candidate instanceof DateTimeImmutable) {
+            return $candidate;
         }
 
-        if ($metadata->xmpDoc instanceof XmpDocument) {
-            $createDate = self::readXmpCreateDate($metadata->xmpDoc);
+        $xmpDocument = $metadata->xmpDoc;
+        if (!$xmpDocument instanceof XmpDocument) {
+            $xmpDocument = $metadata->selectiveXmpDocument();
+        }
+
+        if ($xmpDocument instanceof XmpDocument) {
+            $createDate = self::readXmpCreateDate($xmpDocument);
 
             if ($createDate !== null) {
                 try {
-                    // XMP createDate is already ISO 8601, so we can consume it directly.
                     return new DateTimeImmutable($createDate);
                 } catch (Throwable) {
                     // Ignore malformed timestamps and continue searching for fallbacks.
@@ -65,12 +68,35 @@ final class CaptureDateResolver
         return null;
     }
 
+    private static function captureDate(Capture $capture): ?DateTimeImmutable
+    {
+        return $capture->dateTime();
+    }
+
+    private static function temporalFallback(Temporal $temporal): ?DateTimeImmutable
+    {
+        $candidates = [
+            $temporal->original(),
+            $temporal->create(),
+            $temporal->modify(),
+        ];
+
+        foreach ($candidates as $candidate) {
+            if ($candidate instanceof DateTimeImmutable) {
+                return $candidate;
+            }
+        }
+
+        return null;
+    }
+
+    private static function gpsFallback(Gps $gps): ?DateTimeImmutable
+    {
+        return $gps->timestamp();
+    }
+
     /**
      * Extracts the ISO 8601 create date from the XMP document.
-     *
-     * @param XmpDocument $document XMP document holding metadata properties.
-     *
-     * @return string|null ISO 8601 timestamp or null when unavailable.
      */
     private static function readXmpCreateDate(XmpDocument $document): ?string
     {

--- a/src/Convenience/ExifConvenience.php
+++ b/src/Convenience/ExifConvenience.php
@@ -12,261 +12,178 @@ declare(strict_types=1);
 namespace MagicSunday\ImageMeta\Convenience;
 
 use DateTimeImmutable;
-use MagicSunday\ImageMeta\Core\Util\UInt64;
-use MagicSunday\ImageMeta\Model\Exif\ExifNumericList;
-use MagicSunday\ImageMeta\Model\Exif\ExifRational;
-use MagicSunday\ImageMeta\Model\Exif\ExifRationalList;
-use MagicSunday\ImageMeta\Model\Exif\ExifTag;
-use MagicSunday\ImageMeta\Model\Exif\IfdEntry;
-use MagicSunday\ImageMeta\Model\Exif\ParsedExif;
-use MagicSunday\ImageMeta\Model\Exif\ValueConverters;
-use Throwable;
+use MagicSunday\ImageMeta\Value\Camera;
+use MagicSunday\ImageMeta\Value\Capture;
+use MagicSunday\ImageMeta\Value\Derived;
+use MagicSunday\ImageMeta\Value\Exposure;
+use MagicSunday\ImageMeta\Value\Gps;
+use MagicSunday\ImageMeta\Value\Image;
+use MagicSunday\ImageMeta\Value\Lens;
 
-use function is_float;
-use function is_int;
+use function abs;
+use function implode;
+use function round;
+use function rtrim;
+use function sprintf;
+use function strcasecmp;
+use function strlen;
+use function strncmp;
+use function strtolower;
+use function trim;
+
+use const DATE_ATOM;
 
 /**
- * Helper routines that extract frequently-used EXIF values in a safe manner.
+ * Presentation helpers that format value objects for UI consumption.
  */
 final class ExifConvenience
 {
     /**
-     * Extracts camera identification details from the EXIF document.
-     *
-     * @param ParsedExif $doc parsed EXIF metadata
-     *
-     * @return array{make: ?string, model: ?string, lens: ?string} camera details ready for display
+     * Returns the capture timestamp value from the capture metadata.
      */
-    public static function camera(ParsedExif $doc): array
+    public static function captureDateTime(Capture $capture): ?DateTimeImmutable
     {
-        return [
-            'make'  => $doc->cameraMake(),  // EXIF 3.0 §4.6.4; EXIF 2.32 §4.6.4 (Make)
-            'model' => $doc->cameraModel(), // EXIF 3.0 §4.6.4; EXIF 2.32 §4.6.4 (Model)
-            'lens'  => $doc->lensModel(),   // EXIF 3.0 §4.6.3; EXIF 2.32 §4.6.3 (LensModel)
-        ];
+        return $capture->dateTime();
     }
 
     /**
-     * Normalises the capture timestamp by combining the EXIF datetime and offset.
-     *
-     * @param ParsedExif $doc parsed EXIF metadata
-     *
-     * @return DateTimeImmutable|null the capture timestamp or null when unavailable
+     * Formats the capture timestamp as a string using the supplied format.
      */
-    public static function captureDateTime(ParsedExif $doc): ?DateTimeImmutable
+    public static function captureDateTimeString(Capture $capture, string $format = DATE_ATOM): ?string
     {
-        try {
-            // EXIF 3.0 §4.6.3; EXIF 2.32 §4.6.3 harmonise DateTimeOriginal with OffsetTime*.
-            return $doc->captureDateTime();
-        } catch (Throwable) {
+        $dateTime = $capture->dateTime();
+
+        if (!$dateTime instanceof DateTimeImmutable) {
             return null;
         }
+
+        return $dateTime->format($format);
     }
 
     /**
-     * Returns the GPS coordinates extracted from the EXIF document.
-     *
-     * @param ParsedExif $doc parsed EXIF metadata
-     *
-     * @return array{lat: ?float, lon: ?float, alt: ?float} geographic coordinates
+     * Builds a compact camera and lens description string.
      */
-    public static function gps(ParsedExif $doc): array
+    public static function cameraDescription(Camera $camera, ?Lens $lens = null): ?string
     {
-        // GPSLatitude/GPSLongitude/GPSAltitude (EXIF 3.0 §4.6.8; EXIF 2.32 §4.6.8).
-        return $doc->gps(); // ['lat'=>?float,'lon'=>?float,'alt'=>?float]
-    }
+        $make  = self::normalise($camera->make());
+        $model = self::normalise($camera->model());
 
-    /**
-     * Converts the exposure time rational to seconds.
-     *
-     * @param ParsedExif $doc parsed EXIF metadata
-     *
-     * @return float|null exposure duration in seconds
-     */
-    public static function exposureTime(ParsedExif $doc): ?float
-    {
-        $entry = self::find($doc, ExifTag::EXPOSURE_TIME); // EXIF 3.0 §4.6.3; EXIF 2.32 §4.6.3 (ExposureTime)
+        $cameraLabel = null;
 
-        return $entry instanceof IfdEntry
-            ? self::rationalEntryToFloat($entry)
-            : null;
-    }
-
-    /**
-     * Retrieves the aperture (f-number) from the EXIF data.
-     *
-     * @param ParsedExif $doc parsed EXIF metadata
-     *
-     * @return float|null aperture value
-     */
-    public static function fNumber(ParsedExif $doc): ?float
-    {
-        $entry = self::find($doc, ExifTag::F_NUMBER); // EXIF 3.0 §4.6.3; EXIF 2.32 §4.6.3 (FNumber)
-
-        return $entry instanceof IfdEntry
-            ? self::rationalEntryToFloat($entry)
-            : null;
-    }
-
-    /**
-     * Retrieves the focal length from the EXIF data in millimetres.
-     *
-     * @param ParsedExif $doc parsed EXIF metadata
-     *
-     * @return float|null focal length in millimetres
-     */
-    public static function focalLength(ParsedExif $doc): ?float
-    {
-        $entry = self::find($doc, ExifTag::FOCAL_LENGTH); // EXIF 3.0 §4.6.3; EXIF 2.32 §4.6.3 (FocalLength)
-
-        return $entry instanceof IfdEntry
-            ? self::rationalEntryToFloat($entry)
-            : null;
-    }
-
-    /**
-     * Determines the ISO sensitivity from either the modern or legacy tag.
-     *
-     * @param ParsedExif $doc parsed EXIF metadata
-     *
-     * @return int|null ISO value when available
-     */
-    public static function iso(ParsedExif $doc): ?int
-    {
-        try {
-            $iso = $doc->isoBestEffort();
-            if ($iso !== null) {
-                return $iso;
+        if ($make !== null && $model !== null) {
+            if (self::startsWithCaseInsensitive($model, $make)) {
+                $cameraLabel = $model;
+            } else {
+                $cameraLabel = $make . ' ' . $model;
             }
-        } catch (Throwable) {
-            // ignore and fall back to manual resolution
+        } elseif ($make !== null || $model !== null) {
+            $cameraLabel = $make ?? $model;
         }
 
-        $iso = self::isoFromSensitivityType($doc); // EXIF 3.0 §4.6.3; EXIF 2.32 §4.6.3 (SensitivityType)
+        $lensLabel = self::normalise($lens?->lensModel());
+
+        $parts = [];
+        if ($cameraLabel !== null) {
+            $parts[] = $cameraLabel;
+        }
+
+        if ($lensLabel !== null) {
+            $parts[] = $lensLabel;
+        }
+
+        if ($parts === []) {
+            return null;
+        }
+
+        return implode(' · ', $parts);
+    }
+
+    /**
+     * Formats the exposure metadata into a readable summary string.
+     */
+    public static function exposureSummary(Exposure $exposure, ?Lens $lens = null, ?Derived $derived = null): ?string
+    {
+        $parts = [];
+
+        $seconds = $exposure->exposureTimeSec();
+        if ($seconds !== null) {
+            $parts[] = self::formatExposureTime($seconds);
+        }
+
+        $fNumber = $exposure->fNumber();
+        if ($fNumber !== null) {
+            $parts[] = self::formatFNumber($fNumber);
+        }
+
+        $iso = $exposure->iso();
         if ($iso !== null) {
-            return $iso;
+            $parts[] = self::formatIso($iso);
         }
 
-        $iso = self::isoFromEntry($doc->exifIfd?->get(ExifTag::ISO_SPEED)); // EXIF 3.0 §4.6.3; EXIF 2.32 §4.6.3 (ISOSpeedRatings)
-        if ($iso !== null) {
-            return $iso;
+        $focalLength = $lens?->focalLengthMm();
+        if ($focalLength !== null) {
+            $parts[] = self::formatFocalLength($focalLength);
         }
 
-        $iso = self::isoFromEntry($doc->exifIfd?->get(ExifTag::STANDARD_OUTPUT_SENSITIVITY)); // EXIF 3.0 §4.6.3; EXIF 2.32 §4.6.3 (StandardOutputSensitivity)
-        if ($iso !== null) {
-            return $iso;
+        $equivalent = $derived?->focalLength35mm();
+        if ($equivalent !== null && !self::containsEquivalent($parts, $equivalent)) {
+            $parts[] = sprintf('%d mm eq', $equivalent);
         }
 
-        $iso = self::isoFromEntry($doc->exifIfd?->get(ExifTag::RECOMMENDED_EXPOSURE_INDEX)); // EXIF 3.0 §4.6.3; EXIF 2.32 §4.6.3 (RecommendedExposureIndex)
-        if ($iso !== null) {
-            return $iso;
+        if ($parts === []) {
+            return null;
         }
 
-        $iso = self::isoFromEntry($doc->exifIfd?->get(ExifTag::PHOTOGRAPHIC_SENSITIVITY)); // EXIF 3.0 §4.6.3; EXIF 2.32 §4.6.3 (PhotographicSensitivity)
-
-        // Legacy fallback retained for EXIF 2.32 §4.6.3 compatibility
-        return $iso ?? self::isoFromEntry($doc->ifd0->get(ExifTag::PHOTOGRAPHIC_SENSITIVITY));
+        return implode(' · ', $parts);
     }
 
     /**
-     * Resolves ISO sensitivity using the EXIF 3.x sensitivity type priority rules.
-     *
-     * EXIF 3.0 §4.6.3 formalises the SensitivityType-driven priority order retained from EXIF 2.32 §4.6.3.
+     * Formats the image dimensions into a `WIDTH×HEIGHT px` string.
      */
-    private static function isoFromSensitivityType(ParsedExif $doc): ?int
+    public static function imageDimensions(Image $image): ?string
     {
-        $type = self::isoFromEntry($doc->exifIfd?->get(ExifTag::SENSITIVITY_TYPE)); // EXIF 3.0 §4.6.3; EXIF 2.32 §4.6.3 (SensitivityType)
-        if ($type === null) {
+        $width  = $image->width();
+        $height = $image->height();
+
+        if ($width === null || $height === null) {
             return null;
         }
 
-        foreach (self::sensitivityTagPriority($type) as $tag) {
-            $iso = self::isoFromEntry($doc->exifIfd?->get($tag));
-            if ($iso !== null) {
-                return $iso;
-            }
-        }
-
-        return null;
+        return sprintf('%d×%d px', $width, $height);
     }
 
     /**
-     * Converts various EXIF value representations into an ISO integer.
+     * Formats the primary GPS coordinates and optionally altitude.
      */
-    private static function isoFromEntry(?IfdEntry $entry): ?int
+    public static function gpsString(Gps $gps, int $precision = 6, bool $includeAltitude = false): ?string
     {
-        if (!$entry instanceof IfdEntry) {
+        $latitude  = $gps->latitude();
+        $longitude = $gps->longitude();
+
+        if ($latitude === null || $longitude === null) {
             return null;
         }
 
-        $value = $entry->value;
+        $latitudeRef  = self::resolveLatitudeRef($gps, $latitude);
+        $longitudeRef = self::resolveLongitudeRef($gps, $longitude);
 
-        if ($value instanceof UInt64) {
-            return self::uint64ToInt($value, 'ISO sensitivity');
-        }
+        $latValue = self::formatCoordinate(abs($latitude), $precision) . '° ' . $latitudeRef;
+        $lonValue = self::formatCoordinate(abs($longitude), $precision) . '° ' . $longitudeRef;
 
-        if (is_int($value)) {
-            return $value;
-        }
+        $result = $latValue . ', ' . $lonValue;
 
-        if (is_float($value)) {
-            return (int) $value;
-        }
-
-        if ($value instanceof ExifNumericList) {
-            $first = $value->values[0] ?? null;
-            if (is_int($first)) {
-                return $first;
+        if ($includeAltitude) {
+            $altitude = self::resolveAltitude($gps);
+            if ($altitude !== null) {
+                $result .= ' (' . self::formatNumber($altitude, 1) . ' m)';
             }
-
-            if (is_float($first)) {
-                return (int) $first;
-            }
-
-            $numeric = ValueConverters::rationalToFloat($value);
-            if ($numeric !== null) {
-                return (int) $numeric;
-            }
-
-            return null;
         }
 
-        if ($value instanceof ExifRational || $value instanceof ExifRationalList) {
-            $float = ValueConverters::rationalToFloat($value);
-            if ($float !== null) {
-                return (int) $float;
-            }
-
-            return null;
-        }
-
-        return null;
+        return $result;
     }
 
     /**
-     * Maps sensitivity type enumerations to ISO tag priorities.
-     *
-     * @return list<int>
-     */
-    private static function sensitivityTagPriority(int $type): array
-    {
-        // Mapping derived from the EXIF SensitivityType table (EXIF 3.0 §4.6.3; EXIF 2.32 §4.6.3).
-        return match ($type) {
-            1       => [ExifTag::STANDARD_OUTPUT_SENSITIVITY],
-            2       => [ExifTag::RECOMMENDED_EXPOSURE_INDEX],
-            3       => [ExifTag::ISO_SPEED],
-            4       => [ExifTag::STANDARD_OUTPUT_SENSITIVITY, ExifTag::RECOMMENDED_EXPOSURE_INDEX],
-            5       => [ExifTag::STANDARD_OUTPUT_SENSITIVITY, ExifTag::ISO_SPEED],
-            6       => [ExifTag::RECOMMENDED_EXPOSURE_INDEX, ExifTag::ISO_SPEED],
-            7       => [ExifTag::STANDARD_OUTPUT_SENSITIVITY, ExifTag::RECOMMENDED_EXPOSURE_INDEX, ExifTag::ISO_SPEED],
-            default => [],
-        };
-    }
-
-    /**
-     * Provides a flattened associative representation of common EXIF values.
-     *
-     * @param ParsedExif $doc parsed EXIF metadata
+     * Provides a flattened array representation of frequently used values.
      *
      * @return array{
      *     make:?string,
@@ -281,77 +198,162 @@ final class ExifConvenience
      *     gps_lat:?float,
      *     gps_lon:?float,
      *     gps_alt:?float
-     * } normalised metadata values
+     * }
      */
-    public static function toArray(ParsedExif $doc): array
-    {
-        $dt  = self::captureDateTime($doc);
-        $gps = $doc->gps();
+    public static function toArray(
+        Camera $camera,
+        Lens $lens,
+        Image $image,
+        Capture $capture,
+        Exposure $exposure,
+        Gps $gps
+    ): array {
+        $capturedAt = $capture->dateTime();
 
         return [
-            'make'  => $doc->cameraMake(),  // EXIF 3.0 §4.6.4; EXIF 2.32 §4.6.4 (Make)
-            'model' => $doc->cameraModel(), // EXIF 3.0 §4.6.4; EXIF 2.32 §4.6.4 (Model)
-            'lens'  => $doc->lensModel(),   // EXIF 3.0 §4.6.3; EXIF 2.32 §4.6.3 (LensModel)
-            // Expose the numeric orientation code to preserve the legacy convenience contract.
-            'orientation' => $doc->orientation()?->value,
-            'captured_at' => $dt?->format(DATE_ATOM),
-            'exposure_s'  => self::exposureTime($doc), // EXIF 3.0 §4.6.3; EXIF 2.32 §4.6.3 (ExposureTime)
-            'fnumber'     => self::fNumber($doc),      // EXIF 3.0 §4.6.3; EXIF 2.32 §4.6.3 (FNumber)
-            'focal_mm'    => self::focalLength($doc),  // EXIF 3.0 §4.6.3; EXIF 2.32 §4.6.3 (FocalLength)
-            'iso'         => self::iso($doc),          // EXIF 3.0 §4.6.3; EXIF 2.32 §4.6.3 (ISO values)
-            'gps_lat'     => $gps['lat'],              // EXIF 3.0 §4.6.8; EXIF 2.32 §4.6.8 (GPSLatitude)
-            'gps_lon'     => $gps['lon'],              // EXIF 3.0 §4.6.8; EXIF 2.32 §4.6.8 (GPSLongitude)
-            'gps_alt'     => $gps['alt'],              // EXIF 3.0 §4.6.8; EXIF 2.32 §4.6.8 (GPSAltitude)
+            'make'        => self::normalise($camera->make()),
+            'model'       => self::normalise($camera->model()),
+            'lens'        => self::normalise($lens->lensModel()),
+            'orientation' => $image->orientation()?->value,
+            'captured_at' => $capturedAt?->format(DATE_ATOM),
+            'exposure_s'  => $exposure->exposureTimeSec(),
+            'fnumber'     => $exposure->fNumber(),
+            'focal_mm'    => $lens->focalLengthMm(),
+            'iso'         => $exposure->iso(),
+            'gps_lat'     => $gps->latitude(),
+            'gps_lon'     => $gps->longitude(),
+            'gps_alt'     => self::resolveAltitude($gps),
         ];
     }
 
     /**
-     * Finds a tag either within the EXIF IFD or as a fallback in IFD0.
-     *
-     * @param ParsedExif $doc parsed EXIF metadata
-     * @param int        $tag tag identifier to search for
-     *
-     * @return IfdEntry|null matching tag entry when present
+     * @param list<string> $parts
      */
-    private static function find(ParsedExif $doc, int $tag): ?IfdEntry
+    private static function containsEquivalent(array $parts, int $equivalent): bool
     {
-        $exifEntry = $doc->exifIfd?->get($tag);
-        if ($exifEntry instanceof IfdEntry) {
-            return $exifEntry;
-        }
+        $needle = sprintf('%d mm eq', $equivalent);
 
-        return $doc->ifd0->get($tag);
-    }
-
-    /**
-     * Converts a rational-oriented EXIF entry into a float value.
-     */
-    private static function rationalEntryToFloat(IfdEntry $entry): ?float
-    {
-        $value = $entry->value;
-
-        if ($value instanceof UInt64) {
-            $intValue = self::uint64ToInt($value, 'EXIF rational entry');
-
-            if ($intValue === null) {
-                return null;
+        foreach ($parts as $part) {
+            if (strcasecmp($part, $needle) === 0) {
+                return true;
             }
-
-            $value = $intValue;
         }
 
-        return ValueConverters::rationalToFloat($value);
+        return false;
     }
 
-    /**
-     * Converts an unsigned 64-bit value into an int when it fits the signed range.
-     */
-    private static function uint64ToInt(UInt64 $value, string $context): ?int
+    private static function formatExposureTime(float $seconds): string
     {
-        if (!$value->fitsSignedInt()) {
+        if ($seconds <= 0.0) {
+            return self::formatNumber($seconds, 3) . ' s';
+        }
+
+        if ($seconds >= 1.0) {
+            $formatted = self::formatNumber($seconds, $seconds < 10.0 ? 2 : 1);
+
+            return $formatted . ' s';
+        }
+
+        $denominator = (int) round(1.0 / $seconds);
+        if ($denominator > 0) {
+            $approximation = 1.0 / $denominator;
+            if (abs($approximation - $seconds) < 0.0001) {
+                return '1/' . $denominator . ' s';
+            }
+        }
+
+        return self::formatNumber($seconds, 3) . ' s';
+    }
+
+    private static function formatFNumber(float $fNumber): string
+    {
+        return 'f/' . self::formatNumber($fNumber, 1);
+    }
+
+    private static function formatIso(int $iso): string
+    {
+        return 'ISO ' . $iso;
+    }
+
+    private static function formatFocalLength(float $focalLength): string
+    {
+        return self::formatNumber($focalLength, 1) . ' mm';
+    }
+
+    private static function formatCoordinate(float $value, int $precision): string
+    {
+        if ($precision < 0) {
+            $precision = 0;
+        }
+
+        $format = '%.' . $precision . 'f';
+
+        return sprintf($format, $value);
+    }
+
+    private static function formatNumber(float $value, int $precision): string
+    {
+        $precision = $precision < 0 ? 0 : $precision;
+        $format    = '%.' . $precision . 'f';
+
+        $formatted = sprintf($format, $value);
+
+        return rtrim(rtrim($formatted, '0'), '.');
+    }
+
+    private static function normalise(?string $value): ?string
+    {
+        if ($value === null) {
             return null;
         }
 
-        return $value->toInt($context);
+        $normalised = trim($value);
+
+        return $normalised === '' ? null : $normalised;
+    }
+
+    private static function startsWithCaseInsensitive(string $haystack, string $needle): bool
+    {
+        $needleLength = strlen($needle);
+        if ($needleLength === 0) {
+            return true;
+        }
+
+        return strncmp(strtolower($haystack), strtolower($needle), $needleLength) === 0;
+    }
+
+    private static function resolveLatitudeRef(Gps $gps, float $latitude): string
+    {
+        $ref = $gps->latitudeReference();
+        if ($ref !== null) {
+            return $ref;
+        }
+
+        return $latitude >= 0.0 ? 'N' : 'S';
+    }
+
+    private static function resolveLongitudeRef(Gps $gps, float $longitude): string
+    {
+        $ref = $gps->longitudeReference();
+        if ($ref !== null) {
+            return $ref;
+        }
+
+        return $longitude >= 0.0 ? 'E' : 'W';
+    }
+
+    private static function resolveAltitude(Gps $gps): ?float
+    {
+        $altitude = $gps->altitude();
+        if ($altitude === null) {
+            return null;
+        }
+
+        $reference = $gps->altitudeReference();
+        if ($reference === 1) {
+            return -$altitude;
+        }
+
+        return $altitude;
     }
 }

--- a/tests/Convenience/CaptureDateResolverTest.php
+++ b/tests/Convenience/CaptureDateResolverTest.php
@@ -13,13 +13,12 @@ namespace MagicSunday\ImageMeta\Tests\Convenience;
 
 use DateTimeImmutable;
 use MagicSunday\ImageMeta\Convenience\CaptureDateResolver;
-use MagicSunday\ImageMeta\Convenience\ExifConvenience;
-use MagicSunday\ImageMeta\Core\ExifCapabilities;
+use MagicSunday\ImageMeta\Model\Exif\ExifRational;
+use MagicSunday\ImageMeta\Model\Exif\ExifRationalList;
 use MagicSunday\ImageMeta\Model\Exif\ExifTag;
 use MagicSunday\ImageMeta\Model\Exif\Ifd;
 use MagicSunday\ImageMeta\Model\Exif\IfdEntry;
 use MagicSunday\ImageMeta\Model\Exif\ParsedExif;
-use MagicSunday\ImageMeta\Model\Exif\ValueConverters;
 use MagicSunday\ImageMeta\Model\Metadata;
 use MagicSunday\ImageMeta\Model\Xmp\XmpDocument;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -36,17 +35,10 @@ use PHPUnit\Framework\TestCase;
 #[UsesClass(Ifd::class)]
 #[UsesClass(IfdEntry::class)]
 #[UsesClass(XmpDocument::class)]
-#[UsesClass(ExifConvenience::class)]
-#[UsesClass(ExifCapabilities::class)]
-#[UsesClass(ValueConverters::class)]
 final class CaptureDateResolverTest extends TestCase
 {
     private const string XMP_NAMESPACE = 'http://ns.adobe.com/xap/1.0/';
 
-    /**
-     * Uses only XMP metadata to confirm the resolver falls back to the CreateDate string and
-     * returns a DateTimeImmutable instance.
-     */
     #[Test]
     public function returnsXmpCreateDateWhenExifIsMissing(): void
     {
@@ -66,10 +58,6 @@ final class CaptureDateResolverTest extends TestCase
         self::assertSame('2024-03-30T12:34:56+00:00', $result->format(DATE_ATOM));
     }
 
-    /**
-     * Provides an invalid CreateDate value to ensure the resolver rejects non-ISO formatted
-     * strings and returns null.
-     */
     #[Test]
     public function ignoresNonIsoCreateDateValues(): void
     {
@@ -86,10 +74,6 @@ final class CaptureDateResolverTest extends TestCase
         self::assertNull(CaptureDateResolver::bestCaptureDateTime($metadata));
     }
 
-    /**
-     * Supplies multiple XMP CreateDate entries and checks that the first ISO-8601 value is
-     * accepted and converted to a DateTimeImmutable instance.
-     */
     #[Test]
     public function acceptsFirstArrayElementWhenIsoString(): void
     {
@@ -112,10 +96,6 @@ final class CaptureDateResolverTest extends TestCase
         self::assertSame('2024-03-30T12:34:56+00:00', $result->format(DATE_ATOM));
     }
 
-    /**
-     * Ensures EXIF capture timestamps are preferred and that fallback logic covers digitised
-     * timestamps when DateTimeOriginal is not provided.
-     */
     #[Test]
     public function prefersExifCaptureDateWhenAvailable(): void
     {
@@ -152,5 +132,55 @@ final class CaptureDateResolverTest extends TestCase
 
         self::assertInstanceOf(DateTimeImmutable::class, $result);
         self::assertSame('2024-04-05T01:02:03+01:00', $result->format(DATE_ATOM));
+    }
+
+    #[Test]
+    public function usesGpsTimestampWhenCaptureDateMissing(): void
+    {
+        $timeStamp = new ExifRationalList([
+            new ExifRational(12, 1),
+            new ExifRational(34, 1),
+            new ExifRational(56, 1),
+        ]);
+
+        $gpsIfd = new Ifd([
+            ExifTag::GPS_DATE_STAMP   => new IfdEntry(ExifTag::GPS_DATE_STAMP, 2, 11, '2024:05:01'),
+            ExifTag::GPS_TIME_STAMP   => new IfdEntry(ExifTag::GPS_TIME_STAMP, 5, 3, $timeStamp),
+            ExifTag::GPS_LATITUDE_REF => new IfdEntry(ExifTag::GPS_LATITUDE_REF, 2, 2, 'N'),
+            ExifTag::GPS_LATITUDE     => new IfdEntry(
+                ExifTag::GPS_LATITUDE,
+                5,
+                3,
+                new ExifRationalList([
+                    new ExifRational(51, 1),
+                    new ExifRational(30, 1),
+                    new ExifRational(0, 1),
+                ]),
+            ),
+            ExifTag::GPS_LONGITUDE_REF => new IfdEntry(ExifTag::GPS_LONGITUDE_REF, 2, 2, 'E'),
+            ExifTag::GPS_LONGITUDE     => new IfdEntry(
+                ExifTag::GPS_LONGITUDE,
+                5,
+                3,
+                new ExifRationalList([
+                    new ExifRational(0, 1),
+                    new ExifRational(7, 1),
+                    new ExifRational(3000, 100),
+                ]),
+            ),
+        ]);
+
+        $metadata = new Metadata(
+            exifBlobs: [],
+            quickTime: null,
+            exifDoc: new ParsedExif(new Ifd([]), null, $gpsIfd, null, null),
+            xmpBlobs: [],
+            xmpDoc: null,
+        );
+
+        $result = CaptureDateResolver::bestCaptureDateTime($metadata);
+
+        self::assertInstanceOf(DateTimeImmutable::class, $result);
+        self::assertSame('2024-05-01T12:34:56+00:00', $result->format(DATE_ATOM));
     }
 }

--- a/tests/Convenience/ExifConvenienceTest.php
+++ b/tests/Convenience/ExifConvenienceTest.php
@@ -11,319 +11,237 @@ declare(strict_types=1);
 
 namespace MagicSunday\ImageMeta\Tests\Convenience;
 
+use DateTimeImmutable;
 use MagicSunday\ImageMeta\Convenience\ExifConvenience;
-use MagicSunday\ImageMeta\Core\ExifCapabilities;
-use MagicSunday\ImageMeta\Exif\Support\EnumFromIntStringNullable;
-use MagicSunday\ImageMeta\Model\Exif\ExifNumericList;
-use MagicSunday\ImageMeta\Model\Exif\ExifRational;
-use MagicSunday\ImageMeta\Model\Exif\ExifRationalList;
-use MagicSunday\ImageMeta\Model\Exif\ExifTag;
-use MagicSunday\ImageMeta\Model\Exif\Ifd;
-use MagicSunday\ImageMeta\Model\Exif\IfdEntry;
-use MagicSunday\ImageMeta\Model\Exif\ParsedExif;
-use MagicSunday\ImageMeta\Model\Exif\ValueConverters;
+use MagicSunday\ImageMeta\Value\Camera;
+use MagicSunday\ImageMeta\Value\Capture;
+use MagicSunday\ImageMeta\Value\Derived;
+use MagicSunday\ImageMeta\Value\Exposure;
+use MagicSunday\ImageMeta\Value\Gps;
+use MagicSunday\ImageMeta\Value\Image;
+use MagicSunday\ImageMeta\Value\Lens;
+use MagicSunday\ImageMeta\Value\Enum\Orientation;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
-use PHPUnit\Framework\Attributes\UsesClass;
-use PHPUnit\Framework\Attributes\UsesTrait;
 use PHPUnit\Framework\TestCase;
 
 /**
  * @covers \MagicSunday\ImageMeta\Convenience\ExifConvenience
  */
 #[CoversClass(ExifConvenience::class)]
-#[UsesClass(ParsedExif::class)]
-#[UsesClass(ExifNumericList::class)]
-#[UsesClass(ExifRational::class)]
-#[UsesClass(ExifRationalList::class)]
-#[UsesClass(Ifd::class)]
-#[UsesClass(IfdEntry::class)]
-#[UsesClass(ValueConverters::class)]
-#[UsesClass(ExifCapabilities::class)]
-#[UsesTrait(EnumFromIntStringNullable::class)]
 final class ExifConvenienceTest extends TestCase
 {
-    /**
-     * Provides both modern and legacy ISO sensitivity tags to ensure the helper prefers the
-     * EXIF-specific entry and falls back when absent.
-     */
     #[Test]
-    public function isoPrefersModernTagAndFallsBackToLegacy(): void
+    public function exposureSummaryFormatsValues(): void
     {
-        $ifd0 = new Ifd([
-            ExifTag::PHOTOGRAPHIC_SENSITIVITY => new IfdEntry(ExifTag::PHOTOGRAPHIC_SENSITIVITY, 3, 1, 200),
-        ]);
+        $exposure = new Exposure(
+            iso: 200,
+            exposureTimeSec: 0.5,
+            fNumber: 1.8,
+            exposureBiasEv: null,
+            program: null,
+            meteringMode: null,
+            flash: null,
+            whiteBalance: null,
+            brightnessEv: null,
+            exposureMode: null,
+            gainControl: null,
+            contrast: null,
+            saturation: null,
+            sharpness: null,
+            digitalZoomRatio: null,
+            shutterSpeedEv: null,
+            apertureEv: null,
+            isoLatitudeYyy: null,
+            isoLatitudeZzz: null,
+            exposureIndex: null,
+            flashEnergy: null,
+        );
 
-        $exifIfd = new Ifd([
-            ExifTag::ISO_SPEED => new IfdEntry(ExifTag::ISO_SPEED, 3, 1, 320),
-        ]);
+        $lens = new Lens(null, null, null, 50.0, null, null);
 
-        $doc = new ParsedExif($ifd0, $exifIfd, null, null, null);
+        $summary = ExifConvenience::exposureSummary($exposure, $lens);
 
-        self::assertSame(320, ExifConvenience::iso($doc));
-
-        $docWithLegacy = new ParsedExif($ifd0, null, null, null, null);
-
-        self::assertSame(200, ExifConvenience::iso($docWithLegacy));
-    }
-
-    /**
-     * Ensures the ISO helper returns the first value from array-based entries rather than the raw
-     * array.
-     */
-    #[Test]
-    public function isoExtractsFirstEntryFromArray(): void
-    {
-        $list = new ExifNumericList([100, 200, 400]);
-        $ifd0 = new Ifd([
-            ExifTag::PHOTOGRAPHIC_SENSITIVITY => new IfdEntry(
-                ExifTag::PHOTOGRAPHIC_SENSITIVITY,
-                3,
-                count($list->values),
-                $list,
-            ),
-        ]);
-
-        $doc = new ParsedExif($ifd0, null, null, null, null);
-
-        self::assertSame(100, ExifConvenience::iso($doc));
-    }
-
-    /**
-     * Ensures ISO values stored as floating point scalars are truncated to integers.
-     */
-    #[Test]
-    public function isoCastsFloatValuesToInteger(): void
-    {
-        $list = new ExifNumericList([200.0, 400.0]);
-        $ifd0 = new Ifd([
-            ExifTag::PHOTOGRAPHIC_SENSITIVITY => new IfdEntry(
-                ExifTag::PHOTOGRAPHIC_SENSITIVITY,
-                11,
-                count($list->values),
-                $list,
-            ),
-        ]);
-
-        $doc = new ParsedExif($ifd0, null, null, null, null);
-
-        self::assertSame(200, ExifConvenience::iso($doc));
-    }
-
-    /**
-     * Ensures ISO rational pairs are interpreted via their numerator/denominator representation.
-     */
-    #[Test]
-    public function isoDerivesValueFromRationalPair(): void
-    {
-        $ifd0 = new Ifd([
-            ExifTag::PHOTOGRAPHIC_SENSITIVITY => new IfdEntry(
-                ExifTag::PHOTOGRAPHIC_SENSITIVITY,
-                5,
-                1,
-                new ExifRational(320, 1),
-            ),
-        ]);
-
-        $doc = new ParsedExif($ifd0, null, null, null, null);
-
-        self::assertSame(320, ExifConvenience::iso($doc));
+        self::assertSame('1/2 s · f/1.8 · ISO 200 · 50 mm', $summary);
     }
 
     #[Test]
-    public function isoParsesIsoPrefixedAsciiValues(): void
+    public function exposureSummaryIncludes35MmEquivalent(): void
     {
-        $exifIfd = new Ifd([
-            ExifTag::ISO_SPEED => new IfdEntry(ExifTag::ISO_SPEED, 2, 7, 'ISO 800'),
-        ]);
+        $exposure = new Exposure(
+            iso: null,
+            exposureTimeSec: null,
+            fNumber: null,
+            exposureBiasEv: null,
+            program: null,
+            meteringMode: null,
+            flash: null,
+            whiteBalance: null,
+            brightnessEv: null,
+            exposureMode: null,
+            gainControl: null,
+            contrast: null,
+            saturation: null,
+            sharpness: null,
+            digitalZoomRatio: null,
+            shutterSpeedEv: null,
+            apertureEv: null,
+            isoLatitudeYyy: null,
+            isoLatitudeZzz: null,
+            exposureIndex: null,
+            flashEnergy: null,
+        );
 
-        $doc = new ParsedExif(new Ifd([]), $exifIfd, null, null, null);
+        $derived = new Derived(null, null, null, null, null, 75, null);
 
-        self::assertSame(800, ExifConvenience::iso($doc));
+        self::assertSame('75 mm eq', ExifConvenience::exposureSummary($exposure, null, $derived));
     }
 
     #[Test]
-    public function isoReadsValuesFromSubIfds(): void
+    public function exposureSummaryReturnsNullWhenNoValues(): void
     {
-        $subIfd = new Ifd([
-            ExifTag::PHOTOGRAPHIC_SENSITIVITY => new IfdEntry(
-                ExifTag::PHOTOGRAPHIC_SENSITIVITY,
-                3,
-                1,
-                640,
-            ),
-        ]);
+        $exposure = new Exposure(
+            iso: null,
+            exposureTimeSec: null,
+            fNumber: null,
+            exposureBiasEv: null,
+            program: null,
+            meteringMode: null,
+            flash: null,
+            whiteBalance: null,
+            brightnessEv: null,
+            exposureMode: null,
+            gainControl: null,
+            contrast: null,
+            saturation: null,
+            sharpness: null,
+            digitalZoomRatio: null,
+            shutterSpeedEv: null,
+            apertureEv: null,
+            isoLatitudeYyy: null,
+            isoLatitudeZzz: null,
+            exposureIndex: null,
+            flashEnergy: null,
+        );
 
-        $doc = new ParsedExif(new Ifd([]), null, null, null, null, null, [], [256 => $subIfd]);
-
-        self::assertSame(640, ExifConvenience::iso($doc));
+        self::assertNull(ExifConvenience::exposureSummary($exposure));
     }
 
-    /**
-     * Validates EXIF 3.0 sensitivity metadata honours the documented priority rules and supports
-     * files that only populate the newer tags.
-     */
     #[Test]
-    public function isoRespectsSensitivityTypePriority(): void
+    public function gpsStringFormatsCoordinates(): void
     {
-        $ifd0 = new Ifd([]);
+        $gps = new Gps(
+            latitude: 51.5,
+            longitude: 0.125,
+            latitudeRef: 'N',
+            longitudeRef: 'E',
+            altitude: 45.0,
+            altitudeRef: 0,
+        );
 
-        $sosOnly = new Ifd([
-            ExifTag::SENSITIVITY_TYPE            => new IfdEntry(ExifTag::SENSITIVITY_TYPE, 3, 1, 1),
-            ExifTag::STANDARD_OUTPUT_SENSITIVITY => new IfdEntry(ExifTag::STANDARD_OUTPUT_SENSITIVITY, 3, 1, 250),
-        ]);
+        $formatted = ExifConvenience::gpsString($gps, precision: 3, includeAltitude: true);
 
-        $docWithSosOnly = new ParsedExif($ifd0, $sosOnly, null, null, null);
-
-        self::assertSame(250, ExifConvenience::iso($docWithSosOnly));
-
-        $priorityIfd = new Ifd([
-            ExifTag::SENSITIVITY_TYPE           => new IfdEntry(ExifTag::SENSITIVITY_TYPE, 3, 1, 6),
-            ExifTag::RECOMMENDED_EXPOSURE_INDEX => new IfdEntry(ExifTag::RECOMMENDED_EXPOSURE_INDEX, 3, 1, 320),
-            ExifTag::ISO_SPEED                  => new IfdEntry(ExifTag::ISO_SPEED, 3, 1, 640),
-        ]);
-
-        $docWithPriority = new ParsedExif($ifd0, $priorityIfd, null, null, null);
-
-        self::assertSame(320, ExifConvenience::iso($docWithPriority));
+        self::assertSame('51.500° N, 0.125° E (45 m)', $formatted);
     }
 
-    /**
-     * Reads capture timestamp tags and verifies the helper delegates to the document parser to
-     * return a timezone-aware DateTime.
-     */
     #[Test]
-    public function captureDateTimeDelegatesToDocument(): void
+    public function gpsStringReturnsNullWithoutCoordinates(): void
     {
-        $ifd0 = new Ifd([]);
+        $gps = new Gps();
 
-        $exifIfd = new Ifd([
-            ExifTag::DATETIME_ORIGINAL    => new IfdEntry(ExifTag::DATETIME_ORIGINAL, 2, 1, '2024:05:01 12:34:56'),
-            ExifTag::OFFSET_TIME_ORIGINAL => new IfdEntry(ExifTag::OFFSET_TIME_ORIGINAL, 2, 1, '+02:00'),
-        ]);
-
-        $doc      = new ParsedExif($ifd0, $exifIfd, null, null, null);
-        $captured = ExifConvenience::captureDateTime($doc);
-
-        self::assertNotNull($captured);
-        self::assertSame('2024-05-01T12:34:56+02:00', $captured->format(DATE_ATOM));
+        self::assertNull(ExifConvenience::gpsString($gps));
     }
 
-    /**
-     * Confirms null is returned when neither the IFD0 nor EXIF IFD provide capture date
-     * information.
-     */
     #[Test]
-    public function captureDateTimeReturnsNullWhenMissing(): void
+    public function imageDimensionsFormatsString(): void
     {
-        $doc = new ParsedExif(new Ifd([]), new Ifd([]), null, null, null);
+        $image = new Image(6000, 4000, Orientation::TOP_LEFT, null, null, null, null, null, null, null, null, null, null, null, null);
 
-        self::assertNull(ExifConvenience::captureDateTime($doc));
+        self::assertSame('6000×4000 px', ExifConvenience::imageDimensions($image));
     }
 
-    /**
-     * Provides digitised and modify date tags to confirm the helper relies on the document's
-     * fallback search order when DateTimeOriginal is absent.
-     */
     #[Test]
-    public function captureDateTimeFallsBackToDigitizedAndModifyDates(): void
+    public function imageDimensionsReturnsNullWhenIncomplete(): void
     {
-        $digitizedIfd = new Ifd([
-            ExifTag::DATETIME_DIGITIZED => new IfdEntry(
-                ExifTag::DATETIME_DIGITIZED,
-                2,
-                19,
-                '2023:12:24 06:30:45',
-            ),
-            ExifTag::OFFSET_TIME_DIGITIZED => new IfdEntry(
-                ExifTag::OFFSET_TIME_DIGITIZED,
-                2,
-                6,
-                '-05:30',
-            ),
-        ]);
+        $image = new Image(null, 4000, Orientation::TOP_LEFT, null, null, null, null, null, null, null, null, null, null, null, null);
 
-        $docWithDigitized = new ParsedExif(new Ifd([]), $digitizedIfd, null, null, null);
-
-        $digitized = ExifConvenience::captureDateTime($docWithDigitized);
-
-        self::assertNotNull($digitized);
-        self::assertSame('2023-12-24T06:30:45-05:30', $digitized->format(DATE_ATOM));
-
-        $modifyDateIfd0 = new Ifd([
-            ExifTag::DATETIME => new IfdEntry(
-                ExifTag::DATETIME,
-                2,
-                19,
-                '2023:11:10 09:08:07',
-            ),
-        ]);
-
-        $docWithModifyDate = new ParsedExif($modifyDateIfd0, new Ifd([]), null, null, null);
-
-        $modify = ExifConvenience::captureDateTime($docWithModifyDate);
-
-        self::assertNotNull($modify);
-        self::assertSame('2023-11-10T09:08:07+00:00', $modify->format(DATE_ATOM));
+        self::assertNull(ExifConvenience::imageDimensions($image));
     }
 
-    /**
-     * Supplies an incomplete timestamp string to ensure the helper refuses values lacking time
-     * components.
-     */
     #[Test]
-    public function captureDateTimeReturnsNullForShortTimestamp(): void
+    public function captureDateTimeStringFormatsTimestamp(): void
     {
-        $ifd0 = new Ifd([]);
+        $capture = new Capture(
+            new DateTimeImmutable('2024-05-01T12:34:56+02:00'),
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+        );
 
-        $exifIfd = new Ifd([
-            ExifTag::DATETIME_ORIGINAL => new IfdEntry(ExifTag::DATETIME_ORIGINAL, 2, 1, '2024:05:01'),
-        ]);
-
-        $doc = new ParsedExif($ifd0, $exifIfd, null, null, null);
-
-        self::assertNull(ExifConvenience::captureDateTime($doc));
+        self::assertSame('2024-05-01T12:34:56+02:00', ExifConvenience::captureDateTimeString($capture));
     }
 
-    /**
-     * Ensures the flattened metadata representation exposes the expected shape and value types.
-     */
+    #[Test]
+    public function cameraDescriptionAvoidsDuplicateMake(): void
+    {
+        $camera = new Camera('Canon', 'Canon EOS R6', null, null, null, null, null);
+        $lens   = new Lens(null, 'RF 24-70mm', null, null, null, null);
+
+        self::assertSame('Canon EOS R6 · RF 24-70mm', ExifConvenience::cameraDescription($camera, $lens));
+    }
+
     #[Test]
     public function toArrayReturnsNormalisedShape(): void
     {
-        $ifd0 = new Ifd([
-            ExifTag::MAKE        => new IfdEntry(ExifTag::MAKE, 2, 5, 'Canon'),
-            ExifTag::MODEL       => new IfdEntry(ExifTag::MODEL, 2, 3, 'EOS'),
-            ExifTag::ORIENTATION => new IfdEntry(ExifTag::ORIENTATION, 3, 1, 1),
-        ]);
-
-        $exifIfd = new Ifd([
-            ExifTag::LENS_MODEL           => new IfdEntry(ExifTag::LENS_MODEL, 2, 7, 'EF 50mm'),
-            ExifTag::EXPOSURE_TIME        => new IfdEntry(ExifTag::EXPOSURE_TIME, 5, 1, [1, 2]),
-            ExifTag::F_NUMBER             => new IfdEntry(ExifTag::F_NUMBER, 5, 1, [18, 10]),
-            ExifTag::FOCAL_LENGTH         => new IfdEntry(ExifTag::FOCAL_LENGTH, 5, 1, [50, 1]),
-            ExifTag::ISO_SPEED            => new IfdEntry(ExifTag::ISO_SPEED, 3, 1, 200),
-            ExifTag::DATETIME_ORIGINAL    => new IfdEntry(ExifTag::DATETIME_ORIGINAL, 2, 19, '2024:05:01 12:34:56'),
-            ExifTag::OFFSET_TIME_ORIGINAL => new IfdEntry(ExifTag::OFFSET_TIME_ORIGINAL, 2, 6, '+02:00'),
-        ]);
-
-        $gpsIfd = new Ifd([
-            ExifTag::GPS_LATITUDE_REF  => new IfdEntry(ExifTag::GPS_LATITUDE_REF, 2, 2, 'N'),
-            ExifTag::GPS_LATITUDE      => new IfdEntry(ExifTag::GPS_LATITUDE, 5, 3, [[51, 1], [30, 1], [0, 1]]),
-            ExifTag::GPS_LONGITUDE_REF => new IfdEntry(ExifTag::GPS_LONGITUDE_REF, 2, 2, 'E'),
-            ExifTag::GPS_LONGITUDE     => new IfdEntry(ExifTag::GPS_LONGITUDE, 5, 3, [[0, 1], [7, 1], [3000, 100]]),
-            ExifTag::GPS_ALTITUDE_REF  => new IfdEntry(ExifTag::GPS_ALTITUDE_REF, 1, 1, 0),
-            ExifTag::GPS_ALTITUDE      => new IfdEntry(ExifTag::GPS_ALTITUDE, 5, 1, [450, 10]),
-        ]);
-
-        $doc    = new ParsedExif($ifd0, $exifIfd, $gpsIfd, null, null);
-        $result = ExifConvenience::toArray($doc);
+        $camera = new Camera('Canon', 'EOS', null, null, null, null, null);
+        $lens   = new Lens(null, 'EF 50mm', null, 50.0, null, null);
+        $image  = new Image(6000, 4000, Orientation::TOP_LEFT, null, null, null, null, null, null, null, null, null, null, null, null);
+        $capture = new Capture(
+            new DateTimeImmutable('2024-05-01T12:34:56+02:00'),
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+        );
+        $exposure = new Exposure(
+            iso: 200,
+            exposureTimeSec: 0.5,
+            fNumber: 1.8,
+            exposureBiasEv: null,
+            program: null,
+            meteringMode: null,
+            flash: null,
+            whiteBalance: null,
+            brightnessEv: null,
+            exposureMode: null,
+            gainControl: null,
+            contrast: null,
+            saturation: null,
+            sharpness: null,
+            digitalZoomRatio: null,
+            shutterSpeedEv: null,
+            apertureEv: null,
+            isoLatitudeYyy: null,
+            isoLatitudeZzz: null,
+            exposureIndex: null,
+            flashEnergy: null,
+        );
+        $gps = new Gps(51.5, 0.125, 'N', 'E', 45.0, 0);
 
         $expected = [
             'make'        => 'Canon',
             'model'       => 'EOS',
             'lens'        => 'EF 50mm',
-            'orientation' => 1,
+            'orientation' => Orientation::TOP_LEFT->value,
             'captured_at' => '2024-05-01T12:34:56+02:00',
             'exposure_s'  => 0.5,
             'fnumber'     => 1.8,
@@ -334,6 +252,9 @@ final class ExifConvenienceTest extends TestCase
             'gps_alt'     => 45.0,
         ];
 
-        self::assertSame($expected, $result);
+        self::assertSame(
+            $expected,
+            ExifConvenience::toArray($camera, $lens, $image, $capture, $exposure, $gps)
+        );
     }
 }


### PR DESCRIPTION
<!--
PR-Titel-Empfehlung:
M#: <kurze Beschreibung> — <Bereich>
Beispiel: M1: Unify binary readers — Core/Stream
-->

## Summary
- Format EXIF convenience helpers using value objects and produce UI-ready strings.
- Rework capture date resolver to prefer curated capture/temporal/GPS timestamps before falling back to XMP.

**Issue/Milestone:** Closes #N/A • Milestone M5
**Scope (allowed files only):** src/Convenience/, tests/Convenience/
**Non-Goals:** No changes to other convenience utilities or value factories.



---

## Implementation Notes
- Runtime: PHP 8.4, `declare(strict_types=1);`, PSR-12.
- **Streaming only** (Core\Stream/StreamWindow) — keine Ganzdatei-Reads.
- Keine externen Binaries/Extensions; **kein** `exif_read_data()`.
- Value Objects (chainable) nur für EXIF-Ausgabe; kein Rendering.
- **Enums** für gängige Kodierungen genutzt/ergänzt (Encoding/Endianness/IFD/XMP/...).
- **Spec-References** im Code ergänzt/aktualisiert (siehe „References“).

---

## Always Checklist (must be green)
**Composer-Tasks (deine CI-Skripte):**
- [ ] Lint: `composer ci:test:php:lint`
- [x] PHPStan: `composer ci:test:php:phpstan`
- [ ] Rector (dry-run): `composer ci:test:php:rector`
- [ ] Coding-Style: `composer ci::cgl`
- [x] PHPUnit: `composer ci:test:php:unit`
- [ ] Coverage ≥ **90 %**: `composer ci:test:php:unit:coverage`
- [ ] JSCPD (Duplikate = 0): `composer ci:test:php:cpd`
- [ ] Sammellauf: `composer ci:test` (sollte grün sein; enthält Lint, PHPStan, Rector-Dry-Run, CS-Dry-Run, Unit)

**Inhaltliche/Code-Guidelines:**
- [ ] **Keine** `mixed`-Signaturen • **kein** `empty()` • **keine** verschachtelten Ternaries
- [ ] Fully-qualified native functions (`\strlen`, `\count`, …) und sinnvolle `use`-Imports
- [ ] **Keine** dynamischen Aufrufe statischer Methoden
- [ ] Sinnvolle **Interfaces** verwendet (wo Verträge sinnvoll sind)
- [ ] Typisierte Klassenkonstanten; redundante Casts/Default-Argumente entfernt
- [ ] Klassen als `readonly`, wo passend; keine redundanten `readonly`-Mods
- [ ] **Eine Klasse je Datei** • Test-Namespaces spiegeln `src/`-Struktur
- [ ] Englische PHPDocs & englische Inline-Kommentare an komplexen Stellen
- [ ] Sinnvolle Namen für Variablen/Konstanten; Magic Numbers/Strings vermieden
- [ ] `array_find` / `array_any` / `array_all` gezielt statt trivialer `foreach` verwendet (wo es die Lesbarkeit verbessert)

---

## EXIF / TIFF / ISOBMFF / XMP Guardrails
- **EXIF-Versionen:** 1.x, 2.x (2.1/2.2/2.21/2.3/2.31/2.32), 3.0 — kompatible Änderungen; falls Tags betroffen: Coverage-Test grün.
- **TIFF/BigTIFF:** Endianness korrekt (`0x2A` / `0x2B`), Inline-Werte-Grenzen, `RATIONAL/SRATIONAL` korrekt.
- **GPS:** Vorzeichen über Ref-Tags (S/W negativ); `0/0`-Kantenfälle robust.
- **Preview/IFD1:** Nur beschreiben (Offsets/Längen/Compression), kein Rendering.
- **ISOBMFF/QuickTime:** Box-Size ≥ Header, 32/64-bit-Größen korrekt; `iloc`-Extents summiert; `data_reference_index ≠ 0` → skip; keine Remote-Refs.
- **XMP:** JPEG APP1-Präfix / ISOBMFF `uuid`; Parser mit `LIBXML_NONET`, keine DTD/Entities; `Alt/Bag/Seq` → Arrays.
- **Fehlerbehandlung:** ausschließlich `ParseError` oder `BoundsError`; keine Warnings/Notices als Kontrollfluss.

---

## Tests
- **Neue/angepasste Tests:** Updated convenience tests to cover value-object formatting and GPS timestamp fallback.
- **Negative Cases:** GPS timestamp fallback without capture date ensures XMP validation still handles invalid ISO strings.
- **Fixtures/Streams:** Synthetic EXIF IFDs assembled inline within the tests.

---

## M5 – Convenience konsolidieren (kein Domänen-Clash)
- Ensure convenience helpers consume curated value objects for presentation scenarios.
- Rework capture date resolution to rely on structured capture, temporal, and GPS values before XMP fallback.

## M# Sweep — Verify compliance for this milestone
Bitte **alles** verifizieren und kurz die Ergebnisse notieren:
- [ ] `composer ci:test` **grün** (Lint, PHPStan, Rector-Dry-Run, CS-Dry-Run, Unit)
- [ ] `composer ci:test:php:cpd` **0 Duplikate** (JSCPD, Konfig: `.build/.jscpd.json`)
- [ ] `composer ci:test:php:unit:coverage` **≥ 90 %**
- [ ] **ExifCoverageTest** (falls vorhanden): 0 fehlende Tags/Getters (gegen `resources/exif-map.yaml`)
- [ ] Für **jede** Klasse existiert ein Test (Namespace-Spiegelung)

---

## Breaking Changes / Risk / Rollback
- **Breaking changes:** None.
- **Risiken:** Minimal; presentation helpers only consume value objects.
- **Rollback-Plan:** Revert this PR if needed.

---

## Changelog
- feat(convenience): format value objects for UI helpers

---

## References (Specs & Docs)
<!-- Liste der relevanten Kapitel/Abschnitte, jeweils aktuellste Fassung + abweichende ältere, falls relevant -->
- EXIF 3.0 §4.6.3 (exposure metadata references retained in value objects)
- N/A
- N/A
- XMP (Adobe XMP Packet) §5.4 (CreateDate handling)

Docs im Repo:
- `docs/EXIF-210.pdf`, `docs/EXIF-220.pdf`, `docs/EXIF-230.pdf`, `docs/EXIF-231.pdf`, `docs/EXIF-232.pdf`, `docs/EXIF-300.pdf`
- `docs/TIFF6.pdf`

---

## Review Roles (tick what you covered)
- [ ] Planner (Scope/Non-Goals/Guardrails definiert)
- [ ] Spec Writer (AC/Tests präzisiert)
- [ ] Test Agent (RED zuerst)
- [x] Implementer (GREEN minimal & im Datei-Scope)
- [x] Static/QA (Stan/CS/Rector/JSCPD clean)
- [ ] Security (Bounds, Offsets, XML-Flags)
- [ ] Reviewer (Minimalität, DX, Spec-Refs, Enums)
- [ ] Release (PR-Text, Labels, Milestone, „Closes #…“)


------
https://chatgpt.com/codex/tasks/task_e_690482c53cc88323a689993c4c13e2f6