### PR TITLE
M#: Enforce chromaticity tag defaults — EXIF

### DIFF
--- a/src/Model/Exif/ParsedExif.php
+++ b/src/Model/Exif/ParsedExif.php
@@ -506,11 +506,24 @@ final readonly class ParsedExif
     /**
      * Returns the transfer function lookup table when available.
      *
+     * EXIF 3.0 §4.6.5.3.1 and EXIF 2.32 §4.6.5.3.1 define TransferFunction as
+     * a 3×256 table of SHORT values describing the tone reproduction curve.
+     *
      * @return list<int>|null
      */
     public function transferFunction(): ?array
     {
-        return $this->numericList($this->ifd0, ExifTag::TRANSFER_FUNCTION);
+        $values = $this->numericList($this->ifd0, ExifTag::TRANSFER_FUNCTION);
+
+        if ($values === null) {
+            return null;
+        }
+
+        if (count($values) !== 3 * 256) {
+            return null;
+        }
+
+        return $values;
     }
 
     /**
@@ -2119,6 +2132,10 @@ final readonly class ParsedExif
     /**
      * Returns the YCbCr conversion coefficients when provided.
      *
+     * EXIF 3.0 §4.6.5.3.4 (and EXIF 2.32 §4.6.5.3.4) defines three rational
+     * coefficients for RGB→YCbCr conversion, defaulting to Annex D values when
+     * the tag is absent.
+     *
      * @return array{0:float,1:float,2:float}|null
      */
     public function ycbcrCoefficients(): ?array
@@ -2159,11 +2176,14 @@ final readonly class ParsedExif
             return count($coeffs) === 3 ? $coeffs : null;
         }
 
-        return null;
+        return $this->defaultYCbCrCoefficients();
     }
 
     /**
      * Returns the normalized white point coordinates.
+     *
+     * EXIF 3.0 §4.6.5.3.2 (WhitePoint) and EXIF 2.32 §4.6.5.3.2 encode the
+     * chromaticity of the white point as exactly two rational values (X,Y).
      *
      * @return array{0:float,1:float}|null
      */
@@ -2178,6 +2198,9 @@ final readonly class ParsedExif
 
     /**
      * Returns the primary chromaticities ordered as R,G,B.
+     *
+     * EXIF 3.0 §4.6.5.3.3 (PrimaryChromaticities) and EXIF 2.32 §4.6.5.3.3
+     * define three rational pairs (RedX, RedY, GreenX, GreenY, BlueX, BlueY).
      *
      * @return array{0:float,1:float,2:float,3:float,4:float,5:float}|null
      */
@@ -2903,6 +2926,23 @@ final readonly class ParsedExif
             4 => $values[4],
             5 => $values[5],
         ];
+    }
+
+    /**
+     * Applies EXIF 3.0 §4.6.5.3.4 defaults for missing YCbCrCoefficients.
+     *
+     * Annex D recommends the ITU-R BT.601 coefficients when no matrix is
+     * specified: [0.299, 0.587, 0.114].
+     *
+     * @return array{0: float, 1: float, 2: float}|null
+     */
+    private function defaultYCbCrCoefficients(): ?array
+    {
+        if ($this->photometric() !== Photometric::YCBCR) {
+            return null;
+        }
+
+        return [0.299, 0.587, 0.114];
     }
 
     /**

--- a/src/Model/Exif/ValueConverters.php
+++ b/src/Model/Exif/ValueConverters.php
@@ -369,7 +369,7 @@ final readonly class ValueConverters
         }
 
         /** @var list<array<int, int|float|string>|int|float|ExifRational> $values */
-        if (count($values) < 2) {
+        if (count($values) !== 2) {
             return null;
         }
 
@@ -425,7 +425,7 @@ final readonly class ValueConverters
         }
 
         /** @var list<array<int, int|float|string>|int|float|ExifRational> $values */
-        if (count($values) < 6) {
+        if (count($values) !== 6) {
             return null;
         }
 

--- a/tests/Model/Exif/ParsedExifDefaultValuesTest.php
+++ b/tests/Model/Exif/ParsedExifDefaultValuesTest.php
@@ -207,4 +207,56 @@ final class ParsedExifDefaultValuesTest extends TestCase
 
         self::assertNull($parsedExif->referenceBlackWhite());
     }
