### PR TITLE
docs: align MakerNote and UserComment spec references

### DIFF
--- a/src/Model/Exif/ParsedExif.php
+++ b/src/Model/Exif/ParsedExif.php
@@ -114,6 +114,8 @@ final readonly class ParsedExif
 
     /**
      * Returns the decoded maker note metadata when a decoder is available.
+     *
+     * EXIF 3.0 §4.6.6.4.1 and EXIF 2.32 §4.6.6.4.1 reserve MakerNote for manufacturer-specific data.
      */
     public function makerNotes(): ?MakerNotesRecord
     {
@@ -703,6 +705,9 @@ final readonly class ParsedExif
 
     /**
      * Returns the user comment string after decoding the EXIF prefix.
+     *
+     * EXIF 3.0 §4.6.6.4.2 and EXIF 2.32 §4.6.6.4.2 define the multicode-compatible prefix (see §4.6.4)
+     * that annotates the UserComment character code.
      */
     public function userComment(): ?string
     {

--- a/src/Parse/Tiff/TiffExifReader.php
+++ b/src/Parse/Tiff/TiffExifReader.php
@@ -928,7 +928,7 @@ final class TiffExifReader implements ExifReaderInterface
     /**
      * Resolves maker note metadata using the provided registry when available.
      *
-     * EXIF 3.0 §4.6.5 (Table 4) and EXIF 2.32 §4.6.5 define the MakerNote tag semantics
+     * EXIF 3.0 §4.6.6.4.1 (Table 4) and EXIF 2.32 §4.6.6.4.1 define the MakerNote tag semantics
      * and the MakerNoteSafety flag used to indicate whether in-place modification is safe,
      * continuing the EXIF 2.1 §2.6.5 guidance on manufacturer-specific tags.
      */

--- a/tests/Parse/Tiff/README.md
+++ b/tests/Parse/Tiff/README.md
@@ -121,8 +121,8 @@ These tests validate critical security properties:
 
 Tests reference:
 
-- **EXIF 3.0** (primary) - §4.5, §4.6.5
-- **EXIF 2.32** - §4.5, §4.6.5  
+- **EXIF 3.0** (primary) - §4.5, §4.6.6.4.1–4.6.6.4.2
+- **EXIF 2.32** - §4.5, §4.6.6.4.1–4.6.6.4.2  
 - **TIFF 6.0** - §2, §8
 - **BigTIFF** specification
 

--- a/tests/Parse/Tiff/TESTING.md
+++ b/tests/Parse/Tiff/TESTING.md
@@ -267,7 +267,7 @@ All tests reference relevant EXIF/TIFF specifications:
 - **EXIF 3.0 §4.5**: TIFF header layout and IFD traversal
 - **EXIF 3.0 §4.5.1**: Byte order and magic numbers
 - **EXIF 3.0 §4.5.2**: IFD structure and field types (Table 3)
-- **EXIF 3.0 §4.6.5**: UserComment and MakerNote (Table 11)
+- **EXIF 3.0 §4.6.6.4.1–4.6.6.4.2**: MakerNote and UserComment (Table 11)
 - **TIFF 6.0 §2**: File structure
 - **TIFF 6.0 §8**: Baseline IFD
 

--- a/tests/Parse/Tiff/TiffExifReaderUserCommentTest.php
+++ b/tests/Parse/Tiff/TiffExifReaderUserCommentTest.php
@@ -32,7 +32,7 @@ use function strlen;
 /**
  * Edge case tests for UserComment encoding and special EXIF fields.
  *
- * EXIF 3.0 §4.6.5 (Table 11) and EXIF 2.32 §4.6.5 define the UserComment tag
+ * EXIF 3.0 §4.6.6.4.2 (Table 11) and EXIF 2.32 §4.6.6.4.2 define the UserComment tag
  * structure with character code prefixes ("ASCII\0\0\0", "JIS\0\0\0\0\0", etc.).
  */
 #[CoversClass(TiffExifReader::class)]
@@ -50,7 +50,7 @@ final class TiffExifReaderUserCommentTest extends TestCase
     /**
      * Tests UserComment with ASCII encoding prefix.
      *
-     * EXIF 3.0 §4.6.5 Table 11 defines "ASCII\0\0\0" as the ASCII character code.
+     * EXIF 3.0 §4.6.6.4.2 Table 11 defines "ASCII\0\0\0" as the ASCII character code as noted in §4.6.4.
      */
     #[Test]
     public function parsesUserCommentWithAsciiEncoding(): void
@@ -67,7 +67,7 @@ final class TiffExifReaderUserCommentTest extends TestCase
     /**
      * Tests UserComment with JIS encoding prefix.
      *
-     * EXIF 3.0 §4.6.5 Table 11 defines "JIS\0\0\0\0\0" for JIS character code.
+     * EXIF 3.0 §4.6.6.4.2 Table 11 defines "JIS\0\0\0\0\0" for JIS character code per §4.6.4 prefix rules.
      */
     #[Test]
     public function parsesUserCommentWithJisEncoding(): void
@@ -84,7 +84,7 @@ final class TiffExifReaderUserCommentTest extends TestCase
     /**
      * Tests UserComment with UNICODE encoding prefix.
      *
-     * EXIF 3.0 §4.6.5 Table 11 defines "UNICODE\0" for Unicode character code.
+     * EXIF 3.0 §4.6.6.4.2 Table 11 defines "UNICODE\0" for Unicode character code per §4.6.4 prefix rules.
      */
     #[Test]
     public function parsesUserCommentWithUnicodeEncoding(): void
@@ -101,7 +101,7 @@ final class TiffExifReaderUserCommentTest extends TestCase
     /**
      * Tests UserComment with undefined encoding (no prefix).
      *
-     * EXIF 3.0 §4.6.5 allows undefined character codes (8 bytes of 0x00).
+     * EXIF 3.0 §4.6.6.4.2 allows undefined character codes (8 bytes of 0x00).
      */
     #[Test]
     public function parsesUserCommentWithUndefinedEncoding(): void
@@ -209,7 +209,7 @@ final class TiffExifReaderUserCommentTest extends TestCase
     /**
      * Tests MakerNote field handling.
      *
-     * EXIF 3.0 §4.6.5 (Table 4) defines the MakerNote tag for manufacturer-specific data.
+     * EXIF 3.0 §4.6.6.4.1 (Table 4) and EXIF 2.32 §4.6.6.4.1 define the MakerNote tag for manufacturer-specific data.
      */
     #[Test]
     public function parsesMakerNote(): void


### PR DESCRIPTION
## Summary
- Align MakerNote and UserComment references with EXIF 3.0 §4.6.6.4.x and the matching EXIF 2.32 sections.
- Expand PHPDoc and test annotations to call out the multicode prefix guidance in §4.6.4.

**Issue/Milestone:** Closes #N/A • Milestone M#
**Scope (allowed files only):** src/Model/Exif/ParsedExif.php; src/Parse/Tiff/TiffExifReader.php; tests/Parse/Tiff/README.md; tests/Parse/Tiff/TESTING.md; tests/Parse/Tiff/TiffExifReaderUserCommentTest.php
**Non-Goals:** Parser logic or binary handling changes; decoder behaviour.

---

## Implementation Notes
- Runtime: PHP 8.4, `declare(strict_types=1);`, PSR-12.
- **Streaming only** (Core\\Stream/StreamWindow) — keine Ganzdatei-Reads.
- Keine externen Binaries/Extensions; **kein** `exif_read_data()`.
- Value Objects (chainable) nur für EXIF-Ausgabe; kein Rendering.
- **Enums** für gängige Kodierungen genutzt/ergänzt (Encoding/Endianness/IFD/XMP/...).
- **Spec-References** im Code ergänzt/aktualisiert (siehe „References“).

---

## Always Checklist (must be green)
**Composer-Tasks (deine CI-Skripte):**
- [ ] Lint: `composer ci:test:php:lint`
- [ ] PHPStan: `composer ci:test:php:phpstan`
- [ ] Rector (dry-run): `composer ci:test:php:rector`
- [ ] Coding-Style: `composer ci::cgl`
- [ ] PHPUnit: `composer ci:test:php:unit`
- [ ] Coverage ≥ **90 %**: `composer ci:test:php:unit:coverage`
- [ ] JSCPD (Duplikate = 0): `composer ci:test:php:cpd`
- [ ] Sammellauf: `composer ci:test` (sollte grün sein; enthält Lint, PHPStan, Rector-Dry-Run, CS-Dry-Run, Unit)

**Inhaltliche/Code-Guidelines:**
- [ ] **Keine** `mixed`-Signaturen • **kein** `empty()` • **keine** verschachtelten Ternaries
- [ ] Fully-qualified native functions (`\strlen`, `\count`, …) und sinnvolle `use`-Imports
- [ ] **Keine** dynamischen Aufrufe statischer Methoden
- [ ] Sinnvolle **Interfaces** verwendet (wo Verträge sinnvoll sind)
- [ ] Typisierte Klassenkonstanten; redundante Casts/Default-Argumente entfernt
- [ ] Klassen als `readonly`, wo passend; keine redundante `readonly`-Mods
- [ ] **Eine Klasse je Datei** • Test-Namespaces spiegeln `src/`-Struktur
- [ ] Englische PHPDocs & englische Inline-Kommentare an komplexen Stellen
- [ ] Sinnvolle Namen für Variablen/Konstanten; Magic Numbers/Strings vermieden
- [ ] `array_find` / `array_any` / `array_all` gezielt statt trivialer `foreach` verwendet (wo es die Lesbarkeit verbessert)

---

## EXIF / TIFF / ISOBMFF / XMP Guardrails
- **EXIF-Versionen:** 1.x, 2.x (2.1/2.2/2.21/2.3/2.31/2.32), 3.0 — kompatible Änderungen; falls Tags betroffen: Coverage-Test grün.
- **TIFF/BigTIFF:** Endianness korrekt (`0x2A` / `0x2B`), Inline-Werte-Grenzen, `RATIONAL/SRATIONAL` korrekt.
- **GPS:** Vorzeichen über Ref-Tags (S/W negativ); `0/0`-Kantenfälle robust.
- **Preview/IFD1:** Nur beschreiben (Offsets/Längen/Compression), kein Rendering.
- **ISOBMFF/QuickTime:** Box-Size ≥ Header, 32/64-bit-Größen korrekt; `iloc`-Extents summiert; `data_reference_index ≠ 0` → skip; keine Remote-Refs.
- **XMP:** JPEG APP1-Präfix / ISOBMFF `uuid`; Parser mit `LIBXML_NONET`, keine DTD/Entities; `Alt/Bag/Seq` → Arrays.
- **Fehlerbehandlung:** ausschließlich `ParseError` oder `BoundsError`; keine Warnings/Notices als Kontrollfluss.

---

## Tests
- **Neue/angepasste Tests:** Updated TiffExifReaderUserCommentTest documentation references.
- **Negative Cases:** Not changed.
- **Fixtures/Streams:** No new fixtures added.

---

Updated MakerNote/UserComment references to EXIF 3.0 §4.6.6.4.1–4.6.6.4.2 and matching EXIF 2.32 sections; documentation-only refresh with unchanged parser behaviour.

## M# Sweep — Verify compliance for this milestone
Bitte **alles** verifizieren und kurz die Ergebnisse notieren:
- [ ] `composer ci:test` **grün** (Lint, PHPStan, Rector-Dry-Run, CS-Dry-Run, Unit)
- [ ] `composer ci:test:php:cpd` **0 Duplikate** (JSCPD, Konfig: `.build/.jscpd.json`)
- [ ] `composer ci:test:php:unit:coverage` **≥ 90 %**
- [ ] **ExifCoverageTest** (falls vorhanden): 0 fehlende Tags/Getters (gegen `resources/exif-map.yaml`)
- [ ] Für **jede** Klasse existiert ein Test (Namespace-Spiegelung)

---

## Breaking Changes / Risk / Rollback
- **Breaking changes:** <!-- falls ja: welche und warum notwendig -->
- **Risiken:** <!-- Parser-Sensitivität, Performance, Abhängigkeiten -->
- **Rollback-Plan:** <!-- einfache Revert-Strategie / Feature-Flag falls nötig -->

---

## Changelog
<!-- Kurz und im Stil der Conventional Commits zusammenfassen. -->

---

## References (Specs & Docs)
<!-- Liste der relevanten Kapitel/Abschnitte, jeweils aktuellste Fassung + abweichende ältere, falls relevant -->
- EXIF 3.0 §4.6.6.4.1; EXIF 2.32 §4.6.6.4.1
- EXIF 3.0 §4.6.6.4.2; EXIF 2.32 §4.6.6.4.2
- EXIF 3.0 §4.6.4
- TIFF 6.0 §2; §8

Docs im Repo:
- `docs/EXIF-210.pdf`, `docs/EXIF-220.pdf`, `docs/EXIF-230.pdf`, `docs/EXIF-231.pdf`, `docs/EXIF-232.pdf`, `docs/EXIF-300.pdf`
- `docs/TIFF6.pdf`

---

## Review Roles (tick what you covered)
- [ ] Planner (Scope/Non-Goals/Guardrails definiert)
- [ ] Spec Writer (AC/Tests präzisiert)
- [ ] Test Agent (RED zuerst)
- [ ] Implementer (GREEN minimal & im Datei-Scope)
- [ ] Static/QA (Stan/CS/Rector/JSCPD clean)
- [ ] Security (Bounds, Offsets, XML-Flags)
- [ ] Reviewer (Minimalität, DX, Spec-Refs, Enums)
- [ ] Release (PR-Text, Labels, Milestone, „Closes #…")


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69381c11d68c8323abcd99cbf9314db9)