### PR TITLE
M#: Add GPS reference decoding tests — Parse/Tiff

### DIFF
--- a/tests/Parse/Tiff/TiffExifReaderGpsReferenceTest.php
+++ b/tests/Parse/Tiff/TiffExifReaderGpsReferenceTest.php
@@ -1,0 +1,203 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\ImageMeta\Tests\Parse\Tiff;
+
+use MagicSunday\ImageMeta\Core\Endian;
+use MagicSunday\ImageMeta\Model\Exif\ExifTag;
+use MagicSunday\ImageMeta\Model\Exif\ParsedExif;
+use MagicSunday\ImageMeta\Parse\Tiff\TiffConst;
+use MagicSunday\ImageMeta\Parse\Tiff\TiffExifReader;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\UsesClass;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * GPS reference handling derived from EXIF 3.0 §4.6.6 (GPS tag examples)
+ * and EXIF 2.32 §4.6.6 for backward-compatible hemisphere/altitude signs.
+ */
+#[CoversClass(TiffExifReader::class)]
+#[UsesClass(ParsedExif::class)]
+#[UsesClass(TiffConst::class)]
+final class TiffExifReaderGpsReferenceTest extends TestCase
+{
+    #[Test]
+    public function parsesSouthAndWestCoordinatesFromClassicTiff(): void
+    {
+        $reader = new TiffExifReader();
+        $result = $reader->parseFromBlob($this->buildGpsExample(Endian::Little));
+
+        $gps = $result->gps();
+
+        $expectedLatitude  = -1 * (12 + (34 / 60) + (5678 / 100 / 3600));
+        $expectedLongitude = -1 * (98 + (45 / 60) + (4321 / 100 / 3600));
+
+        self::assertSame('S', $gps['lat_ref']);
+        self::assertSame('W', $gps['lon_ref']);
+        self::assertEqualsWithDelta($expectedLatitude, $gps['lat'], 0.000001);
+        self::assertEqualsWithDelta($expectedLongitude, $gps['lon'], 0.000001);
+        self::assertSame(1, $gps['alt_ref']);
+        self::assertEqualsWithDelta(-5.5, $gps['alt'], 0.000001);
+    }
+
+    #[Test]
+    public function parsesSouthAndWestCoordinatesFromBigTiff(): void
+    {
+        $reader = new TiffExifReader();
+        $result = $reader->parseFromBlob($this->buildBigTiffGpsExample(Endian::Little));
+
+        $gps = $result->gps();
+
+        $expectedLatitude  = -1 * (12 + (34 / 60) + (5678 / 100 / 3600));
+        $expectedLongitude = -1 * (98 + (45 / 60) + (4321 / 100 / 3600));
+
+        self::assertSame('S', $gps['lat_ref']);
+        self::assertSame('W', $gps['lon_ref']);
+        self::assertEqualsWithDelta($expectedLatitude, $gps['lat'], 0.000001);
+        self::assertEqualsWithDelta($expectedLongitude, $gps['lon'], 0.000001);
+        self::assertSame(1, $gps['alt_ref']);
+        self::assertEqualsWithDelta(-5.5, $gps['alt'], 0.000001);
+    }
+
+    private function buildGpsExample(Endian $endian): string
+    {
+        $packShort    = $endian === Endian::Little ? 'v' : 'n';
+        $packLong     = $endian === Endian::Little ? 'V' : 'N';
+        $packRational = $endian === Endian::Little ? 'V2' : 'N2';
+
+        $header = $endian->value
+            . pack($packShort, TiffConst::MAGIC_CLASSIC)
+            . pack($packLong, 8);
+
+        $ifd0 = pack($packShort, 1)
+            . pack($packShort, ExifTag::GPS_IFD_POINTER)
+            . pack($packShort, TiffConst::TYPE_LONG)
+            . pack($packLong, 1)
+            . pack($packLong, 30)
+            . pack($packLong, 0);
+
+        $gpsIfd = pack($packShort, 5)
+            // GPSLatitudeRef = "S"
+            . pack($packShort, ExifTag::GPS_LATITUDE_REF)
+            . pack($packShort, TiffConst::TYPE_ASCII)
+            . pack($packLong, 2)
+            . pack('A4', 'S')
+            // GPSLatitude = [12, 34, 56.78]
+            . pack($packShort, ExifTag::GPS_LATITUDE)
+            . pack($packShort, TiffConst::TYPE_RATIONAL)
+            . pack($packLong, 3)
+            . pack($packLong, 112)
+            // GPSLongitudeRef = "W"
+            . pack($packShort, ExifTag::GPS_LONGITUDE_REF)
+            . pack($packShort, TiffConst::TYPE_ASCII)
+            . pack($packLong, 2)
+            . pack('A4', 'W')
+            // GPSLongitude = [98, 45, 43.21]
+            . pack($packShort, ExifTag::GPS_LONGITUDE)
+            . pack($packShort, TiffConst::TYPE_RATIONAL)
+            . pack($packLong, 3)
+            . pack($packLong, 136)
+            // GPSAltitudeRef = 1 (below sea level)
+            . pack($packShort, ExifTag::GPS_ALTITUDE_REF)
+            . pack($packShort, TiffConst::TYPE_BYTE)
+            . pack($packLong, 1)
+            . pack($packLong, 1)
+            // GPSAltitude = 11/2
+            . pack($packShort, ExifTag::GPS_ALTITUDE)
+            . pack($packShort, TiffConst::TYPE_RATIONAL)
+            . pack($packLong, 1)
+            . pack($packLong, 160)
+            . pack($packLong, 0);
+
+        $gpsData = pack($packRational, 12, 1)
+            . pack($packRational, 34, 1)
+            . pack($packRational, 5678, 100)
+            . pack($packRational, 98, 1)
+            . pack($packRational, 45, 1)
+            . pack($packRational, 4321, 100)
+            . pack($packRational, 11, 2);
+
+        return $header . $ifd0 . $gpsIfd . $gpsData;
+    }
+
+    private function buildBigTiffGpsExample(Endian $endian): string
+    {
+        $packShort = $endian === Endian::Little ? 'v' : 'n';
+        $packLong  = $endian === Endian::Little ? 'V' : 'N';
+        $packLong8 = $endian === Endian::Little ? 'P' : 'J';
+        $packRatio = $endian === Endian::Little ? 'P2' : 'J2';
+
+        $header = $endian->value
+            . pack($packShort, TiffConst::MAGIC_BIG_TIFF)
+            . pack($packShort, 8)
+            . pack($packShort, 0)
+            . pack($packLong, 8)
+            . pack($packLong8, 16);
+
+        $firstIfdOffset = 16;
+        $ifd0EntryCount = pack($packLong8, 1);
+        $gpsIfdOffset   = $firstIfdOffset + 8 + 20 + 8; // header + entry count + one entry + next offset
+
+        $ifd0 = $ifd0EntryCount
+            . pack($packShort, ExifTag::GPS_IFD_POINTER)
+            . pack($packShort, TiffConst::TYPE_IFD8)
+            . pack($packLong8, 1)
+            . pack($packLong8, $gpsIfdOffset)
+            . pack($packLong8, 0);
+
+        $gpsEntryCount = pack($packLong8, 5);
+        $gpsDataOffset = $gpsIfdOffset + 8 + (5 * 20) + 8;
+
+        $gpsIfd = $gpsEntryCount
+            // GPSLatitudeRef = "S" (inline)
+            . pack($packShort, ExifTag::GPS_LATITUDE_REF)
+            . pack($packShort, TiffConst::TYPE_ASCII)
+            . pack($packLong8, 2)
+            . pack('A8', 'S')
+            // GPSLatitude = [12, 34, 56.78]
+            . pack($packShort, ExifTag::GPS_LATITUDE)
+            . pack($packShort, TiffConst::TYPE_RATIONAL)
+            . pack($packLong8, 3)
+            . pack($packLong8, $gpsDataOffset)
+            // GPSLongitudeRef = "W" (inline)
+            . pack($packShort, ExifTag::GPS_LONGITUDE_REF)
+            . pack($packShort, TiffConst::TYPE_ASCII)
+            . pack($packLong8, 2)
+            . pack('A8', 'W')
+            // GPSLongitude = [98, 45, 43.21]
+            . pack($packShort, ExifTag::GPS_LONGITUDE)
+            . pack($packShort, TiffConst::TYPE_RATIONAL)
+            . pack($packLong8, 3)
+            . pack($packLong8, $gpsDataOffset + (3 * 8))
+            // GPSAltitudeRef = 1
+            . pack($packShort, ExifTag::GPS_ALTITUDE_REF)
+            . pack($packShort, TiffConst::TYPE_BYTE)
+            . pack($packLong8, 1)
+            . pack($packLong8, 1)
+            // GPSAltitude = 11/2
+            . pack($packShort, ExifTag::GPS_ALTITUDE)
+            . pack($packShort, TiffConst::TYPE_RATIONAL)
+            . pack($packLong8, 1)
+            . pack($packLong8, $gpsDataOffset + (6 * 8))
+            . pack($packLong8, 0);
+
+        $gpsData = pack($packRatio, 12, 1)
+            . pack($packRatio, 34, 1)
+            . pack($packRatio, 5678, 100)
+            . pack($packRatio, 98, 1)
+            . pack($packRatio, 45, 1)
+            . pack($packRatio, 4321, 100)
+            . pack($packRatio, 11, 2);
+
+        return $header . $ifd0 . $gpsIfd . $gpsData;
+    }
+}