+
+    #[Test]
+    public function transferFunctionRequiresCompleteLut(): void
+    {
+        $incomplete = new Ifd([
+            ExifTag::TRANSFER_FUNCTION => new IfdEntry(ExifTag::TRANSFER_FUNCTION, 3, 6, [0, 1, 2, 3, 4, 5]),
+        ]);
+
+        $parsedExif = new ParsedExif($incomplete, null, null, null, null);
+
+        self::assertNull($parsedExif->transferFunction());
+
+        $table = range(0, 767);
+
+        $complete = new Ifd([
+            ExifTag::TRANSFER_FUNCTION => new IfdEntry(ExifTag::TRANSFER_FUNCTION, 3, count($table), $table),
+        ]);
+
+        $parsedExif = new ParsedExif($complete, null, null, null, null);
+
+        self::assertSame($table, $parsedExif->transferFunction());
+    }
+
+    #[Test]
+    public function ycbcrCoefficientsDefaultToAnnexDWhenMissing(): void
+    {
+        $ifd0 = new Ifd([
+            ExifTag::PHOTOMETRIC_INTERPRETATION => new IfdEntry(
+                ExifTag::PHOTOMETRIC_INTERPRETATION,
+                3,
+                1,
+                Photometric::YCBCR->value,
+            ),
+        ]);
+
+        $parsedExif = new ParsedExif($ifd0, null, null, null, null);
+
+        self::assertSame([0.299, 0.587, 0.114], $parsedExif->ycbcrCoefficients());
+
+        $rgbIfd = new Ifd([
+            ExifTag::PHOTOMETRIC_INTERPRETATION => new IfdEntry(
+                ExifTag::PHOTOMETRIC_INTERPRETATION,
+                3,
+                1,
+                Photometric::RGB->value,
+            ),
+        ]);
+
+        $parsedExif = new ParsedExif($rgbIfd, null, null, null, null);
+
+        self::assertNull($parsedExif->ycbcrCoefficients());
+    }
 }

--- a/tests/Model/Exif/ValueConvertersTest.php
+++ b/tests/Model/Exif/ValueConvertersTest.php
@@ -1000,6 +1000,27 @@ final class ValueConvertersTest extends TestCase
     }
 
     #[Test]
