### PR TITLE
M#: Add sensitivity type accessor — EXIF

### DIFF
--- a/src/Model/Exif/ParsedExif.php
+++ b/src/Model/Exif/ParsedExif.php
@@ -36,6 +36,7 @@ use MagicSunday\ImageMeta\Value\Enum\Photometric;
 use MagicSunday\ImageMeta\Value\Enum\PlanarConfiguration;
 use MagicSunday\ImageMeta\Value\Enum\ResolutionUnit;
 use MagicSunday\ImageMeta\Value\Enum\Saturation;
+use MagicSunday\ImageMeta\Value\Enum\SensitivityType;
 use MagicSunday\ImageMeta\Value\Enum\SceneCaptureType;
 use MagicSunday\ImageMeta\Value\Enum\SceneType;
 use MagicSunday\ImageMeta\Value\Enum\SensingMethod;
@@ -812,13 +813,27 @@ final readonly class ParsedExif
     }
 
     /**
+     * Returns the declared EXIF sensitivity type as defined by EXIF 3.0 §4.6.4 Table 10.
+     */
+    public function sensitivityType(): ?SensitivityType
+    {
+        $value = $this->enumValue($this->exifIfd, ExifTag::SENSITIVITY_TYPE);
+
+        if ($value === null) {
+            return null;
+        }
+
+        return SensitivityType::fromExifValue($value);
+    }
+
+    /**
      * Returns the ISO sensitivity value if present.
      *
      * @return int|null
      */
     public function iso(): ?int
     {
-        $sensitivityType = $this->int($this->exifIfd, ExifTag::SENSITIVITY_TYPE);
+        $sensitivityType = $this->sensitivityType();
         if ($sensitivityType !== null) {
             foreach ($this->sensitivityTagPriority($sensitivityType) as $tag) {
                 $value = $this->int($this->exifIfd, $tag);
@@ -943,16 +958,16 @@ final readonly class ParsedExif
      *
      * @return list<int>
      */
-    private function sensitivityTagPriority(int $type): array
+    private function sensitivityTagPriority(SensitivityType $type): array
     {
         return match ($type) {
-            1       => [ExifTag::STANDARD_OUTPUT_SENSITIVITY],
-            2       => [ExifTag::RECOMMENDED_EXPOSURE_INDEX],
-            3       => [ExifTag::ISO_SPEED],
-            4       => [ExifTag::STANDARD_OUTPUT_SENSITIVITY, ExifTag::RECOMMENDED_EXPOSURE_INDEX],
-            5       => [ExifTag::STANDARD_OUTPUT_SENSITIVITY, ExifTag::ISO_SPEED],
-            6       => [ExifTag::RECOMMENDED_EXPOSURE_INDEX, ExifTag::ISO_SPEED],
-            7       => [ExifTag::STANDARD_OUTPUT_SENSITIVITY, ExifTag::RECOMMENDED_EXPOSURE_INDEX, ExifTag::ISO_SPEED],
+            SensitivityType::STANDARD_OUTPUT_SENSITIVITY => [ExifTag::STANDARD_OUTPUT_SENSITIVITY],
+            SensitivityType::RECOMMENDED_EXPOSURE_INDEX => [ExifTag::RECOMMENDED_EXPOSURE_INDEX],
+            SensitivityType::ISO_SPEED => [ExifTag::ISO_SPEED],
+            SensitivityType::SOS_AND_REI => [ExifTag::STANDARD_OUTPUT_SENSITIVITY, ExifTag::RECOMMENDED_EXPOSURE_INDEX],
+            SensitivityType::SOS_AND_ISO => [ExifTag::STANDARD_OUTPUT_SENSITIVITY, ExifTag::ISO_SPEED],
+            SensitivityType::REI_AND_ISO => [ExifTag::RECOMMENDED_EXPOSURE_INDEX, ExifTag::ISO_SPEED],
+            SensitivityType::SOS_AND_REI_AND_ISO => [ExifTag::STANDARD_OUTPUT_SENSITIVITY, ExifTag::RECOMMENDED_EXPOSURE_INDEX, ExifTag::ISO_SPEED],
             default => [],
         };
     }

--- a/tests/Model/Exif/ParsedExifSensitivityTest.php
+++ b/tests/Model/Exif/ParsedExifSensitivityTest.php
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\ImageMeta\Tests\Model\Exif;
+
+use MagicSunday\ImageMeta\Model\Exif\ExifTag;
+use MagicSunday\ImageMeta\Model\Exif\Ifd;
+use MagicSunday\ImageMeta\Model\Exif\IfdEntry;
+use MagicSunday\ImageMeta\Model\Exif\ParsedExif;
+use MagicSunday\ImageMeta\Value\Enum\SensitivityType;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @psalm-suppress PropertyNotSetInConstructor
+ */
+#[CoversClass(ParsedExif::class)]
+final class ParsedExifSensitivityTest extends TestCase
+{
+    #[Test]
+    public function sensitivityTypeReturnsEnumForNumericStrings(): void
+    {
+        $exifIfd = new Ifd([
+            ExifTag::SENSITIVITY_TYPE => new IfdEntry(ExifTag::SENSITIVITY_TYPE, 3, 1, '4'),
+        ]);
+
+        $parsedExif = new ParsedExif(new Ifd([]), $exifIfd, null, null, null);
+
+        self::assertSame(SensitivityType::SOS_AND_REI, $parsedExif->sensitivityType());
+    }
+
+    #[Test]
+    public function isoUsesSensitivityTypePriorities(): void
+    {
+        $exifIfd = new Ifd([
+            ExifTag::SENSITIVITY_TYPE           => new IfdEntry(ExifTag::SENSITIVITY_TYPE, 3, 1, '6'),
+            ExifTag::RECOMMENDED_EXPOSURE_INDEX => new IfdEntry(ExifTag::RECOMMENDED_EXPOSURE_INDEX, 3, 1, 200),
+            ExifTag::ISO_SPEED                  => new IfdEntry(ExifTag::ISO_SPEED, 3, 1, 400),
+        ]);
+
+        $parsedExif = new ParsedExif(new Ifd([]), $exifIfd, null, null, null);
+
+        self::assertSame(200, $parsedExif->iso());
+    }
+}


### PR DESCRIPTION
## Summary
- Add a SensitivityType accessor that normalises EXIF sensitivity tag values via the shared enum helper
- Update ISO resolution logic to consume the enum priorities when selecting ISO-related tags
- Extend coverage with sensitivity-specific tests for ParsedExif

**Issue/Milestone:** Closes #N/A • Milestone M#
**Scope (allowed files only):** src/Model/Exif/ParsedExif.php; tests/Model/Exif/ParsedExifSensitivityTest.php
**Non-Goals:** No changes to EXIF parsing beyond sensitivity handling.

---

## Implementation Notes
- Runtime: PHP 8.4, `declare(strict_types=1);`, PSR-12.
- **Streaming only** (Core\\Stream/StreamWindow) — keine Ganzdatei-Reads.
- Keine externen Binaries/Extensions; **kein** `exif_read_data()`.
- Value Objects (chainable) nur für EXIF-Ausgabe; kein Rendering.
- **Enums** für gängige Kodierungen genutzt/ergänzt (Encoding/Endianness/IFD/XMP/...).
- **Spec-References** im Code ergänzt/aktualisiert (siehe „References“).

---

## Always Checklist (must be green)
**Composer-Tasks (deine CI-Skripte):**
- [ ] Lint: `composer ci:test:php:lint`
- [ ] PHPStan: `composer ci:test:php:phpstan`
- [ ] Rector (dry-run): `composer ci:test:php:rector`
- [ ] Coding-Style: `composer ci::cgl`
- [x] PHPUnit: `composer ci:test:php:unit`
- [ ] Coverage ≥ **90 %**: `composer ci:test:php:unit:coverage`
- [ ] JSCPD (Duplikate = 0): `composer ci:test:php:cpd`
- [ ] Sammellauf: `composer ci:test` (sollte grün sein; enthält Lint, PHPStan, Rector-Dry-Run, CS-Dry-Run, Unit)

**Inhaltliche/Code-Guidelines:**
- [ ] **Keine** `mixed`-Signaturen • **kein** `empty()` • **keine** verschachtelten Ternaries
- [ ] Fully-qualified native functions (`\\strlen`, `\\count`, …) und sinnvolle `use`-Imports
- [ ] **Keine** dynamischen Aufrufe statischer Methoden
- [ ] Sinnvolle **Interfaces** verwendet (wo Verträge sinnvoll sind)
- [ ] Typisierte Klassenkonstanten; redundante Casts/Default-Argumente entfernt
- [ ] Klassen als `readonly`, wo passend; keine redundanten `readonly`-Mods
- [ ] **Eine Klasse je Datei** • Test-Namespaces spiegeln `src/`-Struktur
- [ ] Englische PHPDocs & englische Inline-Kommentare an komplexen Stellen
- [ ] Sinnvolle Namen für Variablen/Konstanten; Magic Numbers/Strings vermieden
- [ ] `array_find` / `array_any` / `array_all` gezielt statt trivialer `foreach` verwendet (wo es die Lesbarkeit verbessert)

---

## EXIF / TIFF / ISOBMFF / XMP Guardrails
- **EXIF-Versionen:** 1.x, 2.x (2.1/2.2/2.21/2.3/2.31/2.32), 3.0 — kompatible Änderungen; falls Tags betroffen: Coverage-Test grün.
- **TIFF/BigTIFF:** Endianness korrekt (`0x2A` / `0x2B`), Inline-Werte-Grenzen, `RATIONAL/SRATIONAL` korrekt.
- **GPS:** Vorzeichen über Ref-Tags (S/W negativ); `0/0`-Kantenfälle robust.
- **Preview/IFD1:** Nur beschreiben (Offsets/Längen/Compression), kein Rendering.
- **ISOBMFF/QuickTime:** Box-Size ≥ Header, 32/64-bit-Größen korrekt; `iloc`-Extents summiert; `data_reference_index ≠ 0` → skip; keine Remote-Refs.
- **XMP:** JPEG APP1-Präfix / ISOBMFF `uuid`; Parser mit `LIBXML_NONET`, keine DTD/Entities; `Alt/Bag/Seq` → Arrays.
- **Fehlerbehandlung:** ausschließlich `ParseError` oder `BoundsError`; keine Warnings/Notices als Kontrollfluss.

---

## Tests
- **Neue/angepasste Tests:** ParsedExif sensitivity accessor and ISO prioritisation
- **Negative Cases:** N/A
- **Fixtures/Streams:** Synthetic IFD entries

---

## Agent Notes
- `composer ci:test:php:unit` executed locally; other checklist items not yet run in this PR.

## M# Sweep — Verify compliance for this milestone
Bitte **alles** verifizieren und kurz die Ergebnisse notieren:
- [ ] `composer ci:test` **grün** (Lint, PHPStan, Rector-Dry-Run, CS-Dry-Run, Unit)
- [ ] `composer ci:test:php:cpd` **0 Duplikate** (JSCPD, Konfig: `.build/.jscpd.json`)
- [ ] `composer ci:test:php:unit:coverage` **≥ 90 %**
- [ ] **ExifCoverageTest** (falls vorhanden): 0 fehlende Tags/Getters (gegen `resources/exif-map.yaml`)
- [ ] Für **jede** Klasse existiert ein Test (Namespace-Spiegelung)

---

## Breaking Changes / Risk / Rollback
- **Breaking changes:** None anticipated
- **Risiken:** Low; accessor addition and enum wiring for ISO selection
- **Rollback-Plan:** Revert commit if regressions surface

---

## Changelog
- feat: expose SensitivityType accessor and align ISO selection with enum priorities

---

## References (Specs & Docs)
- EXIF 3.0 §4.6.4; EXIF 2.3 §4.6.6
- `docs/EXIF-210.pdf`, `docs/EXIF-220.pdf`, `docs/EXIF-230.pdf`, `docs/EXIF-231.pdf`, `docs/EXIF-232.pdf`, `docs/EXIF-300.pdf`
- `docs/TIFF6.pdf`

---

## Review Roles (tick what you covered)
- [ ] Planner (Scope/Non-Goals/Guardrails definiert)
- [ ] Spec Writer (AC/Tests präzisiert)
- [ ] Test Agent (RED zuerst)
- [ ] Implementer (GREEN minimal & im Datei-Scope)
- [ ] Static/QA (Stan/CS/Rector/JSCPD clean)
- [ ] Security (Bounds, Offsets, XML-Flags)
- [ ] Reviewer (Minimalität, DX, Spec-Refs, Enums)
- [ ] Release (PR-Text, Labels, Milestone, „Closes #…“)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69357fcb91408323b51028277c855140)