### PR DESCRIPTION
## Summary
- Added EXIF 3.0 GPS reference decoding examples for southern/western hemispheres and below-sea altitude.
- Issue/Milestone: Closes #0 • Milestone M#
- Scope (allowed files only): tests/Parse/Tiff
- Non-Goals: Parser/VO changes beyond additional tests.

---

## Implementation Notes
- Runtime: PHP 8.4, `declare(strict_types=1);`, PSR-12.
- **Streaming only** (Core\\Stream/StreamWindow) — keine Ganzdatei-Reads.
- Keine externen Binaries/Extensions; **kein** `exif_read_data()`.
- Value Objects (chainable) nur für EXIF-Ausgabe; kein Rendering.
- **Enums** für gängige Kodierungen genutzt/ergänzt (Encoding/Endianness/IFD/XMP/...).
- **Spec-References** im Code ergänzt/aktualisiert (siehe „References“).

---

## Always Checklist (must be green)
**Composer-Tasks (deine CI-Skripte):**
- [ ] Lint: `composer ci:test:php:lint`
- [ ] PHPStan: `composer ci:test:php:phpstan`
- [ ] Rector (dry-run): `composer ci:test:php:rector`
- [ ] Coding-Style: `composer ci::cgl`
- [ ] PHPUnit: `composer ci:test:php:unit`
- [ ] Coverage ≥ **90 %**: `composer ci:test:php:unit:coverage`
- [ ] JSCPD (Duplikate = 0): `composer ci:test:php:cpd`
- [ ] Sammellauf: `composer ci:test` (sollte grün sein; enthält Lint, PHPStan, Rector-Dry-Run, CS-Dry-Run, Unit)

