### PR TITLE
M?: Harden OECF matrix validation — Exif

### DIFF
--- a/src/Model/Exif/ParsedExif.php
+++ b/src/Model/Exif/ParsedExif.php
@@ -798,8 +798,8 @@ final readonly class ParsedExif
     /**
      * Returns the opto-electronic conversion function data.
      *
-     * EXIF 3.0 §4.6.3 Table 15: OECF describes the relationship between camera's optical input
-     * and the image file values.
+     * EXIF 3.0 §4.6.6.7.6 (Figure 16, Table 11) and EXIF 2.32 §4.6.3: OECF describes the
+     * relationship between camera's optical input and the image file values.
      */
     public function oecf(): ?Oecf
     {

--- a/src/Model/Exif/ValueConverters.php
+++ b/src/Model/Exif/ValueConverters.php
@@ -1043,7 +1043,7 @@ final readonly class ValueConverters
 
     /**
      * Decodes the opto-electronic conversion function payload as defined by
-     * EXIF 3.0 §4.6.3 (table 15) and the earlier EXIF 2.32 §4.6.3 layout.
+     * EXIF 3.0 §4.6.6.7.6 (figure 16, table 11) and the earlier EXIF 2.32 §4.6.3 layout.
      *
      * @param string|null $payload Raw UNDEFINED payload captured from the EXIF tag.
      *

--- a/src/Value/Oecf.php
+++ b/src/Value/Oecf.php
@@ -20,8 +20,8 @@ use function is_string;
 /**
  * Opto-Electronic Conversion Function (OECF) data structure.
  *
- * EXIF 3.0 §4.6.3 Table 15: OECF describes the relationship between the camera's optical input
- * and the image file values. The structure contains:
+ * EXIF 3.0 §4.6.6.7.6 (Figure 16, Table 11) and EXIF 2.32 §4.6.3 describe the relationship
+ * between the camera's optical input and the image file values. The structure contains:
  * - Dimensions (columns × rows matrix)
  * - Column labels (typically input/pixel values)
  * - Row labels (typically output/luminance values)
@@ -50,7 +50,8 @@ final readonly class Oecf
     /**
      * Creates an OECF from the decoded matrix structure.
      *
-     * EXIF 3.0 §4.6.3 Table 15: OECF matrix format with dimensions, labels, and values.
+     * EXIF 3.0 §4.6.6.7.6 (Figure 16, Table 11) and EXIF 2.32 §4.6.3: OECF matrix format with
+     * dimensions, labels, and SRATIONAL values.
      *
      * @param array<string, mixed>|null $matrix Decoded OECF matrix. OECF matrix.
      *
@@ -73,6 +74,10 @@ final readonly class Oecf
             || !is_array($labels)
             || !is_array($values)
         ) {
+            return null;
+        }
+
+        if ($columns <= 0 || $rows <= 0) {
             return null;
         }
 
@@ -123,6 +128,10 @@ final readonly class Oecf
                 $normalizedRow[] = $cell;
             }
 
+            if (count($normalizedRow) !== $columns) {
+                return null;
+            }
+
             $normalizedValues[] = $normalizedRow;
         }
 
@@ -130,6 +139,10 @@ final readonly class Oecf
             (count($normalizedColumnLabels) !== $columns)
             || (count($normalizedRowLabels) !== $rows)
         ) {
+            return null;
+        }
+
+        if (count($normalizedValues) !== $rows) {
             return null;
         }
 

--- a/tests/Value/OecfTest.php
+++ b/tests/Value/OecfTest.php
@@ -19,7 +19,7 @@ use PHPUnit\Framework\TestCase;
 /**
  * Tests for OECF (Opto-Electronic Conversion Function) value object.
  *
- * EXIF 3.0 §4.6.3 Table 15 defines OECF structure:
+ * EXIF 3.0 §4.6.6.7.6 (Figure 16, Table 11) and EXIF 2.32 §4.6.3 define the OECF structure:
  * - columns: number of input (pixel value) columns
  * - rows: number of output (luminance) rows
  * - columnLabels: names for each column
@@ -119,6 +119,42 @@ final class OecfTest extends TestCase
         ];
 
         // Column count mismatch (labels has 1, but columns says 2)
+        self::assertNull(Oecf::fromMatrix($matrix));
+    }
+
+    #[Test]
+    public function mismatchingValueRowCountReturnsNull(): void
+    {
+        $matrix = [
+            'columns' => 2,
+            'rows'    => 2,
+            'labels'  => [
+                'columns' => ['Col1', 'Col2'],
+                'rows'    => ['Row1', 'Row2'],
+            ],
+            'values' => [
+                [1.0, 2.0],
+            ],
+        ];
+
+        self::assertNull(Oecf::fromMatrix($matrix));
+    }
+
+    #[Test]
+    public function mismatchingValueColumnsReturnNull(): void
+    {
+        $matrix = [
+            'columns' => 2,
+            'rows'    => 1,
+            'labels'  => [
+                'columns' => ['Col1', 'Col2'],
+                'rows'    => ['Row1'],
+            ],
+            'values' => [
+                [1.0],
+            ],
+        ];
+
         self::assertNull(Oecf::fromMatrix($matrix));
     }
 }


### PR DESCRIPTION
## Summary
- Hardened OECF matrix validation and null handling against EXIF 3.0 §4.6.6.7.6 / EXIF 2.32 §4.6.3.
- Added negative coverage for mismatching OECF label/value dimensions.

**Issue/Milestone:** Closes #<ID> • Milestone M?
**Scope (allowed files only):** src/Model/Exif/ParsedExif.php; src/Model/Exif/ValueConverters.php; src/Value/Oecf.php; tests/Value/OecfTest.php
**Non-Goals:** TIFF/BigTIFF parser adjustments outside OECF handling.

---

## Implementation Notes
- Runtime: PHP 8.4, `declare(strict_types=1);`, PSR-12.
- **Streaming only** (Core\\Stream/StreamWindow) — keine Ganzdatei-Reads.
- Keine externen Binaries/Extensions; **kein** `exif_read_data()`.
- Value Objects (chainable) nur für EXIF-Ausgabe; kein Rendering.
- **Enums** für gängige Kodierungen genutzt/ergänzt (Encoding/Endianness/IFD/XMP/...).
- **Spec-References** im Code ergänzt/aktualisiert (siehe „References“).

---

## Always Checklist (must be green)
**Composer-Tasks (deine CI-Skripte):**
- [ ] Lint: `composer ci:test:php:lint`
- [ ] PHPStan: `composer ci:test:php:phpstan`
- [ ] Rector (dry-run): `composer ci:test:php:rector`
- [ ] Coding-Style: `composer ci::cgl`
- [ ] PHPUnit: `composer ci:test:php:unit`
- [ ] Coverage ≥ **90 %**: `composer ci:test:php:unit:coverage`
- [ ] JSCPD (Duplikate = 0): `composer ci:test:php:cpd`
- [ ] Sammellauf: `composer ci:test` (sollte grün sein; enthält Lint, PHPStan, Rector-Dry-Run, CS-Dry-Run, Unit)

**Inhaltliche/Code-Guidelines:**
- [ ] **Keine** `mixed`-Signaturen • **kein** `empty()` • **keine** verschachtelten Ternaries
- [ ] Fully-qualified native functions (`\\strlen`, `\\count`, …) und sinnvolle `use`-Imports
- [ ] **Keine** dynamischen Aufrufe statischer Methoden
- [ ] Sinnvolle **Interfaces** verwendet (wo Verträge sinnvoll sind)
- [ ] Typisierte Klassenkonstanten; redundante Casts/Default-Argumente entfernt
- [ ] Klassen als `readonly`, wo passend; keine redundanten `readonly`-Mods
- [ ] **Eine Klasse je Datei** • Test-Namespaces spiegeln `src/`-Struktur
- [ ] Englische PHPDocs & englische Inline-Kommentare an komplexen Stellen
- [ ] Sinnvolle Namen für Variablen/Konstanten; Magic Numbers/Strings vermieden
- [ ] `array_find` / `array_any` / `array_all` gezielt statt trivialer `foreach` verwendet (wo es die Lesbarkeit verbessert)

---

## EXIF / TIFF / ISOBMFF / XMP Guardrails
- **EXIF-Versionen:** 1.x, 2.x (2.1/2.2/2.21/2.3/2.31/2.32), 3.0 — kompatible Änderungen; falls Tags betroffen: Coverage-Test grün.
- **TIFF/BigTIFF:** Endianness korrekt (`0x2A` / `0x2B`), Inline-Werte-Grenzen, `RATIONAL/SRATIONAL` korrekt.
- **GPS:** Vorzeichen über Ref-Tags (S/W negativ); `0/0`-Kantenfälle robust.
- **Preview/IFD1:** Nur beschreiben (Offsets/Längen/Compression), kein Rendering.
- **ISOBMFF/QuickTime:** Box-Size ≥ Header, 32/64-bit-Größen korrekt; `iloc`-Extents summiert; `data_reference_index ≠ 0` → skip; keine Remote-Refs.
- **XMP:** JPEG APP1-Präfix / ISOBMFF `uuid`; Parser mit `LIBXML_NONET`, keine DTD/Entities; `Alt/Bag/Seq` → Arrays.
- **Fehlerbehandlung:** ausschließlich `ParseError` oder `BoundsError`; keine Warnings/Notices als Kontrollfluss.

---

## Tests
- **Neue/angepasste Tests:** `tests/Value/OecfTest`
- **Negative Cases:** OECF dimension mismatches and invalid row/column counts
- **Fixtures/Streams:** Synthetic matrices only

---

## Execution Notes
- `composer ci:test:php:unit` reports two pre-existing TIFF GPS reference errors; OECF value-object coverage passes within that suite.

## M# Sweep — Verify compliance for this milestone
Bitte **alles** verifizieren und kurz die Ergebnisse notieren:
- [ ] `composer ci:test` **grün** (Lint, PHPStan, Rector-Dry-Run, CS-Dry-Run, Unit)
- [ ] `composer ci:test:php:cpd` **0 Duplikate** (JSCPD, Konfig: `.build/.jscpd.json`)
- [ ] `composer ci:test:php:unit:coverage` **≥ 90 %**
- [ ] **ExifCoverageTest** (falls vorhanden): 0 fehlende Tags/Getters (gegen `resources/exif-map.yaml`)
- [ ] Für **jede** Klasse existiert ein Test (Namespace-Spiegelung)

---

## Breaking Changes / Risk / Rollback
- **Breaking changes:** None
- **Risiken:** None observed beyond existing TIFF GPS test failures
- **Rollback-Plan:** Revert commit if necessary

---

## Changelog
- fix(exif): harden OECF matrix validation and tighten dimension checks

---

## References (Specs & Docs)
- EXIF 3.0 §4.6.6.7.6; EXIF 2.32 §4.6.3
- TIFF 6.0 §2.2
- `docs/EXIF-232.pdf`, `docs/EXIF-300.pdf`, `docs/TIFF6.pdf`

---

## Review Roles (tick what you covered)
- [x] Planner (Scope/Non-Goals/Guardrails definiert)
- [x] Spec Writer (AC/Tests präzisiert)
- [x] Test Agent (RED zuerst)
- [x] Implementer (GREEN minimal & im Datei-Scope)
- [ ] Static/QA (Stan/CS/Rector/JSCPD clean)
- [ ] Security (Bounds, Offsets, XML-Flags)
- [x] Reviewer (Minimalität, DX, Spec-Refs, Enums)
- [ ] Release (PR-Text, Labels, Milestone, „Closes #…“)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69381d8c0e3c8323ab5b1297dc48cb37)