### PR TITLE
M#: ReferenceBlackWhite defaults — EXIF

### DIFF
--- a/resources/exif-spec-tags.yaml
+++ b/resources/exif-spec-tags.yaml
@@ -660,8 +660,8 @@ tiff_tags:
     name: ReferenceBlackWhite
     tag: 532
     hex: 214
-    type: LONG
-    count: 2*SamplesPerPixel
+    type: RATIONAL
+    count: 6
     ifd: IFD0
     source: TIFF 6.0
 
@@ -937,6 +937,8 @@ exif_tags:
     ifd: IFD0
     category: I
     update: 0
+    type: RATIONAL
+    count: 6
     source: EXIF 3.0
 
   0x8298:

--- a/src/Model/Exif/ParsedExif.php
+++ b/src/Model/Exif/ParsedExif.php
@@ -635,11 +635,20 @@ final readonly class ParsedExif
     /**
      * Returns the reference black and white point values as floating point numbers.
      *
+     * EXIF 3.0 §4.6.5.3.5 and EXIF 2.32 §4.6.5 describe defaults when the
+     * colour space is declared.
+     *
      * @return list<float>|null
      */
     public function referenceBlackWhite(): ?array
     {
-        return $this->rationalList($this->ifd0, ExifTag::REFERENCE_BLACK_WHITE);
+        $values = $this->rationalList($this->ifd0, ExifTag::REFERENCE_BLACK_WHITE);
+
+        if ($values !== null) {
+            return $this->normaliseReferenceBlackWhite($values);
+        }
+
+        return $this->defaultReferenceBlackWhite();
     }
 
     /**
@@ -2868,6 +2877,56 @@ final readonly class ParsedExif
         }
 
         return null;
+    }
+
+    /**
+     * Normalises a reference black and white array to six components.
+     *
+     * EXIF 3.0 §4.6.5.3.5 requires six rational values representing the
+     * black and white points for each channel.
+     *
+     * @param list<float> $values
+     *
+     * @return array{0: float, 1: float, 2: float, 3: float, 4: float, 5: float}|null
+     */
+    private function normaliseReferenceBlackWhite(array $values): ?array
+    {
+        if (count($values) !== 6) {
+            return null;
+        }
+
+        return [
+            0 => $values[0],
+            1 => $values[1],
+            2 => $values[2],
+            3 => $values[3],
+            4 => $values[4],
+            5 => $values[5],
+        ];
+    }
+
+    /**
+     * Applies EXIF 3.0 §4.6.5.3.5 defaults when ReferenceBlackWhite is absent.
+     *
+     * Defaults are only valid when the colour space is explicitly defined and
+     * the photometric interpretation is RGB or YCbCr.
+     *
+     * @return array{0: float, 1: float, 2: float, 3: float, 4: float, 5: float}|null
+     */
+    private function defaultReferenceBlackWhite(): ?array
+    {
+        $photometric = $this->photometric();
+        $colorSpace  = $this->colorSpace();
+
+        if (($photometric === null) || ($colorSpace === null) || ($colorSpace === ColorSpace::UNCALIBRATED)) {
+            return null;
+        }
+
+        return match ($photometric) {
+            Photometric::RGB => [0.0, 255.0, 0.0, 255.0, 0.0, 255.0],
+            Photometric::YCBCR => [0.0, 255.0, 128.0, 128.0, 128.0, 128.0],
+            default => null,
+        };
     }
 
     /**

--- a/tests/Model/Exif/ParsedExifDefaultValuesTest.php
+++ b/tests/Model/Exif/ParsedExifDefaultValuesTest.php
@@ -12,11 +12,15 @@ declare(strict_types=1);
 namespace MagicSunday\ImageMeta\Tests\Model\Exif;
 
 use MagicSunday\ImageMeta\Model\Exif\Ifd;
+use MagicSunday\ImageMeta\Model\Exif\IfdEntry;
 use MagicSunday\ImageMeta\Model\Exif\ParsedExif;
+use MagicSunday\ImageMeta\Model\Exif\ExifTag;
 use MagicSunday\ImageMeta\Value\Enum\Compression;
+use MagicSunday\ImageMeta\Value\Enum\ColorSpace;
 use MagicSunday\ImageMeta\Value\Enum\Orientation;
 use MagicSunday\ImageMeta\Value\Enum\PlanarConfiguration;
 use MagicSunday\ImageMeta\Value\Enum\ResolutionUnit;
+use MagicSunday\ImageMeta\Value\Enum\Photometric;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -121,5 +125,86 @@ final class ParsedExifDefaultValuesTest extends TestCase
         $parsedExif = new ParsedExif($ifd0, null, null, null, null);
 
         self::assertSame(ResolutionUnit::INCHES, $parsedExif->resolutionUnit());
+    }
+
+    /**
+     * Verifies that ReferenceBlackWhite returns the EXIF 3.0 §4.6.5.3.5 default
+     * when the colour space is defined and the photometric interpretation is RGB.
+     */
+    #[Test]
+    public function referenceBlackWhiteDefaultsForRgb(): void
+    {
+        $ifd0 = new Ifd([
+            ExifTag::PHOTOMETRIC_INTERPRETATION => new IfdEntry(
+                ExifTag::PHOTOMETRIC_INTERPRETATION,
+                3,
+                1,
+                Photometric::RGB->value,
+            ),
+        ]);
+
+        $exifIfd = new Ifd([
+            ExifTag::COLOR_SPACE => new IfdEntry(ExifTag::COLOR_SPACE, 3, 1, ColorSpace::SRGB->value),
+        ]);
+
+        $parsedExif = new ParsedExif($ifd0, $exifIfd, null, null, null);
+
+        self::assertSame(
+            [0.0, 255.0, 0.0, 255.0, 0.0, 255.0],
+            $parsedExif->referenceBlackWhite(),
+        );
+    }
+
+    /**
+     * Verifies that ReferenceBlackWhite returns the EXIF 3.0 §4.6.5.3.5 default
+     * when the colour space is defined and the photometric interpretation is YCbCr.
+     */
+    #[Test]
+    public function referenceBlackWhiteDefaultsForYCbCr(): void
+    {
+        $ifd0 = new Ifd([
+            ExifTag::PHOTOMETRIC_INTERPRETATION => new IfdEntry(
+                ExifTag::PHOTOMETRIC_INTERPRETATION,
+                3,
+                1,
+                Photometric::YCBCR->value,
+            ),
+        ]);
+
+        $exifIfd = new Ifd([
+            ExifTag::COLOR_SPACE => new IfdEntry(ExifTag::COLOR_SPACE, 3, 1, ColorSpace::ADOBE_RGB->value),
+        ]);
+
+        $parsedExif = new ParsedExif($ifd0, $exifIfd, null, null, null);
+
+        self::assertSame(
+            [0.0, 255.0, 128.0, 128.0, 128.0, 128.0],
+            $parsedExif->referenceBlackWhite(),
+        );
+    }
+
+    /**
+     * Ensures no default ReferenceBlackWhite is applied when the colour space
+     * is uncalibrated even if the photometric interpretation is RGB.
+     */
+    #[Test]
+    public function referenceBlackWhiteDefaultsAreSuppressedForUncalibratedColorSpace(): void
+    {
+        $ifd0 = new Ifd([
+            ExifTag::PHOTOMETRIC_INTERPRETATION => new IfdEntry(
+                ExifTag::PHOTOMETRIC_INTERPRETATION,
+                3,
+                1,
+                Photometric::RGB->value,
+            ),
+        ]);
+
+        $exifIfd = new Ifd([
+            ExifTag::COLOR_SPACE => new IfdEntry(ExifTag::COLOR_SPACE, 3, 1, ColorSpace::UNCALIBRATED->value),
+        ]);
+
+        $parsedExif = new ParsedExif($ifd0, $exifIfd, null, null, null);
+
+        self::assertNull($parsedExif->referenceBlackWhite());
     }
 }


