### PR TITLE
M#: Update sensitivity tag priorities — Model/Exif

### DIFF
--- a/src/Model/Exif/ParsedExif.php
+++ b/src/Model/Exif/ParsedExif.php
@@ -844,10 +844,11 @@ final readonly class ParsedExif
         }
 
         $candidates = [
+            [$this->exifIfd, ExifTag::PHOTOGRAPHIC_SENSITIVITY],
             [$this->exifIfd, ExifTag::ISO_SPEED],
             [$this->exifIfd, ExifTag::STANDARD_OUTPUT_SENSITIVITY],
             [$this->exifIfd, ExifTag::RECOMMENDED_EXPOSURE_INDEX],
-            [$this->exifIfd, ExifTag::PHOTOGRAPHIC_SENSITIVITY],
+            [$this->exifIfd, ExifTag::EXPOSURE_INDEX],
             [$this->ifd0, ExifTag::PHOTOGRAPHIC_SENSITIVITY],
             [$this->ifd0, ExifTag::ISO_SPEED],
         ];
@@ -962,14 +963,35 @@ final readonly class ParsedExif
     {
         return match ($type) {
             SensitivityType::STANDARD_OUTPUT_SENSITIVITY => [ExifTag::STANDARD_OUTPUT_SENSITIVITY],
-            SensitivityType::RECOMMENDED_EXPOSURE_INDEX => [ExifTag::RECOMMENDED_EXPOSURE_INDEX],
-            SensitivityType::ISO_SPEED => [ExifTag::ISO_SPEED],
-            SensitivityType::SOS_AND_REI => [ExifTag::STANDARD_OUTPUT_SENSITIVITY, ExifTag::RECOMMENDED_EXPOSURE_INDEX],
-            SensitivityType::SOS_AND_ISO => [ExifTag::STANDARD_OUTPUT_SENSITIVITY, ExifTag::ISO_SPEED],
-            SensitivityType::REI_AND_ISO => [ExifTag::RECOMMENDED_EXPOSURE_INDEX, ExifTag::ISO_SPEED],
+            SensitivityType::RECOMMENDED_EXPOSURE_INDEX => [
+                ExifTag::RECOMMENDED_EXPOSURE_INDEX,
+                ExifTag::EXPOSURE_INDEX,
+            ],
+            SensitivityType::ISO_SPEED => [
+                ExifTag::PHOTOGRAPHIC_SENSITIVITY,
+                ExifTag::ISO_SPEED,
+            ],
+            SensitivityType::SOS_AND_REI => [
+                ExifTag::STANDARD_OUTPUT_SENSITIVITY,
+                ExifTag::RECOMMENDED_EXPOSURE_INDEX,
+                ExifTag::EXPOSURE_INDEX,
+            ],
+            SensitivityType::SOS_AND_ISO => [
+                ExifTag::STANDARD_OUTPUT_SENSITIVITY,
+                ExifTag::PHOTOGRAPHIC_SENSITIVITY,
+                ExifTag::ISO_SPEED,
+            ],
+            SensitivityType::REI_AND_ISO => [
+                ExifTag::RECOMMENDED_EXPOSURE_INDEX,
+                ExifTag::EXPOSURE_INDEX,
+                ExifTag::PHOTOGRAPHIC_SENSITIVITY,
+                ExifTag::ISO_SPEED,
+            ],
             SensitivityType::SOS_AND_REI_AND_ISO => [
                 ExifTag::STANDARD_OUTPUT_SENSITIVITY,
                 ExifTag::RECOMMENDED_EXPOSURE_INDEX,
+                ExifTag::EXPOSURE_INDEX,
+                ExifTag::PHOTOGRAPHIC_SENSITIVITY,
                 ExifTag::ISO_SPEED,
             ],
             SensitivityType::UNKNOWN => [],

--- a/tests/Model/Exif/ParsedExifSensitivityTest.php
+++ b/tests/Model/Exif/ParsedExifSensitivityTest.php
@@ -99,6 +99,7 @@ final class ParsedExifSensitivityTest extends TestCase
                 ExifTag::STANDARD_OUTPUT_SENSITIVITY => 100,
                 ExifTag::RECOMMENDED_EXPOSURE_INDEX => 200,
                 ExifTag::ISO_SPEED => 300,
+                ExifTag::EXPOSURE_INDEX => 250,
             ],
             'expected' => 200,
         ];
@@ -109,8 +110,9 @@ final class ParsedExifSensitivityTest extends TestCase
                 ExifTag::STANDARD_OUTPUT_SENSITIVITY => 100,
                 ExifTag::RECOMMENDED_EXPOSURE_INDEX => 200,
                 ExifTag::ISO_SPEED => 300,