**Inhaltliche/Code-Guidelines:**
- [ ] **Keine** `mixed`-Signaturen • **kein** `empty()` • **keine** verschachtelten Ternaries
- [ ] Fully-qualified native functions (`\\strlen`, `\\count`, …) und sinnvolle `use`-Imports
- [ ] **Keine** dynamischen Aufrufe statischer Methoden
- [ ] Sinnvolle **Interfaces** verwendet (wo Verträge sinnvoll sind)
- [ ] Typisierte Klassenkonstanten; redundante Casts/Default-Argumente entfernt
- [ ] Klassen als `readonly`, wo passend; keine redundanten `readonly`-Mods
- [ ] **Eine Klasse je Datei** • Test-Namespaces spiegeln `src/`-Struktur
- [ ] Englische PHPDocs & englische Inline-Kommentare an komplexen Stellen
- [ ] Sinnvolle Namen für Variablen/Konstanten; Magic Numbers/Strings vermieden
- [ ] `array_find` / `array_any` / `array_all` gezielt statt trivialer `foreach` verwendet (wo es die Lesbarkeit verbessert)

---

## Pre-Sweep Status
- Tooling for `phpunit` unavailable in the container; sweep items pending local CI.

## M# Sweep — Verify compliance for this milestone
Bitte **alles** verifizieren und kurz die Ergebnisse notieren:
- [ ] `composer ci:test` **grün** (Lint, PHPStan, Rector-Dry-Run, CS-Dry-Run, Unit)
- [ ] `composer ci:test:php:cpd` **0 Duplikate** (JSCPD, Konfig: `.build/.jscpd.json`)
- [ ] `composer ci:test:php:unit:coverage` **≥ 90 %**
- [ ] **ExifCoverageTest** (falls vorhanden): 0 fehlende Tags/Getters (gegen `resources/exif-map.yaml`)
- [ ] Für **jede** Klasse existiert ein Test (Namespace-Spiegelung)

---

## Breaking Changes / Risk / Rollback
- **Breaking changes:** Keine.
- **Risiken:** Nur neue Tests; Parser bleibt unverändert.
- **Rollback-Plan:** Commit revertieren.

---

## Changelog
- test(exif): add gps reference decoding examples

---

## References (Specs & Docs)
- EXIF 3.0 §4.6.6 ; ggf. EXIF 2.32 §4.6.6 ; EXIF 2.31 §4.6.6
- TIFF 6.0 §—
- ISOBMFF/QuickTime §—
- XMP (Adobe XMP Packet) §—

Docs im Repo:
- `docs/EXIF-210.pdf`, `docs/EXIF-220.pdf`, `docs/EXIF-230.pdf`, `docs/EXIF-231.pdf`, `docs/EXIF-232.pdf`, `docs/EXIF-300.pdf`
- `docs/TIFF6.pdf`

---

## Review Roles (tick what you covered)
- [ ] Planner (Scope/Non-Goals/Guardrails definiert)
- [ ] Spec Writer (AC/Tests präzisiert)
- [ ] Test Agent (RED zuerst)
- [ ] Implementer (GREEN minimal & im Datei-Scope)
- [ ] Static/QA (Stan/CS/Rector/JSCPD clean)
- [ ] Security (Bounds, Offsets, XML-Flags)
- [ ] Reviewer (Minimalität, DX, Spec-Refs, Enums)
- [ ] Release (PR-Text, Labels, Milestone, „Closes #…“)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6936e227d0b483238eca992f394bb17a)