### PR TITLE
feat(exif): expose profile hue sat map encodings

### DIFF
--- a/resources/exif-map.yaml
+++ b/resources/exif-map.yaml
@@ -785,6 +785,12 @@ PROFILE_HUE_SAT_MAP_DATA_3:
   minVersion: "2.32"
   voGetter:
     - raw.profileHueSatMap
+PROFILE_HUE_SAT_MAP_ENCODINGS:
+  ifd: ExifIFD
+  type: auto
+  minVersion: "2.32"
+  voGetter:
+    - raw.profileHueSatMap
 PROFILE_HUE_SAT_MAP_DIMS:
   ifd: ExifIFD
   type: auto

--- a/src/Curate/Exif/ValueFactory.php
+++ b/src/Curate/Exif/ValueFactory.php
@@ -396,6 +396,7 @@ final class ValueFactory
                 $dimensions[0] ?? null,
                 $dimensions[1] ?? null,
                 $dimensions[2] ?? null,
+                $hueSatMapData['encodings'] ?? null,
                 $hueSatMapData['map1'] ?? null,
                 $hueSatMapData['map2'] ?? null,
                 $hueSatMapData['map3'] ?? null,

--- a/src/Model/Exif/ExifTag.php
+++ b/src/Model/Exif/ExifTag.php
@@ -469,6 +469,12 @@ final readonly class ExifTag
     public const int PROFILE_CALIBRATION_SIGNATURE = 0xC6F4; // EXIF 3.0 §4.6.3 Tables 35–41; EXIF 2.32 §4.6.3 Tables 35–41
 
     /**
+     * Lists the encoding functions applied to each hue/saturation/value channel in the profile maps.
+     * EXIF 3.0 §4.6.3 Tables 35–41; EXIF 2.32 §4.6.3 Tables 35–41.
+     */
+    public const int PROFILE_HUE_SAT_MAP_ENCODINGS = 0xC6F5; // EXIF 3.0 §4.6.3 Tables 35–41; EXIF 2.32 §4.6.3 Tables 35–41
+
+    /**
      * Records the hue/saturation/value grid dimensions used by the profile maps.
      */
     public const int PROFILE_HUE_SAT_MAP_DIMS = 0xC6F6; // EXIF 3.0 §4.6.3 Tables 35–41; EXIF 2.32 §4.6.3 Tables 35–41