+                ExifTag::PHOTOGRAPHIC_SENSITIVITY => 320,
             ],
-            'expected' => 300,
+            'expected' => 320,
         ];
 
         yield 'sos and rei' => [
@@ -119,6 +121,7 @@ final class ParsedExifSensitivityTest extends TestCase
                 ExifTag::STANDARD_OUTPUT_SENSITIVITY => 100,
                 ExifTag::RECOMMENDED_EXPOSURE_INDEX => 200,
                 ExifTag::ISO_SPEED => 300,
+                ExifTag::EXPOSURE_INDEX => 250,
             ],
             'expected' => 100,
         ];
@@ -129,6 +132,7 @@ final class ParsedExifSensitivityTest extends TestCase
                 ExifTag::STANDARD_OUTPUT_SENSITIVITY => 100,
                 ExifTag::RECOMMENDED_EXPOSURE_INDEX => 200,
                 ExifTag::ISO_SPEED => 300,
+                ExifTag::PHOTOGRAPHIC_SENSITIVITY => 320,
             ],
             'expected' => 100,
         ];
@@ -139,6 +143,8 @@ final class ParsedExifSensitivityTest extends TestCase
                 ExifTag::STANDARD_OUTPUT_SENSITIVITY => 100,
                 ExifTag::RECOMMENDED_EXPOSURE_INDEX => 200,
                 ExifTag::ISO_SPEED => 300,
+                ExifTag::PHOTOGRAPHIC_SENSITIVITY => 320,
+                ExifTag::EXPOSURE_INDEX => 250,
             ],
             'expected' => 200,
         ];
@@ -149,6 +155,8 @@ final class ParsedExifSensitivityTest extends TestCase
                 ExifTag::STANDARD_OUTPUT_SENSITIVITY => 100,
                 ExifTag::RECOMMENDED_EXPOSURE_INDEX => 200,
                 ExifTag::ISO_SPEED => 300,
+                ExifTag::PHOTOGRAPHIC_SENSITIVITY => 320,
+                ExifTag::EXPOSURE_INDEX => 250,
             ],
             'expected' => 100,
         ];
@@ -159,7 +167,7 @@ final class ParsedExifSensitivityTest extends TestCase
                 ExifTag::ISO_SPEED => 400,
                 ExifTag::PHOTOGRAPHIC_SENSITIVITY => 500,
             ],
-            'expected' => 400,
+            'expected' => 500,
         ];
     }
 }


### PR DESCRIPTION
## Summary
- Align EXIF sensitivity tag priorities with photographic sensitivity and exposure index fallbacks for ISO speed combinations.
- Prefer photographic sensitivity when resolving ISO values and cover mixed-type combinations.

**Issue/Milestone:** Closes #<ID> • Milestone M#
**Scope (allowed files only):** src/Model/Exif/ParsedExif.php; tests/Model/Exif/ParsedExifSensitivityTest.php
**Non-Goals:** Broader EXIF parsing changes.

---

## Implementation Notes
- Runtime: PHP 8.4, `declare(strict_types=1);`, PSR-12.
- **Streaming only** (Core\\Stream/StreamWindow) — keine Ganzdatei-Reads.
- Keine externen Binaries/Extensions; **kein** `exif_read_data()`.
- Value Objects (chainable) nur für EXIF-Ausgabe; kein Rendering.
- **Enums** für gängige Kodierungen genutzt/ergänzt (Encoding/Endianness/IFD/XMP/...).
- **Spec-References** im Code ergänzt/aktualisiert (siehe „References“).

---

## Always Checklist (must be green)
**Composer-Tasks (deine CI-Skripte):**
- [ ] Lint: `composer ci:test:php:lint`
- [ ] PHPStan: `composer ci:test:php:phpstan`
- [ ] Rector (dry-run): `composer ci:test:php:rector`
- [ ] Coding-Style: `composer ci::cgl`
- [ ] PHPUnit: `composer ci:test:php:unit`
- [ ] Coverage ≥ **90 %**: `composer ci:test:php:unit:coverage`
- [ ] JSCPD (Duplikate = 0): `composer ci:test:php:cpd`
- [ ] Sammellauf: `composer ci:test` (sollte grün sein; enthält Lint, PHPStan, Rector-Dry-Run, CS-Dry-Run, Unit)

