### PR TITLE
M#: Apply EXIF defaults for samples and resolution — Exif

### DIFF
--- a/src/Model/Exif/ParsedExif.php
+++ b/src/Model/Exif/ParsedExif.php
@@ -1992,14 +1992,16 @@ final readonly class ParsedExif
     /**
      * Returns the number of samples per pixel.
      *
-     * TIFF 6.0 §8 specifies default value 1 when not present.
+     * EXIF 3.0 §4.6.5.1.7 specifies a default of 3 samples for RGB/YCbCr images.
+     * TIFF 6.0 §8 lists 1 as the grayscale default; the EXIF profile overrides
+     * this for the supported colour models.
      *
      * @return int
      */
     public function samplesPerPixel(): int
     {
-        // TIFF 6.0 §8: Default is 1 when tag is not present
-        return $this->int($this->ifd0, ExifTag::SAMPLES_PER_PIXEL) ?? 1;
+        // EXIF 3.0 §4.6.5.1.7: Default is 3 when tag is not present (RGB/YCbCr)
+        return $this->int($this->ifd0, ExifTag::SAMPLES_PER_PIXEL) ?? 3;
     }
 
     /**
@@ -2073,7 +2075,8 @@ final readonly class ParsedExif
      */
     public function xResolution(): ?float
     {
-        return $this->rational($this->ifd0, ExifTag::X_RESOLUTION);
+        // EXIF 3.0 §4.6.5.1.8: Default is 72 dpi when resolution is unknown
+        return $this->rational($this->ifd0, ExifTag::X_RESOLUTION) ?? 72.0;
     }
 
     /**
@@ -2081,7 +2084,14 @@ final readonly class ParsedExif
      */
     public function yResolution(): ?float
     {
-        return $this->rational($this->ifd0, ExifTag::Y_RESOLUTION);
+        $resolution = $this->rational($this->ifd0, ExifTag::Y_RESOLUTION);
+
+        if ($resolution !== null) {
+            return $resolution;
+        }
+
+        // EXIF 3.0 §4.6.5.1.9: Default matches XResolution (72 dpi when unknown)
+        return $this->xResolution();
     }
 
     /**

--- a/tests/Model/Exif/ParsedExifDefaultValuesTest.php
+++ b/tests/Model/Exif/ParsedExifDefaultValuesTest.php
@@ -51,10 +51,10 @@ final class ParsedExifDefaultValuesTest extends TestCase
     }
 
     /**
-     * Verifies that samplesPerPixel() returns the TIFF 6.0 default value of 1
+     * Verifies that samplesPerPixel() returns the EXIF 3.0 default value of 3
      * when the tag is not present.
      *
-     * @see TIFF 6.0 §8: SamplesPerPixel default is 1 (grayscale image)
+     * @see EXIF 3.0 §4.6.5.1.7: SamplesPerPixel defaults to 3 for RGB/YCbCr
      */
     #[Test]
     public function samplesPerPixelReturnsDefaultWhenMissing(): void
@@ -62,7 +62,7 @@ final class ParsedExifDefaultValuesTest extends TestCase
         $ifd0       = new Ifd([]);
         $parsedExif = new ParsedExif($ifd0, null, null, null, null);
 
