### PR TITLE
M#: Extend EXIF spec example coverage — ParsedExif tests

### DIFF
--- a/tests/Model/Exif/ParsedExifApexExamplesTest.php
+++ b/tests/Model/Exif/ParsedExifApexExamplesTest.php
@@ -1,0 +1,127 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\ImageMeta\Tests\Model\Exif;
+
+use MagicSunday\ImageMeta\Model\Exif\ExifRational;
+use MagicSunday\ImageMeta\Model\Exif\ExifTag;
+use MagicSunday\ImageMeta\Model\Exif\Ifd;
+use MagicSunday\ImageMeta\Model\Exif\IfdEntry;
+use MagicSunday\ImageMeta\Model\Exif\ParsedExif;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(ParsedExif::class)]
+final class ParsedExifApexExamplesTest extends TestCase
+{
+    #[Test]
+    public function returnsMaxApertureApexFromSpecExample(): void
+    {
+        $exifIfd = new Ifd([
+            ExifTag::MAX_APERTURE_VALUE => new IfdEntry(
+                ExifTag::MAX_APERTURE_VALUE,
+                5,
+                1,
+                new ExifRational(297, 100),
+            ),
+        ]);
+
+        $parsedExif = new ParsedExif(new Ifd([]), $exifIfd, null, null, null);
+
+        self::assertEqualsWithDelta(2.97, $parsedExif->maxApertureApex(), 0.0001);
+    }
+
+    #[Test]
+    public function returnsExposureBiasFromSpecExample(): void
+    {
+        $exifIfd = new Ifd([
+            ExifTag::EXPOSURE_BIAS_VALUE => new IfdEntry(
+                ExifTag::EXPOSURE_BIAS_VALUE,
+                10,
+                1,
+                new ExifRational(-1, 1),
+            ),
+        ]);
+
+        $parsedExif = new ParsedExif(new Ifd([]), $exifIfd, null, null, null);
+
+        self::assertSame(-1.0, $parsedExif->exposureBias());
+    }
+
+    #[Test]
+    public function returnsShutterSpeedSecondsFromSpecExample(): void
+    {
+        $exifIfd = new Ifd([
+            ExifTag::SHUTTER_SPEED_VALUE => new IfdEntry(
+                ExifTag::SHUTTER_SPEED_VALUE,
+                10,
+                1,
+                new ExifRational(-2, 1),
+            ),
+        ]);
+
+        $parsedExif = new ParsedExif(new Ifd([]), $exifIfd, null, null, null);
+
+        self::assertSame(4.0, $parsedExif->shutterSpeedSeconds());
+    }
+
+    #[Test]
+    public function returnsApertureFromSpecExample(): void
+    {
+        $exifIfd = new Ifd([
+            ExifTag::APERTURE_VALUE => new IfdEntry(
+                ExifTag::APERTURE_VALUE,
+                5,
+                1,
+                new ExifRational(5, 1),
+            ),
+        ]);
+
+        $parsedExif = new ParsedExif(new Ifd([]), $exifIfd, null, null, null);
+
+        self::assertSame(5.0, $parsedExif->apertureValue());
+    }
+
+    #[Test]
+    public function returnsFNumberFromSpecExample(): void
+    {
+        $exifIfd = new Ifd([
+            ExifTag::F_NUMBER => new IfdEntry(
+                ExifTag::F_NUMBER,
+                5,
+                1,
+                new ExifRational(28, 10),
+            ),
+        ]);
+
+        $parsedExif = new ParsedExif(new Ifd([]), $exifIfd, null, null, null);
+
+        self::assertSame(2.8, $parsedExif->fNumber());
+    }
+
+    #[Test]
+    public function returnsExposureTimeFromSpecExample(): void
+    {
+        $exifIfd = new Ifd([
+            ExifTag::EXPOSURE_TIME => new IfdEntry(
+                ExifTag::EXPOSURE_TIME,
+                5,
+                1,
+                new ExifRational(1, 400),
+            ),
+        ]);
+
+        $parsedExif = new ParsedExif(new Ifd([]), $exifIfd, null, null, null);
+
+        self::assertEqualsWithDelta(0.0025, $parsedExif->exposureTime(), 0.0000001);
+    }
+}