**Inhaltliche/Code-Guidelines:**
- [ ] **Keine** `mixed`-Signaturen • **kein** `empty()` • **keine** verschachtelten Ternaries
- [ ] Fully-qualified native functions (`\\strlen`, `\\count`, …) und sinnvolle `use`-Imports
- [ ] **Keine** dynamischen Aufrufe statischer Methoden
- [ ] Sinnvolle **Interfaces** verwendet (wo Verträge sinnvoll sind)
- [ ] Typisierte Klassenkonstanten; redundante Casts/Default-Argumente entfernt
- [ ] Klassen als `readonly`, wo passend; keine redundanten `readonly`-Mods
- [ ] **Eine Klasse je Datei** • Test-Namespaces spiegeln `src/`-Struktur
- [ ] Englische PHPDocs & englische Inline-Kommentare an komplexen Stellen
- [ ] Sinnvolle Namen für Variablen/Konstanten; Magic Numbers/Strings vermieden
- [ ] `array_find` / `array_any` / `array_all` gezielt statt trivialer `foreach` verwendet (wo es die Lesbarkeit verbessert)

---

## EXIF / TIFF / ISOBMFF / XMP Guardrails
- **EXIF-Versionen:** 1.x, 2.x (2.1/2.2/2.21/2.3/2.31/2.32), 3.0 — kompatible Änderungen; falls Tags betroffen: Coverage-Test grün.
- **TIFF/BigTIFF:** Endianness korrekt (`0x2A` / `0x2B`), Inline-Werte-Grenzen, `RATIONAL/SRATIONAL` korrekt.
- **GPS:** Vorzeichen über Ref-Tags (S/W negativ); `0/0`-Kantenfälle robust.
- **Preview/IFD1:** Nur beschreiben (Offsets/Längen/Compression), kein Rendering.
- **ISOBMFF/QuickTime:** Box-Size ≥ Header, 32/64-bit-Größen korrekt; `iloc`-Extents summiert; `data_reference_index ≠ 0` → skip; keine Remote-Refs.
- **XMP:** JPEG APP1-Präfix / ISOBMFF `uuid`; Parser mit `LIBXML_NONET`, keine DTD/Entities; `Alt/Bag/Seq` → Arrays.
- **Fehlerbehandlung:** ausschließlich `ParseError` oder `BoundsError`; keine Warnings/Notices als Kontrollfluss.

---

## Tests
- **Neue/angepasste Tests:** ParsedExif::iso sensitivity priorities including photographic sensitivity and exposure index combinations.
- **Negative Cases:** Not applicable for this change.
- **Fixtures/Streams:** Synthetic IFD entries within unit tests.

---

## Pre-Sweep Notes
- Executed: `composer ci:test:php:unit -- --filter ParsedExifSensitivityTest`.

## M# Sweep — Verify compliance for this milestone
Bitte **alles** verifizieren und kurz die Ergebnisse notieren:
- [ ] `composer ci:test` **grün** (Lint, PHPStan, Rector-Dry-Run, CS-Dry-Run, Unit)
- [ ] `composer ci:test:php:cpd` **0 Duplikate** (JSCPD, Konfig: `.build/.jscpd.json`)
- [ ] `composer ci:test:php:unit:coverage` **≥ 90 %**
- [ ] **ExifCoverageTest** (falls vorhanden): 0 fehlende Tags/Getters (gegen `resources/exif-map.yaml`)
- [ ] Für **jede** Klasse existiert ein Test (Namespace-Spiegelung)

---

## Breaking Changes / Risk / Rollback
- **Breaking changes:** None.
- **Risiken:** Minimal; confined to ISO sensitivity resolution order.
- **Rollback-Plan:** Revert this PR.

---

## Changelog
- fix(exif): honor photographic sensitivity tags when resolving ISO values.

---

## References (Specs & Docs)
- EXIF 3.0 §4.6.4; EXIF 2.32 §4.6.4
- TIFF 6.0 §—

Docs im Repo:
- `docs/EXIF-210.pdf`, `docs/EXIF-220.pdf`, `docs/EXIF-230.pdf`, `docs/EXIF-231.pdf`, `docs/EXIF-232.pdf`, `docs/EXIF-300.pdf`
- `docs/TIFF6.pdf`

---

## Review Roles (tick what you covered)
- [ ] Planner (Scope/Non-Goals/Guardrails definiert)
- [ ] Spec Writer (AC/Tests präzisiert)
- [ ] Test Agent (RED zuerst)
- [ ] Implementer (GREEN minimal & im Datei-Scope)
- [ ] Static/QA (Stan/CS/Rector/JSCPD clean)
- [ ] Security (Bounds, Offsets, XML-Flags)
- [ ] Reviewer (Minimalität, DX, Spec-Refs, Enums)
- [ ] Release (PR-Text, Labels, Milestone, „Closes #…“)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69358667b1ec8323a25879286c4154c5)