+    public function rejectsInvalidWhitePointAndChromaticityLengths(): void
+    {
+        $whitePoint = new ExifRationalList([
+            new ExifRational(1, 2),
+            new ExifRational(1, 2),
+            new ExifRational(1, 2),
+        ]);
+
+        self::assertNull(ValueConverters::toWhitePoint($whitePoint));
+
+        $chromaticities = new ExifRationalList([
+            new ExifRational(1, 1),
+            new ExifRational(1, 1),
+            new ExifRational(1, 1),
+            new ExifRational(1, 1),
+        ]);
+
+        self::assertNull(ValueConverters::toPrimaryChromaticities($chromaticities));
+    }
+
+    #[Test]
     public function calculatesFieldOfViewAndHyperfocalMetrics(): void
     {
         $cropFactor = ValueConverters::calcCropFactor(75, 50.0);


### PR DESCRIPTION
## Summary
- Enforced EXIF 4.6.5.3 chromaticity tag constraints and defaults for transfer functions, white point, primary chromaticities, and YCbCr coefficients.
- Added guardrail tests for chromaticity value lengths and Annex D defaults.

**Issue/Milestone:** Closes #N/A • Milestone M#
**Scope (allowed files only):** src/Model/Exif/ParsedExif.php; src/Model/Exif/ValueConverters.php; tests/Model/Exif/ParsedExifDefaultValuesTest.php; tests/Model/Exif/ValueConvertersTest.php
**Non-Goals:** No streaming reader changes; no additional EXIF tag support beyond the specified chromaticity entries.

---

## Implementation Notes
- Runtime: PHP 8.4, `declare(strict_types=1);`, PSR-12.
- **Streaming only** (Core\Stream/StreamWindow) — keine Ganzdatei-Reads.
- Keine externen Binaries/Extensions; **kein** `exif_read_data()`.
- Value Objects (chainable) nur für EXIF-Ausgabe; kein Rendering.
- **Enums** für gängige Kodierungen genutzt/ergänzt (Encoding/Endianness/IFD/XMP/...).
- **Spec-References** im Code ergänzt/aktualisiert (siehe „References“).

---

## Always Checklist (must be green)
**Composer-Tasks (deine CI-Skripte):**
- [ ] Lint: `composer ci:test:php:lint`
- [ ] PHPStan: `composer ci:test:php:phpstan`
- [ ] Rector (dry-run): `composer ci:test:php:rector`
- [ ] Coding-Style: `composer ci::cgl`
- [ ] PHPUnit: `composer ci:test:php:unit`
- [ ] Coverage ≥ **90 %**: `composer ci:test:php:unit:coverage`
- [ ] JSCPD (Duplikate = 0): `composer ci:test:php:cpd`
- [ ] Sammellauf: `composer ci:test` (sollte grün sein; enthält Lint, PHPStan, Rector-Dry-Run, CS-Dry-Run, Unit)

**Inhaltliche/Code-Guidelines:**
- [ ] **Keine** `mixed`-Signaturen • **kein** `empty()` • **keine** verschachtelten Ternaries
- [ ] Fully-qualified native functions (`\strlen`, `\count`, …) und sinnvolle `use`-Imports
- [ ] **Keine** dynamischen Aufrufe statischer Methoden
- [ ] Sinnvolle **Interfaces** verwendet (wo Verträge sinnvoll sind)
- [ ] Typisierte Klassenkonstanten; redundante Casts/Default-Argumente entfernt
- [ ] Klassen als `readonly`, wo passend; keine redundanten `readonly`-Mods
- [ ] **Eine Klasse je Datei** • Test-Namespaces spiegeln `src/`-Struktur
- [ ] Englische PHPDocs & englische Inline-Kommentare an komplexen Stellen
- [ ] Sinnvolle Namen für Variablen/Konstanten; Magic Numbers/Strings vermieden
- [ ] `array_find` / `array_any` / `array_all` gezielt statt trivialer `foreach` verwendet (wo es die Lesbarkeit verbessert)

---

## EXIF / TIFF / ISOBMFF / XMP Guardrails
- **EXIF-Versionen:** 1.x, 2.x (2.1/2.2/2.21/2.3/2.31/2.32), 3.0 — kompatible Änderungen; falls Tags betroffen: Coverage-Test grün.
- **TIFF/BigTIFF:** Endianness korrekt (`0x2A` / `0x2B`), Inline-Werte-Grenzen, `RATIONAL/SRATIONAL` korrekt.
- **GPS:** Vorzeichen über Ref-Tags (S/W negativ); `0/0`-Kantenfälle robust.
- **Preview/IFD1:** Nur beschreiben (Offsets/Längen/Compression), kein Rendering.
- **ISOBMFF/QuickTime:** Box-Size ≥ Header, 32/64-bit-Größen korrekt; `iloc`-Extents summiert; `data_reference_index ≠ 0` → skip; keine Remote-Refs.
- **XMP:** JPEG APP1-Präfix / ISOBMFF `uuid`; Parser mit `LIBXML_NONET`, keine DTD/Entities; `Alt/Bag/Seq` → Arrays.
- **Fehlerbehandlung:** ausschließlich `ParseError` oder `BoundsError`; keine Warnings/Notices als Kontrollfluss.

---

## Tests
- **Neue/angepasste Tests:** Chromaticity validation for TransferFunction, white point, primary chromaticities, YCbCr coefficients defaults.
- **Negative Cases:** Invalid component counts for chromaticity tags; missing YCbCr coefficients fallback when photometric interpretation differs.
- **Fixtures/Streams:** Synthetic Ifd/IfdEntry values.

---
### Execution Status
- composer ci:test:php:unit (fails: pre-existing TIFF GPS reference test errors; see log for details)

## M# Sweep — Verify compliance for this milestone
Bitte **alles** verifizieren und kurz die Ergebnisse notieren:
- [ ] `composer ci:test` **grün** (Lint, PHPStan, Rector-Dry-Run, CS-Dry-Run, Unit)
- [ ] `composer ci:test:php:cpd` **0 Duplikate** (JSCPD, Konfig: `.build/.jscpd.json`)
- [ ] `composer ci:test:php:unit:coverage` **≥ 90 %**
- [ ] **ExifCoverageTest** (falls vorhanden): 0 fehlende Tags/Getters (gegen `resources/exif-map.yaml`)
- [ ] Für **jede** Klasse existiert ein Test (Namespace-Spiegelung)

---

## Breaking Changes / Risk / Rollback
- **Breaking changes:** None anticipated; changes validate existing EXIF getters.
- **Risiken:** Stricter chromaticity validation may return null when malformed data is present.
- **Rollback-Plan:** Revert this PR if issues arise.

---

## Changelog
- fix(exif): validate chromaticity tag handling per EXIF 4.6.5.3

---

## References (Specs & Docs)
- EXIF 3.0 §4.6.5.3.1; EXIF 3.0 §4.6.5.3.2; EXIF 3.0 §4.6.5.3.3; EXIF 3.0 §4.6.5.3.4; EXIF 2.32 §4.6.5.3.1–3.4
- TIFF 6.0 §8

Docs im Repo:
- `docs/EXIF-210.pdf`, `docs/EXIF-220.pdf`, `docs/EXIF-230.pdf`, `docs/EXIF-231.pdf`, `docs/EXIF-232.pdf`, `docs/EXIF-300.pdf`
- `docs/TIFF6.pdf`

---

## Review Roles (tick what you covered)
- [ ] Planner (Scope/Non-Goals/Guardrails definiert)
- [ ] Spec Writer (AC/Tests präzisiert)
- [ ] Test Agent (RED zuerst)
- [ ] Implementer (GREEN minimal & im Datei-Scope)
- [ ] Static/QA (Stan/CS/Rector/JSCPD clean)
- [ ] Security (Bounds, Offsets, XML-Flags)
- [ ] Reviewer (Minimalität, DX, Spec-Refs, Enums)
- [ ] Release (PR-Text, Labels, Milestone, „Closes #…“)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69381b6a8d7883239b4a498716c1f053)