### PR TITLE
M#: Align TIFF baseline datatype definitions — Resources

### DIFF
--- a/resources/exif-spec-tags.yaml
+++ b/resources/exif-spec-tags.yaml
@@ -120,7 +120,7 @@ tiff_tags:
     name: ImageDescription
     tag: 270
     hex: 10E
-    type: ASCII
+    type: ASCII or UTF-8
     count: any
     ifd: IFD0
     source: TIFF 6.0
@@ -129,7 +129,7 @@ tiff_tags:
     name: Make
     tag: 271
     hex: 10F
-    type: ASCII
+    type: ASCII or UTF-8
     count: any
     ifd: IFD0
     source: TIFF 6.0
@@ -138,7 +138,7 @@ tiff_tags:
     name: Model
     tag: 272
     hex: 110
-    type: ASCII
+    type: ASCII or UTF-8
     count: any
     ifd: IFD0
     source: TIFF 6.0
@@ -345,7 +345,7 @@ tiff_tags:
     name: Software
     tag: 305
     hex: 131
-    type: ASCII
+    type: ASCII or UTF-8
     count: any
     ifd: IFD0
     source: TIFF 6.0
@@ -363,7 +363,7 @@ tiff_tags:
     name: Artist
     tag: 315
     hex: 13B
-    type: ASCII
+    type: ASCII or UTF-8
     count: any
     ifd: IFD0
     source: TIFF 6.0
@@ -660,8 +660,8 @@ tiff_tags:
     name: ReferenceBlackWhite
     tag: 532
     hex: 214
-    type: LONG
-    count: 2*SamplesPerPixel
+    type: RATIONAL
+    count: 6
     ifd: IFD0
     source: TIFF 6.0
 
@@ -669,7 +669,7 @@ tiff_tags:
     name: Copyright
     tag: 33432
     hex: 8298
-    type: ASCII
+    type: ASCII or UTF-8
     count: Any
     ifd: IFD0
     source: TIFF 6.0


### PR DESCRIPTION
## Summary
- Align TIFF baseline tag datatype definitions with TIFF 6.0 guidance.

**Issue/Milestone:** Closes #N/A • Milestone M?
**Scope (allowed files only):** resources/exif-spec-tags.yaml
**Non-Goals:** No parser or model changes.

---

## Implementation Notes
- Runtime: PHP 8.4, `declare(strict_types=1);`, PSR-12.
- **Streaming only** (Core\Stream/StreamWindow) — keine Ganzdatei-Reads.
- Keine externen Binaries/Extensions; **kein** `exif_read_data()`.
- Value Objects (chainable) nur für EXIF-Ausgabe; kein Rendering.
- **Enums** für gängige Kodierungen genutzt/ergänzt (Encoding/Endianness/IFD/XMP/...).
- **Spec-References** im Code ergänzt/aktualisiert (siehe „References“).

---

## Always Checklist (must be green)
**Composer-Tasks (deine CI-Skripte):**
- [ ] Lint: `composer ci:test:php:lint`
- [ ] PHPStan: `composer ci:test:php:phpstan`
- [ ] Rector (dry-run): `composer ci:test:php:rector`
- [ ] Coding-Style: `composer ci::cgl`
- [ ] PHPUnit: `composer ci:test:php:unit`
- [ ] Coverage ≥ **90 %**: `composer ci:test:php:unit:coverage`
- [ ] JSCPD (Duplikate = 0): `composer ci:test:php:cpd`
- [ ] Sammellauf: `composer ci:test` (sollte grün sein; enthält Lint, PHPStan, Rector-Dry-Run, CS-Dry-Run, Unit)

**Inhaltliche/Code-Guidelines:**
- [ ] **Keine** `mixed`-Signaturen • **kein** `empty()` • **keine** verschachtelten Ternaries
- [ ] Fully-qualified native functions (`\strlen`, `\count`, …) und sinnvolle `use`-Imports
- [ ] **Keine** dynamischen Aufrufe statischer Methoden
- [ ] Sinnvolle **Interfaces** verwendet (wo Verträge sinnvoll sind)
- [ ] Typisierte Klassenkonstanten; redundante Casts/Default-Argumente entfernt
- [ ] Klassen als `readonly`, wo passend; keine redundanten `readonly`-Mods
- [ ] **Eine Klasse je Datei** • Test-Namespaces spiegeln `src/`-Struktur
- [ ] Englische PHPDocs & englische Inline-Kommentare an komplexen Stellen
- [ ] Sinnvolle Namen für Variablen/Konstanten; Magic Numbers/Strings vermieden
- [ ] `array_find` / `array_any` / `array_all` gezielt statt trivialer `foreach` verwendet (wo es die Lesbarkeit verbessert)

