### PR TITLE
M7: Modernize structured metadata API — Curate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,8 @@
 ## Unreleased
 
 ### Added
-- Added `Value\Derived::fovHorizontalDeg` and `Value\Derived::fovVerticalDeg` to expose axis specific angles of view alongside the
-  diagonal `fovDiagonalDeg` helper.
+- Added `Value\Derived::fieldOfViewHorizontalDeg` and `Value\Derived::fieldOfViewVerticalDeg` to expose axis specific angles of view alongside the
+  diagonal `fieldOfViewDiagonalDeg` helper.
 - Extended `Value\Temporal` with offset tags, a resolved `DateTimeZone` instance and minute level EXIF offsets for reliable
   capture time reconstruction.
 - Enriched `Value\File` with mime type, file size, extension and SHA-1/MD5 digests so that consumers can correlate assets without
@@ -18,7 +18,7 @@
   primary thumbnails, including timezone offsets carried outside the main EXIF directory.
 
 ### Changed
-- Renamed the diagonal field-of-view helper from `fovDeg` to `fovDiagonalDeg`; consumers should switch to the new property name.
+- Renamed derived field helpers to `equivalent35mm`, `fieldOfView*` and `hyperfocalDistanceMetres`; legacy accessors remain as deprecated aliases.
 - Backfilled structured JPEG image bit depth from the start-of-frame precision when the EXIF tag is missing.
 
 ### Removed

--- a/README.md
+++ b/README.md
@@ -18,16 +18,16 @@ use MagicSunday\ImageMeta\MetadataReader;
 
 $meta = (new MetadataReader())->read('photo.heic')->structured();
 
-$meta->file->mimeType;
-$meta->camera->device->software;
-$meta->lens->model;
-$meta->lens->focalLength;
-$meta->lens->equivalent35mm();
-$meta->exposure->program;
-$meta->gps->latitude?->toFloat();
-$meta->makerNotes->apple?->cameraType;
-$meta->processing->whiteBalance->kelvin;
-$meta->sensor->hardware->focalPlaneXResolution;
+$meta->file()->file()->mimeType;
+$meta->camera()->device->software;
+$meta->lens()->lens()->lensModel();
+$meta->lens()->lens()->focalLengthMm();
+$meta->lens()->equivalent35mm();
+$meta->exposure()->exposure->program;
+$meta->gps()->latitude()?->toFloat();
+$meta->preview()->hasThumbnail();
+$meta->interop()->relatedImageWidth();
+$meta->standards()->exifVersion();
 ```
 
 ### Mapping overview
@@ -75,15 +75,15 @@ used directly without consulting tag identifiers.
 
 ```php
 $s = $meta->structured();
-$s->tiff->compression;              // Compression::JPEG
-$s->lens->specification;       // [minF, minAperture, maxF, maxAperture]
-$s->composite->type;                // CompositeImage::GeneralComposite
-$s->standards->exifVersion;         // "3.00"
+$s->technical()->tiff->compression;              // Compression::JPEG
+$s->lens()->lens()->lensSpecification();       // [minF, minAperture, maxF, maxAperture]
+$s->media()->composite->type;                // CompositeImage::GeneralComposite
+$s->technical()->standards->exifVersion;         // "3.00"
 ```
 
 The aggregate always instantiates each value object. Consumers therefore never have to deal with tag identifiers or container-specific key names.
 
-The diagonal field of view exposed via `lens->fieldOfViewDiagonal` corresponds to the value previously documented as `fovDeg`. The new horizontal and vertical helpers provide axis-specific angles so clients can present per-dimension compositions without additional trigonometry.
+The diagonal field of view exposed via `lens()->derived()->fieldOfViewDiagonalDeg()` corresponds to the value previously documented as `fovDeg`. The new horizontal and vertical helpers provide axis-specific angles so clients can present per-dimension compositions without additional trigonometry.
 
 The expanded temporal aggregate surfaces raw EXIF offset tags alongside a resolved `DateTimeZone` instance. This makes it possible to reconstruct original capture times even when the offset varies between creation, digitisation and modification steps. File level metadata now reports size, extension and cryptographic digests to help consumers correlate assets or detect tampering.
 

--- a/docs/fields.md
+++ b/docs/fields.md
@@ -6,13 +6,13 @@ circle of confusion (CoC) model used by the derived metrics helper.
 ## Units
 
 * **Metres (m)**
-  * `Derived::hyperfocalM`
+  * `Derived::hyperfocalDistanceMetres`
   * `Capture::waterDepthM`
   * `Gps::altitude`, `Gps::destinationDistanceMetres`, `Gps::horizontalPositioningError`
 * **Kelvin (K)**
   * `Apple::colorTemperature` reports the device supplied white balance as an absolute colour temperature.
 * **Degrees (°)**
-  * `Derived::fovDiagonalDeg`, `Derived::fovHorizontalDeg`, `Derived::fovVerticalDeg`
+  * `Derived::fieldOfViewDiagonalDeg`, `Derived::fieldOfViewHorizontalDeg`, `Derived::fieldOfViewVerticalDeg`
   * `Motion::rollDeg`, `Motion::pitchDeg`, `Motion::yawDeg`
   * `Capture::cameraElevationAngleDeg`
   * `Gps::track`, `Gps::imageDirection`, `Gps::destinationBearing`

--- a/docs/upgrade/m1-single-value-layer.md
+++ b/docs/upgrade/m1-single-value-layer.md
@@ -21,12 +21,12 @@ The following classes are tagged with `@deprecated` and will be removed after Mi
 2. Access curated value objects directly, for example:
    ```php
    $metadata = (new MetadataReader())->read($path)->structured();
