### PR TITLE
Handle sensitivity type enums in ISO resolution

### DIFF
--- a/src/Model/Exif/ParsedExif.php
+++ b/src/Model/Exif/ParsedExif.php
@@ -967,8 +967,12 @@ final readonly class ParsedExif
             SensitivityType::SOS_AND_REI => [ExifTag::STANDARD_OUTPUT_SENSITIVITY, ExifTag::RECOMMENDED_EXPOSURE_INDEX],
             SensitivityType::SOS_AND_ISO => [ExifTag::STANDARD_OUTPUT_SENSITIVITY, ExifTag::ISO_SPEED],
             SensitivityType::REI_AND_ISO => [ExifTag::RECOMMENDED_EXPOSURE_INDEX, ExifTag::ISO_SPEED],
-            SensitivityType::SOS_AND_REI_AND_ISO => [ExifTag::STANDARD_OUTPUT_SENSITIVITY, ExifTag::RECOMMENDED_EXPOSURE_INDEX, ExifTag::ISO_SPEED],
-            default => [],
+            SensitivityType::SOS_AND_REI_AND_ISO => [
+                ExifTag::STANDARD_OUTPUT_SENSITIVITY,
+                ExifTag::RECOMMENDED_EXPOSURE_INDEX,
+                ExifTag::ISO_SPEED,
+            ],
+            SensitivityType::UNKNOWN => [],
         };
     }
 

--- a/tests/Model/Exif/ParsedExifSensitivityTest.php
+++ b/tests/Model/Exif/ParsedExifSensitivityTest.php
@@ -17,6 +17,7 @@ use MagicSunday\ImageMeta\Model\Exif\IfdEntry;
 use MagicSunday\ImageMeta\Model\Exif\ParsedExif;
 use MagicSunday\ImageMeta\Value\Enum\SensitivityType;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
@@ -38,17 +39,127 @@ final class ParsedExifSensitivityTest extends TestCase
         self::assertSame(SensitivityType::SOS_AND_REI, $parsedExif->sensitivityType());
     }
 
+    /**
+     * @param array<int, int> $tagValues
+     */
     #[Test]