---

## EXIF / TIFF / ISOBMFF / XMP Guardrails
- **EXIF-Versionen:** 1.x, 2.x (2.1/2.2/2.21/2.3/2.31/2.32), 3.0 — kompatible Änderungen; falls Tags betroffen: Coverage-Test grün.
- **TIFF/BigTIFF:** Endianness korrekt (`0x2A` / `0x2B`), Inline-Werte-Grenzen, `RATIONAL/SRATIONAL` korrekt.
- **GPS:** Vorzeichen über Ref-Tags (S/W negativ); `0/0`-Kantenfälle robust.
- **Preview/IFD1:** Nur beschreiben (Offsets/Längen/Compression), kein Rendering.
- **ISOBMFF/QuickTime:** Box-Size ≥ Header, 32/64-bit-Größen korrekt; `iloc`-Extents summiert; `data_reference_index ≠ 0` → skip; keine Remote-Refs.
- **XMP:** JPEG APP1-Präfix / ISOBMFF `uuid`; Parser mit `LIBXML_NONET`, keine DTD/Entities; `Alt/Bag/Seq` → Arrays.
- **Fehlerbehandlung:** ausschließlich `ParseError` oder `BoundsError`; keine Warnings/Notices als Kontrollfluss.

---

## Tests
- **Neue/angepasste Tests:** Keine neuen Tests erforderlich; Ressourcendefinitionen aktualisiert.
- **Negative Cases:** Nicht geändert (Datenquelle-only Änderung).
- **Fixtures/Streams:** Keine neuen Fixtures.

---

### Pre-flight notes
- Updated textual TIFF baseline tags to allow ASCII or UTF-8 encodings and corrected ReferenceBlackWhite to use RATIONAL values with the expected count.

## M# Sweep — Verify compliance for this milestone
Bitte **alles** verifizieren und kurz die Ergebnisse notieren:
- [ ] `composer ci:test` **grün** (Lint, PHPStan, Rector-Dry-Run, CS-Dry-Run, Unit)
- [ ] `composer ci:test:php:cpd` **0 Duplikate** (JSCPD, Konfig: `.build/.jscpd.json`)
- [ ] `composer ci:test:php:unit:coverage` **≥ 90 %**
- [ ] **ExifCoverageTest** (falls vorhanden): 0 fehlende Tags/Getters (gegen `resources/exif-map.yaml`)
- [ ] Für **jede** Klasse existiert ein Test (Namespace-Spiegelung)

---

## Breaking Changes / Risk / Rollback
- **Breaking changes:** Keine.
- **Risiken:** Gering; Anpassungen nur in Tag-Metadaten.
- **Rollback-Plan:** Commit revertieren.

---

## Changelog
- chore(tiff): align TIFF tag datatypes with TIFF 6.0 guidance

---

## References (Specs & Docs)
- TIFF 6.0 §8 (tag type definitions)

Docs im Repo:
- `docs/EXIF-210.pdf`, `docs/EXIF-220.pdf`, `docs/EXIF-230.pdf`, `docs/EXIF-231.pdf`, `docs/EXIF-232.pdf`, `docs/EXIF-300.pdf`
- `docs/TIFF6.pdf`

---

## Review Roles (tick what you covered)
- [ ] Planner (Scope/Non-Goals/Guardrails definiert)
- [ ] Spec Writer (AC/Tests präzisiert)
- [ ] Test Agent (RED zuerst)
- [ ] Implementer (GREEN minimal & im Datei-Scope)
- [ ] Static/QA (Stan/CS/Rector/JSCPD clean)
- [ ] Security (Bounds, Offsets, XML-Flags)
- [ ] Reviewer (Minimalität, DX, Spec-Refs, Enums)
- [ ] Release (PR-Text, Labels, Milestone, „Closes #…“)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693816ceeed88323b959af96585d7590)