--- a/src/Model/Exif/ParsedExif.php
+++ b/src/Model/Exif/ParsedExif.php
@@ -1861,22 +1861,30 @@ final readonly class ParsedExif
     /**
      * Returns the hue/saturation/value profile adjustment maps.
      *
-     * @return array{dimensions:list<int>|null,map1:list<float>|null,map2:list<float>|null,map3:list<float>|null}|null
+     * @return array{
+     *     dimensions:list<int>|null,
+     *     encodings:list<int>|null,
+     *     map1:list<float>|null,
+     *     map2:list<float>|null,
+     *     map3:list<float>|null,
+     * }|null
      */
     public function profileHueSatMap(): ?array
     {
         foreach ($this->profileIfds() as $ifd) {
             $dimensions = $this->numericList($ifd, ExifTag::PROFILE_HUE_SAT_MAP_DIMS);
+            $encodings  = $this->numericList($ifd, ExifTag::PROFILE_HUE_SAT_MAP_ENCODINGS);
             $map1       = $this->rationalList($ifd, ExifTag::PROFILE_HUE_SAT_MAP_DATA_1);
             $map2       = $this->rationalList($ifd, ExifTag::PROFILE_HUE_SAT_MAP_DATA_2);
             $map3       = $this->rationalList($ifd, ExifTag::PROFILE_HUE_SAT_MAP_DATA_3);
 
-            if ($dimensions === null && $map1 === null && $map2 === null && $map3 === null) {
+            if ($dimensions === null && $encodings === null && $map1 === null && $map2 === null && $map3 === null) {
                 continue;
             }
 
             return [
                 'dimensions' => $dimensions,
+                'encodings'  => $encodings,
                 'map1'       => $map1,
                 'map2'       => $map2,
                 'map3'       => $map3,
@@ -3007,6 +3015,7 @@ final readonly class ParsedExif
 
         foreach ($this->profileSourceIfds() as $ifd) {
             if ($ifd->get(ExifTag::PROFILE_HUE_SAT_MAP_DIMS) instanceof IfdEntry
+                || $ifd->get(ExifTag::PROFILE_HUE_SAT_MAP_ENCODINGS) instanceof IfdEntry
                 || $ifd->get(ExifTag::PROFILE_LOOK_TABLE_DIMS) instanceof IfdEntry
                 || $ifd->get(ExifTag::PROFILE_TONE_CURVE) instanceof IfdEntry
                 || $ifd->get($gainTableTag->value) instanceof IfdEntry) {

--- a/src/Value/ColorProfileHueSatMap.php
+++ b/src/Value/ColorProfileHueSatMap.php
@@ -20,6 +20,7 @@ final readonly class ColorProfileHueSatMap
      * @param int|null         $hueDivisions        Number of hue slices stored in the map.
      * @param int|null         $saturationDivisions Number of saturation slices stored in the map.
      * @param int|null         $valueDivisions      Number of value/lightness slices stored in the map.
+     * @param list<int>|null   $encodings           Optional encoding identifiers for hue/saturation/value channels.
      * @param list<float>|null $mapData1            Primary hue/saturation/value adjustment table.
      * @param list<float>|null $mapData2            Secondary adjustment table when provided by the profile.
      * @param list<float>|null $mapData3            Tertiary adjustment table when present in the profile.
@@ -28,6 +29,7 @@ final readonly class ColorProfileHueSatMap
         public ?int $hueDivisions,
         public ?int $saturationDivisions,
         public ?int $valueDivisions,
+        public ?array $encodings,
         public ?array $mapData1,
         public ?array $mapData2,
         public ?array $mapData3,
@@ -66,6 +68,16 @@ final readonly class ColorProfileHueSatMap
     public function mapData1(): ?array
     {
         return $this->mapData1;
+    }
+
+    /**
+     * Returns the encoding identifiers applied to the hue/saturation/value channels.
+     *
+     * @return list<int>|null
+     */
+    public function encodings(): ?array
+    {
+        return $this->encodings;
     }
 
     /**

--- a/tests/Curate/ExifAssemblerTest.php
+++ b/tests/Curate/ExifAssemblerTest.php
@@ -2020,6 +2020,7 @@ final class ExifAssemblerTest extends TestCase
 
         $profileIfd = new Ifd([
             ExifTag::PROFILE_HUE_SAT_MAP_DIMS   => new IfdEntry(ExifTag::PROFILE_HUE_SAT_MAP_DIMS, 4, 3, new ExifNumericList([6, 3, 2])),
+            ExifTag::PROFILE_HUE_SAT_MAP_ENCODINGS => new IfdEntry(ExifTag::PROFILE_HUE_SAT_MAP_ENCODINGS, 3, 3, new ExifNumericList([0, 1, 2])),
             ExifTag::PROFILE_HUE_SAT_MAP_DATA_1 => new IfdEntry(ExifTag::PROFILE_HUE_SAT_MAP_DATA_1, 11, 12, new ExifNumericList([
                 0.1,
                 0.2,
@@ -2068,6 +2069,7 @@ final class ExifAssemblerTest extends TestCase
         self::assertSame(6, $profile->hueSatMap->hueDivisions);
         self::assertSame(3, $profile->hueSatMap->saturationDivisions);
         self::assertSame(2, $profile->hueSatMap->valueDivisions);
+        self::assertSame([0, 1, 2], $profile->hueSatMap->encodings);
         self::assertNotNull($profile->hueSatMap->mapData1);
         self::assertCount(12, $profile->hueSatMap->mapData1);
         self::assertNotNull($profile->hueSatMap->mapData2);

--- a/tests/Model/Exif/ExifTagTest.php
+++ b/tests/Model/Exif/ExifTagTest.php
@@ -175,6 +175,7 @@ final class ExifTagTest extends TestCase
             'MAKER_NOTE'                               => 0x927C,
             'PRINT_IMAGE_MATCHING'                     => 0xC4A5,
             'MAKER_NOTE_SAFETY'                        => 0xC635,
+            'PROFILE_HUE_SAT_MAP_ENCODINGS'            => 0xC6F5,
             'PROFILE_HUE_SAT_MAP_DIMS'                 => 0xC6F6,
             'PROFILE_HUE_SAT_MAP_DATA_1'               => 0xC6F7,
             'PROFILE_HUE_SAT_MAP_DATA_2'               => 0xC6F8,

--- a/tests/Model/Exif/ParsedExifTest.php
+++ b/tests/Model/Exif/ParsedExifTest.php
@@ -1902,6 +1902,27 @@ final class ParsedExifTest extends TestCase
     }
 
     #[Test]
+    public function profileHueSatMapIncludesEncodings(): void
+    {
+        $profileIfd = new Ifd([
+            ExifTag::PROFILE_HUE_SAT_MAP_DIMS      => new IfdEntry(ExifTag::PROFILE_HUE_SAT_MAP_DIMS, 4, 3, new ExifNumericList([4, 2, 1])),
+            ExifTag::PROFILE_HUE_SAT_MAP_ENCODINGS => new IfdEntry(ExifTag::PROFILE_HUE_SAT_MAP_ENCODINGS, 3, 3, new ExifNumericList([0, 2, 1])),
+            ExifTag::PROFILE_HUE_SAT_MAP_DATA_1    => new IfdEntry(ExifTag::PROFILE_HUE_SAT_MAP_DATA_1, 11, 2, new ExifNumericList([0.25, 0.5])),
+        ]);
+
+        $document = new ParsedExif(new Ifd([]), null, null, null, null, null, [], [
+            0 => $profileIfd,
+        ]);
+
+        $map = $document->profileHueSatMap();
+
+        self::assertNotNull($map);
+        self::assertSame([4, 2, 1], $map['dimensions']);
+        self::assertSame([0, 2, 1], $map['encodings']);
+        self::assertSame([0.25, 0.5], $map['map1']);
+    }
+
+    #[Test]
     #[DataProvider('provideExifVersionMatrix')]
     public function normalizesExifVersions(string $raw, string $expectedVersion, string $expectedProfile): void
     {


### PR DESCRIPTION
## Summary
* Added the EXIF 3.0 `ProfileHueSatMapEncodings` tag to the central registry and documented its specification reference.
* Extended the hue/saturation/value map handling to surface encoding metadata and wired it into the curated colour profile value object.
* Exercised the new metadata path with unit and assembler tests and updated the EXIF coverage map.

**Issue/Milestone:** Closes #N/A • Milestone M6
**Scope (allowed files only):** `src/Model/Exif`, `src/Curate/Exif`, `src/Value`, `tests/**`, `resources/exif-map.yaml`
**Non-Goals:** Broader DNG gain-table changes or new maker-note decoders.

---

## Implementation Notes
- Runtime: PHP 8.4, `declare(strict_types=1);`, PSR-12.
- **Streaming only** (Core\Stream/StreamWindow) — keine Ganzdatei-Reads.
- Keine externen Binaries/Extensions; **kein** `exif_read_data()`.
- Value Objects (chainable) nur für EXIF-Ausgabe; kein Rendering.
- **Enums** für gängige Kodierungen genutzt/ergänzt (Encoding/Endianness/IFD/XMP/...).
- **Spec-References** im Code ergänzt/aktualisiert (siehe „References“).

---

## M6 Sweep — Verify compliance for this milestone
- Hue/Sat map encodings exposed via model, curated values, and expectations for tag coverage.

## M# Sweep — Verify compliance for this milestone
Bitte **alles** verifizieren und kurz die Ergebnisse notieren:
- [ ] `composer ci:test` **grün** (Lint, PHPStan, Rector-Dry-Run, CS-Dry-Run, Unit)
- [ ] `composer ci:test:php:cpd` **0 Duplikate** (JSCPD, Konfig: `.build/.jscpd.json`)
- [ ] `composer ci:test:php:unit:coverage` **≥ 90 %**
- [ ] **ExifCoverageTest** (falls vorhanden): 0 fehlende Tags/Getters (gegen `resources/exif-map.yaml`)
- [ ] Für **jede** Klasse existiert ein Test (Namespace-Spiegelung)

---

## Always Checklist (must be green)
**Composer-Tasks (deine CI-Skripte):**
- [ ] Lint: `composer ci:test:php:lint`
- [ ] PHPStan: `composer ci:test:php:phpstan`
- [ ] Rector (dry-run): `composer ci:test:php:rector`
- [ ] Coding-Style: `composer ci::cgl`
- [x] PHPUnit: `composer ci:test:php:unit`
- [ ] Coverage ≥ **90 %**: `composer ci:test:php:unit:coverage`
- [ ] JSCPD (Duplikate = 0): `composer ci:test:php:cpd`
- [ ] Sammellauf: `composer ci:test`

**Inhaltliche/Code-Guidelines:**
- [ ] **Keine** `mixed`-Signaturen • **kein** `empty()` • **keine** verschachtelten Ternaries
- [ ] Fully-qualified native functions (`\\strlen`, `\\count`, …) und sinnvolle `use`-Imports
- [ ] **Keine** dynamischen Aufrufe statischer Methoden
- [ ] Sinnvolle **Interfaces** verwendet (wo Verträge sinnvoll sind)
- [ ] Typisierte Klassenkonstanten; redundante Casts/Default-Argumente entfernt
- [ ] Klassen als `readonly`, wo passend; keine redundanten `readonly`-Mods
- [ ] **Eine Klasse je Datei** • Test-Namespaces spiegeln `src/`-Struktur
- [ ] Englische PHPDocs & englische Inline-Kommentare an komplexen Stellen
- [ ] Sinnvolle Namen für Variablen/Konstanten; Magic Numbers/Strings vermieden
- [ ] `array_find` / `array_any` / `array_all` gezielt statt trivialer `foreach` verwendet (wo es die Lesbarkeit verbessert)

---

## EXIF / TIFF / ISOBMFF / XMP Guardrails
- **EXIF-Versionen:** 1.x, 2.x (2.1/2.2/2.21/2.3/2.31/2.32), 3.0 — kompatible Änderungen; falls Tags betroffen: Coverage-Test grün.
- **TIFF/BigTIFF:** Endianness korrekt (`0x2A` / `0x2B`), Inline-Werte-Grenzen, `RATIONAL/SRATIONAL` korrekt.
- **GPS:** Vorzeichen über Ref-Tags (S/W negativ); `0/0`-Kantenfälle robust.
- **Preview/IFD1:** Nur beschreiben (Offsets/Längen/Compression), kein Rendering.
- **ISOBMFF/QuickTime:** Box-Size ≥ Header, 32/64-bit-Größen korrekt; `iloc`-Extents summiert; `data_reference_index ≠ 0` → skip; keine Remote-Refs.
- **XMP:** JPEG APP1-Präfix / ISOBMFF `uuid`; Parser mit `LIBXML_NONET`, keine DTD/Entities; `Alt/Bag/Seq` → Arrays.
- **Fehlerbehandlung:** ausschließlich `ParseError` oder `BoundsError`; keine Warnings/Notices als Kontrollfluss.

---

## Tests
- **Neue/angepasste Tests:** `ParsedExifTest::profileHueSatMapIncludesEncodings`, colour profile assertions in `ExifAssemblerTest`, `ExifTagTest` coverage check.
- **Negative Cases:** Existing gating tests ensure legacy tags remain null for EXIF ≥ 3.0.
- **Fixtures/Streams:** Synthetic IFDs for DNG profile data; no large binaries added.

---

## Breaking Changes / Risk / Rollback
- **Breaking changes:** Keine.
- **Risiken:** Minimal – limited to DNG profile metadata handling.
- **Rollback-Plan:** Revert commit `feat(exif): expose profile hue sat map encodings`.

---

## Changelog
- feat: expose profile hue/sat map encodings in EXIF and curated colour profiles

---

## References (Specs & Docs)
- EXIF 3.0 §4.6.3 (Tables 35–41); EXIF 2.32 §4.6.3 (Tables 35–41)

Docs im Repo:
- `docs/EXIF-210.pdf`, `docs/EXIF-220.pdf`, `docs/EXIF-230.pdf`, `docs/EXIF-231.pdf`, `docs/EXIF-232.pdf`, `docs/EXIF-300.pdf`
- `docs/TIFF6.pdf`

---

## Review Roles (tick what you covered)
- [ ] Planner (Scope/Non-Goals/Guardrails definiert)
- [ ] Spec Writer (AC/Tests präzisiert)
- [x] Test Agent (RED zuerst)
- [x] Implementer (GREEN minimal & im Datei-Scope)
- [ ] Static/QA (Stan/CS/Rector/JSCPD clean)
- [ ] Security (Bounds, Offsets, XML-Flags)
- [ ] Reviewer (Minimalität, DX, Spec-Refs, Enums)
- [ ] Release (PR-Text, Labels, Milestone, „Closes #…“)


------
https://chatgpt.com/codex/tasks/task_e_690488b634288323bb1c20e0f37a54b5