-    public function isoUsesSensitivityTypePriorities(): void
+    #[DataProvider('isoSensitivityPriorityProvider')]
+    public function isoUsesSensitivityTypePriorities(
+        SensitivityType $sensitivityType,
+        array $tagValues,
+        int $expected
+    ): void
+    {
+        $entries = [
+            ExifTag::SENSITIVITY_TYPE => new IfdEntry(ExifTag::SENSITIVITY_TYPE, 3, 1, $sensitivityType->value),
+        ];
+
+        foreach ($tagValues as $tag => $value) {
+            $entries[$tag] = new IfdEntry($tag, 3, 1, $value);
+        }
+
+        $exifIfd = new Ifd($entries);
+
+        $parsedExif = new ParsedExif(new Ifd([]), $exifIfd, null, null, null);
+
+        self::assertSame($expected, $parsedExif->iso());
+    }
+
+    #[Test]
+    public function isoFallsBackWhenSensitivityTypeValueIsUnknown(): void
     {
         $exifIfd = new Ifd([
-            ExifTag::SENSITIVITY_TYPE           => new IfdEntry(ExifTag::SENSITIVITY_TYPE, 3, 1, '6'),
-            ExifTag::RECOMMENDED_EXPOSURE_INDEX => new IfdEntry(ExifTag::RECOMMENDED_EXPOSURE_INDEX, 3, 1, 200),
-            ExifTag::ISO_SPEED                  => new IfdEntry(ExifTag::ISO_SPEED, 3, 1, 400),
+            ExifTag::SENSITIVITY_TYPE => new IfdEntry(ExifTag::SENSITIVITY_TYPE, 3, 1, 99),
+            ExifTag::ISO_SPEED        => new IfdEntry(ExifTag::ISO_SPEED, 3, 1, 1600),
         ]);
 
         $parsedExif = new ParsedExif(new Ifd([]), $exifIfd, null, null, null);
 
-        self::assertSame(200, $parsedExif->iso());
+        self::assertSame(1600, $parsedExif->iso());
+    }
+
+    /**
+     * @return iterable<string, array{sensitivityType: SensitivityType, tagValues: array<int, int>, expected: int}>
+     */
+    public static function isoSensitivityPriorityProvider(): iterable
+    {
+        yield 'standard output sensitivity' => [
+            'sensitivityType' => SensitivityType::STANDARD_OUTPUT_SENSITIVITY,
+            'tagValues' => [
+                ExifTag::STANDARD_OUTPUT_SENSITIVITY => 100,
+                ExifTag::RECOMMENDED_EXPOSURE_INDEX => 200,
+                ExifTag::ISO_SPEED => 300,
+            ],
+            'expected' => 100,
+        ];
+
+        yield 'recommended exposure index' => [
+            'sensitivityType' => SensitivityType::RECOMMENDED_EXPOSURE_INDEX,
+            'tagValues' => [
+                ExifTag::STANDARD_OUTPUT_SENSITIVITY => 100,
+                ExifTag::RECOMMENDED_EXPOSURE_INDEX => 200,
+                ExifTag::ISO_SPEED => 300,
+            ],
+            'expected' => 200,
+        ];
+
+        yield 'iso speed' => [
+            'sensitivityType' => SensitivityType::ISO_SPEED,
+            'tagValues' => [
+                ExifTag::STANDARD_OUTPUT_SENSITIVITY => 100,
+                ExifTag::RECOMMENDED_EXPOSURE_INDEX => 200,
+                ExifTag::ISO_SPEED => 300,
+            ],
+            'expected' => 300,
+        ];
+
+        yield 'sos and rei' => [
+            'sensitivityType' => SensitivityType::SOS_AND_REI,
+            'tagValues' => [
+                ExifTag::STANDARD_OUTPUT_SENSITIVITY => 100,
+                ExifTag::RECOMMENDED_EXPOSURE_INDEX => 200,
+                ExifTag::ISO_SPEED => 300,
+            ],
+            'expected' => 100,
+        ];
+
+        yield 'sos and iso' => [
+            'sensitivityType' => SensitivityType::SOS_AND_ISO,
+            'tagValues' => [
+                ExifTag::STANDARD_OUTPUT_SENSITIVITY => 100,
+                ExifTag::RECOMMENDED_EXPOSURE_INDEX => 200,
+                ExifTag::ISO_SPEED => 300,
+            ],
+            'expected' => 100,
+        ];
+
+        yield 'rei and iso' => [
+            'sensitivityType' => SensitivityType::REI_AND_ISO,
+            'tagValues' => [
+                ExifTag::STANDARD_OUTPUT_SENSITIVITY => 100,
+                ExifTag::RECOMMENDED_EXPOSURE_INDEX => 200,
+                ExifTag::ISO_SPEED => 300,
+            ],
+            'expected' => 200,
+        ];
+
+        yield 'sos and rei and iso' => [
+            'sensitivityType' => SensitivityType::SOS_AND_REI_AND_ISO,
+            'tagValues' => [
+                ExifTag::STANDARD_OUTPUT_SENSITIVITY => 100,
+                ExifTag::RECOMMENDED_EXPOSURE_INDEX => 200,
+                ExifTag::ISO_SPEED => 300,
+            ],
+            'expected' => 100,
+        ];
+
+        yield 'unknown sensitivity type' => [
+            'sensitivityType' => SensitivityType::UNKNOWN,
+            'tagValues' => [
+                ExifTag::ISO_SPEED => 400,
+                ExifTag::PHOTOGRAPHIC_SENSITIVITY => 500,
+            ],
+            'expected' => 400,
+        ];
     }
 }


### PR DESCRIPTION
## Pre-M# Notes
- Added enum-based sensitivity tag priority handling and coverage for ISO resolution.

## Summary
- Adjusted sensitivity tag mapping to operate on SensitivityType enums and clarified priority handling.
- Expanded sensitivity-related PHPUnit coverage to assert priorities and fallback behaviour.

**Issue/Milestone:** Closes #N/A • Milestone M#
**Scope (allowed files only):** src/Model/Exif/ParsedExif.php; tests/Model/Exif/ParsedExifSensitivityTest.php
**Non-Goals:** Changes outside sensitivity tag resolution.

---

## Implementation Notes
- Runtime: PHP 8.4, `declare(strict_types=1);`, PSR-12.
- **Streaming only** (Core\Stream/StreamWindow) — keine Ganzdatei-Reads.
- Keine externen Binaries/Extensions; **kein** `exif_read_data()`.
- Value Objects (chainable) nur für EXIF-Ausgabe; kein Rendering.
- **Enums** für gängige Kodierungen genutzt/ergänzt (Encoding/Endianness/IFD/XMP/...).
- **Spec-References** im Code ergänzt/aktualisiert (siehe „References“).

---

## Always Checklist (must be green)
**Composer-Tasks (deine CI-Skripte):**
- [ ] Lint: `composer ci:test:php:lint`
- [ ] PHPStan: `composer ci:test:php:phpstan`
- [ ] Rector (dry-run): `composer ci:test:php:rector`
- [ ] Coding-Style: `composer ci::cgl`
- [ ] PHPUnit: `composer ci:test:php:unit`
- [ ] Coverage ≥ **90 %**: `composer ci:test:php:unit:coverage`
- [ ] JSCPD (Duplikate = 0): `composer ci:test:php:cpd`
- [ ] Sammellauf: `composer ci:test` (sollte grün sein; enthält Lint, PHPStan, Rector-Dry-Run, CS-Dry-Run, Unit)