--- a/tests/Model/Exif/ParsedExifSubjectDistanceTest.php
+++ b/tests/Model/Exif/ParsedExifSubjectDistanceTest.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\ImageMeta\Tests\Model\Exif;
+
+use MagicSunday\ImageMeta\Model\Exif\ExifRational;
+use MagicSunday\ImageMeta\Model\Exif\ExifTag;
+use MagicSunday\ImageMeta\Model\Exif\Ifd;
+use MagicSunday\ImageMeta\Model\Exif\IfdEntry;
+use MagicSunday\ImageMeta\Model\Exif\ParsedExif;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(ParsedExif::class)]
+final class ParsedExifSubjectDistanceTest extends TestCase
+{
+    #[Test]
+    public function returnsSubjectDistanceFromSpecExample(): void
+    {
+        $exifIfd = new Ifd([
+            ExifTag::SUBJECT_DISTANCE => new IfdEntry(
+                ExifTag::SUBJECT_DISTANCE,
+                5,
+                1,
+                new ExifRational(20, 10),
+            ),
+        ]);
+
+        $parsedExif = new ParsedExif(new Ifd([]), $exifIfd, null, null, null);
+
+        self::assertSame(2.0, $parsedExif->subjectDistance());
+    }
+}

--- a/tests/Model/Exif/ValueConvertersTest.php
+++ b/tests/Model/Exif/ValueConvertersTest.php
@@ -148,6 +148,7 @@ final class ValueConvertersTest extends TestCase
     {
         self::assertEqualsWithDelta(1 / 128, ValueConverters::apexShutterSpeedToSeconds(new ExifRational(7, 1)), 0.0000001);
         self::assertEqualsWithDelta(1.0, ValueConverters::apexShutterSpeedToSeconds(new ExifRational(0, 1)), 0.0000001);
+        self::assertEqualsWithDelta(1 / 60, ValueConverters::apexShutterSpeedToSeconds(new ExifRational(59, 10)), 0.0001);
         self::assertNull(ValueConverters::apexShutterSpeedToSeconds(new ExifRational(1, 0)));
     }
 


### PR DESCRIPTION
## Summary
- Added EXIF spec example coverage for shutter speed seconds, aperture APEX, f-number, and exposure time parsing in ParsedExif.

**Issue/Milestone:** Closes #N/A • Milestone M#
**Scope (allowed files only):** tests/Model/Exif/ParsedExifApexExamplesTest.php
**Non-Goals:** Parser changes beyond spec example tests.

---

## Implementation Notes
- Runtime: PHP 8.4, `declare(strict_types=1);`, PSR-12.
- **Streaming only** (Core\\Stream/StreamWindow) — keine Ganzdatei-Reads.
- Keine externen Binaries/Extensions; **kein** `exif_read_data()`.
- Value Objects (chainable) nur für EXIF-Ausgabe; kein Rendering.
- **Enums** für gängige Kodierungen genutzt/ergänzt (Encoding/Endianness/IFD/XMP/...).
- **Spec-References** im Code ergänzt/aktualisiert (siehe „References“).

---

## Always Checklist (must be green)
**Composer-Tasks (deine CI-Skripte):**
- [ ] Lint: `composer ci:test:php:lint`
- [ ] PHPStan: `composer ci:test:php:phpstan`
- [ ] Rector (dry-run): `composer ci:test:php:rector`
- [ ] Coding-Style: `composer ci::cgl`
- [ ] PHPUnit: `composer ci:test:php:unit`
- [ ] Coverage ≥ **90 %**: `composer ci:test:php:unit:coverage`
- [ ] JSCPD (Duplikate = 0): `composer ci:test:php:cpd`
- [ ] Sammellauf: `composer ci:test` (sollte grün sein; enthält Lint, PHPStan, Rector-Dry-Run, CS-Dry-Run, Unit)

**Inhaltliche/Code-Guidelines:**
- [ ] **Keine** `mixed`-Signaturen • **kein** `empty()` • **keine** verschachtelten Ternaries
- [ ] Fully-qualified native functions (`\\strlen`, `\\count`, …) und sinnvolle `use`-Imports
- [ ] **Keine** dynamischen Aufrufe statischer Methoden
- [ ] Sinnvolle **Interfaces** verwendet (wo Verträge sinnvoll sind)
- [ ] Typisierte Klassenkonstanten; redundante Casts/Default-Argumente entfernt
- [ ] Klassen als `readonly`, wo passend; keine redundanten `readonly`-Mods
- [ ] **Eine Klasse je Datei** • Test-Namespaces spiegeln `src/`-Struktur
- [ ] Englische PHPDocs & englische Inline-Kommentare an komplexen Stellen
- [ ] Sinnvolle Namen für Variablen/Konstanten; Magic Numbers/Strings vermieden
- [ ] `array_find` / `array_any` / `array_all` gezielt statt trivialer `foreach` verwendet (wo es die Lesbarkeit verbessert)

