### PR TITLE
M1: Document structured wrapper removal — Docs

### DIFF
--- a/docs/API-README.md
+++ b/docs/API-README.md
@@ -29,12 +29,12 @@ if ($exposure->program === ExposureProgram::PROGRAM_APERTURE_PRIORITY) {
     echo "Captured in aperture priority mode" . PHP_EOL;
 }
 
-if ($exposure->flash?->fired() === true) {
+if ($exposure->flash?->fired === true) {
     echo "Flash fired" . PHP_EOL;
 }
 
-$whiteBalanceKelvin = $metadata->processing->whiteBalance->kelvin();
-printf("White balance: %s K\n", $whiteBalanceKelvin !== null ? (string) $whiteBalanceKelvin : 'auto');
+$whiteBalance = $metadata->whiteBalance();
+printf("White balance: %s K\n", $whiteBalance->kelvin !== null ? (string) $whiteBalance->kelvin : 'auto');
 ```
 
 The `MetadataReader` streams the file, so the example works for JPEG and HEIC containers without loading the full asset into
@@ -46,13 +46,13 @@ memory. Every nested aggregate returns well-defined value objects, e.g. the flas
 ```php
 $gps = $metadata->gps;
 
-if (($gps->latitude !== null) && ($gps->longitude !== null)) {
+if (($gps->latitudeSigned !== null) && ($gps->longitudeSigned !== null)) {
     printf(
         "Coordinates: %.6f°, %.6f° (%s/%s)\n",
-        $gps->latitude->toFloat() ?? 0.0,
-        $gps->longitude->toFloat() ?? 0.0,
-        $gps->latitude->reference() ?? '?',
-        $gps->longitude->reference() ?? '?',
+        $gps->latitudeSigned,
+        $gps->longitudeSigned,
+        $gps->latitudeRef ?? '?',
+        $gps->longitudeRef ?? '?',
     );
 }
 ```

--- a/docs/m1-inventory.md
+++ b/docs/m1-inventory.md
@@ -1,17 +1,17 @@
 # Milestone M1 Inventory
 
-This inventory documents every reference to the legacy structured EXIF wrappers and the curated metadata aggregates. It highlights call sites that need to be migrated while converging on a single value layer.
+This inventory tracks the migration towards a single structured value layer and
+documents the remaining touch points after removing the legacy wrappers.
 
-## `MagicSunday\\ImageMeta\\Curate\\Exif\\Structured\\*`
+## Removed structured EXIF wrappers
 
-| Wrapper | Location | Purpose |
-| --- | --- | --- |
-| `Camera` | `src/Exif/StructuredExif.php` | Imported and instantiated inside `StructuredExif` to expose EXIF-only camera metadata without cross-container fallbacks. |
-| `Lens` | `src/Exif/StructuredExif.php` | Instantiated by `StructuredExif` to wrap the derived lens value objects. |
-| `Exposure` | `src/Exif/StructuredExif.php` | Created by `StructuredExif` to surface exposure settings alongside derived EV helpers. |
-| `Gps` | `src/Exif/StructuredExif.php` | Provides EXIF-only GPS data for the legacy `StructuredExif` aggregate. |
-| `Image` | `src/Exif/StructuredExif.php` | Supplies image dimension accessors required by the EXIF wrapper. |
-| `Preview` | `src/Exif/StructuredExif.php`, `tests/Support/ExifExpectationAssertions.php` | Used by the API wrapper and expectation helpers to expose thumbnail and preview metadata. |
+* No PHP files remain under `src/Curate/Exif/Structured`; the namespace was
+  deleted as part of the wrapper removal.
+* `src/Exif/StructuredExif.php` instantiates `MagicSunday\\ImageMeta\\Value`
+  objects directly (`Camera`, `Lens`, `Exposure`, `Gps`, `Image`, `Preview`).
+* `tests/Support/ExifExpectationAssertions.php` exercises these value objects
+  without intermediate wrappers, ensuring API expectations stay aligned with the
+  curated aggregates.
 
 ## Structured metadata value layer
 
@@ -21,7 +21,12 @@ This inventory documents every reference to the legacy structured EXIF wrappers 
 | `Camera`, `Lens`, `Exposure`, `Gps` | `src/Curate/StructuredMetadata.php`, `src/Curate/Exif/ValueFactory.php` | Immutable value objects assembled by `ValueFactory` and exposed directly via `StructuredMetadata`. |
 | `Capture`, `Scene`, `Temporal`, `Regions`, `Keywords`, `Sensor`, `Focus`, `Motion`, `Uav`, `ProcessingSettings`, `WhiteBalanceDetails`, `Interop`, `TiffData`, `Standards`, `FlashPix`, `Xmp`, `Rights`, `Author`, `RelatedAssets`, `Container`, `Integrity`, `Preview`, `Image`, `Video`, `Audio`, `AudioClips`, `ColorProfile`, `CompositeImageInfo`, `MultiPicture`, `Derived` | `src/Curate/StructuredMetadata.php`, `src/Curate/Exif/ValueFactory.php` | Additional metadata slices exposed through dedicated getters on `StructuredMetadata`. |
 
-## `MagicSunday\\ImageMeta\\Convenience\\ExifConvenience::gps()`
+## Convenience helpers
 
-* Defined in `src/Convenience/ExifConvenience.php` where it forwards to `ParsedExif::gps()` while retaining EXIF specification references.
-* No external call sites were found during the repository scan, indicating that the helper currently lacks dedicated consumers or tests.
+* `src/Convenience/ExifConvenience.php` exposes presentation helpers for
+  formatted strings (`cameraDescription`, `exposureSummary`, `gpsString`,
+  `imageDimensions`, `captureDateTimeString`, `toArray`). The helper only
+  formats data supplied via value objects; it does not perform parsing or tag
+  resolution.
+* `tests/Convenience/ExifConvenienceTest.php` covers formatting behaviour and
+  ensures the helper remains side-effect free.

--- a/docs/upgrade/m1-single-value-layer.md
+++ b/docs/upgrade/m1-single-value-layer.md
@@ -1,35 +1,43 @@
-# Milestone M1 Upgrade Notes — Single Value Layer
-
-Milestone M1 introduces a single structured metadata layer backed by immutable value objects. The EXIF-only wrapper classes under `MagicSunday\ImageMeta\Curate\Exif\Structured` remain functional for the current release but are marked as internal deprecations to guide integrators towards the curated aggregates.
-
 ## Impacted APIs
 
-The following classes are tagged with `@deprecated` and will be removed after Milestone M1:
+Milestone M1 removed the transitional wrapper classes that previously lived under
+`MagicSunday\\ImageMeta\\Curate\\Exif\\Structured`. `StructuredExif` now exposes the
+immutable value objects from `MagicSunday\\ImageMeta\\Value` directly so API consumers
+no longer need to hop through intermediate wrappers.
 
-- `MagicSunday\ImageMeta\Curate\Exif\Structured\Camera`
-- `MagicSunday\ImageMeta\Curate\Exif\Structured\Lens`
-- `MagicSunday\ImageMeta\Curate\Exif\Structured\Exposure`
-- `MagicSunday\ImageMeta\Curate\Exif\Structured\Gps`
-- `MagicSunday\ImageMeta\Curate\Exif\Structured\Image`
-- `MagicSunday\ImageMeta\Curate\Exif\Structured\Preview`
+Removed wrappers:
 
-`MagicSunday\ImageMeta\Exif\StructuredExif` continues to expose these wrappers so existing integrations remain operational during the transition.
+- `MagicSunday\\ImageMeta\\Curate\\Exif\\Structured\\Camera`
+- `MagicSunday\\ImageMeta\\Curate\\Exif\\Structured\\Lens`
+- `MagicSunday\\ImageMeta\\Curate\\Exif\\Structured\\Exposure`
+- `MagicSunday\\ImageMeta\\Curate\\Exif\\Structured\\Gps`
+- `MagicSunday\\ImageMeta\\Curate\\Exif\\Structured\\Image`
+- `MagicSunday\\ImageMeta\\Curate\\Exif\\Structured\\Preview`
+
+`MagicSunday\\ImageMeta\\Exif\\StructuredExif` continues to return the same value
+objects as the curated metadata aggregate so existing integrations can migrate at
+their own pace.
 
 ## Migration Guidance
 
-1. Prefer `Metadata::structured()` which returns `MagicSunday\ImageMeta\Curate\Structured\StructuredMetadata`.
+1. Prefer `Metadata::structured()` which returns
+   `MagicSunday\\ImageMeta\\Curate\\Structured\\StructuredMetadata`.
 2. Access curated value objects directly, for example:
    ```php
    $metadata = (new MetadataReader())->read($path)->structured();
    $metadata->camera->model;
    $metadata->lens->focalLengthMm;
-   $metadata->media()->image->width;
-   $metadata->gps->latitudeCoordinate()?->toFloat();
+   $metadata->image->width;
+   $metadata->gps->latitude;
    ```
-3. For preview information, use `$metadata->media()->preview` instead of the deprecated `Structured\Preview` wrapper.
+3. For preview information, use `$metadata->preview` instead of the removed
+   `Structured\\Preview` wrapper.
 
 ## Deprecation Mechanics
 
-- Deprecations are expressed via PHPDoc `@deprecated` annotations with internal wording to avoid accidental public API promotion.
-- No runtime triggers are emitted; consumers must rely on static analysis or IDE inspections.
-- Removal is scheduled after Milestone M1 once library consumers confirm migration to the curated aggregates.
+- Deprecations were expressed via PHPDoc `@deprecated` annotations with internal
+  wording to avoid accidental public API promotion.
+- No runtime triggers were emitted; consumers had to rely on static analysis or
+  IDE inspections.
+- Removal took place once library consumers confirmed migration to the curated
+  aggregates.


### PR DESCRIPTION
<!--
PR-Titel-Empfehlung:
M#: <kurze Beschreibung> — <Bereich>
Beispiel: M1: Unify binary readers — Core/Stream
-->

## Summary
- Document removal of the legacy `Curate\Exif\Structured` wrappers across the documentation.
- Refresh the M1 inventory to emphasise direct value objects and formatting-only helpers.
- Update the EXIF quickstart snippet so the sample code matches the current value object properties.

**Issue/Milestone:** Closes #N/A • Milestone M1
**Scope (allowed files only):** docs/API-README.md; docs/m1-inventory.md; docs/upgrade/m1-single-value-layer.md
**Non-Goals:** Runtime or parser behaviour changes.

---

## Implementation Notes
- Runtime: PHP 8.4, `declare(strict_types=1);`, PSR-12.
- **Streaming only** (Core\Stream/StreamWindow) — keine Ganzdatei-Reads.
- Keine externen Binaries/Extensions; **kein** `exif_read_data()`.
- Value Objects (chainable) nur für EXIF-Ausgabe; kein Rendering.
- **Enums** für gängige Kodierungen genutzt/ergänzt (Encoding/Endianness/IFD/XMP/...).
- **Spec-References** im Code ergänzt/aktualisiert (siehe „References“).

---

## Always Checklist (must be green)
**Composer-Tasks (deine CI-Skripte):**
- [ ] Lint: `composer ci:test:php:lint`
- [ ] PHPStan: `composer ci:test:php:phpstan`
- [ ] Rector (dry-run): `composer ci:test:php:rector`
- [ ] Coding-Style: `composer ci::cgl`
- [ ] PHPUnit: `composer ci:test:php:unit`
- [ ] Coverage ≥ **90 %**: `composer ci:test:php:unit:coverage`
- [ ] JSCPD (Duplikate = 0): `composer ci:test:php:cpd`
- [ ] Sammellauf: `composer ci:test` (sollte grün sein; enthält Lint, PHPStan, Rector-Dry-Run, CS-Dry-Run, Unit)

**Inhaltliche/Code-Guidelines:**
- [ ] **Keine** `mixed`-Signaturen • **kein** `empty()` • **keine** verschachtelten Ternaries
- [ ] Fully-qualified native functions (`\strlen`, `\count`, …) und sinnvolle `use`-Imports
- [ ] **Keine** dynamischen Aufrufe statischer Methoden
- [ ] Sinnvolle **Interfaces** verwendet (wo Verträge sinnvoll sind)
- [ ] Typisierte Klassenkonstanten; redundante Casts/Default-Argumente entfernt
- [ ] Klassen als `readonly`, wo passend; keine redundanten `readonly`-Mods
- [ ] **Eine Klasse je Datei** • Test-Namespaces spiegeln `src/`-Struktur
- [ ] Englische PHPDocs & englische Inline-Kommentare an komplexen Stellen
- [ ] Sinnvolle Namen für Variablen/Konstanten; Magic Numbers/Strings vermieden
- [ ] `array_find` / `array_any` / `array_all` gezielt statt trivialer `foreach` verwendet (wo es die Lesbarkeit verbessert)

---

## EXIF / TIFF / ISOBMFF / XMP Guardrails
- **EXIF-Versionen:** 1.x, 2.x (2.1/2.2/2.21/2.3/2.31/2.32), 3.0 — kompatible Änderungen; falls Tags betroffen: Coverage-Test grün.
- **TIFF/BigTIFF:** Endianness korrekt (`0x2A` / `0x2B`), Inline-Werte-Grenzen, `RATIONAL/SRATIONAL` korrekt.
- **GPS:** Vorzeichen über Ref-Tags (S/W negativ); `0/0`-Kantenfälle robust.
- **Preview/IFD1:** Nur beschreiben (Offsets/Längen/Compression), kein Rendering.
- **ISOBMFF/QuickTime:** Box-Size ≥ Header, 32/64-bit-Größen korrekt; `iloc`-Extents summiert; `data_reference_index ≠ 0` → skip; keine Remote-Refs.
- **XMP:** JPEG APP1-Präfix / ISOBMFF `uuid`; Parser mit `LIBXML_NONET`, keine DTD/Entities; `Alt/Bag/Seq` → Arrays.
- **Fehlerbehandlung:** ausschließlich `ParseError` oder `BoundsError`; keine Warnings/Notices als Kontrollfluss.

---

## Tests
- **Neue/angepasste Tests:** Docs-only update; no automated tests executed.
- **Negative Cases:** Not applicable for documentation updates.
- **Fixtures/Streams:** No fixtures required — textual documentation only.

---

## M# Sweep — Verify compliance for this milestone
Bitte **alles** verifizieren und kurz die Ergebnisse notieren:
- [ ] `composer ci:test` **grün** (Lint, PHPStan, Rector-Dry-Run, CS-Dry-Run, Unit)
- [ ] `composer ci:test:php:cpd` **0 Duplikate** (JSCPD, Konfig: `.build/.jscpd.json`)
- [ ] `composer ci:test:php:unit:coverage` **≥ 90 %**
- [ ] **ExifCoverageTest** (falls vorhanden): 0 fehlende Tags/Getters (gegen `resources/exif-map.yaml`)
- [ ] Für **jede** Klasse existiert ein Test (Namespace-Spiegelung)

---

## Breaking Changes / Risk / Rollback
- **Breaking changes:** None.
- **Risiken:** Low risk – documentation updates only.
- **Rollback-Plan:** Rollback by reverting this PR.

---

## Changelog
- docs: document structured wrapper removal and align API examples

---

## References (Specs & Docs)
<!-- Liste der relevanten Kapitel/Abschnitte, jeweils aktuellste Fassung + abweichende ältere, falls relevant -->
- EXIF 3.0 §… ; ggf. EXIF 2.32 §… ; EXIF 2.31 §…
- TIFF 6.0 §…
- ISOBMFF/QuickTime §…
- XMP (Adobe XMP Packet) §…

Docs im Repo:
- `docs/EXIF-210.pdf`, `docs/EXIF-220.pdf`, `docs/EXIF-230.pdf`, `docs/EXIF-231.pdf`, `docs/EXIF-232.pdf`, `docs/EXIF-300.pdf`
- `docs/TIFF6.pdf`

---

## Review Roles (tick what you covered)
- [ ] Planner (Scope/Non-Goals/Guardrails definiert)
- [ ] Spec Writer (AC/Tests präzisiert)
- [ ] Test Agent (RED zuerst)
- [x] Implementer (GREEN minimal & im Datei-Scope)
- [ ] Static/QA (Stan/CS/Rector/JSCPD clean)
- [ ] Security (Bounds, Offsets, XML-Flags)
- [ ] Reviewer (Minimalität, DX, Spec-Refs, Enums)
- [ ] Release (PR-Text, Labels, Milestone, „Closes #…“)


------
https://chatgpt.com/codex/tasks/task_e_6906154d951c83238e463433935cc52d