**Inhaltliche/Code-Guidelines:**
- [ ] **Keine** `mixed`-Signaturen • **kein** `empty()` • **keine** verschachtelten Ternaries
- [ ] Fully-qualified native functions (`\strlen`, `\count`, …) und sinnvolle `use`-Imports
- [ ] **Keine** dynamischen Aufrufe statischer Methoden
- [ ] Sinnvolle **Interfaces** verwendet (wo Verträge sinnvoll sind)
- [ ] Typisierte Klassenkonstanten; redundante Casts/Default-Argumente entfernt
- [ ] Klassen als `readonly`, wo passend; keine redundanten `readonly`-Mods
- [ ] **Eine Klasse je Datei** • Test-Namespaces spiegeln `src/`-Struktur
- [ ] Englische PHPDocs & englische Inline-Kommentare an komplexen Stellen
- [ ] Sinnvolle Namen für Variablen/Konstanten; Magic Numbers/Strings vermieden
- [ ] `array_find` / `array_any` / `array_all` gezielt statt trivialer `foreach` verwendet (wo es die Lesbarkeit verbessert)

---

## EXIF / TIFF / ISOBMFF / XMP Guardrails
- **EXIF-Versionen:** 1.x, 2.x (2.1/2.2/2.21/2.3/2.31/2.32), 3.0 — kompatible Änderungen; falls Tags betroffen: Coverage-Test grün.
- **TIFF/BigTIFF:** Endianness korrekt (`0x2A` / `0x2B`), Inline-Werte-Grenzen, `RATIONAL/SRATIONAL` korrekt.
- **GPS:** Vorzeichen über Ref-Tags (S/W negativ); `0/0`-Kantenfälle robust.
- **Preview/IFD1:** Nur beschreiben (Offsets/Längen/Compression), kein Rendering.
- **ISOBMFF/QuickTime:** Box-Size ≥ Header, 32/64-bit-Größen korrekt; `iloc`-Extents summiert; `data_reference_index ≠ 0` → skip; keine Remote-Refs.
- **XMP:** JPEG APP1-Präfix / ISOBMFF `uuid`; Parser mit `LIBXML_NONET`, keine DTD/Entities; `Alt/Bag/Seq` → Arrays.
- **Fehlerbehandlung:** ausschließlich `ParseError` oder `BoundsError`; keine Warnings/Notices als Kontrollfluss.

---

## Tests
- **Neue/angepasste Tests:** SensitivityType priority mapping, unknown sensitivity fallback.
- **Negative Cases:** Invalid SensitivityType values fallback safely.
- **Fixtures/Streams:** Synthetic Ifd entries only.

---

## M# Sweep — Verify compliance for this milestone
Bitte **alles** verifizieren und kurz die Ergebnisse notieren:
- [ ] `composer ci:test` **grün** (Lint, PHPStan, Rector-Dry-Run, CS-Dry-Run, Unit)
- [ ] `composer ci:test:php:cpd` **0 Duplikate** (JSCPD, Konfig: `.build/.jscpd.json`)
- [ ] `composer ci:test:php:unit:coverage` **≥ 90 %**
- [ ] **ExifCoverageTest** (falls vorhanden): 0 fehlende Tags/Getters (gegen `resources/exif-map.yaml`)
- [ ] Für **jede** Klasse existiert ein Test (Namespace-Spiegelung)

---

## Breaking Changes / Risk / Rollback
- **Breaking changes:** None.
- **Risiken:** Minimal; focuses on enum matching and test coverage.
- **Rollback-Plan:** Revert this PR.

---

## Changelog
- fix: ensure SensitivityType-driven ISO resolution and coverage.

---

## References (Specs & Docs)
- EXIF 3.0 §4.6.4 (SensitivityType mapping).
- EXIF 2.3 §4.6.6 (SensitivityType introduction).

Docs im Repo:
- `docs/EXIF-210.pdf`, `docs/EXIF-220.pdf`, `docs/EXIF-230.pdf`, `docs/EXIF-231.pdf`, `docs/EXIF-232.pdf`, `docs/EXIF-300.pdf`
- `docs/TIFF6.pdf`

---

## Review Roles (tick what you covered)
- [ ] Planner (Scope/Non-Goals/Guardrails definiert)
- [ ] Spec Writer (AC/Tests präzisiert)
- [ ] Test Agent (RED zuerst)
- [ ] Implementer (GREEN minimal & im Datei-Scope)
- [ ] Static/QA (Stan/CS/Rector/JSCPD clean)
- [ ] Security (Bounds, Offsets, XML-Flags)
- [ ] Reviewer (Minimalität, DX, Spec-Refs, Enums)
- [ ] Release (PR-Text, Labels, Milestone, „Closes #…“)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6935826a3c1c832393427934aaac4c4e)