-   $metadata->camera->device->model;
-   $metadata->lens->optics->equivalent35mm();
-   $metadata->media->image->width;
-   $metadata->gps->coordinates->latitude?->toFloat();
+   $metadata->camera()->camera()->model;
+   $metadata->lens()->equivalent35mm();
+   $metadata->media()->image->width;
+   $metadata->gps()->latitude()?->toFloat();
    ```
-3. For preview information, use `$metadata->media->preview` instead of the deprecated `Structured\Preview` wrapper.
+3. For preview information, use `$metadata->media()->preview` instead of the deprecated `Structured\Preview` wrapper.
 
 ## Deprecation Mechanics
 

--- a/scripts/dump_exif_versions.php
+++ b/scripts/dump_exif_versions.php
@@ -21,11 +21,11 @@ foreach ($files as $file) {
     $raw = $metadata->exifDoc;
     $maker = $metadata->makerNotes;
 
-    $standards = $structured->technical->standards;
-    $preview = $structured->media->preview;
-    $interop = $structured->technical->interop;
-    $image = $structured->media->image;
-    $capture = $structured->capture->temporal;
+    $standards = $structured->technical()->standards;
+    $preview = $structured->media()->preview;
+    $interop = $structured->technical()->interop;
+    $image = $structured->media()->image;
+    $capture = $structured->capture()->temporal;
 
     $makerInfo = null;
     if ($maker !== null) {
@@ -37,7 +37,7 @@ foreach ($files as $file) {
         ];
     }
 
-    $sensor = $structured->sensor->hardware;
+    $sensor = $structured->sensor()->hardware;
 
     $env = [
         'temperatureC' => $raw?->temperatureCelsius(),
@@ -57,7 +57,7 @@ foreach ($files as $file) {
                 'tiffEpStandardString' => $standards->tiffEpStandardString(),
             ],
             'exposure' => [
-                'iso' => $structured->exposure->iso,
+                'iso' => $structured->exposure()->exposure->iso,
             ],
             'capture' => [
                 'dateTimeOriginal' => $capture->original?->format(DATE_ATOM),

--- a/src/Convenience/CaptureDateResolver.php
+++ b/src/Convenience/CaptureDateResolver.php
@@ -36,9 +36,9 @@ final class CaptureDateResolver
     {
         $structured = $metadata->structured();
 
-        $capture   = $structured->capture->details;
-        $temporal  = $structured->capture->temporal;
-        $gps       = $structured->gps->gps();
+        $capture   = $structured->capture()->details;
+        $temporal  = $structured->capture()->temporal;
+        $gps       = $structured->gps()->gps();
 
         $candidate = self::captureDate($capture)
             ?? self::temporalFallback($temporal)

--- a/src/Convenience/ExifConvenience.php
+++ b/src/Convenience/ExifConvenience.php
@@ -125,7 +125,7 @@ final class ExifConvenience
             $parts[] = self::formatFocalLength($focalLength);
         }
 
-        $equivalent = $derived?->focalLength35mm();
+        $equivalent = $derived?->equivalent35mm();
         if ($equivalent !== null && !self::containsEquivalent($parts, $equivalent)) {
             $parts[] = sprintf('%d mm eq', $equivalent);
         }

--- a/src/Curate/Exif/Structured/Gps.php
+++ b/src/Curate/Exif/Structured/Gps.php
@@ -38,7 +38,7 @@ final readonly class Gps
             return null;
         }
 
-        return new GpsCoordinate($this->gps->latitude, $this->gps->latitudeRef);
+        return new GpsCoordinate($this->gps->latitude, $this->gps->latitudeReference());
     }
 
     public function longitude(): ?GpsCoordinate
@@ -47,7 +47,7 @@ final readonly class Gps
             return null;
         }
 
-        return new GpsCoordinate($this->gps->longitude, $this->gps->longitudeRef);
+        return new GpsCoordinate($this->gps->longitude, $this->gps->longitudeReference());
     }
 
     public function altitude(): ?float
@@ -57,7 +57,7 @@ final readonly class Gps
 
     public function altitudeReference(): ?int
     {
-        return $this->gps->altitudeRef;
+        return $this->gps->altitudeReference();
     }
 
     public function version(): ?string
@@ -87,12 +87,12 @@ final readonly class Gps
 
     public function dilutionOfPrecision(): ?float
     {
-        return $this->gps->dop;
+        return $this->gps->dilutionOfPrecision();
     }
 
     public function speedReference(): ?string
     {
-        return $this->gps->speedRef;
+        return $this->gps->speedReference();
     }
 
     public function speedMs(): ?float
@@ -102,7 +102,7 @@ final readonly class Gps
 
     public function speedOriginalReference(): ?string
     {
-        return $this->gps->speedOriginalRef;
+        return $this->gps->speedOriginalReference();
     }
 
     public function speedOriginal(): ?float
@@ -112,7 +112,7 @@ final readonly class Gps
 
     public function trackReference(): ?string
     {
-        return $this->gps->trackRef;
+        return $this->gps->trackReference();
     }
 
     public function track(): ?float
@@ -122,7 +122,7 @@ final readonly class Gps
 
     public function imageDirectionReference(): ?string
     {
-        return $this->gps->imageDirectionRef;
+        return $this->gps->imageDirectionReference();
     }
 
     public function imageDirection(): ?float
@@ -141,7 +141,7 @@ final readonly class Gps
             return null;
         }
 
-        return new GpsCoordinate($this->gps->destinationLatitude, $this->gps->destinationLatitudeRef);
+        return new GpsCoordinate($this->gps->destinationLatitude, $this->gps->destinationLatitudeReference());
     }
 
     public function destinationLongitude(): ?GpsCoordinate
@@ -150,12 +150,12 @@ final readonly class Gps
             return null;
         }
 
-        return new GpsCoordinate($this->gps->destinationLongitude, $this->gps->destinationLongitudeRef);
+        return new GpsCoordinate($this->gps->destinationLongitude, $this->gps->destinationLongitudeReference());
     }
 
     public function destinationBearingReference(): ?string
     {
-        return $this->gps->destinationBearingRef;
+        return $this->gps->destinationBearingReference();
     }
 
     public function destinationBearing(): ?float
@@ -165,7 +165,7 @@ final readonly class Gps
 
     public function destinationDistanceReference(): ?string
     {
-        return $this->gps->destinationDistanceRef;
+        return $this->gps->destinationDistanceReference();
     }
 
     public function destinationDistanceMetres(): ?float
@@ -175,7 +175,7 @@ final readonly class Gps
 
     public function destinationDistanceOriginalReference(): ?string
     {
-        return $this->gps->destinationDistanceOriginalRef;
+        return $this->gps->destinationDistanceOriginalReference();
     }
 
     public function destinationDistanceOriginal(): ?float

--- a/src/Curate/Exif/Structured/Lens.php
+++ b/src/Curate/Exif/Structured/Lens.php
@@ -73,7 +73,7 @@ final readonly class Lens
 
     public function equivalent35mm(): ?int
     {
-        return $this->lens->focalLengthIn35mm ?? $this->derived->focalLength35mm;
+        return $this->lens->focalLengthIn35mm ?? $this->derived->equivalent35mm;
     }
 
     public function cropFactor(): ?float
@@ -83,21 +83,21 @@ final readonly class Lens
 
     public function hyperfocalDistance(): ?float
     {
-        return $this->derived->hyperfocalM;
+        return $this->derived->hyperfocalDistanceMetres;
     }
 
     public function fieldOfViewHorizontal(): ?float
     {
-        return $this->derived->fovHorizontalDeg;
+        return $this->derived->fieldOfViewHorizontalDeg;
     }
 
     public function fieldOfViewVertical(): ?float
     {
-        return $this->derived->fovVerticalDeg;
+        return $this->derived->fieldOfViewVerticalDeg;
     }
 
     public function fieldOfViewDiagonal(): ?float
     {
-        return $this->derived->fovDiagonalDeg;
+        return $this->derived->fieldOfViewDiagonalDeg;
     }
 }

--- a/src/Curate/Exif/ValueFactory.php
+++ b/src/Curate/Exif/ValueFactory.php
@@ -552,15 +552,15 @@ final class ValueFactory
                 $exposure->fNumber,
                 $exposure->iso,
             ),
-            hyperfocalM: ValueConverters::calcHyperfocalM(
+            hyperfocalDistanceMetres: ValueConverters::calcHyperfocalM(
                 $lens->focalLengthMm,
                 $exposure->fNumber,
                 $circleOfConfusionMm,
             ),
-            fovDiagonalDeg: ValueConverters::calcFovDeg($lens->focalLengthIn35mm, $cropFactor, $lens->focalLengthMm),
-            fovHorizontalDeg: ValueConverters::calcHorizontalFovDeg($lens->focalLengthIn35mm, $cropFactor, $lens->focalLengthMm),
-            fovVerticalDeg: ValueConverters::calcVerticalFovDeg($lens->focalLengthIn35mm, $cropFactor, $lens->focalLengthMm),
-            focalLength35mm: $lens->focalLengthIn35mm,
+            fieldOfViewDiagonalDeg: ValueConverters::calcFovDeg($lens->focalLengthIn35mm, $cropFactor, $lens->focalLengthMm),
+            fieldOfViewHorizontalDeg: ValueConverters::calcHorizontalFovDeg($lens->focalLengthIn35mm, $cropFactor, $lens->focalLengthMm),
+            fieldOfViewVerticalDeg: ValueConverters::calcVerticalFovDeg($lens->focalLengthIn35mm, $cropFactor, $lens->focalLengthMm),
+            equivalent35mm: $lens->focalLengthIn35mm,
             cropFactor: $cropFactor,
         );
 

--- a/src/Curate/Structured/GpsMetadata.php
+++ b/src/Curate/Structured/GpsMetadata.php
@@ -34,7 +34,7 @@ final readonly class GpsMetadata
             return null;
         }
 
-        return new GpsCoordinate($this->gps->latitude, $this->gps->latitudeRef);
+        return new GpsCoordinate($this->gps->latitude, $this->gps->latitudeReference());
     }
 
     public function longitude(): ?GpsCoordinate
@@ -43,7 +43,7 @@ final readonly class GpsMetadata
             return null;
         }
 
-        return new GpsCoordinate($this->gps->longitude, $this->gps->longitudeRef);
+        return new GpsCoordinate($this->gps->longitude, $this->gps->longitudeReference());
     }
 
     public function altitude(): ?float
@@ -53,7 +53,7 @@ final readonly class GpsMetadata
 
     public function altitudeReference(): ?int
     {
-        return $this->gps->altitudeRef;
+        return $this->gps->altitudeReference();
     }
 
     public function version(): ?string
@@ -83,12 +83,12 @@ final readonly class GpsMetadata
 
     public function dilutionOfPrecision(): ?float
     {
-        return $this->gps->dop;
+        return $this->gps->dilutionOfPrecision();
     }
 
     public function speedReference(): ?string
     {
-        return $this->gps->speedRef;
+        return $this->gps->speedReference();
     }
 
     public function speedMs(): ?float
@@ -98,7 +98,7 @@ final readonly class GpsMetadata
 
     public function speedOriginalReference(): ?string
     {
-        return $this->gps->speedOriginalRef;
+        return $this->gps->speedOriginalReference();
     }
 
     public function speedOriginal(): ?float
@@ -108,7 +108,7 @@ final readonly class GpsMetadata
 
     public function trackReference(): ?string
     {
-        return $this->gps->trackRef;
+        return $this->gps->trackReference();
     }
 
     public function track(): ?float
@@ -118,7 +118,7 @@ final readonly class GpsMetadata
 
     public function imageDirectionReference(): ?string
     {
-        return $this->gps->imageDirectionRef;
+        return $this->gps->imageDirectionReference();
     }
 
     public function imageDirection(): ?float
@@ -137,7 +137,7 @@ final readonly class GpsMetadata
             return null;
         }
 
-        return new GpsCoordinate($this->gps->destinationLatitude, $this->gps->destinationLatitudeRef);
+        return new GpsCoordinate($this->gps->destinationLatitude, $this->gps->destinationLatitudeReference());
     }
 
     public function destinationLongitude(): ?GpsCoordinate
@@ -146,12 +146,12 @@ final readonly class GpsMetadata
             return null;
         }
 
-        return new GpsCoordinate($this->gps->destinationLongitude, $this->gps->destinationLongitudeRef);
+        return new GpsCoordinate($this->gps->destinationLongitude, $this->gps->destinationLongitudeReference());
     }
 
     public function destinationBearingReference(): ?string
     {
-        return $this->gps->destinationBearingRef;
+        return $this->gps->destinationBearingReference();
     }
 
     public function destinationBearing(): ?float
@@ -161,7 +161,7 @@ final readonly class GpsMetadata
 
     public function destinationDistanceReference(): ?string
     {
-        return $this->gps->destinationDistanceRef;
+        return $this->gps->destinationDistanceReference();
     }
 
     public function destinationDistanceMetres(): ?float
@@ -171,7 +171,7 @@ final readonly class GpsMetadata
 
     public function destinationDistanceOriginalReference(): ?string
     {
-        return $this->gps->destinationDistanceOriginalRef;
+        return $this->gps->destinationDistanceOriginalReference();
     }
 
     public function destinationDistanceOriginal(): ?float

--- a/src/Curate/Structured/LensMetadata.php
+++ b/src/Curate/Structured/LensMetadata.php
@@ -37,6 +37,6 @@ final readonly class LensMetadata
 
     public function equivalent35mm(): ?int
     {
-        return $this->lens->focalLengthIn35mm ?? $this->derived->focalLength35mm;
+        return $this->lens->focalLengthIn35mm ?? $this->derived->equivalent35mm;
     }
 }

--- a/src/Curate/StructuredMetadata.php
+++ b/src/Curate/StructuredMetadata.php
@@ -23,6 +23,11 @@ use MagicSunday\ImageMeta\Curate\Structured\ProcessingMetadata;
 use MagicSunday\ImageMeta\Curate\Structured\RightsMetadata;
 use MagicSunday\ImageMeta\Curate\Structured\SensorMetadata;
 use MagicSunday\ImageMeta\Curate\Structured\TechnicalMetadata;
+use MagicSunday\ImageMeta\Value\Derived;
+use MagicSunday\ImageMeta\Value\Image;
+use MagicSunday\ImageMeta\Value\Interop;
+use MagicSunday\ImageMeta\Value\Preview;
+use MagicSunday\ImageMeta\Value\Standards;
 
 /**
  * Aggregates curated metadata in a grouped, chainable representation.
@@ -30,18 +35,103 @@ use MagicSunday\ImageMeta\Curate\Structured\TechnicalMetadata;
 final readonly class StructuredMetadata
 {
     public function __construct(
-        public FileMetadata $file,
-        public CameraMetadata $camera,
-        public LensMetadata $lens,
-        public MediaMetadata $media,
-        public ExposureMetadata $exposure,
-        public CaptureMetadata $capture,
-        public GpsMetadata $gps,
-        public SensorMetadata $sensor,
-        public ProcessingMetadata $processing,
-        public TechnicalMetadata $technical,
-        public RightsMetadata $rights,
-        public MakerNotesView $makerNotes,
+        private FileMetadata $file,
+        private CameraMetadata $camera,
+        private LensMetadata $lens,
+        private MediaMetadata $media,
+        private ExposureMetadata $exposure,
+        private CaptureMetadata $capture,
+        private GpsMetadata $gps,
+        private SensorMetadata $sensor,
+        private ProcessingMetadata $processing,
+        private TechnicalMetadata $technical,
+        private RightsMetadata $rights,
+        private MakerNotesView $makerNotes,
     ) {
+    }
+
+    public function file(): FileMetadata
+    {
+        return $this->file;
+    }
+
+    public function camera(): CameraMetadata
+    {
+        return $this->camera;
+    }
+
+    public function lens(): LensMetadata
+    {
+        return $this->lens;
+    }
+
+    public function media(): MediaMetadata
+    {
+        return $this->media;
+    }
+
+    public function exposure(): ExposureMetadata
+    {
+        return $this->exposure;
+    }
+
+    public function capture(): CaptureMetadata
+    {
+        return $this->capture;
+    }
+
+    public function gps(): GpsMetadata
+    {
+        return $this->gps;
+    }
+
+    public function sensor(): SensorMetadata
+    {
+        return $this->sensor;
+    }
+
+    public function processing(): ProcessingMetadata
+    {
+        return $this->processing;
+    }
+
+    public function technical(): TechnicalMetadata
+    {
+        return $this->technical;
+    }
+
+    public function rights(): RightsMetadata
+    {
+        return $this->rights;
+    }
+
+    public function makerNotes(): MakerNotesView
+    {
+        return $this->makerNotes;
+    }
+
+    public function image(): Image
+    {
+        return $this->media->image;
+    }
+
+    public function preview(): Preview
+    {
+        return $this->media->preview;
+    }
+
+    public function interop(): Interop
+    {
+        return $this->technical->interop;
+    }
+
+    public function standards(): Standards
+    {
+        return $this->technical->standards;
+    }
+
+    public function derived(): Derived
+    {
+        return $this->lens->derived();
     }
 }

--- a/src/Exif/StructuredExif.php
+++ b/src/Exif/StructuredExif.php
@@ -397,15 +397,15 @@ final readonly class StructuredExif
                 $exposure->fNumber,
                 $exposure->iso,
             ),
-            hyperfocalM: ValueConverters::calcHyperfocalM(
+            hyperfocalDistanceMetres: ValueConverters::calcHyperfocalM(
                 $lens->focalLengthMm,
                 $exposure->fNumber,
                 $circleOfConfusionMm,
             ),
-            fovDiagonalDeg: ValueConverters::calcFovDeg($lens->focalLengthIn35mm, $cropFactor, $lens->focalLengthMm),
-            fovHorizontalDeg: ValueConverters::calcHorizontalFovDeg($lens->focalLengthIn35mm, $cropFactor, $lens->focalLengthMm),
-            fovVerticalDeg: ValueConverters::calcVerticalFovDeg($lens->focalLengthIn35mm, $cropFactor, $lens->focalLengthMm),
-            focalLength35mm: $lens->focalLengthIn35mm,
+            fieldOfViewDiagonalDeg: ValueConverters::calcFovDeg($lens->focalLengthIn35mm, $cropFactor, $lens->focalLengthMm),
+            fieldOfViewHorizontalDeg: ValueConverters::calcHorizontalFovDeg($lens->focalLengthIn35mm, $cropFactor, $lens->focalLengthMm),
+            fieldOfViewVerticalDeg: ValueConverters::calcVerticalFovDeg($lens->focalLengthIn35mm, $cropFactor, $lens->focalLengthMm),
+            equivalent35mm: $lens->focalLengthIn35mm,
             cropFactor: $cropFactor,
         );
     }

--- a/src/Value/Derived.php
+++ b/src/Value/Derived.php
@@ -17,21 +17,21 @@ namespace MagicSunday\ImageMeta\Value;
 final readonly class Derived
 {
     /**
-     * @param float|null $ev100            Exposure value normalised to ISO 100.
-     * @param float|null $hyperfocalM      Hyperfocal distance in metres.
-     * @param float|null $fovDiagonalDeg   Diagonal field of view in degrees.
-     * @param float|null $fovHorizontalDeg Horizontal field of view in degrees.
-     * @param float|null $fovVerticalDeg   Vertical field of view in degrees.
-     * @param int|null   $focalLength35mm  Equivalent focal length in 35mm terms.
-     * @param float|null $cropFactor       Estimated crop factor.
+     * @param float|null $ev100                      Exposure value normalised to ISO 100.
+     * @param float|null $hyperfocalDistanceMetres   Hyperfocal distance in metres.
+     * @param float|null $fieldOfViewDiagonalDeg     Diagonal field of view in degrees.
+     * @param float|null $fieldOfViewHorizontalDeg   Horizontal field of view in degrees.
+     * @param float|null $fieldOfViewVerticalDeg     Vertical field of view in degrees.
+     * @param int|null   $equivalent35mm             Equivalent focal length in 35mm terms.
+     * @param float|null $cropFactor                 Estimated crop factor.
      */
     public function __construct(
         public ?float $ev100,
-        public ?float $hyperfocalM,
-        public ?float $fovDiagonalDeg,
-        public ?float $fovHorizontalDeg,
-        public ?float $fovVerticalDeg,
-        public ?int $focalLength35mm,
+        public ?float $hyperfocalDistanceMetres,
+        public ?float $fieldOfViewDiagonalDeg,
+        public ?float $fieldOfViewHorizontalDeg,
+        public ?float $fieldOfViewVerticalDeg,
+        public ?int $equivalent35mm,
         public ?float $cropFactor,
     ) {
     }
@@ -47,41 +47,91 @@ final readonly class Derived
     /**
      * Returns the hyperfocal distance in metres.
      */
+    public function hyperfocalDistanceMetres(): ?float
+    {
+        return $this->hyperfocalDistanceMetres;
+    }
+
+    /**
+     * Returns the hyperfocal distance in metres.
+     *
+     * @deprecated Use {@see hyperfocalDistanceMetres()} instead.
+     */
     public function hyperfocalM(): ?float
     {
-        return $this->hyperfocalM;
+        return $this->hyperfocalDistanceMetres();
     }
 
     /**
      * Returns the diagonal field of view in degrees.
      */
+    public function fieldOfViewDiagonalDeg(): ?float
+    {
+        return $this->fieldOfViewDiagonalDeg;
+    }
+
+    /**
+     * Returns the diagonal field of view in degrees.
+     *
+     * @deprecated Use {@see fieldOfViewDiagonalDeg()} instead.
+     */
     public function fovDiagonalDeg(): ?float
     {
-        return $this->fovDiagonalDeg;
+        return $this->fieldOfViewDiagonalDeg();
     }
 
     /**
      * Returns the horizontal field of view in degrees.
      */
+    public function fieldOfViewHorizontalDeg(): ?float
+    {
+        return $this->fieldOfViewHorizontalDeg;
+    }
+
+    /**
+     * Returns the horizontal field of view in degrees.
+     *
+     * @deprecated Use {@see fieldOfViewHorizontalDeg()} instead.
+     */
     public function fovHorizontalDeg(): ?float
     {
-        return $this->fovHorizontalDeg;
+        return $this->fieldOfViewHorizontalDeg();
     }
 
     /**
      * Returns the vertical field of view in degrees.
      */
+    public function fieldOfViewVerticalDeg(): ?float
+    {
+        return $this->fieldOfViewVerticalDeg;
+    }
+
+    /**
+     * Returns the vertical field of view in degrees.
+     *
+     * @deprecated Use {@see fieldOfViewVerticalDeg()} instead.
+     */
     public function fovVerticalDeg(): ?float
     {
-        return $this->fovVerticalDeg;
+        return $this->fieldOfViewVerticalDeg();
     }
 
     /**
      * Returns the 35mm equivalent focal length.
      */
+    public function equivalent35mm(): ?int
+    {
+        return $this->equivalent35mm;
+    }
+
+    /**
+     * Returns the 35mm equivalent focal length.
+     *
+     * @deprecated Use {@see equivalent35mm()} instead.
+     */
     public function focalLength35mm(): ?int
     {
-        return $this->focalLength35mm;
+        return $this->equivalent35mm();
     }
 
     /**

--- a/test-images/TruthComparisonTest.php
+++ b/test-images/TruthComparisonTest.php
@@ -90,67 +90,67 @@ final class TruthComparisonTest extends TestCase
             ->structured();
 
         // Camera information
-        $this->assertSame($exif['IFD0:Make'] ?? null, $meta->camera->make ?? null, "$file: Make");
-        $this->assertSame($exif['IFD0:Model'] ?? null, $meta->camera->model ?? null, "$file: Model");
-        $this->assertSame($exif['IFD0:Software'] ?? null, $meta->camera->firmware ?? null, "$file: Firmware");
+        $this->assertSame($exif['IFD0:Make'] ?? null, $meta->camera()->camera->make ?? null, "$file: Make");
+        $this->assertSame($exif['IFD0:Model'] ?? null, $meta->camera()->camera->model ?? null, "$file: Model");
+        $this->assertSame($exif['IFD0:Software'] ?? null, $meta->camera()->camera->firmware ?? null, "$file: Firmware");
 
         // Image dimensions
-        $this->assertSame((int)($exif['File:ImageWidth'] ?? 0), $meta->media->image->width ?? 0, "$file: width");
-        $this->assertSame((int)($exif['File:ImageHeight'] ?? 0), $meta->media->image->height ?? 0, "$file: height");
+        $this->assertSame((int)($exif['File:ImageWidth'] ?? 0), $meta->media()->image->width ?? 0, "$file: width");
+        $this->assertSame((int)($exif['File:ImageHeight'] ?? 0), $meta->media()->image->height ?? 0, "$file: height");
 
         if ($file === 'Landscape_0.jpg') {
-            $this->assertNotNull($meta->media->image->width, 'Landscape_0.jpg: width fallback expected non-null value');
-            $this->assertNotNull($meta->media->image->height, 'Landscape_0.jpg: height fallback expected non-null value');
-            $this->assertSame((int)($exif['File:ImageWidth'] ?? 0), $meta->media->image->width, 'Landscape_0.jpg: width fallback matches ExifTool');
-            $this->assertSame((int)($exif['File:ImageHeight'] ?? 0), $meta->media->image->height, 'Landscape_0.jpg: height fallback matches ExifTool');
+            $this->assertNotNull($meta->media()->image->width, 'Landscape_0.jpg: width fallback expected non-null value');
+            $this->assertNotNull($meta->media()->image->height, 'Landscape_0.jpg: height fallback expected non-null value');
+            $this->assertSame((int)($exif['File:ImageWidth'] ?? 0), $meta->media()->image->width, 'Landscape_0.jpg: width fallback matches ExifTool');
+            $this->assertSame((int)($exif['File:ImageHeight'] ?? 0), $meta->media()->image->height, 'Landscape_0.jpg: height fallback matches ExifTool');
         }
 
         // Orientation
         if (isset($exif['IFD0:Orientation'], $this->map['Orientation'])) {
-            $ok = $this->norm->compareEnum('Orientation', (int)$exif['IFD0:Orientation'], $meta->media->image->orientation ?? null);
+            $ok = $this->norm->compareEnum('Orientation', (int)$exif['IFD0:Orientation'], $meta->media()->image->orientation ?? null);
             $this->assertTrue($ok, "$file: Orientation enum mapping");
         }
 
         // ColorSpace
         if (isset($exif['EXIF:ColorSpace'], $this->map['ColorSpace'])) {
-            $ok = $this->norm->compareEnum('ColorSpace', (int)$exif['EXIF:ColorSpace'], $meta->media->image->colorSpace ?? null);
+            $ok = $this->norm->compareEnum('ColorSpace', (int)$exif['EXIF:ColorSpace'], $meta->media()->image->colorSpace ?? null);
             $this->assertTrue($ok, "$file: ColorSpace enum mapping");
         }
 
         // Core EXIF exposure data
-        $this->assertEqualsWithDelta((float)($exif['EXIF:FNumber'] ?? 0), (float)($meta->exposure->fNumber ?? 0), Normalizer::DELTA, "$file: FNumber");
-        $this->assertEqualsWithDelta((float)($exif['EXIF:ExposureTime'] ?? 0), (float)($meta->exposure->exposureTimeSec ?? 0), Normalizer::DELTA, "$file: ExposureTime");
-        $this->assertSame((int)($exif['EXIF:ISOSpeedRatings'] ?? $exif['EXIF:ISO'] ?? 0), (int)($meta->exposure->iso ?? 0), "$file: ISO");
+        $this->assertEqualsWithDelta((float)($exif['EXIF:FNumber'] ?? 0), (float)($meta->exposure()->exposure->fNumber ?? 0), Normalizer::DELTA, "$file: FNumber");
+        $this->assertEqualsWithDelta((float)($exif['EXIF:ExposureTime'] ?? 0), (float)($meta->exposure()->exposure->exposureTimeSec ?? 0), Normalizer::DELTA, "$file: ExposureTime");
+        $this->assertSame((int)($exif['EXIF:ISOSpeedRatings'] ?? $exif['EXIF:ISO'] ?? 0), (int)($meta->exposure()->exposure->iso ?? 0), "$file: ISO");
 
         // Program, metering and white balance
         if (isset($exif['EXIF:ExposureProgram'])) {
-            $ok = $this->norm->compareEnum('ExposureProgram', (int)$exif['EXIF:ExposureProgram'], $meta->exposure->program ?? null);
+            $ok = $this->norm->compareEnum('ExposureProgram', (int)$exif['EXIF:ExposureProgram'], $meta->exposure()->exposure->program ?? null);
             $this->assertTrue($ok, "$file: ExposureProgram enum");
         }
         if (isset($exif['EXIF:MeteringMode'])) {
-            $ok = $this->norm->compareEnum('MeteringMode', (int)$exif['EXIF:MeteringMode'], $meta->exposure->meteringMode ?? null);
+            $ok = $this->norm->compareEnum('MeteringMode', (int)$exif['EXIF:MeteringMode'], $meta->exposure()->exposure->meteringMode ?? null);
             $this->assertTrue($ok, "$file: MeteringMode enum");
         }
         if (isset($exif['EXIF:WhiteBalance'])) {
-            $ok = $this->norm->compareEnum('WhiteBalance', (int)$exif['EXIF:WhiteBalance'], $meta->exposure->whiteBalance ?? $meta->processing->whiteBalance->mode ?? null);
+            $ok = $this->norm->compareEnum('WhiteBalance', (int)$exif['EXIF:WhiteBalance'], $meta->exposure()->exposure->whiteBalance ?? $meta->processing()->whiteBalance->mode ?? null);
             $this->assertTrue($ok, "$file: WhiteBalance enum");
         }
 
         // Exposure mode
         if (isset($exif['EXIF:ExposureMode'])) {
-            $ok = $this->norm->compareEnum('ExposureMode', (int)$exif['EXIF:ExposureMode'], $meta->exposure->exposureMode ?? null);
+            $ok = $this->norm->compareEnum('ExposureMode', (int)$exif['EXIF:ExposureMode'], $meta->exposure()->exposure->exposureMode ?? null);
             $this->assertTrue($ok, "$file: ExposureMode enum");
         }
 
         // Lens information
         if (isset($exif['EXIF:FocalLength'])) {
-            $this->assertEqualsWithDelta((float)$exif['EXIF:FocalLength'], (float)($meta->lens->focalLength ?? $meta->media->image->focalLengthMm ?? 0.0), Normalizer::DELTA, "$file: FocalLength");
+            $this->assertEqualsWithDelta((float)$exif['EXIF:FocalLength'], (float)($meta->lens()->lens()->focalLengthMm ?? $meta->media()->image->focalLengthMm ?? 0.0), Normalizer::DELTA, "$file: FocalLength");
         }
         if (isset($exif['EXIF:FocalLengthIn35mmFormat'])) {
-            $this->assertSame((int)$exif['EXIF:FocalLengthIn35mmFormat'], (int)($meta->lens->equivalent35mm() ?? 0), "$file: FocalLength35mm");
+            $this->assertSame((int)$exif['EXIF:FocalLengthIn35mmFormat'], (int)($meta->lens()->equivalent35mm() ?? 0), "$file: FocalLength35mm");
         }
         if (isset($exif['EXIF:LensModel'])) {
-            $this->assertSame($exif['EXIF:LensModel'], $meta->lens->model ?? null, "$file: LensModel");
+            $this->assertSame($exif['EXIF:LensModel'], $meta->lens()->lens()->lensModel ?? null, "$file: LensModel");
         }
 
         // Temporal metadata (ISO-8601)
@@ -159,49 +159,49 @@ final class TruthComparisonTest extends TestCase
         $modifyIso = Normalizer::buildIso8601FromExif($exif, 'IFD0:ModifyDate');
 
         if ($createIso !== null) {
-            $this->assertSame($createIso, safeIso($meta->capture->temporal->create ?? null), "$file: CreateDate");
+            $this->assertSame($createIso, safeIso($meta->capture()->temporal->create ?? null), "$file: CreateDate");
         }
         if ($origIso !== null) {
-            $this->assertSame($origIso, safeIso($meta->capture->temporal->original ?? null), "$file: DateTimeOriginal");
+            $this->assertSame($origIso, safeIso($meta->capture()->temporal->original ?? null), "$file: DateTimeOriginal");
         }
         if ($modifyIso !== null) {
-            $this->assertSame($modifyIso, safeIso($meta->capture->temporal->modify ?? null), "$file: ModifyDate");
+            $this->assertSame($modifyIso, safeIso($meta->capture()->temporal->modify ?? null), "$file: ModifyDate");
         }
 
         // GPS
         if (isset($exif['GPS:GPSLatitude'], $exif['GPS:GPSLongitude'])) {
-            $this->assertEqualsWithDelta((float)$exif['GPS:GPSLatitude'],  (float)($meta->gps->latitude?->toFloat() ?? 0), Normalizer::DELTA, "$file: GPS lat");
-            $this->assertEqualsWithDelta((float)$exif['GPS:GPSLongitude'], (float)($meta->gps->longitude?->toFloat() ?? 0), Normalizer::DELTA, "$file: GPS lon");
+            $this->assertEqualsWithDelta((float)$exif['GPS:GPSLatitude'],  (float)($meta->gps()->latitude?->toFloat() ?? 0), Normalizer::DELTA, "$file: GPS lat");
+            $this->assertEqualsWithDelta((float)$exif['GPS:GPSLongitude'], (float)($meta->gps()->longitude?->toFloat() ?? 0), Normalizer::DELTA, "$file: GPS lon");
         }
         if (isset($exif['GPS:GPSAltitude'])) {
-            $this->assertEqualsWithDelta((float)$exif['GPS:GPSAltitude'], (float)($meta->gps->altitude ?? 0), 1e-3, "$file: GPS alt");
+            $this->assertEqualsWithDelta((float)$exif['GPS:GPSAltitude'], (float)($meta->gps()->altitude() ?? 0), 1e-3, "$file: GPS alt");
         }
         if (isset($exif['GPS:GPSImgDirection'])) {
-            $this->assertEqualsWithDelta((float)$exif['GPS:GPSImgDirection'], (float)($meta->gps->imageDirection ?? 0), 1e-6, "$file: GPS direction");
+            $this->assertEqualsWithDelta((float)$exif['GPS:GPSImgDirection'], (float)($meta->gps()->imageDirection() ?? 0), 1e-6, "$file: GPS direction");
         }
 
         // ICC profile
         if (isset($exif['ICC_Profile:ProfileDescription'])) {
-            $this->assertSame($exif['ICC_Profile:ProfileDescription'], $meta->media->colorProfile->profileName ?? null, "$file: ICC name");
+            $this->assertSame($exif['ICC_Profile:ProfileDescription'], $meta->media()->colorProfile->profileName ?? null, "$file: ICC name");
         }
         if (isset($exif['ICC_Profile:ProfileVersion'])) {
-            $this->assertStringStartsWith((string)$exif['ICC_Profile:ProfileVersion'], (string)($meta->media->colorProfile->profileVersion ?? ''), "$file: ICC version");
+            $this->assertStringStartsWith((string)$exif['ICC_Profile:ProfileVersion'], (string)($meta->media()->colorProfile->profileVersion ?? ''), "$file: ICC version");
         }
         if (isset($exif['ICC_Profile:RenderingIntent'])) {
-            $this->assertSame($exif['ICC_Profile:RenderingIntent'], $meta->media->colorProfile->renderingIntent ?? null, "$file: ICC intent");
+            $this->assertSame($exif['ICC_Profile:RenderingIntent'], $meta->media()->colorProfile->renderingIntent ?? null, "$file: ICC intent");
         }
         if (isset($exif['ICC_Profile:ProfileID'])) {
-            $this->assertSame(strtoupper((string)$exif['ICC_Profile:ProfileID']), strtoupper((string)($meta->media->colorProfile->profileId ?? '')), "$file: ICC id");
+            $this->assertSame(strtoupper((string)$exif['ICC_Profile:ProfileID']), strtoupper((string)($meta->media()->colorProfile->profileId ?? '')), "$file: ICC id");
         }
 
         // Flash bitmask decoded into structured fields
-        if (isset($exif['EXIF:Flash']) && isset($meta->exposure->flash)) {
+        if (isset($exif['EXIF:Flash']) && isset($meta->exposure()->exposure->flash)) {
             $decoded = Normalizer::decodeExifFlash((int)$exif['EXIF:Flash']);
-            $this->assertSame($decoded['fired'], (bool)$meta->exposure->flash->fired, "$file: Flash fired");
-            $this->assertSame($decoded['returnDetection'], enumName($meta->exposure->flash->returnDetection ?? null), "$file: Flash returnDetection");
-            $this->assertSame($decoded['mode'],             enumName($meta->exposure->flash->mode ?? null),             "$file: Flash mode");
-            $this->assertSame($decoded['functionPresence'],  enumName($meta->exposure->flash->functionPresence ?? null), "$file: Flash functionPresence");
-            $this->assertSame($decoded['redEyeReduction'],  (bool)$meta->exposure->flash->redEyeReduction,              "$file: Flash redEyeReduction");
+            $this->assertSame($decoded['fired'], (bool)$meta->exposure()->exposure->flash->fired, "$file: Flash fired");
+            $this->assertSame($decoded['returnDetection'], enumName($meta->exposure()->exposure->flash->returnDetection ?? null), "$file: Flash returnDetection");
+            $this->assertSame($decoded['mode'],             enumName($meta->exposure()->exposure->flash->mode ?? null),             "$file: Flash mode");
+            $this->assertSame($decoded['functionPresence'],  enumName($meta->exposure()->exposure->flash->functionPresence ?? null), "$file: Flash functionPresence");
+            $this->assertSame($decoded['redEyeReduction'],  (bool)$meta->exposure()->exposure->flash->redEyeReduction,              "$file: Flash redEyeReduction");
         }
     }
 
@@ -221,7 +221,7 @@ final class TruthComparisonTest extends TestCase
 
         $facesExif = Normalizer::mwgFaces($exif);
         $facesMeta = [];
-        foreach (($meta->capture->regions->items ?? []) as $r) {
+        foreach (($meta->capture()->regions->items ?? []) as $r) {
             if (enumName($r->type ?? null) === 'FACE') {
                 $facesMeta[] = ['x' => (float)$r->x, 'y' => (float)$r->y, 'w' => (float)$r->w, 'h' => (float)$r->h];
             }

--- a/tests/Acceptance/ExifFallbacksTest.php
+++ b/tests/Acceptance/ExifFallbacksTest.php
@@ -26,18 +26,18 @@ final class ExifFallbacksTest extends TestCase
             ->read(self::SAMPLE)
             ->structured();
 
-        self::assertSame(80, $structured->exposure->exposure->iso);
+        self::assertSame(80, $structured->exposure()->exposure->iso);
         self::assertSame(
             '2011-12-06T11:08:37+00:00',
-            $structured->capture->temporal->original?->format(DATE_ATOM),
+            $structured->capture()->temporal->original?->format(DATE_ATOM),
         );
         self::assertSame(
             '400 N Michigan Ave, Chicago, IL 60611, USA',
-            $structured->media->image->userComment,
+            $structured->media()->image->userComment,
         );
-        self::assertSame('ASCII', $structured->media->image->userCommentEncoding);
+        self::assertSame('ASCII', $structured->media()->image->userCommentEncoding);
 
-        $interop = $structured->technical->interop;
+        $interop = $structured->technical()->interop;
         self::assertSame('R98', $interop->index);
         self::assertSame('0100', $interop->version);
         self::assertSame(4000, $interop->relatedImageWidth);

--- a/tests/Curate/ExifAssemblerTest.php
+++ b/tests/Curate/ExifAssemblerTest.php
@@ -267,131 +267,131 @@ final class ExifAssemblerTest extends TestCase
                 'relatedImageWidth'      => 4000,
                 'relatedImageLength'     => 3000,
             ],
-            get_object_vars($structured->technical->interop),
+            get_object_vars($structured->technical()->interop),
         );
 
-        self::assertSame(Compression::JPEG, $structured->technical->tiff->compression);
-        self::assertSame(Photometric::YCBCR, $structured->technical->tiff->photometric);
-        self::assertSame([2, 2], $structured->technical->tiff->ycbcrSubSampling);
-        self::assertSame([0.299, 0.587, 0.114], $structured->technical->tiff->ycbcrCoefficients);
-        self::assertSame([0.3127, 0.329], $structured->technical->tiff->whitePoint);
-        self::assertSame([0.64, 0.33, 0.3, 0.6, 0.15, 0.6], $structured->technical->tiff->primaryChromaticities);
-        self::assertSame([512, 1024, 1536], $structured->technical->tiff->stripOffsets);
-        self::assertSame([2048, 2048, 1024], $structured->technical->tiff->stripByteCounts);
-        self::assertSame(256, $structured->technical->tiff->tileWidth);
-        self::assertSame(256, $structured->technical->tiff->tileLength);
-        self::assertSame([4096, 8192, 12288], $structured->technical->tiff->tileOffsets);
-        self::assertSame([1024, 2048, 2048], $structured->technical->tiff->tileByteCounts);
-        self::assertSame([0, 32768, 65535], $structured->technical->tiff->transferFunction);
-        self::assertSame(24576, $structured->technical->tiff->jpegInterchangeFormat);
-        self::assertSame(8192, $structured->technical->tiff->jpegInterchangeFormatLength);
-        self::assertSame([0.0, 255.0, 0.0, 255.0, 0.0, 255.0], $structured->technical->tiff->referenceBlackWhite);
-        self::assertSame('Jane Doe 2024', $structured->technical->tiff->copyright);
+        self::assertSame(Compression::JPEG, $structured->technical()->tiff->compression);
+        self::assertSame(Photometric::YCBCR, $structured->technical()->tiff->photometric);
+        self::assertSame([2, 2], $structured->technical()->tiff->ycbcrSubSampling);
+        self::assertSame([0.299, 0.587, 0.114], $structured->technical()->tiff->ycbcrCoefficients);
+        self::assertSame([0.3127, 0.329], $structured->technical()->tiff->whitePoint);
+        self::assertSame([0.64, 0.33, 0.3, 0.6, 0.15, 0.6], $structured->technical()->tiff->primaryChromaticities);
+        self::assertSame([512, 1024, 1536], $structured->technical()->tiff->stripOffsets);
+        self::assertSame([2048, 2048, 1024], $structured->technical()->tiff->stripByteCounts);
+        self::assertSame(256, $structured->technical()->tiff->tileWidth);
+        self::assertSame(256, $structured->technical()->tiff->tileLength);
+        self::assertSame([4096, 8192, 12288], $structured->technical()->tiff->tileOffsets);
+        self::assertSame([1024, 2048, 2048], $structured->technical()->tiff->tileByteCounts);
+        self::assertSame([0, 32768, 65535], $structured->technical()->tiff->transferFunction);
+        self::assertSame(24576, $structured->technical()->tiff->jpegInterchangeFormat);
+        self::assertSame(8192, $structured->technical()->tiff->jpegInterchangeFormatLength);
+        self::assertSame([0.0, 255.0, 0.0, 255.0, 0.0, 255.0], $structured->technical()->tiff->referenceBlackWhite);
+        self::assertSame('Jane Doe 2024', $structured->technical()->tiff->copyright);
 
-        self::assertSame('Canon', $structured->camera->camera()->make);
-        self::assertSame('EOS R6 II', $structured->camera->camera()->model);
-        self::assertSame('Jane Doe', $structured->rights->author->artist);
-        self::assertSame('Jane Owner', $structured->rights->author->ownerName);
-        self::assertSame('Jane Doe 2024', $structured->rights->rights()->copyright);
-        self::assertSame('Restricted', $structured->rights->rights()->securityClassification);
-        self::assertSame('1.2.3', $structured->camera->camera()->firmware);
-        self::assertSame(FileSource::DIGITAL_CAMERA, $structured->camera->camera()->fileSource);
-        self::assertSame(SensingMethod::ONE_CHIP_COLOR_AREA, $structured->camera->camera()->sensingMethod);
-        self::assertSame([], $structured->technical->flashPix->streams);
+        self::assertSame('Canon', $structured->camera()->camera()->make);
+        self::assertSame('EOS R6 II', $structured->camera()->camera()->model);
+        self::assertSame('Jane Doe', $structured->rights()->author->artist);
+        self::assertSame('Jane Owner', $structured->rights()->author->ownerName);
+        self::assertSame('Jane Doe 2024', $structured->rights()->rights()->copyright);
+        self::assertSame('Restricted', $structured->rights()->rights()->securityClassification);
+        self::assertSame('1.2.3', $structured->camera()->camera()->firmware);
+        self::assertSame(FileSource::DIGITAL_CAMERA, $structured->camera()->camera()->fileSource);
+        self::assertSame(SensingMethod::ONE_CHIP_COLOR_AREA, $structured->camera()->camera()->sensingMethod);
+        self::assertSame([], $structured->technical()->flashPix->streams);
 
-        self::assertSame('EF 85mm f/1.4L', $structured->lens->lens()->lensModel);
-        self::assertSame(85.0, $structured->lens->lens()->focalLengthMm);
-        self::assertSame(85, $structured->lens->equivalent35mm());
-        self::assertSame([35.0, 4.0, 150.0, 5.6], $structured->lens->lens()->lensSpecification);
-        self::assertEqualsWithDelta(1.9965, $structured->lens->lens()->maxApertureFNumber, 0.001);
+        self::assertSame('EF 85mm f/1.4L', $structured->lens()->lens()->lensModel);
+        self::assertSame(85.0, $structured->lens()->lens()->focalLengthMm);
+        self::assertSame(85, $structured->lens()->equivalent35mm());
+        self::assertSame([35.0, 4.0, 150.0, 5.6], $structured->lens()->lens()->lensSpecification);
+        self::assertEqualsWithDelta(1.9965, $structured->lens()->lens()->maxApertureFNumber, 0.001);
 
-        self::assertEqualsWithDelta(43.09095238095239, $structured->lens->derived()->hyperfocalM, 1e-6);
-        self::assertEqualsWithDelta(28.558322, $structured->lens->derived()->fovDiagonalDeg, 1e-6);
-        self::assertEqualsWithDelta(23.913168, $structured->lens->derived()->fovHorizontalDeg, 1e-6);
-        self::assertEqualsWithDelta(16.071421, $structured->lens->derived()->fovVerticalDeg, 1e-6);
-        self::assertEqualsWithDelta(1.0, $structured->lens->derived()->cropFactor, 1e-6);
+        self::assertEqualsWithDelta(43.09095238095239, $structured->lens()->derived()->hyperfocalDistanceMetres(), 1e-6);
+        self::assertEqualsWithDelta(28.558322, $structured->lens()->derived()->fieldOfViewDiagonalDeg(), 1e-6);
+        self::assertEqualsWithDelta(23.913168, $structured->lens()->derived()->fieldOfViewHorizontalDeg(), 1e-6);
+        self::assertEqualsWithDelta(16.071421, $structured->lens()->derived()->fieldOfViewVerticalDeg(), 1e-6);
+        self::assertEqualsWithDelta(1.0, $structured->lens()->derived()->cropFactor, 1e-6);
 
-        self::assertSame(6720, $structured->media->image->width);
-        self::assertSame(4480, $structured->media->image->height);
-        self::assertSame(Orientation::RIGHT_TOP, $structured->media->image->orientation);
-        self::assertSame(ColorSpace::SRGB, $structured->media->image->colorSpace);
-        self::assertSame(128, $structured->media->image->imageNumber);
-        self::assertSame('Sunset Title', $structured->media->image->documentName);
-        self::assertSame('Sunset over Alps', $structured->media->image->description);
-        self::assertSame('Sunset Title', $structured->media->image->title);
-        self::assertSame([1, 2, 3, 0], $structured->media->image->componentsConfiguration);
-        self::assertSame(4.5, $structured->media->image->compressedBitsPerPixel);
-        self::assertSame(1, $structured->media->image->interlace);
-        self::assertSame('Shot with ND filter', $structured->media->image->userComment);
-        self::assertSame('ASCII', $structured->media->image->userCommentEncoding);
-        self::assertSame('Developed in Raw Studio', $structured->file->integrity->imageHistory);
-        self::assertTrue($structured->file->integrity->makerNotesSafe);
-        self::assertTrue($structured->media->preview->hasThumbnail);
-        self::assertTrue($structured->media->preview->hasPreview);
-        self::assertSame(2_048, $structured->media->preview->previewWidth);
-        self::assertSame(1_152, $structured->media->preview->previewHeight);
-        self::assertSame(ColorSpace::ADOBE_RGB, $structured->media->preview->previewColorSpace);
-        self::assertSame(12, $structured->media->preview->previewBitDepth);
-        self::assertSame(Compression::JPEG, $structured->media->preview->previewCompression);
-        self::assertSame(1.0, $structured->media->preview->previewScale);
-        self::assertSame('JPEG', $structured->media->preview->previewEncoding);
-        self::assertSame('image/jpeg', $structured->media->preview->previewMimeType);
-        self::assertSame(131_072, $structured->media->preview->previewOffset);
-        self::assertSame(65_536, $structured->media->preview->previewLength);
+        self::assertSame(6720, $structured->media()->image->width);
+        self::assertSame(4480, $structured->media()->image->height);
+        self::assertSame(Orientation::RIGHT_TOP, $structured->media()->image->orientation);
+        self::assertSame(ColorSpace::SRGB, $structured->media()->image->colorSpace);
+        self::assertSame(128, $structured->media()->image->imageNumber);
+        self::assertSame('Sunset Title', $structured->media()->image->documentName);
+        self::assertSame('Sunset over Alps', $structured->media()->image->description);
+        self::assertSame('Sunset Title', $structured->media()->image->title);
+        self::assertSame([1, 2, 3, 0], $structured->media()->image->componentsConfiguration);
+        self::assertSame(4.5, $structured->media()->image->compressedBitsPerPixel);
+        self::assertSame(1, $structured->media()->image->interlace);
+        self::assertSame('Shot with ND filter', $structured->media()->image->userComment);
+        self::assertSame('ASCII', $structured->media()->image->userCommentEncoding);
+        self::assertSame('Developed in Raw Studio', $structured->file()->integrity->imageHistory);
+        self::assertTrue($structured->file()->integrity->makerNotesSafe);
+        self::assertTrue($structured->media()->preview->hasThumbnail);
+        self::assertTrue($structured->media()->preview->hasPreview);
+        self::assertSame(2_048, $structured->media()->preview->previewWidth);
+        self::assertSame(1_152, $structured->media()->preview->previewHeight);
+        self::assertSame(ColorSpace::ADOBE_RGB, $structured->media()->preview->previewColorSpace);
+        self::assertSame(12, $structured->media()->preview->previewBitDepth);
+        self::assertSame(Compression::JPEG, $structured->media()->preview->previewCompression);
+        self::assertSame(1.0, $structured->media()->preview->previewScale);
+        self::assertSame('JPEG', $structured->media()->preview->previewEncoding);
+        self::assertSame('image/jpeg', $structured->media()->preview->previewMimeType);
+        self::assertSame(131_072, $structured->media()->preview->previewOffset);
+        self::assertSame(65_536, $structured->media()->preview->previewLength);
 
-        self::assertSame(400, $structured->exposure->exposure->iso);
-        self::assertSame(0.008, $structured->exposure->exposure->exposureTimeSec);
-        self::assertSame(5.6, $structured->exposure->exposure->fNumber);
-        self::assertSame(-2.0, $structured->exposure->exposure->exposureBiasEv);
-        self::assertEqualsWithDelta(6.97, $structured->exposure->exposure->shutterSpeedEv, 0.01);
-        self::assertEqualsWithDelta(4.97, $structured->exposure->exposure->apertureEv, 0.01);
-        self::assertSame(ExposureProgram::APERTURE_PRIORITY, $structured->exposure->exposure->program);
-        self::assertSame(MeteringMode::PATTERN, $structured->exposure->exposure->meteringMode);
-        self::assertSame(WhiteBalance::MANUAL, $structured->exposure->exposure->whiteBalance);
-        self::assertSame(GainControl::LOW_GAIN_UP, $structured->exposure->exposure->gainControl);
-        self::assertSame(Contrast::SOFT, $structured->exposure->exposure->contrast);
-        self::assertSame(Saturation::NORMAL, $structured->exposure->exposure->saturation);
-        self::assertSame(Sharpness::HARD, $structured->exposure->exposure->sharpness);
-        self::assertSame(320, $structured->exposure->exposure->isoLatitudeYyy);
-        self::assertSame(540, $structured->exposure->exposure->isoLatitudeZzz);
-        self::assertSame(400.0, $structured->exposure->exposure->exposureIndex);
-        self::assertSame(25.0, $structured->exposure->exposure->flashEnergy);
+        self::assertSame(400, $structured->exposure()->exposure->iso);
+        self::assertSame(0.008, $structured->exposure()->exposure->exposureTimeSec);
+        self::assertSame(5.6, $structured->exposure()->exposure->fNumber);
+        self::assertSame(-2.0, $structured->exposure()->exposure->exposureBiasEv);
+        self::assertEqualsWithDelta(6.97, $structured->exposure()->exposure->shutterSpeedEv, 0.01);
+        self::assertEqualsWithDelta(4.97, $structured->exposure()->exposure->apertureEv, 0.01);
+        self::assertSame(ExposureProgram::APERTURE_PRIORITY, $structured->exposure()->exposure->program);
+        self::assertSame(MeteringMode::PATTERN, $structured->exposure()->exposure->meteringMode);
+        self::assertSame(WhiteBalance::MANUAL, $structured->exposure()->exposure->whiteBalance);
+        self::assertSame(GainControl::LOW_GAIN_UP, $structured->exposure()->exposure->gainControl);
+        self::assertSame(Contrast::SOFT, $structured->exposure()->exposure->contrast);
+        self::assertSame(Saturation::NORMAL, $structured->exposure()->exposure->saturation);
+        self::assertSame(Sharpness::HARD, $structured->exposure()->exposure->sharpness);
+        self::assertSame(320, $structured->exposure()->exposure->isoLatitudeYyy);
+        self::assertSame(540, $structured->exposure()->exposure->isoLatitudeZzz);
+        self::assertSame(400.0, $structured->exposure()->exposure->exposureIndex);
+        self::assertSame(25.0, $structured->exposure()->exposure->flashEnergy);
 
-        $flash = $structured->exposure->exposure->flash;
+        $flash = $structured->exposure()->exposure->flash;
         self::assertNotNull($flash);
         self::assertTrue($flash->fired);
 
-        self::assertSame(SceneCaptureType::STANDARD, $structured->capture->scene->type);
-        self::assertSame(SceneType::DIRECTLY_PHOTOGRAPHED_IMAGE, $structured->capture->scene->sceneType);
-        self::assertSame(SubjectDistanceRange::DISTANT, $structured->capture->scene->subjectDistanceRange);
+        self::assertSame(SceneCaptureType::STANDARD, $structured->capture()->scene->type);
+        self::assertSame(SceneType::DIRECTLY_PHOTOGRAPHED_IMAGE, $structured->capture()->scene->sceneType);
+        self::assertSame(SubjectDistanceRange::DISTANT, $structured->capture()->scene->subjectDistanceRange);
 
-        self::assertSame('3.00', $structured->technical->standards->exifVersion);
-        self::assertSame('3.0', $structured->technical->standards->profile);
-        self::assertSame('1.00', $structured->technical->standards->flashpixVersion);
-        self::assertSame([1, 0, 0, 0], $structured->technical->standards->tiffEpStandardId);
-        self::assertSame('1.0.0.0', $structured->technical->standards->tiffEpStandardString);
+        self::assertSame('3.00', $structured->technical()->standards->exifVersion);
+        self::assertSame('3.0', $structured->technical()->standards->profile);
+        self::assertSame('1.00', $structured->technical()->standards->flashpixVersion);
+        self::assertSame([1, 0, 0, 0], $structured->technical()->standards->tiffEpStandardId);
+        self::assertSame('1.0.0.0', $structured->technical()->standards->tiffEpStandardString);
 
-        self::assertEqualsWithDelta(1.9965, $structured->lens->lens()->maxApertureFNumber, 0.001);
+        self::assertEqualsWithDelta(1.9965, $structured->lens()->lens()->maxApertureFNumber, 0.001);
 
-        self::assertEqualsWithDelta(21.5, $structured->capture->details->temperatureC, 0.001);
-        self::assertEqualsWithDelta(82.0, $structured->capture->details->batteryLevelPercent, 0.001);
-        self::assertEqualsWithDelta(60.0, $structured->capture->details->humidityPercent, 0.001);
-        self::assertEqualsWithDelta(1013.25, $structured->capture->details->pressureHPa, 0.001);
-        self::assertEqualsWithDelta(15.0, $structured->capture->details->waterDepthM, 0.001);
-        self::assertEqualsWithDelta(9.8, $structured->capture->details->accelerationMs2, 0.001);
-        self::assertEqualsWithDelta(15.0, $structured->capture->details->cameraElevationAngleDeg, 0.001);
-        self::assertSame(10, $structured->capture->details->selfTimerModeSeconds);
-        self::assertSame('DJI', $structured->sensor->uav->manufacturer);
-        self::assertSame('Mavic 3', $structured->sensor->uav->model);
-        self::assertEqualsWithDelta(12.3, $structured->sensor->uav->flightYaw ?? 0.0, 0.0001);
-        self::assertEqualsWithDelta(-3.5, $structured->sensor->uav->flightPitch ?? 0.0, 0.0001);
-        self::assertEqualsWithDelta(2.0, $structured->sensor->uav->flightRoll ?? 0.0, 0.0001);
-        self::assertEqualsWithDelta(21.0, $structured->sensor->uav->gimbalYaw ?? 0.0, 0.0001);
-        self::assertEqualsWithDelta(-11.0, $structured->sensor->uav->gimbalPitch ?? 0.0, 0.0001);
-        self::assertEqualsWithDelta(0.5, $structured->sensor->uav->gimbalRoll ?? 0.0, 0.0001);
-        $motionRoll  = $structured->sensor->motion->rollDeg;
-        $motionPitch = $structured->sensor->motion->pitchDeg;
-        $motionYaw   = $structured->sensor->motion->yawDeg;
+        self::assertEqualsWithDelta(21.5, $structured->capture()->details->temperatureC, 0.001);
+        self::assertEqualsWithDelta(82.0, $structured->capture()->details->batteryLevelPercent, 0.001);
+        self::assertEqualsWithDelta(60.0, $structured->capture()->details->humidityPercent, 0.001);
+        self::assertEqualsWithDelta(1013.25, $structured->capture()->details->pressureHPa, 0.001);
+        self::assertEqualsWithDelta(15.0, $structured->capture()->details->waterDepthM, 0.001);
+        self::assertEqualsWithDelta(9.8, $structured->capture()->details->accelerationMs2, 0.001);
+        self::assertEqualsWithDelta(15.0, $structured->capture()->details->cameraElevationAngleDeg, 0.001);
+        self::assertSame(10, $structured->capture()->details->selfTimerModeSeconds);
+        self::assertSame('DJI', $structured->sensor()->uav->manufacturer);
+        self::assertSame('Mavic 3', $structured->sensor()->uav->model);
+        self::assertEqualsWithDelta(12.3, $structured->sensor()->uav->flightYaw ?? 0.0, 0.0001);
+        self::assertEqualsWithDelta(-3.5, $structured->sensor()->uav->flightPitch ?? 0.0, 0.0001);
+        self::assertEqualsWithDelta(2.0, $structured->sensor()->uav->flightRoll ?? 0.0, 0.0001);
+        self::assertEqualsWithDelta(21.0, $structured->sensor()->uav->gimbalYaw ?? 0.0, 0.0001);
+        self::assertEqualsWithDelta(-11.0, $structured->sensor()->uav->gimbalPitch ?? 0.0, 0.0001);
+        self::assertEqualsWithDelta(0.5, $structured->sensor()->uav->gimbalRoll ?? 0.0, 0.0001);
+        $motionRoll  = $structured->sensor()->motion->rollDeg;
+        $motionPitch = $structured->sensor()->motion->pitchDeg;
+        $motionYaw   = $structured->sensor()->motion->yawDeg;
         self::assertNotNull($motionRoll);
         self::assertNotNull($motionPitch);
         self::assertNotNull($motionYaw);
@@ -399,10 +399,10 @@ final class ExifAssemblerTest extends TestCase
         self::assertEqualsWithDelta(-3.5, $motionPitch, 0.0001);
         self::assertEqualsWithDelta(12.3, $motionYaw, 0.0001);
 
-        self::assertSame('sound.wav', $structured->rights->related->relatedSoundFile);
+        self::assertSame('sound.wav', $structured->rights()->related->relatedSoundFile);
 
-        self::assertSame('Standard Spectral', $structured->sensor->hardware->spectralSensitivity);
-        $sensorOecf = $structured->sensor->hardware->oecf;
+        self::assertSame('Standard Spectral', $structured->sensor()->hardware->spectralSensitivity);
+        $sensorOecf = $structured->sensor()->hardware->oecf;
         self::assertNotNull($sensorOecf);
         self::assertSame($oecfPayload, $sensorOecf['payload']);
         $sensorOecfMatrix = $sensorOecf['matrix'];
@@ -413,7 +413,7 @@ final class ExifAssemblerTest extends TestCase
         self::assertEqualsWithDelta(0.2, $sensorOecfMatrix['values'][0][1] ?? 0.0, 0.0001);
         self::assertEqualsWithDelta(0.3, $sensorOecfMatrix['values'][1][0] ?? 0.0, 0.0001);
         self::assertEqualsWithDelta(0.4, $sensorOecfMatrix['values'][1][1] ?? 0.0, 0.0001);
-        $sensorSfr = $structured->sensor->hardware->spatialFrequencyResponse;
+        $sensorSfr = $structured->sensor()->hardware->spatialFrequencyResponse;
         self::assertNotNull($sensorSfr);
         self::assertSame(['10lp/mm', '20lp/mm', '40lp/mm'], $sensorSfr['labels']['columns']);
         self::assertSame(['Luminance', 'Chrominance'], $sensorSfr['labels']['rows']);
@@ -423,36 +423,36 @@ final class ExifAssemblerTest extends TestCase
         self::assertEqualsWithDelta(0.85, $sensorSfr['values'][1][0] ?? 0.0, 0.0001);
         self::assertEqualsWithDelta(0.7, $sensorSfr['values'][1][1] ?? 0.0, 0.0001);
         self::assertEqualsWithDelta(0.55, $sensorSfr['values'][1][2] ?? 0.0, 0.0001);
-        self::assertSame(8, $structured->sensor->hardware->cfaWidth);
-        self::assertSame(6, $structured->sensor->hardware->cfaHeight);
-        self::assertSame([2, 1, 1, 0], $structured->sensor->hardware->cfaPattern);
-        self::assertEqualsWithDelta(43.21, $structured->sensor->hardware->focalPlaneXResolution, 0.001);
-        self::assertEqualsWithDelta(43.0, $structured->sensor->hardware->focalPlaneYResolution, 0.001);
-        self::assertSame(ResolutionUnit::CENTIMETER, $structured->sensor->hardware->focalPlaneResolutionUnit);
+        self::assertSame(8, $structured->sensor()->hardware->cfaWidth);
+        self::assertSame(6, $structured->sensor()->hardware->cfaHeight);
+        self::assertSame([2, 1, 1, 0], $structured->sensor()->hardware->cfaPattern);
+        self::assertEqualsWithDelta(43.21, $structured->sensor()->hardware->focalPlaneXResolution, 0.001);
+        self::assertEqualsWithDelta(43.0, $structured->sensor()->hardware->focalPlaneYResolution, 0.001);
+        self::assertSame(ResolutionUnit::CENTIMETER, $structured->sensor()->hardware->focalPlaneResolutionUnit);
 
-        self::assertSame(Sharpness::HARD, $structured->processing->settings->sharpness);
-        self::assertSame(Contrast::SOFT, $structured->processing->settings->contrast);
-        self::assertSame(Saturation::NORMAL, $structured->processing->settings->saturation);
-        self::assertSame('Profile:Portrait', $structured->processing->settings->deviceSettingDescription);
-        self::assertSame(1, $structured->processing->settings->customRendered);
-        self::assertSame('ImageMeta Studio', $structured->processing->settings->processingSoftware);
-        self::assertEqualsWithDelta(45.6, $structured->processing->settings->noiseReduction, 0.0001);
+        self::assertSame(Sharpness::HARD, $structured->processing()->settings->sharpness);
+        self::assertSame(Contrast::SOFT, $structured->processing()->settings->contrast);
+        self::assertSame(Saturation::NORMAL, $structured->processing()->settings->saturation);
+        self::assertSame('Profile:Portrait', $structured->processing()->settings->deviceSettingDescription);
+        self::assertSame(1, $structured->processing()->settings->customRendered);
+        self::assertSame('ImageMeta Studio', $structured->processing()->settings->processingSoftware);
+        self::assertEqualsWithDelta(45.6, $structured->processing()->settings->noiseReduction, 0.0001);
 
-        self::assertSame('Jane D. Photographer', $structured->rights->author->photographer);
-        self::assertSame('John Editor', $structured->rights->author->imageEditor);
+        self::assertSame('Jane D. Photographer', $structured->rights()->author->photographer);
+        self::assertSame('John Editor', $structured->rights()->author->imageEditor);
 
-        self::assertSame('Raw Studio', $structured->camera->device->rawDevelopingSoftware);
-        self::assertSame('Image Studio', $structured->camera->device->imageEditingSoftware);
-        self::assertSame('Metadata Studio', $structured->camera->device->metadataEditingSoftware);
+        self::assertSame('Raw Studio', $structured->camera()->device->rawDevelopingSoftware);
+        self::assertSame('Image Studio', $structured->camera()->device->imageEditingSoftware);
+        self::assertSame('Metadata Studio', $structured->camera()->device->metadataEditingSoftware);
 
-        self::assertSame('321', $structured->capture->temporal->subSecTime);
-        self::assertSame('123', $structured->capture->temporal->subSecTimeOriginal);
-        self::assertSame('456', $structured->capture->temporal->subSecTimeDigitized);
-        self::assertSame('+01:30', $structured->capture->temporal->offsetTime);
-        self::assertSame('+01:30', $structured->capture->temporal->offsetTimeOriginal);
-        self::assertSame('+01:30', $structured->capture->temporal->offsetTimeDigitized);
-        self::assertSame([-120, -60], $structured->capture->temporal->timeZoneOffsetMinutes);
-        self::assertSame('OffsetTimeOriginal', $structured->capture->temporal->tzSource);
+        self::assertSame('321', $structured->capture()->temporal->subSecTime);
+        self::assertSame('123', $structured->capture()->temporal->subSecTimeOriginal);
+        self::assertSame('456', $structured->capture()->temporal->subSecTimeDigitized);
+        self::assertSame('+01:30', $structured->capture()->temporal->offsetTime);
+        self::assertSame('+01:30', $structured->capture()->temporal->offsetTimeOriginal);
+        self::assertSame('+01:30', $structured->capture()->temporal->offsetTimeDigitized);
+        self::assertSame([-120, -60], $structured->capture()->temporal->timeZoneOffsetMinutes);
+        self::assertSame('OffsetTimeOriginal', $structured->capture()->temporal->tzSource);
     }
 
     #[Test]
@@ -480,7 +480,7 @@ final class ExifAssemblerTest extends TestCase
 
         $structured = (new ExifAssembler())->assemble($metadata);
 
-        $preview = $structured->media->preview;
+        $preview = $structured->media()->preview;
         self::assertTrue($preview->hasThumbnail);
         self::assertTrue($preview->hasPreview);
         self::assertNull($preview->previewCompression);
@@ -519,17 +519,17 @@ final class ExifAssemblerTest extends TestCase
 
         $metadata   = new Metadata(['primary'], null, new ParsedExif($ifd0, $exifIfd, null, null, null));
         $structured = (new ExifAssembler())->assemble($metadata);
-        $temporal   = $structured->capture->temporal;
-        $preview    = $structured->media->preview;
+        $temporal   = $structured->capture()->temporal;
+        $preview    = $structured->media()->preview;
 
-        self::assertSame(400, $structured->exposure->exposure->iso);
+        self::assertSame(400, $structured->exposure()->exposure->iso);
 
         $original = $temporal->original;
         self::assertInstanceOf(DateTimeImmutable::class, $original);
         self::assertSame('2024-05-06T07:08:09+02:00', $original->format(DATE_ATOM));
 
-        self::assertSame('Travel day', $structured->media->image->userComment);
-        self::assertSame('ASCII', $structured->media->image->userCommentEncoding);
+        self::assertSame('Travel day', $structured->media()->image->userComment);
+        self::assertSame('ASCII', $structured->media()->image->userCommentEncoding);
 
         self::assertTrue($preview->hasThumbnail);
         self::assertTrue($preview->hasPreview);
@@ -558,9 +558,9 @@ final class ExifAssemblerTest extends TestCase
 
         $structured = (new ExifAssembler())->assemble($metadata);
 
-        self::assertNull($structured->rights->rights()->copyright);
-        self::assertNull($structured->rights->author->ownerName);
-        self::assertSame('XMP Creator', $structured->rights->author->creator);
+        self::assertNull($structured->rights()->rights()->copyright);
+        self::assertNull($structured->rights()->author->ownerName);
+        self::assertSame('XMP Creator', $structured->rights()->author->creator);
     }
 
     #[Test]
@@ -575,7 +575,7 @@ final class ExifAssemblerTest extends TestCase
 
         $structured = (new ExifAssembler())->assemble($metadata);
 
-        self::assertSame(Orientation::UNKNOWN, $structured->media->image->orientation);
+        self::assertSame(Orientation::UNKNOWN, $structured->media()->image->orientation);
     }
 
     #[Test]
@@ -597,14 +597,14 @@ final class ExifAssemblerTest extends TestCase
         $metadata   = new Metadata(['primary'], $quickTime, $exifDocument);
         $structured = (new ExifAssembler())->assemble($metadata);
 
-        self::assertSame('Parrot', $structured->sensor->uav->manufacturer);
-        self::assertSame('Anafi', $structured->sensor->uav->model);
-        self::assertEqualsWithDelta(72.5, $structured->sensor->uav->flightYaw ?? 0.0, 0.0001);
-        self::assertEqualsWithDelta(-12.0, $structured->sensor->uav->flightPitch ?? 0.0, 0.0001);
-        self::assertEqualsWithDelta(3.2, $structured->sensor->uav->flightRoll ?? 0.0, 0.0001);
-        self::assertEqualsWithDelta(15.4, $structured->sensor->uav->gimbalYaw ?? 0.0, 0.0001);
-        self::assertEqualsWithDelta(-8.6, $structured->sensor->uav->gimbalPitch ?? 0.0, 0.0001);
-        self::assertEqualsWithDelta(1.1, $structured->sensor->uav->gimbalRoll ?? 0.0, 0.0001);
+        self::assertSame('Parrot', $structured->sensor()->uav->manufacturer);
+        self::assertSame('Anafi', $structured->sensor()->uav->model);
+        self::assertEqualsWithDelta(72.5, $structured->sensor()->uav->flightYaw ?? 0.0, 0.0001);
+        self::assertEqualsWithDelta(-12.0, $structured->sensor()->uav->flightPitch ?? 0.0, 0.0001);
+        self::assertEqualsWithDelta(3.2, $structured->sensor()->uav->flightRoll ?? 0.0, 0.0001);
+        self::assertEqualsWithDelta(15.4, $structured->sensor()->uav->gimbalYaw ?? 0.0, 0.0001);
+        self::assertEqualsWithDelta(-8.6, $structured->sensor()->uav->gimbalPitch ?? 0.0, 0.0001);
+        self::assertEqualsWithDelta(1.1, $structured->sensor()->uav->gimbalRoll ?? 0.0, 0.0001);
     }
 
     #[Test]
@@ -625,8 +625,8 @@ final class ExifAssemblerTest extends TestCase
 
         $structured = (new ExifAssembler())->assemble($metadata);
 
-        self::assertNull($structured->sensor->hardware->cfaWidth);
-        self::assertNull($structured->sensor->hardware->cfaHeight);
+        self::assertNull($structured->sensor()->hardware->cfaWidth);
+        self::assertNull($structured->sensor()->hardware->cfaHeight);
     }
 
     #[Test]
@@ -639,7 +639,7 @@ final class ExifAssemblerTest extends TestCase
         $structured = (new ExifAssembler())
             ->assemble(new Metadata(['primary'], null, new ParsedExif($ifd0, null, null, null, null)));
 
-        self::assertSame('Legacy Document', $structured->media->image->documentName);
+        self::assertSame('Legacy Document', $structured->media()->image->documentName);
     }
 
     #[Test]
@@ -656,12 +656,12 @@ final class ExifAssemblerTest extends TestCase
         $structured = (new ExifAssembler())
             ->assemble(new Metadata(['primary'], null, new ParsedExif($ifd0, null, null, null, null)));
 
-        self::assertSame('XP Subject', $structured->media->image->documentName);
-        self::assertSame('XP Title', $structured->media->image->title);
-        self::assertSame('XP Comment', $structured->media->image->description);
-        self::assertSame('XP Author', $structured->rights->author->photographer);
-        self::assertSame('XP Author', $structured->rights->author->imageEditor);
-        self::assertSame(['Alpha', 'Beta'], $structured->capture->keywords->flat);
+        self::assertSame('XP Subject', $structured->media()->image->documentName);
+        self::assertSame('XP Title', $structured->media()->image->title);
+        self::assertSame('XP Comment', $structured->media()->image->description);
+        self::assertSame('XP Author', $structured->rights()->author->photographer);
+        self::assertSame('XP Author', $structured->rights()->author->imageEditor);
+        self::assertSame(['Alpha', 'Beta'], $structured->capture()->keywords->flat);
     }
 
     /**
@@ -693,11 +693,11 @@ final class ExifAssemblerTest extends TestCase
 
         $structured = (new ExifAssembler())->assemble($metadata);
 
-        self::assertSame('image/jpeg', $structured->file->file()->mimeType);
-        self::assertSame(54321, $structured->file->file()->fileSize);
-        self::assertSame('jpg', $structured->file->file()->extension);
-        self::assertSame('sha1-digest', $structured->file->file()->digestSha1);
-        self::assertSame('md5-digest', $structured->file->file()->digestMd5);
+        self::assertSame('image/jpeg', $structured->file()->file()->mimeType);
+        self::assertSame(54321, $structured->file()->file()->fileSize);
+        self::assertSame('jpg', $structured->file()->file()->extension);
+        self::assertSame('sha1-digest', $structured->file()->file()->digestSha1);
+        self::assertSame('md5-digest', $structured->file()->file()->digestMd5);
     }
 
     /**
@@ -711,7 +711,7 @@ final class ExifAssemblerTest extends TestCase
 
         $metadata   = new Metadata([$blob], null, $document);
         $structured = (new ExifAssembler())->assemble($metadata);
-        $standards  = $structured->technical->standards;
+        $standards  = $structured->technical()->standards;
 
         self::assertSame('2.32', $standards->exifVersion);
         self::assertSame('1.00', $standards->flashpixVersion);
@@ -765,8 +765,8 @@ final class ExifAssemblerTest extends TestCase
 
         $structured = (new ExifAssembler())->assemble($metadata);
 
-        self::assertSame(CompositeImage::GENERAL_COMPOSITE, $structured->media->composite->type);
-        self::assertSame([9, 4], $structured->media->composite->counts);
+        self::assertSame(CompositeImage::GENERAL_COMPOSITE, $structured->media()->composite->type);
+        self::assertSame([9, 4], $structured->media()->composite->counts);
         $expectedCompositeExposureTimes = [
             0.008333333333333333,
             0.016666666666666666,
@@ -774,7 +774,7 @@ final class ExifAssemblerTest extends TestCase
             0.06666666666666667,
         ];
 
-        $compositeExposureTimes = $structured->media->composite->exposureTimesTotal;
+        $compositeExposureTimes = $structured->media()->composite->exposureTimesTotal;
         self::assertNotNull($compositeExposureTimes);
         self::assertCount(count($expectedCompositeExposureTimes), $compositeExposureTimes);
 
@@ -786,15 +786,15 @@ final class ExifAssemblerTest extends TestCase
             );
         }
 
-        self::assertSame('iOS 17.3', $structured->camera->device->software);
+        self::assertSame('iOS 17.3', $structured->camera()->device->software);
 
-        self::assertTrue($structured->capture->scene->hdrScene);
-        self::assertTrue($structured->capture->scene->nightMode);
+        self::assertTrue($structured->capture()->scene->hdrScene);
+        self::assertTrue($structured->capture()->scene->nightMode);
 
-        self::assertSame('3.0', $structured->technical->standards->profile);
+        self::assertSame('3.0', $structured->technical()->standards->profile);
 
-        self::assertSame('OffsetTimeOriginal', $structured->capture->temporal->tzSource);
-        $originalCaptureTime = $structured->capture->temporal->original;
+        self::assertSame('OffsetTimeOriginal', $structured->capture()->temporal->tzSource);
+        $originalCaptureTime = $structured->capture()->temporal->original;
         self::assertInstanceOf(DateTimeImmutable::class, $originalCaptureTime);
         self::assertSame('+01:00', $originalCaptureTime->format('P'));
     }
@@ -823,7 +823,7 @@ final class ExifAssemblerTest extends TestCase
 
         $structured = (new ExifAssembler())->assemble($metadata);
 
-        self::assertSame('ImageMeta Studio', $structured->camera->device->software);
+        self::assertSame('ImageMeta Studio', $structured->camera()->device->software);
     }
 
     #[Test]
@@ -849,7 +849,7 @@ final class ExifAssemblerTest extends TestCase
 
         $structured = (new ExifAssembler())->assemble($metadata);
 
-        self::assertSame('PowerMac G4', $structured->camera->device->software);
+        self::assertSame('PowerMac G4', $structured->camera()->device->software);
     }
 
     #[Test]
@@ -866,7 +866,7 @@ final class ExifAssemblerTest extends TestCase
         $metadata   = new Metadata(['primary'], $quickTime, $exifDocument);
         $structured = (new ExifAssembler())->assemble($metadata);
 
-        self::assertSame('QuickTime Studio', $structured->camera->device->software);
+        self::assertSame('QuickTime Studio', $structured->camera()->device->software);
     }
 
     /**
@@ -937,7 +937,7 @@ final class ExifAssemblerTest extends TestCase
         $metadata   = new Metadata(['primary'], $quickTime, $exifDocument, [], null, $makerNotes);
         $structured = (new ExifAssembler())->assemble($metadata);
 
-        $apple = $this->assertAppleMakerNotes($structured->makerNotes->apple);
+        $apple = $this->assertAppleMakerNotes($structured->makerNotes()->apple);
         self::assertSame($appleMakerNotes, $apple);
 
         self::assertSame('maker-content', $apple->contentIdentifier);
@@ -983,15 +983,15 @@ final class ExifAssemblerTest extends TestCase
         self::assertSame(100, $runTime->value);
         self::assertSame(9, $runTime->flags);
 
-        self::assertSame(4300, $structured->processing->whiteBalance->kelvin);
-        self::assertNull($structured->sensor->motion->rollDeg);
-        self::assertNull($structured->sensor->motion->pitchDeg);
-        self::assertNull($structured->sensor->motion->yawDeg);
-        self::assertEqualsWithDelta(0.05, $structured->sensor->motion->accelX, 1e-12);
-        self::assertEqualsWithDelta(0.1, $structured->sensor->motion->accelY, 1e-12);
-        self::assertEqualsWithDelta(-0.1, $structured->sensor->motion->accelZ, 1e-12);
-        self::assertFalse($structured->capture->scene->nightMode);
-        self::assertFalse($structured->file->integrity->makerNotesSafe);
+        self::assertSame(4300, $structured->processing()->whiteBalance->kelvin);
+        self::assertNull($structured->sensor()->motion->rollDeg);
+        self::assertNull($structured->sensor()->motion->pitchDeg);
+        self::assertNull($structured->sensor()->motion->yawDeg);
+        self::assertEqualsWithDelta(0.05, $structured->sensor()->motion->accelX, 1e-12);
+        self::assertEqualsWithDelta(0.1, $structured->sensor()->motion->accelY, 1e-12);
+        self::assertEqualsWithDelta(-0.1, $structured->sensor()->motion->accelZ, 1e-12);
+        self::assertFalse($structured->capture()->scene->nightMode);
+        self::assertFalse($structured->file()->integrity->makerNotesSafe);
     }
 
     #[Test]
@@ -1021,7 +1021,7 @@ final class ExifAssemblerTest extends TestCase
         $metadata   = new Metadata(['primary'], null, null, [], null, $makerNotes);
         $structured = (new ExifAssembler())->assemble($metadata);
 
-        $apple = $this->assertAppleMakerNotes($structured->makerNotes->apple);
+        $apple = $this->assertAppleMakerNotes($structured->makerNotes()->apple);
         self::assertTrue($apple->flags['nightMode']);
         self::assertTrue($apple->flags['longExposure']);
         self::assertTrue($apple->flags['hdrEnabled']);
@@ -1058,11 +1058,11 @@ final class ExifAssemblerTest extends TestCase
         $metadata   = new Metadata(['primary'], null, $exifDocument, []);
         $structured = (new ExifAssembler())->assemble($metadata);
 
-        $apple = $this->assertAppleMakerNotes($structured->makerNotes->apple);
+        $apple = $this->assertAppleMakerNotes($structured->makerNotes()->apple);
         self::assertNull($apple->accelerationVector);
-        self::assertEqualsWithDelta(-3.0, $structured->sensor->motion->accelX, 1e-12);
-        self::assertEqualsWithDelta(4.0, $structured->sensor->motion->accelY, 1e-12);
-        self::assertEqualsWithDelta(0.5, $structured->sensor->motion->accelZ, 1e-12);
+        self::assertEqualsWithDelta(-3.0, $structured->sensor()->motion->accelX, 1e-12);
+        self::assertEqualsWithDelta(4.0, $structured->sensor()->motion->accelY, 1e-12);
+        self::assertEqualsWithDelta(0.5, $structured->sensor()->motion->accelZ, 1e-12);
     }
 
     /**
@@ -1089,12 +1089,12 @@ final class ExifAssemblerTest extends TestCase
         $metadata   = new Metadata(['primary'], null, $exifDocument, []);
         $structured = (new ExifAssembler())->assemble($metadata);
 
-        $apple = $this->assertAppleMakerNotes($structured->makerNotes->apple);
+        $apple = $this->assertAppleMakerNotes($structured->makerNotes()->apple);
         self::assertNull($apple->accelerationVector);
 
-        self::assertEqualsWithDelta(0.2, $structured->sensor->motion->accelX, 1e-12);
-        self::assertEqualsWithDelta(-0.3, $structured->sensor->motion->accelY, 1e-12);
-        self::assertEqualsWithDelta(0.35, $structured->sensor->motion->accelZ, 1e-12);
+        self::assertEqualsWithDelta(0.2, $structured->sensor()->motion->accelX, 1e-12);
+        self::assertEqualsWithDelta(-0.3, $structured->sensor()->motion->accelY, 1e-12);
+        self::assertEqualsWithDelta(0.35, $structured->sensor()->motion->accelZ, 1e-12);
     }
 
     /**
@@ -1142,7 +1142,7 @@ final class ExifAssemblerTest extends TestCase
 
         $structured = (new ExifAssembler())->assemble($metadata);
 
-        self::assertSame($nightModeFlag, $structured->capture->scene->nightMode);
+        self::assertSame($nightModeFlag, $structured->capture()->scene->nightMode);
     }
 
     /**
@@ -1195,7 +1195,7 @@ final class ExifAssemblerTest extends TestCase
 
         $structured = (new ExifAssembler())->assemble($metadata);
 
-        self::assertNull($structured->capture->scene->hdrScene);
+        self::assertNull($structured->capture()->scene->hdrScene);
 
         $headroomMakerNotes = new AppleMakerNotes(
             contentIdentifier: null,
@@ -1230,7 +1230,7 @@ final class ExifAssemblerTest extends TestCase
 
         $structuredHeadroom = (new ExifAssembler())->assemble($headroomMetadata);
 
-        self::assertTrue($structuredHeadroom->capture->scene->hdrScene);
+        self::assertTrue($structuredHeadroom->capture()->scene->hdrScene);
 
         $flagMakerNotes = new AppleMakerNotes(
             contentIdentifier: null,
@@ -1265,7 +1265,7 @@ final class ExifAssemblerTest extends TestCase
 
         $structuredFlags = (new ExifAssembler())->assemble($flagMetadata);
 
-        self::assertTrue($structuredFlags->capture->scene->hdrScene);
+        self::assertTrue($structuredFlags->capture()->scene->hdrScene);
     }
 
     /**
@@ -1313,8 +1313,8 @@ final class ExifAssemblerTest extends TestCase
 
         $structured = (new ExifAssembler())->assemble($metadata);
 
-        self::assertTrue($structured->capture->scene->nightMode);
-        self::assertTrue($structured->capture->scene->hdrScene);
+        self::assertTrue($structured->capture()->scene->nightMode);
+        self::assertTrue($structured->capture()->scene->hdrScene);
     }
 
     /**
@@ -1353,7 +1353,7 @@ final class ExifAssemblerTest extends TestCase
 
         $structured = (new ExifAssembler())->assemble($metadata);
 
-        self::assertTrue($structured->capture->scene->hdrScene);
+        self::assertTrue($structured->capture()->scene->hdrScene);
 
         $makerNotesWithFlags = new AppleMakerNotes(
             contentIdentifier: null,
@@ -1385,7 +1385,7 @@ final class ExifAssemblerTest extends TestCase
 
         $structuredFlags = (new ExifAssembler())->assemble($metadataFlags);
 
-        self::assertTrue($structuredFlags->capture->scene->hdrScene);
+        self::assertTrue($structuredFlags->capture()->scene->hdrScene);
     }
 
     /**
@@ -1404,8 +1404,8 @@ final class ExifAssemblerTest extends TestCase
 
         $structured = (new ExifAssembler())->assemble($metadata);
 
-        self::assertSame('2.20', $structured->technical->standards->exifVersion);
-        self::assertSame('2.2', $structured->technical->standards->profile);
+        self::assertSame('2.20', $structured->technical()->standards->exifVersion);
+        self::assertSame('2.2', $structured->technical()->standards->profile);
     }
 
     /**
@@ -1424,8 +1424,8 @@ final class ExifAssemblerTest extends TestCase
 
         $structured = (new ExifAssembler())->assemble($metadata);
 
-        self::assertSame('2.31', $structured->technical->standards->exifVersion);
-        self::assertSame('2.31', $structured->technical->standards->profile);
+        self::assertSame('2.31', $structured->technical()->standards->exifVersion);
+        self::assertSame('2.31', $structured->technical()->standards->profile);
     }
 
     /**
@@ -1446,11 +1446,11 @@ final class ExifAssemblerTest extends TestCase
                 'relatedImageWidth'      => null,
                 'relatedImageLength'     => null,
             ],
-            get_object_vars($structured->technical->interop),
+            get_object_vars($structured->technical()->interop),
         );
-        self::assertNull($structured->technical->tiff->compression);
-        self::assertNull($structured->camera->camera()->make);
-        self::assertSame('2.2', $structured->technical->standards->profile);
+        self::assertNull($structured->technical()->tiff->compression);
+        self::assertNull($structured->camera()->camera()->make);
+        self::assertSame('2.2', $structured->technical()->standards->profile);
     }
 
     /**
@@ -1479,10 +1479,10 @@ final class ExifAssemblerTest extends TestCase
 
         $structured = (new ExifAssembler())->assemble($metadata);
 
-        self::assertNull($structured->camera->camera()->make);
-        self::assertNull($structured->camera->camera()->model);
-        self::assertNull($structured->lens->lens()->lensModel);
-        self::assertNull($structured->media->image->documentName);
+        self::assertNull($structured->camera()->camera()->make);
+        self::assertNull($structured->camera()->camera()->model);
+        self::assertNull($structured->lens()->lens()->lensModel);
+        self::assertNull($structured->media()->image->documentName);
     }
 
     #[Test]
@@ -1509,10 +1509,10 @@ final class ExifAssemblerTest extends TestCase
 
         $structured = (new ExifAssembler())->assemble($metadata);
 
-        self::assertNull($structured->exposure->exposure->iso);
-        self::assertNull($structured->exposure->exposure->exposureTimeSec);
-        self::assertNull($structured->exposure->exposure->fNumber);
-        self::assertNull($structured->capture->details->dateTime);
+        self::assertNull($structured->exposure()->exposure->iso);
+        self::assertNull($structured->exposure()->exposure->exposureTimeSec);
+        self::assertNull($structured->exposure()->exposure->fNumber);
+        self::assertNull($structured->capture()->details->dateTime);
     }
 
     /**
@@ -1552,7 +1552,7 @@ final class ExifAssemblerTest extends TestCase
 
         $structured = (new ExifAssembler())->assemble($metadata);
 
-        self::assertSame($expectedIso, $structured->exposure->exposure->iso);
+        self::assertSame($expectedIso, $structured->exposure()->exposure->iso);
     }
 
     /**
@@ -1575,8 +1575,8 @@ final class ExifAssemblerTest extends TestCase
 
         $structured = (new ExifAssembler())->assemble($metadata);
 
-        self::assertSame('TimeZoneOffset', $structured->capture->temporal->tzSource);
-        $originalCaptureTime = $structured->capture->temporal->original;
+        self::assertSame('TimeZoneOffset', $structured->capture()->temporal->tzSource);
+        $originalCaptureTime = $structured->capture()->temporal->original;
         self::assertInstanceOf(DateTimeImmutable::class, $originalCaptureTime);
         self::assertSame('-02:00', $originalCaptureTime->format('P'));
     }
@@ -1605,11 +1605,11 @@ final class ExifAssemblerTest extends TestCase
 
         $structured = (new ExifAssembler())->assemble($metadata);
 
-        self::assertSame('TimeZoneOffset', $structured->capture->temporal->tzSource);
-        $originalCaptureTime = $structured->capture->temporal->original;
+        self::assertSame('TimeZoneOffset', $structured->capture()->temporal->tzSource);
+        $originalCaptureTime = $structured->capture()->temporal->original;
         self::assertInstanceOf(DateTimeImmutable::class, $originalCaptureTime);
         self::assertSame('+05:30', $originalCaptureTime->format('P'));
-        self::assertSame([330], $structured->capture->temporal->timeZoneOffsetMinutes);
+        self::assertSame([330], $structured->capture()->temporal->timeZoneOffsetMinutes);
     }
 
     /**
@@ -1631,15 +1631,15 @@ final class ExifAssemblerTest extends TestCase
 
         $structured = (new ExifAssembler())->assemble($metadata);
 
-        $originalCaptureTime = $structured->capture->temporal->original;
+        $originalCaptureTime = $structured->capture()->temporal->original;
         self::assertInstanceOf(DateTimeImmutable::class, $originalCaptureTime);
         self::assertSame('2024-07-03T10:11:12+02:30', $originalCaptureTime->format('c'));
-        $timeZone = $structured->capture->temporal->tz;
+        $timeZone = $structured->capture()->temporal->tz;
         self::assertNotNull($timeZone);
         self::assertSame('+02:30', $timeZone->getName());
-        self::assertNull($structured->capture->temporal->subSecTimeOriginal);
-        self::assertSame('987', $structured->capture->temporal->subSecTimeDigitized);
-        self::assertSame('987', $structured->capture->temporal->subSecTime);
+        self::assertNull($structured->capture()->temporal->subSecTimeOriginal);
+        self::assertSame('987', $structured->capture()->temporal->subSecTimeDigitized);
+        self::assertSame('987', $structured->capture()->temporal->subSecTime);
     }
 
     /**
@@ -1661,9 +1661,9 @@ final class ExifAssemblerTest extends TestCase
 
         $structured = (new ExifAssembler())->assemble($metadata);
 
-        self::assertInstanceOf(DateTimeImmutable::class, $structured->capture->temporal->original);
-        self::assertNull($structured->capture->temporal->tz);
-        self::assertNull($structured->capture->temporal->tzSource);
+        self::assertInstanceOf(DateTimeImmutable::class, $structured->capture()->temporal->original);
+        self::assertNull($structured->capture()->temporal->tz);
+        self::assertNull($structured->capture()->temporal->tzSource);
     }
 
     /**
@@ -1687,11 +1687,11 @@ final class ExifAssemblerTest extends TestCase
 
         $structured = (new ExifAssembler())->assemble($metadata);
 
-        self::assertSame(200, $structured->exposure->exposure->iso);
-        self::assertSame(4000, $structured->media->image->width);
-        self::assertSame(3000, $structured->media->image->height);
-        self::assertNull($structured->capture->temporal->tz);
-        self::assertNull($structured->capture->temporal->tzSource);
+        self::assertSame(200, $structured->exposure()->exposure->iso);
+        self::assertSame(4000, $structured->media()->image->width);
+        self::assertSame(3000, $structured->media()->image->height);
+        self::assertNull($structured->capture()->temporal->tz);
+        self::assertNull($structured->capture()->temporal->tzSource);
     }
 
     #[Test]
@@ -1708,7 +1708,7 @@ final class ExifAssemblerTest extends TestCase
 
         $structured = (new ExifAssembler())->assemble($metadata);
 
-        self::assertSame(12_800, $structured->exposure->exposure->iso);
+        self::assertSame(12_800, $structured->exposure()->exposure->iso);
     }
 
     /**
@@ -1727,16 +1727,16 @@ final class ExifAssemblerTest extends TestCase
 
         $structured = (new ExifAssembler())->assemble($metadata);
 
-        self::assertSame(5472, $structured->media->image->width);
-        self::assertSame(3648, $structured->media->image->height);
-        self::assertNull($structured->media->video->width);
-        self::assertNull($structured->media->video->height);
-        self::assertNull($structured->media->video->durationSec);
-        self::assertNull($structured->media->video->frameRate);
-        self::assertNull($structured->media->video->codec);
-        self::assertNull($structured->media->video->hdr);
-        self::assertNull($structured->media->video->transferFunction);
-        self::assertNull($structured->media->video->colorPrimaries);
+        self::assertSame(5472, $structured->media()->image->width);
+        self::assertSame(3648, $structured->media()->image->height);
+        self::assertNull($structured->media()->video->width);
+        self::assertNull($structured->media()->video->height);
+        self::assertNull($structured->media()->video->durationSec);
+        self::assertNull($structured->media()->video->frameRate);
+        self::assertNull($structured->media()->video->codec);
+        self::assertNull($structured->media()->video->hdr);
+        self::assertNull($structured->media()->video->transferFunction);
+        self::assertNull($structured->media()->video->colorPrimaries);
     }
 
     /**
@@ -1754,7 +1754,7 @@ final class ExifAssemblerTest extends TestCase
 
         $structured = (new ExifAssembler())->assemble($metadata);
 
-        self::assertSame(160, $structured->exposure->exposure->iso);
+        self::assertSame(160, $structured->exposure()->exposure->iso);
     }
 
     /**
@@ -1773,8 +1773,8 @@ final class ExifAssemblerTest extends TestCase
 
         $structured = (new ExifAssembler())->assemble($metadata);
 
-        self::assertSame(2048, $structured->media->image->width);
-        self::assertSame(1536, $structured->media->image->height);
+        self::assertSame(2048, $structured->media()->image->width);
+        self::assertSame(1536, $structured->media()->image->height);
     }
 
     /**
@@ -1795,12 +1795,12 @@ final class ExifAssemblerTest extends TestCase
 
         $structured = (new ExifAssembler())->assemble($metadata);
 
-        self::assertSame(320, $structured->exposure->exposure->iso);
-        self::assertSame('TimeZoneOffset', $structured->capture->temporal->tzSource);
-        $originalCaptureTime = $structured->capture->temporal->original;
+        self::assertSame(320, $structured->exposure()->exposure->iso);
+        self::assertSame('TimeZoneOffset', $structured->capture()->temporal->tzSource);
+        $originalCaptureTime = $structured->capture()->temporal->original;
         self::assertInstanceOf(DateTimeImmutable::class, $originalCaptureTime);
         self::assertSame('-01:30', $originalCaptureTime->format('P'));
-        self::assertSame([-90], $structured->capture->temporal->timeZoneOffsetMinutes);
+        self::assertSame([-90], $structured->capture()->temporal->timeZoneOffsetMinutes);
     }
 
     /**
@@ -1830,15 +1830,15 @@ final class ExifAssemblerTest extends TestCase
 
         $structured = (new ExifAssembler())->assemble($metadata);
 
-        self::assertSame('OffsetTimeOriginal', $structured->capture->temporal->tzSource);
-        self::assertSame('+02:30', $structured->capture->temporal->offsetTimeOriginal);
-        self::assertSame('321', $structured->capture->temporal->subSecTime);
-        self::assertSame('654', $structured->capture->temporal->subSecTimeOriginal);
-        self::assertSame('987', $structured->capture->temporal->subSecTimeDigitized);
+        self::assertSame('OffsetTimeOriginal', $structured->capture()->temporal->tzSource);
+        self::assertSame('+02:30', $structured->capture()->temporal->offsetTimeOriginal);
+        self::assertSame('321', $structured->capture()->temporal->subSecTime);
+        self::assertSame('654', $structured->capture()->temporal->subSecTimeOriginal);
+        self::assertSame('987', $structured->capture()->temporal->subSecTimeDigitized);
 
-        self::assertSame(CompositeImage::GENERAL_COMPOSITE, $structured->media->composite->type);
-        self::assertSame([5, 2], $structured->media->composite->counts);
-        $compositeExposureTimes = $structured->media->composite->exposureTimesTotal;
+        self::assertSame(CompositeImage::GENERAL_COMPOSITE, $structured->media()->composite->type);
+        self::assertSame([5, 2], $structured->media()->composite->counts);
+        $compositeExposureTimes = $structured->media()->composite->exposureTimesTotal;
         self::assertNotNull($compositeExposureTimes);
         $expectedExposureTimes = [0.0333333333, 0.0666666666, 0.125];
         self::assertCount(count($expectedExposureTimes), $compositeExposureTimes);
@@ -1865,9 +1865,9 @@ final class ExifAssemblerTest extends TestCase
 
         $structured = (new ExifAssembler())->assemble($metadata);
 
-        self::assertSame('654', $structured->capture->temporal->subSecTime);
-        self::assertSame('123', $structured->capture->temporal->subSecTimeOriginal);
-        self::assertSame('987', $structured->capture->temporal->subSecTimeDigitized);
+        self::assertSame('654', $structured->capture()->temporal->subSecTime);
+        self::assertSame('123', $structured->capture()->temporal->subSecTimeOriginal);
+        self::assertSame('987', $structured->capture()->temporal->subSecTimeDigitized);
     }
 
     /**
@@ -1886,9 +1886,9 @@ final class ExifAssemblerTest extends TestCase
 
         $structured = (new ExifAssembler())->assemble($metadata);
 
-        self::assertSame('957', $structured->capture->temporal->subSecTimeOriginal);
-        self::assertSame('957', $structured->capture->temporal->subSecTimeDigitized);
-        self::assertSame('957', $structured->capture->temporal->subSecTime);
+        self::assertSame('957', $structured->capture()->temporal->subSecTimeOriginal);
+        self::assertSame('957', $structured->capture()->temporal->subSecTimeDigitized);
+        self::assertSame('957', $structured->capture()->temporal->subSecTime);
     }
 
     /**
@@ -1906,9 +1906,9 @@ final class ExifAssemblerTest extends TestCase
 
         $structured = (new ExifAssembler())->assemble($metadata);
 
-        self::assertNull($structured->capture->temporal->subSecTimeOriginal);
-        self::assertSame('957', $structured->capture->temporal->subSecTimeDigitized);
-        self::assertSame('957', $structured->capture->temporal->subSecTime);
+        self::assertNull($structured->capture()->temporal->subSecTimeOriginal);
+        self::assertSame('957', $structured->capture()->temporal->subSecTimeDigitized);
+        self::assertSame('957', $structured->capture()->temporal->subSecTime);
     }
 
     /**
@@ -1935,7 +1935,7 @@ final class ExifAssemblerTest extends TestCase
 
         $structured = (new ExifAssembler())->assemble($metadata);
 
-        self::assertSame(ColorSpace::ADOBE_RGB, $structured->media->image->colorSpace);
+        self::assertSame(ColorSpace::ADOBE_RGB, $structured->media()->image->colorSpace);
     }
 
     /**
@@ -1962,7 +1962,7 @@ final class ExifAssemblerTest extends TestCase
 
         $structured = (new ExifAssembler())->assemble($metadata);
 
-        self::assertSame(ColorSpace::SRGB, $structured->media->image->colorSpace);
+        self::assertSame(ColorSpace::SRGB, $structured->media()->image->colorSpace);
     }
 
     /**
@@ -1980,8 +1980,8 @@ final class ExifAssemblerTest extends TestCase
 
         $structured = (new ExifAssembler())->assemble($metadata);
 
-        self::assertNotNull($structured->lens->lens()->maxApertureFNumber);
-        self::assertEqualsWithDelta(4.0, $structured->lens->lens()->maxApertureFNumber, 0.0001);
+        self::assertNotNull($structured->lens()->lens()->maxApertureFNumber);
+        self::assertEqualsWithDelta(4.0, $structured->lens()->lens()->maxApertureFNumber, 0.0001);
     }
 
     /**
@@ -1995,7 +1995,7 @@ final class ExifAssemblerTest extends TestCase
         $metadata   = new Metadata([], null, null, [], null, null, $icc, []);
         $structured = (new ExifAssembler())->assemble($metadata);
 
-        $profile = $structured->media->colorProfile;
+        $profile = $structured->media()->colorProfile;
         self::assertSame('Test Profile', $profile->profileName);
         self::assertSame('4.2.1', $profile->profileVersion);
         self::assertSame('XYZ ', $profile->pcs);
@@ -2062,7 +2062,7 @@ final class ExifAssemblerTest extends TestCase
         $metadata   = new Metadata(['primary'], null, $document);
         $structured = (new ExifAssembler())->assemble($metadata);
 
-        $profile = $structured->media->colorProfile;
+        $profile = $structured->media()->colorProfile;
         self::assertSame('CameraSig v1.0', $profile->cameraCalibrationSignature);
         self::assertSame('ProfileSig v2', $profile->profileCalibrationSignature);
         self::assertNotNull($profile->hueSatMap);
@@ -2103,10 +2103,10 @@ final class ExifAssemblerTest extends TestCase
 
         $structured = (new ExifAssembler())->assemble($metadata);
 
-        self::assertSame('K', $structured->gps->speedReference());
-        self::assertEqualsWithDelta(33.3333333, $structured->gps->speedMs(), 1e-6);
-        self::assertSame('K', $structured->gps->speedOriginalReference());
-        self::assertEqualsWithDelta(120.0, $structured->gps->speedOriginal(), 1e-6);
+        self::assertSame('K', $structured->gps()->speedReference());
+        self::assertEqualsWithDelta(33.3333333, $structured->gps()->speedMs(), 1e-6);
+        self::assertSame('K', $structured->gps()->speedOriginalReference());
+        self::assertEqualsWithDelta(120.0, $structured->gps()->speedOriginal(), 1e-6);
     }
 
     /**
@@ -2200,51 +2200,51 @@ final class ExifAssemblerTest extends TestCase
 
         $structured = (new ExifAssembler())->assemble($metadata);
 
-        $latitude = $this->assertGpsCoordinate($structured->gps->latitude());
+        $latitude = $this->assertGpsCoordinate($structured->gps()->latitude());
         self::assertSame('N', $latitude->reference());
         self::assertEqualsWithDelta(51.5, $latitude->toFloat(), 1e-6);
 
-        $longitude = $this->assertGpsCoordinate($structured->gps->longitude());
+        $longitude = $this->assertGpsCoordinate($structured->gps()->longitude());
         self::assertSame('E', $longitude->reference());
         self::assertEqualsWithDelta(8.5, $longitude->toFloat(), 1e-6);
-        self::assertSame(0, $structured->gps->altitudeReference());
-        self::assertEqualsWithDelta(150.0, $structured->gps->altitude(), 1e-6);
-        self::assertSame('3.0.0.0', $structured->gps->version());
-        self::assertSame('05', $structured->gps->satellites());
-        self::assertSame('A', $structured->gps->status());
-        self::assertSame('3', $structured->gps->measureMode());
-        self::assertEqualsWithDelta(2.5, $structured->gps->dilutionOfPrecision(), 1e-6);
-        self::assertSame('K', $structured->gps->speedReference());
-        self::assertEqualsWithDelta(20.0, $structured->gps->speedMs(), 1e-6);
-        self::assertSame('K', $structured->gps->speedOriginalReference());
-        self::assertEqualsWithDelta(72.0, $structured->gps->speedOriginal(), 1e-6);
-        self::assertSame('T', $structured->gps->trackReference());
-        self::assertEqualsWithDelta(123.45, $structured->gps->track(), 1e-6);
-        self::assertSame('M', $structured->gps->imageDirectionReference());
-        self::assertEqualsWithDelta(250.0, $structured->gps->imageDirection(), 1e-6);
-        self::assertSame('WGS-84', $structured->gps->mapDatum());
-        $destinationLatitude = $this->assertGpsCoordinate($structured->gps->destinationLatitude());
+        self::assertSame(0, $structured->gps()->altitudeReference());
+        self::assertEqualsWithDelta(150.0, $structured->gps()->altitude(), 1e-6);
+        self::assertSame('3.0.0.0', $structured->gps()->version());
+        self::assertSame('05', $structured->gps()->satellites());
+        self::assertSame('A', $structured->gps()->status());
+        self::assertSame('3', $structured->gps()->measureMode());
+        self::assertEqualsWithDelta(2.5, $structured->gps()->dilutionOfPrecision(), 1e-6);
+        self::assertSame('K', $structured->gps()->speedReference());
+        self::assertEqualsWithDelta(20.0, $structured->gps()->speedMs(), 1e-6);
+        self::assertSame('K', $structured->gps()->speedOriginalReference());
+        self::assertEqualsWithDelta(72.0, $structured->gps()->speedOriginal(), 1e-6);
+        self::assertSame('T', $structured->gps()->trackReference());
+        self::assertEqualsWithDelta(123.45, $structured->gps()->track(), 1e-6);
+        self::assertSame('M', $structured->gps()->imageDirectionReference());
+        self::assertEqualsWithDelta(250.0, $structured->gps()->imageDirection(), 1e-6);
+        self::assertSame('WGS-84', $structured->gps()->mapDatum());
+        $destinationLatitude = $this->assertGpsCoordinate($structured->gps()->destinationLatitude());
         self::assertSame('N', $destinationLatitude->reference());
         self::assertEqualsWithDelta(41.0, $destinationLatitude->toFloat(), 1e-6);
 
-        $destinationLongitude = $this->assertGpsCoordinate($structured->gps->destinationLongitude());
+        $destinationLongitude = $this->assertGpsCoordinate($structured->gps()->destinationLongitude());
         self::assertSame('E', $destinationLongitude->reference());
         self::assertEqualsWithDelta(8.5, $destinationLongitude->toFloat(), 1e-6);
-        self::assertSame('T', $structured->gps->destinationBearingReference());
-        self::assertEqualsWithDelta(123.0, $structured->gps->destinationBearing(), 1e-6);
-        self::assertSame('K', $structured->gps->destinationDistanceReference());
-        self::assertEqualsWithDelta(42000.0, $structured->gps->destinationDistanceMetres(), 1e-6);
-        self::assertSame('K', $structured->gps->destinationDistanceOriginalReference());
-        self::assertEqualsWithDelta(42.0, $structured->gps->destinationDistanceOriginal(), 1e-6);
-        self::assertSame('NETWORK', $structured->gps->processingMethod());
-        self::assertSame('AreaName', $structured->gps->areaInformation());
-        self::assertSame('2024-05-06', $structured->gps->date());
-        self::assertSame('12:34:56.789', $structured->gps->time());
-        $timestamp = $structured->gps->timestamp();
+        self::assertSame('T', $structured->gps()->destinationBearingReference());
+        self::assertEqualsWithDelta(123.0, $structured->gps()->destinationBearing(), 1e-6);
+        self::assertSame('K', $structured->gps()->destinationDistanceReference());
+        self::assertEqualsWithDelta(42000.0, $structured->gps()->destinationDistanceMetres(), 1e-6);
+        self::assertSame('K', $structured->gps()->destinationDistanceOriginalReference());
+        self::assertEqualsWithDelta(42.0, $structured->gps()->destinationDistanceOriginal(), 1e-6);
+        self::assertSame('NETWORK', $structured->gps()->processingMethod());
+        self::assertSame('AreaName', $structured->gps()->areaInformation());
+        self::assertSame('2024-05-06', $structured->gps()->date());
+        self::assertSame('12:34:56.789', $structured->gps()->time());
+        $timestamp = $structured->gps()->timestamp();
         self::assertInstanceOf(DateTimeImmutable::class, $timestamp);
         self::assertSame('2024-05-06T12:34:56+00:00', $timestamp->format(DATE_ATOM));
-        self::assertSame(2, $structured->gps->differential());
-        self::assertEqualsWithDelta(1.5, $structured->gps->horizontalPositioningError(), 1e-6);
+        self::assertSame(2, $structured->gps()->differential());
+        self::assertEqualsWithDelta(1.5, $structured->gps()->horizontalPositioningError(), 1e-6);
     }
 
     /**
@@ -2255,16 +2255,26 @@ final class ExifAssemblerTest extends TestCase
     {
         $structured = (new ExifAssembler())->assemble(new Metadata([], null, null, []));
 
-        foreach (get_object_vars($structured) as $name => $value) {
+        $components = [
+            'file' => $structured->file(),
+            'camera' => $structured->camera(),
+            'lens' => $structured->lens(),
+            'media' => $structured->media(),
+            'exposure' => $structured->exposure(),
+            'capture' => $structured->capture(),
+            'gps' => $structured->gps(),
+            'sensor' => $structured->sensor(),
+            'processing' => $structured->processing(),
+            'technical' => $structured->technical(),
+            'rights' => $structured->rights(),
+            'makerNotes' => $structured->makerNotes(),
+        ];
+
+        foreach ($components as $name => $value) {
             self::assertIsObject($value, sprintf('Expected %s to be an object value object', $name));
 
             foreach (get_object_vars($value) as $field => $fieldValue) {
                 if ($fieldValue === null) {
-                    continue;
-                }
-
-                if ($name === 'standards' && $field === 'profile') {
-                    self::assertSame('2.2', $fieldValue, 'standards::profile should fall back to the default EXIF capability profile');
                     continue;
                 }
 
@@ -2275,11 +2285,11 @@ final class ExifAssemblerTest extends TestCase
 
                 if (is_object($fieldValue)) {
                     foreach (get_object_vars($fieldValue) as $nestedField => $nestedValue) {
-                        if ($name === 'media' && $field === 'multiPicture' && $nestedField === 'imageCount' && $nestedValue === 0) {
+                        if (($name === 'media') && ($field === 'multiPicture') && ($nestedField === 'imageCount') && ($nestedValue === 0)) {
                             continue;
                         }
 
-                        if ($name === 'technical' && $field === 'standards' && $nestedField === 'profile' && $nestedValue === '2.2') {
+                        if (($name === 'technical') && ($field === 'standards') && ($nestedField === 'profile') && ($nestedValue === '2.2')) {
                             continue;
                         }
 
@@ -2295,10 +2305,6 @@ final class ExifAssemblerTest extends TestCase
                         self::fail(sprintf('%s::%s::%s expected null/empty, got %s', $name, $field, $nestedField, var_export($nestedValue, true)));
                     }
 
-                    continue;
-                }
-
-                if ($name === 'multiPicture' && $field === 'imageCount' && $fieldValue === 0) {
                     continue;
                 }
 
@@ -2329,7 +2335,7 @@ final class ExifAssemblerTest extends TestCase
 
         $structured = (new ExifAssembler())->assemble($metadata);
 
-        self::assertSame($flashPix, $structured->technical->flashPix->streams);
+        self::assertSame($flashPix, $structured->technical()->flashPix->streams);
     }
 
     /**
@@ -2360,10 +2366,10 @@ final class ExifAssemblerTest extends TestCase
         $metadata   = new Metadata([], null, null, [], $xmpDocument);
         $structured = (new ExifAssembler())->assemble($metadata);
 
-        self::assertSame(2, $structured->capture->scene->faceCount);
-        self::assertCount(3, $structured->capture->regions->items);
+        self::assertSame(2, $structured->capture()->scene->faceCount);
+        self::assertCount(3, $structured->capture()->regions->items);
 
-        $first = $structured->capture->regions->items[0];
+        $first = $structured->capture()->regions->items[0];
         self::assertSame(RegionType::FACE, $first->type);
         self::assertSame('Alice', $first->personName);
         self::assertSame('101', $first->faceId);
@@ -2372,7 +2378,7 @@ final class ExifAssemblerTest extends TestCase
         self::assertNotNull($first->rotationDeg);
         self::assertEqualsWithDelta(12.5, $first->rotationDeg, 0.0001);
 
-        $third = $structured->capture->regions->items[2];
+        $third = $structured->capture()->regions->items[2];
         self::assertSame(RegionType::FACE, $third->type);
         self::assertSame('Bob', $third->personName);
         self::assertSame('202', $third->faceId);
@@ -2426,10 +2432,10 @@ final class ExifAssemblerTest extends TestCase
 
         $structured = (new ExifAssembler())->assemble($metadata);
 
-        self::assertSame(WhiteBalance::AUTO, $structured->processing->whiteBalance->mode);
-        self::assertSame(5200, $structured->processing->whiteBalance->kelvin);
+        self::assertSame(WhiteBalance::AUTO, $structured->processing()->whiteBalance->mode);
+        self::assertSame(5200, $structured->processing()->whiteBalance->kelvin);
 
-        $apple = $this->assertAppleMakerNotes($structured->makerNotes->apple);
+        $apple = $this->assertAppleMakerNotes($structured->makerNotes()->apple);
         self::assertSame('uuid-123', $apple->contentIdentifier);
         self::assertSame(5200, $apple->colorTemperature);
         self::assertArrayHasKey('hdrEnabled', $apple->flags);
@@ -2457,13 +2463,13 @@ final class ExifAssemblerTest extends TestCase
 
         $structured = (new ExifAssembler())->assemble($metadata);
 
-        self::assertSame('3.00', $structured->technical->standards->exifVersion);
-        self::assertSame('3.0', $structured->technical->standards->profile);
-        self::assertSame('Autumn Sunset', $structured->media->image->title);
-        self::assertNull($structured->camera->camera()->firmware);
-        self::assertSame('Raw Developer X', $structured->camera->device->rawDevelopingSoftware);
-        self::assertSame('Image Editor Y', $structured->camera->device->imageEditingSoftware);
-        self::assertSame('Metadata Tool Z', $structured->camera->device->metadataEditingSoftware);
+        self::assertSame('3.00', $structured->technical()->standards->exifVersion);
+        self::assertSame('3.0', $structured->technical()->standards->profile);
+        self::assertSame('Autumn Sunset', $structured->media()->image->title);
+        self::assertNull($structured->camera()->camera()->firmware);
+        self::assertSame('Raw Developer X', $structured->camera()->device->rawDevelopingSoftware);
+        self::assertSame('Image Editor Y', $structured->camera()->device->imageEditingSoftware);
+        self::assertSame('Metadata Tool Z', $structured->camera()->device->metadataEditingSoftware);
     }
 
     #[Test]
@@ -2494,25 +2500,25 @@ final class ExifAssemblerTest extends TestCase
         $metadata   = new Metadata([], $quickTime);
         $structured = (new ExifAssembler())->assemble($metadata);
 
-        self::assertSame('qt', $structured->file->container->format);
-        self::assertSame('Apple Encoder', $structured->file->container->encoder);
-        self::assertSame(22000000, $structured->file->container->bitrate);
-        self::assertSame('Apple ProRes 422', $structured->file->container->videoCodec);
-        self::assertSame('lpcm', $structured->file->container->audioCodec);
+        self::assertSame('qt', $structured->file()->container->format);
+        self::assertSame('Apple Encoder', $structured->file()->container->encoder);
+        self::assertSame(22000000, $structured->file()->container->bitrate);
+        self::assertSame('Apple ProRes 422', $structured->file()->container->videoCodec);
+        self::assertSame('lpcm', $structured->file()->container->audioCodec);
 
-        self::assertEqualsWithDelta(12.5, $structured->media->video->durationSec, 1e-6);
-        self::assertSame(24.0, $structured->media->video->frameRate);
-        self::assertSame(1920, $structured->media->video->width);
-        self::assertSame(1080, $structured->media->video->height);
-        self::assertSame('Apple ProRes 422', $structured->media->video->codec);
-        self::assertTrue($structured->media->video->hdr);
-        self::assertSame('PQ', $structured->media->video->transferFunction);
-        self::assertSame('BT2020', $structured->media->video->colorPrimaries);
+        self::assertEqualsWithDelta(12.5, $structured->media()->video->durationSec, 1e-6);
+        self::assertSame(24.0, $structured->media()->video->frameRate);
+        self::assertSame(1920, $structured->media()->video->width);
+        self::assertSame(1080, $structured->media()->video->height);
+        self::assertSame('Apple ProRes 422', $structured->media()->video->codec);
+        self::assertTrue($structured->media()->video->hdr);
+        self::assertSame('PQ', $structured->media()->video->transferFunction);
+        self::assertSame('BT2020', $structured->media()->video->colorPrimaries);
 
-        self::assertSame(2, $structured->media->audio->channels);
-        self::assertSame(48000, $structured->media->audio->sampleRate);
-        self::assertSame('lpcm', $structured->media->audio->codec);
-        self::assertSame(24, $structured->media->audio->bitDepth);
+        self::assertSame(2, $structured->media()->audio->channels);
+        self::assertSame(48000, $structured->media()->audio->sampleRate);
+        self::assertSame('lpcm', $structured->media()->audio->codec);
+        self::assertSame(24, $structured->media()->audio->bitDepth);
     }
 
     #[Test]
@@ -2523,9 +2529,9 @@ final class ExifAssemblerTest extends TestCase
 
         $structured = (new ExifAssembler())->assemble($metadata);
 
-        self::assertCount(1, $structured->media->embeddedAudio->clips);
+        self::assertCount(1, $structured->media()->embeddedAudio->clips);
 
-        $clip = $structured->media->embeddedAudio->clips[0];
+        $clip = $structured->media()->embeddedAudio->clips[0];
         self::assertSame('PCM', $clip->format);
         self::assertSame(2, $clip->channels);
         self::assertSame(44_100, $clip->sampleRate);
@@ -2562,8 +2568,8 @@ final class ExifAssemblerTest extends TestCase
 
         $structured = (new ExifAssembler())->assemble($metadata);
 
-        self::assertSame(8, $structured->technical->tiff->bitsPerSample);
-        self::assertSame([2, 2], $structured->technical->tiff->ycbcrSubSampling);
+        self::assertSame(8, $structured->technical()->tiff->bitsPerSample);
+        self::assertSame([2, 2], $structured->technical()->tiff->ycbcrSubSampling);
     }
 
     /**
@@ -2603,7 +2609,7 @@ final class ExifAssemblerTest extends TestCase
         );
 
         $structured   = (new ExifAssembler())->assemble($metadata);
-        $multiPicture = $structured->media->multiPicture;
+        $multiPicture = $structured->media()->multiPicture;
 
         self::assertSame('0100', $multiPicture->version);
         self::assertSame(2, $multiPicture->imageCount);

--- a/tests/MetadataReaderTest.php
+++ b/tests/MetadataReaderTest.php
@@ -91,11 +91,11 @@ final class MetadataReaderTest extends TestCase
         self::assertNull($metadata->digestMd5);
 
         $structured = $metadata->structured();
-        self::assertSame('image/jpeg', $structured->file->file()->mimeType);
-        self::assertSame(strlen($jpeg), $structured->file->file()->fileSize);
-        self::assertSame('jpg', $structured->file->file()->extension);
-        self::assertNull($structured->file->file()->digestSha1);
-        self::assertNull($structured->file->file()->digestMd5);
+        self::assertSame('image/jpeg', $structured->file()->file()->mimeType);
+        self::assertSame(strlen($jpeg), $structured->file()->file()->fileSize);
+        self::assertSame('jpg', $structured->file()->file()->extension);
+        self::assertNull($structured->file()->file()->digestSha1);
+        self::assertNull($structured->file()->file()->digestMd5);
     }
 
     /**
@@ -126,8 +126,8 @@ final class MetadataReaderTest extends TestCase
         self::assertSame($expectedMd5, $metadata->digestMd5);
 
         $structured = $metadata->structured();
-        self::assertSame($expectedSha1, $structured->file->file()->digestSha1);
-        self::assertSame($expectedMd5, $structured->file->file()->digestMd5);
+        self::assertSame($expectedSha1, $structured->file()->file()->digestSha1);
+        self::assertSame($expectedMd5, $structured->file()->file()->digestMd5);
     }
 
     /**
@@ -152,7 +152,7 @@ final class MetadataReaderTest extends TestCase
 
         self::assertSame(8, $metadata->jpegBitsPerSample);
 
-        $image = $metadata->structured()->media->image;
+        $image = $metadata->structured()->media()->image;
 
         self::assertSame(8, $image->bitsPerSample);
         self::assertSame(448, $image->width);

--- a/tests/Support/ExifExpectationAssertions.php
+++ b/tests/Support/ExifExpectationAssertions.php
@@ -96,7 +96,7 @@ trait ExifExpectationAssertions
     private static function assertStructuredMatches(string $fixture, Metadata $metadata, array $expected): void
     {
         $structured        = $metadata->structured();
-        $standards         = $structured->technical->standards;
+        $standards         = $structured->technical()->standards;
         $expectedStandards = $expected['standards'];
 
         Assert::assertSame($expectedStandards['exifVersion'], $standards->exifVersion(), sprintf('%s: EXIF version', $fixture));
@@ -105,9 +105,9 @@ trait ExifExpectationAssertions
         Assert::assertSame($expectedStandards['tiffEpStandardId'], $standards->tiffEpStandardId(), sprintf('%s: TIFF/EP standard ID', $fixture));
         Assert::assertSame($expectedStandards['tiffEpStandardString'], $standards->tiffEpStandardString(), sprintf('%s: TIFF/EP standard string', $fixture));
 
-        Assert::assertSame($expected['exposure']['iso'], $structured->exposure->exposure->iso, sprintf('%s: ISO fallback', $fixture));
+        Assert::assertSame($expected['exposure']['iso'], $structured->exposure()->exposure->iso, sprintf('%s: ISO fallback', $fixture));
 
-        $temporal        = $structured->capture->temporal;
+        $temporal        = $structured->capture()->temporal;
         $expectedCapture = $expected['capture']['dateTimeOriginal'];
         $actualOriginal  = $temporal->original;
         if ($expectedCapture === null) {
@@ -129,11 +129,11 @@ trait ExifExpectationAssertions
             sprintf('%s: SubSecTimeOriginal', $fixture),
         );
 
-        $image = $structured->media->image;
+        $image = $structured->media()->image;
         Assert::assertSame($expected['image']['userComment'], $image->userComment(), sprintf('%s: UserComment fallback', $fixture));
         Assert::assertSame($expected['image']['userCommentEncoding'], $image->userCommentEncoding(), sprintf('%s: UserComment encoding', $fixture));
 
-        $interop         = $structured->technical->interop;
+        $interop         = $structured->technical()->interop;
         $expectedInterop = $expected['interop'];
         Assert::assertSame($expectedInterop['index'], $interop->index(), sprintf('%s: Interop index', $fixture));
         Assert::assertSame($expectedInterop['version'], $interop->version(), sprintf('%s: Interop version', $fixture));
@@ -141,7 +141,7 @@ trait ExifExpectationAssertions
         Assert::assertSame($expectedInterop['width'], $interop->relatedImageWidth(), sprintf('%s: Interop width', $fixture));
         Assert::assertSame($expectedInterop['length'], $interop->relatedImageLength(), sprintf('%s: Interop length', $fixture));
 
-        self::assertPreviewMatches($fixture, $expected['preview'], $structured->media->preview);
+        self::assertPreviewMatches($fixture, $expected['preview'], $structured->media()->preview);
 
         $expectedMaker = $expected['makerNotes'];
         $actualMaker   = $metadata->makerNotes;
@@ -184,7 +184,7 @@ trait ExifExpectationAssertions
 
         Assert::assertSame(
             $expected['sensor']['spatialFrequencyResponse'],
-            $structured->sensor->hardware->spatialFrequencyResponse,
+            $structured->sensor()->hardware->spatialFrequencyResponse,
             sprintf('%s: Spatial frequency response', $fixture),
         );
     }


### PR DESCRIPTION
## Summary
- Added method accessors on `StructuredMetadata` and convenience helpers for image, preview, interop and standards.
- Renamed derived optics helpers to `equivalent35mm`, `fieldOfView*` and `hyperfocalDistanceMetres` while keeping deprecated aliases.
- Updated GPS metadata to prefer `*Reference()` accessors and refreshed docs, scripts and tests for the new naming scheme.

**Issue/Milestone:** Closes #N/A • Milestone M7
**Scope (allowed files only):** src/Curate/**, src/Value/Derived.php, src/Convenience/**, src/Exif/StructuredExif.php, scripts/dump_exif_versions.php, docs/**, tests/**, test-images/TruthComparisonTest.php
**Non-Goals:** Parser feature additions or maker note decoding changes.

---
<!--
PR-Titel-Empfehlung:
M#: <kurze Beschreibung> — <Bereich>
Beispiel: M1: Unify binary readers — Core/Stream
-->

## Summary
<!-- Kurzbeschreibung der Änderung und des Ziels. -->

**Issue/Milestone:** Closes #<ID> • Milestone M#
**Scope (allowed files only):** <!-- Liste der Dateien/Verzeichnisse, die in diesem PR geändert werden dürfen. -->
**Non-Goals:** <!-- Was explizit NICHT Bestandteil ist. -->

---

## Implementation Notes
- Runtime: PHP 8.4, `declare(strict_types=1);`, PSR-12.
- **Streaming only** (Core\Stream/StreamWindow) — keine Ganzdatei-Reads.
- Keine externen Binaries/Extensions; **kein** `exif_read_data()`.
- Value Objects (chainable) nur für EXIF-Ausgabe; kein Rendering.
- **Enums** für gängige Kodierungen genutzt/ergänzt (Encoding/Endianness/IFD/XMP/...).
- **Spec-References** im Code ergänzt/aktualisiert (siehe „References“).

---

## Always Checklist (must be green)
**Composer-Tasks (deine CI-Skripte):**
- [ ] Lint: `composer ci:test:php:lint`
- [ ] PHPStan: `composer ci:test:php:phpstan`
- [ ] Rector (dry-run): `composer ci:test:php:rector`
- [ ] Coding-Style: `composer ci::cgl`
- [x] PHPUnit: `composer ci:test:php:unit`
- [ ] Coverage ≥ **90 %**: `composer ci:test:php:unit:coverage`
- [ ] JSCPD (Duplikate = 0): `composer ci:test:php:cpd`
- [ ] Sammellauf: `composer ci:test` (sollte grün sein; enthält Lint, PHPStan, Rector-Dry-Run, CS-Dry-Run, Unit)

**Inhaltliche/Code-Guidelines:**
- [ ] **Keine** `mixed`-Signaturen • **kein** `empty()` • **keine** verschachtelten Ternaries
- [ ] Fully-qualified native functions (`\strlen`, `\count`, …) und sinnvolle `use`-Imports
- [ ] **Keine** dynamischen Aufrufe statischer Methoden
- [ ] Sinnvolle **Interfaces** verwendet (wo Verträge sinnvoll sind)
- [ ] Typisierte Klassenkonstanten; redundante Casts/Default-Argumente entfernt
- [ ] Klassen als `readonly`, wo passend; keine redundanten `readonly`-Mods
- [ ] **Eine Klasse je Datei** • Test-Namespaces spiegeln `src/`-Struktur
- [ ] Englische PHPDocs & englische Inline-Kommentare an komplexen Stellen
- [ ] Sinnvolle Namen für Variablen/Konstanten; Magic Numbers/Strings vermieden
- [ ] `array_find` / `array_any` / `array_all` gezielt statt trivialer `foreach` verwendet (wo es die Lesbarkeit verbessert)

---

## EXIF / TIFF / ISOBMFF / XMP Guardrails
- **EXIF-Versionen:** 1.x, 2.x (2.1/2.2/2.21/2.3/2.31/2.32), 3.0 — kompatible Änderungen; falls Tags betroffen: Coverage-Test grün.
- **TIFF/BigTIFF:** Endianness korrekt (`0x2A` / `0x2B`), Inline-Werte-Grenzen, `RATIONAL/SRATIONAL` korrekt.
- **GPS:** Vorzeichen über Ref-Tags (S/W negativ); `0/0`-Kantenfälle robust.
- **Preview/IFD1:** Nur beschreiben (Offsets/Längen/Compression), kein Rendering.
- **ISOBMFF/QuickTime:** Box-Size ≥ Header, 32/64-bit-Größen korrekt; `iloc`-Extents summiert; `data_reference_index ≠ 0` → skip; keine Remote-Refs.
- **XMP:** JPEG APP1-Präfix / ISOBMFF `uuid`; Parser mit `LIBXML_NONET`, keine DTD/Entities; `Alt/Bag/Seq` → Arrays.
- **Fehlerbehandlung:** ausschließlich `ParseError` oder `BoundsError`; keine Warnings/Notices als Kontrollfluss.

---

## Tests
- **Neue/angepasste Tests:** Updated structured metadata, GPS and derived metric expectations for the renamed API.
- **Negative Cases:** Existing null-state regression coverage for structured aggregates continues to run.
- **Fixtures/Streams:** Reused existing fixtures (`tests/Fixtures`, `test-images/Fixtures`).

---

## Agent Summary
- Structured metadata now exposes method-based entry points and new convenience accessors.
- Derived metrics and GPS references adopt the milestone naming scheme with deprecated fallbacks.
- Documentation, fixtures and regression tests updated for the fluent API.

---
## M# Sweep — Verify compliance for this milestone
Bitte **alles** verifizieren und kurz die Ergebnisse notieren:
- [ ] `composer ci:test` **grün** (Lint, PHPStan, Rector-Dry-Run, CS-Dry-Run, Unit)
- [ ] `composer ci:test:php:cpd` **0 Duplikate** (JSCPD, Konfig: `.build/.jscpd.json`)
- [ ] `composer ci:test:php:unit:coverage` **≥ 90 %**
- [ ] **ExifCoverageTest** (falls vorhanden): 0 fehlende Tags/Getters (gegen `resources/exif-map.yaml`)
- [ ] Für **jede** Klasse existiert ein Test (Namespace-Spiegelung)

---

## Breaking Changes / Risk / Rollback
- **Breaking changes:** <!-- falls ja: welche und warum notwendig -->
- **Risiken:** <!-- Parser-Sensitivität, Performance, Abhängigkeiten -->
- **Rollback-Plan:** <!-- einfache Revert-Strategie / Feature-Flag falls nötig -->

---

## Changelog
<!-- Kurz und im Stil der Conventional Commits zusammenfassen. -->

---

## References (Specs & Docs)
<!-- Liste der relevanten Kapitel/Abschnitte, jeweils aktuellste Fassung + abweichende ältere, falls relevant -->
- EXIF 3.0 §… ; ggf. EXIF 2.32 §… ; EXIF 2.31 §…
- TIFF 6.0 §…
- ISOBMFF/QuickTime §…
- XMP (Adobe XMP Packet) §…

Docs im Repo:
- `docs/EXIF-210.pdf`, `docs/EXIF-220.pdf`, `docs/EXIF-230.pdf`, `docs/EXIF-231.pdf`, `docs/EXIF-232.pdf`, `docs/EXIF-300.pdf`
- `docs/TIFF6.pdf`

---

## Review Roles (tick what you covered)
- [ ] Planner (Scope/Non-Goals/Guardrails definiert)
- [ ] Spec Writer (AC/Tests präzisiert)
- [ ] Test Agent (RED zuerst)
- [ ] Implementer (GREEN minimal & im Datei-Scope)
- [ ] Static/QA (Stan/CS/Rector/JSCPD clean)
- [ ] Security (Bounds, Offsets, XML-Flags)
- [ ] Reviewer (Minimalität, DX, Spec-Refs, Enums)
- [ ] Release (PR-Text, Labels, Milestone, „Closes #…“)


------
https://chatgpt.com/codex/tasks/task_e_69048d5f5724832385c2c03f6ef42e2c