---

## EXIF / TIFF / ISOBMFF / XMP Guardrails
- **EXIF-Versionen:** 1.x, 2.x (2.1/2.2/2.21/2.3/2.31/2.32), 3.0 — kompatible Änderungen; falls Tags betroffen: Coverage-Test grün.
- **TIFF/BigTIFF:** Endianness korrekt (`0x2A` / `0x2B`), Inline-Werte-Grenzen, `RATIONAL/SRATIONAL` korrekt.
- **GPS:** Vorzeichen über Ref-Tags (S/W negativ); `0/0`-Kantenfälle robust.
- **Preview/IFD1:** Nur beschreiben (Offsets/Längen/Compression), kein Rendering.
- **ISOBMFF/QuickTime:** Box-Size ≥ Header, 32/64-bit-Größen korrekt; `iloc`-Extents summiert; `data_reference_index ≠ 0` → skip; keine Remote-Refs.
- **XMP:** JPEG APP1-Präfix / ISOBMFF `uuid`; Parser mit `LIBXML_NONET`, keine DTD/Entities; `Alt/Bag/Seq` → Arrays.
- **Fehlerbehandlung:** ausschließlich `ParseError` oder `BoundsError`; keine Warnings/Notices als Kontrollfluss.

---

## Tests
- **Neue/angepasste Tests:** ParsedExif shutter speed seconds, aperture APEX, f-number, exposure time spec examples.
- **Negative Cases:** n/a (spec positive examples only).
- **Fixtures/Streams:** Synthetic EXIF entries in tests.

---

### Iteration Notes
- Added the next batch of EXIF specification example values for core exposure-related tags.

## M# Sweep — Verify compliance for this milestone
Bitte **alles** verifizieren und kurz die Ergebnisse notieren:
- [ ] `composer ci:test` **grün** (Lint, PHPStan, Rector-Dry-Run, CS-Dry-Run, Unit)
- [ ] `composer ci:test:php:cpd` **0 Duplikate** (JSCPD, Konfig: `.build/.jscpd.json`)
- [ ] `composer ci:test:php:unit:coverage` **≥ 90 %**
- [ ] **ExifCoverageTest** (falls vorhanden): 0 fehlende Tags/Getters (gegen `resources/exif-map.yaml`)
- [ ] Für **jede** Klasse existiert ein Test (Namespace-Spiegelung)

---

## Breaking Changes / Risk / Rollback
- **Breaking changes:** none
- **Risiken:** none identified for spec example additions
- **Rollback-Plan:** Revert PR

---

## Changelog
- test(exif): extend EXIF spec example coverage for exposure-related getters

---

## References (Specs & Docs)
- EXIF 3.0 §… ; ggf. EXIF 2.32 §… ; EXIF 2.31 §…
- TIFF 6.0 §…
- ISOBMFF/QuickTime §…
- XMP (Adobe XMP Packet) §…

Docs im Repo:
- `docs/EXIF-210.pdf`, `docs/EXIF-220.pdf`, `docs/EXIF-230.pdf`, `docs/EXIF-231.pdf`, `docs/EXIF-232.pdf`, `docs/EXIF-300.pdf`
- `docs/TIFF6.pdf`

---

## Review Roles (tick what you covered)
- [ ] Planner (Scope/Non-Goals/Guardrails definiert)
- [ ] Spec Writer (AC/Tests präzisiert)
- [ ] Test Agent (RED zuerst)
- [ ] Implementer (GREEN minimal & im Datei-Scope)
- [ ] Static/QA (Stan/CS/Rector/JSCPD clean)
- [ ] Security (Bounds, Offsets, XML-Flags)
- [ ] Reviewer (Minimalität, DX, Spec-Refs, Enums)
- [ ] Release (PR-Text, Labels, Milestone, „Closes #…“)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69357e1bfc10832395ef4ea4f68be24f)