-        self::assertSame(1, $parsedExif->samplesPerPixel());
+        self::assertSame(3, $parsedExif->samplesPerPixel());
     }
 
     /**
@@ -125,6 +125,39 @@ final class ParsedExifDefaultValuesTest extends TestCase
         $parsedExif = new ParsedExif($ifd0, null, null, null, null);
 
         self::assertSame(ResolutionUnit::INCHES, $parsedExif->resolutionUnit());
+    }
+
+    /**
+     * Verifies that xResolution() returns the EXIF 3.0 default value of 72 when
+     * the tag is not present.
+     *
+     * @see EXIF 3.0 §4.6.5.1.8: XResolution defaults to 72 when unknown
+     */
+    #[Test]
+    public function xResolutionReturnsDefaultWhenMissing(): void
+    {
+        $ifd0       = new Ifd([]);
+        $parsedExif = new ParsedExif($ifd0, null, null, null, null);
+
+        self::assertSame(72.0, $parsedExif->xResolution());
+    }
+
+    /**
+     * Verifies that yResolution() defaults to the value of xResolution() when
+     * not provided separately.
+     *
+     * @see EXIF 3.0 §4.6.5.1.9: YResolution shall match XResolution
+     */
+    #[Test]
+    public function yResolutionFallsBackToXResolution(): void
+    {
+        $ifd0 = new Ifd([
+            ExifTag::X_RESOLUTION => new IfdEntry(ExifTag::X_RESOLUTION, 5, 1, [300, 1]),
+        ]);
+
+        $parsedExif = new ParsedExif($ifd0, null, null, null, null);
+
+        self::assertSame(300.0, $parsedExif->yResolution());
     }
 
     /**


### PR DESCRIPTION
## Summary
Aligned SamplesPerPixel and resolution defaults with EXIF 3.0 guidance for RGB/YCbCr images and ensured Y resolution falls back to X resolution.

**Issue/Milestone:** Closes #0 • Milestone M#
**Scope (allowed files only):** src/Model/Exif/ParsedExif.php; tests/Model/Exif/ParsedExifDefaultValuesTest.php
**Non-Goals:** None.

---

## Implementation Notes
- Runtime: PHP 8.4, `declare(strict_types=1);`, PSR-12.
- **Streaming only** (Core\\Stream/StreamWindow) — keine Ganzdatei-Reads.
- Keine externen Binaries/Extensions; **kein** `exif_read_data()`.
- Value Objects (chainable) nur für EXIF-Ausgabe; kein Rendering.
- **Enums** für gängige Kodierungen genutzt/ergänzt (Encoding/Endianness/IFD/XMP/...).
- **Spec-References** im Code ergänzt/aktualisiert (siehe „References“).

---

## Always Checklist (must be green)
**Composer-Tasks (deine CI-Skripte):**
- [ ] Lint: `composer ci:test:php:lint`
- [ ] PHPStan: `composer ci:test:php:phpstan`
- [ ] Rector (dry-run): `composer ci:test:php:rector`
- [ ] Coding-Style: `composer ci::cgl`
- [ ] PHPUnit: `composer ci:test:php:unit`
- [ ] Coverage ≥ **90 %**: `composer ci:test:php:unit:coverage`
- [ ] JSCPD (Duplikate = 0): `composer ci:test:php:cpd`
- [ ] Sammellauf: `composer ci:test` (sollte grün sein; enthält Lint, PHPStan, Rector-Dry-Run, CS-Dry-Run, Unit)

**Inhaltliche/Code-Guidelines:**
- [ ] **Keine** `mixed`-Signaturen • **kein** `empty()` • **keine** verschachtelten Ternaries
- [ ] Fully-qualified native functions (`\\strlen`, `\\count`, …) und sinnvolle `use`-Imports
- [ ] **Keine** dynamischen Aufrufe statischer Methoden
- [ ] Sinnvolle **Interfaces** verwendet (wo Verträge sinnvoll sind)
- [ ] Typisierte Klassenkonstanten; redundante Casts/Default-Argumente entfernt
- [ ] Klassen als `readonly`, wo passend; keine redundanten `readonly`-Mods
- [ ] **Eine Klasse je Datei** • Test-Namespaces spiegeln `src/`-Struktur
- [ ] Englische PHPDocs & englische Inline-Kommentare an komplexen Stellen
- [ ] Sinnvolle Namen für Variablen/Konstanten; Magic Numbers/Strings vermieden
- [ ] `array_find` / `array_any` / `array_all` gezielt statt trivialer `foreach` verwendet (wo es die Lesbarkeit verbessert)

---

## EXIF / TIFF / ISOBMFF / XMP Guardrails
- **EXIF-Versionen:** 1.x, 2.x (2.1/2.2/2.21/2.3/2.31/2.32), 3.0 — kompatible Änderungen; falls Tags betroffen: Coverage-Test grün.
- **TIFF/BigTIFF:** Endianness korrekt (`0x2A` / `0x2B`), Inline-Werte-Grenzen, `RATIONAL/SRATIONAL` korrekt.
- **GPS:** Vorzeichen über Ref-Tags (S/W negativ); `0/0`-Kantenfälle robust.
- **Preview/IFD1:** Nur beschreiben (Offsets/Längen/Compression), kein Rendering.
- **ISOBMFF/QuickTime:** Box-Size ≥ Header, 32/64-bit-Größen korrekt; `iloc`-Extents summiert; `data_reference_index ≠ 0` → skip; keine Remote-Refs.
- **XMP:** JPEG APP1-Präfix / ISOBMFF `uuid`; Parser mit `LIBXML_NONET`, keine DTD/Entities; `Alt/Bag/Seq` → Arrays.
- **Fehlerbehandlung:** ausschließlich `ParseError` oder `BoundsError`; keine Warnings/Notices als Kontrollfluss.

---

## Tests
- **Neue/angepasste Tests:** SamplesPerPixel, XResolution, YResolution defaults in `ParsedExifDefaultValuesTest`.
- **Negative Cases:** None added; defaults validated on missing tags.
- **Fixtures/Streams:** Synthetic IFD entries only.

---

Updates align SamplesPerPixel and resolution defaults with EXIF 3.0 expectations.

## M# Sweep — Verify compliance for this milestone
Bitte **alles** verifizieren und kurz die Ergebnisse notieren:
- [ ] `composer ci:test` **grün** (Lint, PHPStan, Rector-Dry-Run, CS-Dry-Run, Unit)
- [ ] `composer ci:test:php:cpd` **0 Duplikate** (JSCPD, Konfig: `.build/.jscpd.json`)
- [ ] `composer ci:test:php:unit:coverage` **≥ 90 %**
- [ ] **ExifCoverageTest** (falls vorhanden): 0 fehlende Tags/Getters (gegen `resources/exif-map.yaml`)
- [ ] Für **jede** Klasse existiert ein Test (Namespace-Spiegelung)

---

## Breaking Changes / Risk / Rollback
- **Breaking changes:** None.
- **Risiken:** Minimal; defaults now enforced for missing resolution tags.
- **Rollback-Plan:** Revert this PR if issues arise.

---

## Changelog
- fix: apply EXIF defaults for samples per pixel and resolution fallbacks

---

## References (Specs & Docs)
- EXIF 3.0 §4.6.5.1.7, §4.6.5.1.8, §4.6.5.1.9
- TIFF 6.0 §8

Docs im Repo:
- `docs/EXIF-210.pdf`, `docs/EXIF-220.pdf`, `docs/EXIF-230.pdf`, `docs/EXIF-231.pdf`, `docs/EXIF-232.pdf`, `docs/EXIF-300.pdf`
- `docs/TIFF6.pdf`

---

## Review Roles (tick what you covered)
- [ ] Planner (Scope/Non-Goals/Guardrails definiert)
- [ ] Spec Writer (AC/Tests präzisiert)
- [ ] Test Agent (RED zuerst)
- [ ] Implementer (GREEN minimal & im Datei-Scope)
- [ ] Static/QA (Stan/CS/Rector/JSCPD clean)
- [ ] Security (Bounds, Offsets, XML-Flags)
- [ ] Reviewer (Minimalität, DX, Spec-Refs, Enums)
- [ ] Release (PR-Text, Labels, Milestone, „Closes #…“)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69381ad5a5d08323b3eddb622648d007)