### PR TITLE
Fix EXIF blank text tag handling

### DIFF
--- a/src/Model/Exif/ParsedExif.php
+++ b/src/Model/Exif/ParsedExif.php
@@ -48,6 +48,7 @@ use MagicSunday\ImageMeta\Value\Oecf;
 use MagicSunday\ImageMeta\Value\SpatialFrequencyResponse;
 use MagicSunday\ImageMeta\Value\SubjectArea;
 
+use function array_find;
 use function array_map;
 use function count;
 use function iconv;
@@ -653,6 +654,9 @@ final readonly class ParsedExif
 
     /**
      * Returns the copyright notice string when present.
+     *
+     * EXIF 3.0 §4.6.5.4.7 and EXIF 2.32 §4.6.5.4.7 represent empty or
+     * blank-filled copyright fields as unknown values.
      */
     public function copyright(): ?string
     {
@@ -1957,6 +1961,10 @@ final readonly class ParsedExif
     /**
      * Returns the ModifyDate/DateTime tag combined with its optional offset.
      *
+     * EXIF 3.0 §4.6.5.4.5 (and EXIF 2.32 §4.6.5.4.5) define DateTime as
+     * "YYYY:MM:DD HH:MM:SS" with blank-filled placeholders treated as
+     * unknown values.
+     *
      * @return DateTimeImmutable|null
      */
     public function dateTime(): ?DateTimeImmutable
@@ -1970,10 +1978,30 @@ final readonly class ParsedExif
 
     /**
      * Returns the artist tag value when present.
+     *
+     * EXIF 3.0 §4.6.5.4.6 (also EXIF 2.32 §4.6.5.4.6) requires Artist to be
+     * populated alongside CameraOwnerName, Photographer, or ImageEditor. The
+     * closest available attribution is returned when the primary tag is
+     * missing.
      */
     public function artist(): ?string
     {
-        return $this->str($this->ifd0, ExifTag::ARTIST);
+        $artist = $this->str($this->ifd0, ExifTag::ARTIST);
+
+        if ($artist !== null) {
+            return $artist;
+        }
+
+        return array_find(
+            [
+                $this->str($this->exifIfd, ExifTag::CAMERA_OWNER_NAME),
+                $this->str($this->ifd0, ExifTag::PHOTOGRAPHER),
+                $this->str($this->exifIfd, ExifTag::PHOTOGRAPHER),
+                $this->str($this->ifd0, ExifTag::IMAGE_EDITOR),
+                $this->str($this->exifIfd, ExifTag::IMAGE_EDITOR),
+            ],
+            static fn (?string $value): bool => $value !== null,
+        );
     }
 
     /**
@@ -2423,7 +2451,11 @@ final readonly class ParsedExif
 
         $trimmed = rtrim($value, "\0");
 
-        return $trimmed === '' ? null : $trimmed;
+        if ($trimmed === '') {
+            return null;
+        }
+
+        return trim($trimmed) === '' ? null : $trimmed;
     }
 
     /**
@@ -3369,7 +3401,7 @@ final readonly class ParsedExif
      */
     private function parseExifDateTime(?string $rawDateTime, ?string $rawOffset, ?string $subSeconds): ?DateTimeImmutable
     {
-        if ($rawDateTime === null || $rawDateTime === '' || strlen($rawDateTime) < 19) {
+        if ($rawDateTime === null || $rawDateTime === '' || strlen($rawDateTime) < 19 || $this->isBlankDateTimeString($rawDateTime)) {
             return null;
         }
 
@@ -3397,6 +3429,18 @@ final readonly class ParsedExif
         $dt = DateTimeImmutable::createFromFormat($format, $normalized, $tz);
 
         return $dt !== false ? $dt : null;
+    }
+
+    /**
+     * Detects EXIF DateTime placeholders filled with blanks instead of numeric content.
+     */
+    private function isBlankDateTimeString(string $value): bool
+    {
+        if (trim($value) === '') {
+            return true;
+        }
+
+        return trim(str_replace(':', '', $value)) === '';
     }
 
     // ========================================================================

--- a/tests/Model/Exif/ParsedExifStringTagsTest.php
+++ b/tests/Model/Exif/ParsedExifStringTagsTest.php
@@ -1,0 +1,90 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\ImageMeta\Tests\Model\Exif;
+
+use MagicSunday\ImageMeta\Model\Exif\ExifTag;
+use MagicSunday\ImageMeta\Model\Exif\Ifd;
+use MagicSunday\ImageMeta\Model\Exif\IfdEntry;
+use MagicSunday\ImageMeta\Model\Exif\ParsedExif;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(ParsedExif::class)]
+final class ParsedExifStringTagsTest extends TestCase
+{
+    #[Test]
+    public function dateTimeTreatsBlankPlaceholderAsUnknown(): void
+    {
+        $ifd0 = new Ifd([
+            ExifTag::DATETIME => new IfdEntry(
+                ExifTag::DATETIME,
+                2,
+                20,
+                '    :  :  :  :  ',
+            ),
+        ]);
+
+        $parsedExif = new ParsedExif($ifd0, null, null, null, null);
+
+        self::assertNull($parsedExif->dateTime());
+    }
+
+    #[Test]
+    public function artistFallsBackToRelatedAttributionTags(): void
+    {
+        $ifd0 = new Ifd([
+            ExifTag::PHOTOGRAPHER => new IfdEntry(
+                ExifTag::PHOTOGRAPHER,
+                2,
+                1,
+                'Photographer',
+            ),
+        ]);
+
+        $exifIfd = new Ifd([
+            ExifTag::CAMERA_OWNER_NAME => new IfdEntry(
+                ExifTag::CAMERA_OWNER_NAME,
+                2,
+                1,
+                'Camera Owner',
+            ),
+            ExifTag::IMAGE_EDITOR => new IfdEntry(
+                ExifTag::IMAGE_EDITOR,
+                2,
+                1,
+                'Image Editor',
+            ),
+        ]);
+
+        $parsedExif = new ParsedExif($ifd0, $exifIfd, null, null, null);
+
+        self::assertSame('Camera Owner', $parsedExif->artist());
+    }
+
+    #[Test]
+    public function copyrightTreatsBlankFilledFieldAsUnknown(): void
+    {
+        $ifd0 = new Ifd([
+            ExifTag::COPYRIGHT => new IfdEntry(
+                ExifTag::COPYRIGHT,
+                2,
+                20,
+                '                    ',
+            ),
+        ]);
+
+        $parsedExif = new ParsedExif($ifd0, null, null, null, null);
+
+        self::assertNull($parsedExif->copyright());
+    }
+}


### PR DESCRIPTION
## Summary
- Normalise EXIF DateTime parsing to treat blank placeholders as unknown values and document the spec references.
- Add Artist fallback to related attribution tags when the primary field is empty.
- Treat whitespace-only EXIF strings (including Copyright) as unknown and cover the behaviour with new PHPUnit tests.

**Issue/Milestone:** Closes #N/A • Milestone M#
**Scope (allowed files only):** src/Model/Exif/ParsedExif.php; tests/Model/Exif/ParsedExifStringTagsTest.php
**Non-Goals:** No changes to other EXIF tags or parsing pipelines beyond the specified text fields.

---

## Implementation Notes
- Runtime: PHP 8.4, `declare(strict_types=1);`, PSR-12.
- **Streaming only** (Core\\Stream/StreamWindow) — keine Ganzdatei-Reads.
- Keine externen Binaries/Extensions; **kein** `exif_read_data()`.
- Value Objects (chainable) nur für EXIF-Ausgabe; kein Rendering.
- **Enums** für gängige Kodierungen genutzt/ergänzt (Encoding/Endianness/IFD/XMP/...).
- **Spec-References** im Code ergänzt/aktualisiert (siehe „References“).

---

## Always Checklist (must be green)
**Composer-Tasks (deine CI-Skripte):**
- [ ] Lint: `composer ci:test:php:lint`
- [ ] PHPStan: `composer ci:test:php:phpstan`
- [ ] Rector (dry-run): `composer ci:test:php:rector`
- [ ] Coding-Style: `composer ci::cgl`
- [ ] PHPUnit: `composer ci:test:php:unit`
- [ ] Coverage ≥ **90 %**: `composer ci:test:php:unit:coverage`
- [ ] JSCPD (Duplikate = 0): `composer ci:test:php:cpd`
- [ ] Sammellauf: `composer ci:test` (sollte grün sein; enthält Lint, PHPStan, Rector-Dry-Run, CS-Dry-Run, Unit)

**Inhaltliche/Code-Guidelines:**
- [ ] **Keine** `mixed`-Signaturen • **kein** `empty()` • **keine** verschachtelten Ternaries
- [ ] Fully-qualified native functions (`\\strlen`, `\\count`, …) und sinnvolle `use`-Imports
- [ ] **Keine** dynamischen Aufrufe statischer Methoden
- [ ] Sinnvolle **Interfaces** verwendet (wo Verträge sinnvoll sind)
- [ ] Typisierte Klassenkonstanten; redundante Casts/Default-Argumente entfernt
- [ ] Klassen als `readonly`, wo passend; keine redundanten `readonly`-Mods
- [ ] **Eine Klasse je Datei** • Test-Namespaces spiegeln `src/`-Struktur
- [ ] Englische PHPDocs & englische Inline-Kommentare an komplexen Stellen
- [ ] Sinnvolle Namen für Variablen/Konstanten; Magic Numbers/Strings vermieden
- [ ] `array_find` / `array_any` / `array_all` gezielt statt trivialer `foreach` verwendet (wo es die Lesbarkeit verbessert)

---

## EXIF / TIFF / ISOBMFF / XMP Guardrails
- **EXIF-Versionen:** 1.x, 2.x (2.1/2.2/2.21/2.3/2.31/2.32), 3.0 — kompatible Änderungen; falls Tags betroffen: Coverage-Test grün.
- **TIFF/BigTIFF:** Endianness korrekt (`0x2A` / `0x2B`), Inline-Werte-Grenzen, `RATIONAL/SRATIONAL` korrekt.
- **GPS:** Vorzeichen über Ref-Tags (S/W negativ); `0/0`-Kantenfälle robust.
- **Preview/IFD1:** Nur beschreiben (Offsets/Längen/Compression), kein Rendering.
- **ISOBMFF/QuickTime:** Box-Size ≥ Header, 32/64-bit-Größen korrekt; `iloc`-Extents summiert; `data_reference_index ≠ 0` → skip; keine Remote-Refs.
- **XMP:** JPEG APP1-Präfix / ISOBMFF `uuid`; Parser mit `LIBXML_NONET`, keine DTD/Entities; `Alt/Bag/Seq` → Arrays.
- **Fehlerbehandlung:** ausschließlich `ParseError` oder `BoundsError`; keine Warnings/Notices als Kontrollfluss.

---

## Tests
- **Neue/angepasste Tests:** ParsedExifStringTagsTest (blank DateTime placeholder, Artist fallback, whitespace Copyright)
- **Negative Cases:** Blank DateTime placeholder and whitespace-only copyright treated as unknown
- **Fixtures/Streams:** Synthetic Ifd entries in unit tests

---

## PR Notes
- Executed `.build/bin/phpunit --configuration phpunit.xml --filter ParsedExifStringTagsTest`

## M# Sweep — Verify compliance for this milestone
Bitte **alles** verifizieren und kurz die Ergebnisse notieren:
- [ ] `composer ci:test` **grün** (Lint, PHPStan, Rector-Dry-Run, CS-Dry-Run, Unit)
- [ ] `composer ci:test:php:cpd` **0 Duplikate** (JSCPD, Konfig: `.build/.jscpd.json`)
- [ ] `composer ci:test:php:unit:coverage` **≥ 90 %**
- [ ] **ExifCoverageTest** (falls vorhanden): 0 fehlende Tags/Getters (gegen `resources/exif-map.yaml`)
- [ ] Für **jede** Klasse existiert ein Test (Namespace-Spiegelung)

---

## Breaking Changes / Risk / Rollback
- **Breaking changes:** <!-- falls ja: welche und warum notwendig -->
- **Risiken:** <!-- Parser-Sensitivität, Performance, Abhängigkeiten -->
- **Rollback-Plan:** <!-- einfache Revert-Strategie / Feature-Flag falls nötig -->

---

## Changelog
<!-- Kurz und im Stil der Conventional Commits zusammenfassen. -->

---

## References (Specs & Docs)
<!-- Liste der relevanten Kapitel/Abschnitte, jeweils aktuellste Fassung + abweichende ältere, falls relevant -->
- EXIF 3.0 §… ; ggf. EXIF 2.32 §… ; EXIF 2.31 §…
- TIFF 6.0 §…
- ISOBMFF/QuickTime §…
- XMP (Adobe XMP Packet) §…

Docs im Repo:
- `docs/EXIF-210.pdf`, `docs/EXIF-220.pdf`, `docs/EXIF-230.pdf`, `docs/EXIF-231.pdf`, `docs/EXIF-232.pdf`, `docs/EXIF-300.pdf`
- `docs/TIFF6.pdf`

---

## Review Roles (tick what you covered)
- [ ] Planner (Scope/Non-Goals/Guardrails definiert)
- [ ] Spec Writer (AC/Tests präzisiert)
- [ ] Test Agent (RED zuerst)
- [ ] Implementer (GREEN minimal & im Datei-Scope)
- [ ] Static/QA (Stan/CS/Rector/JSCPD clean)
- [ ] Security (Bounds, Offsets, XML-Flags)
- [ ] Reviewer (Minimalität, DX, Spec-Refs, Enums)
- [ ] Release (PR-Text, Labels, Milestone, „Closes #…")


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69381babc3f483239d3a213b33c17e01)