### PR DESCRIPTION
## Summary
- Applied EXIF 3.0 ReferenceBlackWhite defaults for RGB and YCbCr images when the tag is absent but a calibrated colour space is declared.
- Normalised ReferenceBlackWhite parsing to six rational components and aligned the tag metadata with the EXIF 3.0/TIFF 6.0 RATIONAL definition.

**Issue/Milestone:** Closes #0 • Milestone M#
**Scope (allowed files only):** src/Model/Exif/ParsedExif.php; resources/exif-spec-tags.yaml; tests/Model/Exif/ParsedExifDefaultValuesTest.php
**Non-Goals:** TIFF GPS reader coverage beyond ReferenceBlackWhite defaults.

---

## Implementation Notes
- Implemented EXIF 3.0 §4.6.5.3.5 defaults when ColorSpace is set (non-UNCALIBRATED) and PhotometricInterpretation is RGB or YCbCr.
- Sanitised ReferenceBlackWhite lists to exactly six rational values before exposing them via ParsedExif.

---

## Always Checklist (must be green)
**Composer-Tasks (deine CI-Skripte):**
- [ ] Lint: `composer ci:test:php:lint`
- [ ] PHPStan: `composer ci:test:php:phpstan`
- [ ] Rector (dry-run): `composer ci:test:php:rector`
- [ ] Coding-Style: `composer ci::cgl`
- [ ] PHPUnit: `composer ci:test:php:unit` (fails: existing GPS reader tests report missing `TiffConst::MAGIC_BIG_TIFF` and unsupported TIFF type `0`)
- [ ] Coverage ≥ **90 %**: `composer ci:test:php:unit:coverage`
- [ ] JSCPD (Duplikate = 0): `composer ci:test:php:cpd`
- [ ] Sammellauf: `composer ci:test` (sollte grün sein; enthält Lint, PHPStan, Rector-Dry-Run, CS-Dry-Run, Unit)

**Inhaltliche/Code-Guidelines:**
- [ ] **Keine** `mixed`-Signaturen • **kein** `empty()` • **keine** verschachtelten Ternaries
- [ ] Fully-qualified native functions (`\\strlen`, `\\count`, …) und sinnvolle `use`-Imports
- [ ] **Keine** dynamischen Aufrufe statischer Methoden
- [ ] Sinnvolle **Interfaces** verwendet (wo Verträge sinnvoll sind)
- [ ] Typisierte Klassenkonstanten; redundante Casts/Default-Argumente entfernt
- [ ] Klassen als `readonly`, wo passend; keine redundanten `readonly`-Mods
- [ ] **Eine Klasse je Datei** • Test-Namespaces spiegeln `src/`-Struktur
- [ ] Englische PHPDocs & englische Inline-Kommentare an komplexen Stellen
- [ ] Sinnvolle Namen für Variablen/Konstanten; Magic Numbers/Strings vermieden
- [ ] `array_find` / `array_any` / `array_all` gezielt statt trivialer `foreach` verwendet (wo es die Lesbarkeit verbessert)

---

## EXIF / TIFF / ISOBMFF / XMP Guardrails
- **EXIF-Versionen:** 1.x, 2.x (2.1/2.2/2.21/2.3/2.31/2.32), 3.0 — kompatible Änderungen; falls Tags betroffen: Coverage-Test grün.
- **TIFF/BigTIFF:** Endianness korrekt (`0x2A` / `0x2B`), Inline-Werte-Grenzen, `RATIONAL/SRATIONAL` korrekt.
- **GPS:** Vorzeichen über Ref-Tags (S/W negativ); `0/0`-Kantenfälle robust.
- **Preview/IFD1:** Nur beschreiben (Offsets/Längen/Compression), kein Rendering.
- **ISOBMFF/QuickTime:** Box-Size ≥ Header, 32/64-bit-Größen korrekt; `iloc`-Extents summiert; `data_reference_index ≠ 0` → skip; keine Remote-Refs.
- **XMP:** JPEG APP1-Präfix / ISOBMFF `uuid`; Parser mit `LIBXML_NONET`, keine DTD/Entities; `Alt/Bag/Seq` → Arrays.
- **Fehlerbehandlung:** ausschließlich `ParseError` oder `BoundsError`; keine Warnings/Notices als Kontrollfluss.

---

## Tests
- **Neue/angepasste Tests:** ParsedExifDefaultValuesTest::referenceBlackWhiteDefaultsForRgb(), ParsedExifDefaultValuesTest::referenceBlackWhiteDefaultsForYCbCr(), ParsedExifDefaultValuesTest::referenceBlackWhiteDefaultsAreSuppressedForUncalibratedColorSpace().
- **Negative Cases:** Uncalibrated colour space suppresses defaults.
- **Fixtures/Streams:** Synthetic IFD instances for EXIF and ColourSpace combinations.

---

## M# Sweep — Verify compliance for this milestone
Bitte **alles** verifizieren und kurz die Ergebnisse notieren:
- [ ] `composer ci:test` **grün** (Lint, PHPStan, Rector-Dry-Run, CS-Dry-Run, Unit)
- [ ] `composer ci:test:php:cpd` **0 Duplikate** (JSCPD, Konfig: `.build/.jscpd.json`)
- [ ] `composer ci:test:php:unit:coverage` **≥ 90 %**
- [ ] **ExifCoverageTest** (falls vorhanden): 0 fehlende Tags/Getters (gegen `resources/exif-map.yaml`)
- [ ] Für **jede** Klasse existiert ein Test (Namespace-Spiegelung)

---

## Breaking Changes / Risk / Rollback
- **Breaking changes:** Keine.
- **Risiken:** None beyond existing TIFF GPS coverage failures noted above.
- **Rollback-Plan:** Revert this PR.

---

## Changelog
- feat(exif): apply ReferenceBlackWhite defaults for RGB/YCbCr when missing

---

## References (Specs & Docs)
- EXIF 3.0 §4.6.5.3.5; EXIF 2.32 §4.6.5
- TIFF 6.0 §8

Docs im Repo:
- `docs/EXIF-210.pdf`, `docs/EXIF-220.pdf`, `docs/EXIF-230.pdf`, `docs/EXIF-231.pdf`, `docs/EXIF-232.pdf`, `docs/EXIF-300.pdf`
- `docs/TIFF6.pdf`

---

## Review Roles (tick what you covered)
- [ ] Planner (Scope/Non-Goals/Guardrails definiert)
- [ ] Spec Writer (AC/Tests präzisiert)
- [ ] Test Agent (RED zuerst)
- [ ] Implementer (GREEN minimal & im Datei-Scope)
- [ ] Static/QA (Stan/CS/Rector/JSCPD clean)
- [ ] Security (Bounds, Offsets, XML-Flags)
- [ ] Reviewer (Minimalität, DX, Spec-Refs, Enums)
- [ ] Release (PR-Text, Labels, Milestone, „Closes #…“)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693817f94e408323a013019ff223870d)