### PR TITLE
M#: Align EXIF planar/resolution metadata handling

### DIFF
--- a/src/Model/Exif/ParsedExif.php
+++ b/src/Model/Exif/ParsedExif.php
@@ -2039,7 +2039,9 @@ final readonly class ParsedExif
     /**
      * Returns the planar configuration enum.
      *
-     * TIFF 6.0 §8 specifies default value 1 (chunky format) when not present.
+     * EXIF 3.0 §4.6.5.1.10 / TIFF 6.0 §8 specify default value 1 (chunky format)
+     * when not present. JPEG compressed data shall not record this tag because
+     * the JPEG marker carries the equivalent information.
      *
      * @return PlanarConfiguration
      */
@@ -2055,7 +2057,8 @@ final readonly class ParsedExif
     /**
      * Returns the resolution unit enum for the reported X/Y resolution values.
      *
-     * TIFF 6.0 §8 and EXIF 3.0 §4.6.2 specify default value 2 (inches) when not present.
+     * EXIF 3.0 §4.6.5.1.11 and TIFF 6.0 §8 specify default value 2 (inches) when
+     * not present.
      *
      * @return ResolutionUnit
      */
@@ -2096,6 +2099,11 @@ final readonly class ParsedExif
 
     /**
      * Returns the YCbCr subsampling factors.
+     *
+     * EXIF 3.0 §4.6.5.1.12 defines only [2,1] (YCbCr4:2:2) and [2,2]
+     * (YCbCr4:2:0) as legal values. The tag shall not be recorded for JPEG
+     * compressed data because the JPEG marker stream already encodes the
+     * sampling factors.
      *
      * @return array{0:int,1:int}|null
      */

--- a/src/Model/Exif/ValueConverters.php
+++ b/src/Model/Exif/ValueConverters.php
@@ -513,7 +513,8 @@ final readonly class ValueConverters
 
     /**
      * Converts a textual YCbCr subsampling representation into integer pairs as
-     * described in EXIF 2.32 §4.6.2 / EXIF 3.0 §4.6.2 (image data structure).
+     * described in EXIF 2.32 §4.6.5.1.12 / EXIF 3.0 §4.6.5.1.12 (image data
+     * structure).
      *
      * EXIF 3.0 §4.6.5.1.12 (YCbCrSubSampling) defines only [2,1] (YCbCr4:2:2) and
      * [2,2] (YCbCr4:2:0) as legal values. Other combinations are reserved and rejected.

--- a/src/Value/Enum/PlanarConfiguration.php
+++ b/src/Value/Enum/PlanarConfiguration.php
@@ -15,8 +15,11 @@ use MagicSunday\ImageMeta\Exif\Support\EnumFromIntStringNullable;
 
 /**
  * Enumerates the planar configuration options for the PlanarConfiguration tag
- * in EXIF 3.0 §4.6.2 (image data structure), following the mappings from EXIF
- * 2.32 §4.6.2 and TIFF 6.0 §8.
+ * in EXIF 3.0 §4.6.5.1.10 (image data structure), following the mappings from
+ * EXIF 2.32 §4.6.5.1.10 and TIFF 6.0 §8.
+ *
+ * JPEG compressed data shall not record this tag because the JPEG marker
+ * carries the equivalent information.
  */
 enum PlanarConfiguration: int
 {

--- a/src/Value/Enum/ResolutionUnit.php
+++ b/src/Value/Enum/ResolutionUnit.php
@@ -15,14 +15,32 @@ use MagicSunday\ImageMeta\Exif\Support\EnumFromIntStringNullable;
 
 /**
  * Enumerates the resolution units recorded by the XResolution/YResolution tags
- * in EXIF 3.0 §4.6.2 (image data structure), continuing the EXIF 2.32 §4.6.2
- * set.
+ * in EXIF 3.0 §4.6.5.1.11 (image data structure), continuing the EXIF
+ * 2.32 §4.6.5.1.11 set.
  */
 enum ResolutionUnit: int
 {
-    use EnumFromIntStringNullable;
+    use EnumFromIntStringNullable {
+        EnumFromIntStringNullable::fromExifValue as private fromExifValueNullable;
+    }
 
     case NONE       = 1;
     case INCHES     = 2;
     case CENTIMETER = 3;
+
+    /**
+     * Returns only valid EXIF resolution unit values per EXIF 3.0 §4.6.5.1.11.
+     *
+     * Values outside the defined set (2 = inches, 3 = centimeters) are
+     * considered reserved and rejected.
+     */
+    public static function fromExifValue(int|string|null $value): ?self
+    {
+        $resolved = self::fromExifValueNullable($value);
+
+        return match ($resolved) {
+            self::INCHES, self::CENTIMETER => $resolved,
+            default                        => null,
+        };
+    }
 }

--- a/tests/Model/Exif/ParsedExifDefaultValuesTest.php
+++ b/tests/Model/Exif/ParsedExifDefaultValuesTest.php
@@ -97,10 +97,11 @@ final class ParsedExifDefaultValuesTest extends TestCase
     }
 
     /**
-     * Verifies that planarConfiguration() returns the TIFF 6.0 default value
-     * of PlanarConfiguration::CHUNKY when the tag is not present.
+     * Verifies that planarConfiguration() returns the TIFF 6.0/EXIF 3.0 default
+     * value of PlanarConfiguration::CHUNKY when the tag is not present.
      *
      * @see TIFF 6.0 §8: PlanarConfiguration default is 1 (chunky format)
+     * @see EXIF 3.0 §4.6.5.1.10: PlanarConfiguration default is 1
      */
     #[Test]
     public function planarConfigurationReturnsDefaultWhenMissing(): void
@@ -112,11 +113,11 @@ final class ParsedExifDefaultValuesTest extends TestCase
     }
 
     /**
-     * Verifies that resolutionUnit() returns the TIFF 6.0/EXIF 3.0 default value
-     * of ResolutionUnit::INCHES when the tag is not present.
+     * Verifies that resolutionUnit() returns the TIFF 6.0/EXIF 3.0 default
+     * value of ResolutionUnit::INCHES when the tag is not present.
      *
      * @see TIFF 6.0 §8: ResolutionUnit default is 2 (inches)
-     * @see EXIF 3.0 §4.6.2: ResolutionUnit default is 2
+     * @see EXIF 3.0 §4.6.5.1.11: ResolutionUnit default is 2
      */
     #[Test]
     public function resolutionUnitReturnsDefaultWhenMissing(): void

--- a/tests/Value/Enum/EnumMappingTest.php
+++ b/tests/Value/Enum/EnumMappingTest.php
@@ -68,6 +68,7 @@ final class EnumMappingTest extends TestCase
         self::assertSame(Photometric::YCBCR, Photometric::fromExifValue(6));
         self::assertSame(PlanarConfiguration::CHUNKY, PlanarConfiguration::fromExifValue(1));
         self::assertSame(ResolutionUnit::CENTIMETER, ResolutionUnit::fromExifValue(3));
+        self::assertNull(ResolutionUnit::fromExifValue(1));
         self::assertSame(YCbCrPositioning::CO_SITED, YCbCrPositioning::fromExifValue(2));
         self::assertSame(ExposureMode::AUTO_BRACKET, ExposureMode::fromExifValue(2));
         self::assertSame(GainControl::HIGH_GAIN_UP, GainControl::fromExifValue(2));


### PR DESCRIPTION
## Summary
- Align PlanarConfiguration and ResolutionUnit documentation with EXIF 3.0 §§4.6.5.1.10–4.6.5.1.11 defaults and JPEG caveats.
- Document YCbCrSubSampling limits from EXIF 3.0 §4.6.5.1.12 and reject reserved resolution unit values in enum mapping.

**Issue/Milestone:** Closes #N/A • Milestone M#
**Scope (allowed files only):** src/Model/Exif/ParsedExif.php; src/Model/Exif/ValueConverters.php; src/Value/Enum/PlanarConfiguration.php; src/Value/Enum/ResolutionUnit.php; tests/Model/Exif/ParsedExifDefaultValuesTest.php; tests/Value/Enum/EnumMappingTest.php
**Non-Goals:** Broader TIFF reader changes.

---

## Implementation Notes
- Runtime: PHP 8.4, `declare(strict_types=1);`, PSR-12.
- **Streaming only** (Core\\Stream/StreamWindow) — keine Ganzdatei-Reads.
- Keine externen Binaries/Extensions; **kein** `exif_read_data()`.
- Value Objects (chainable) nur für EXIF-Ausgabe; kein Rendering.
- **Enums** für gängige Kodierungen genutzt/ergänzt (Encoding/Endianness/IFD/XMP/...).
- **Spec-References** im Code ergänzt/aktualisiert (siehe „References“).

---

## Always Checklist (must be green)
**Composer-Tasks (deine CI-Skripte):**
- [ ] Lint: `composer ci:test:php:lint`
- [ ] PHPStan: `composer ci:test:php:phpstan`
- [ ] Rector (dry-run): `composer ci:test:php:rector`
- [ ] Coding-Style: `composer ci::cgl`
- [ ] PHPUnit: `composer ci:test:php:unit`
- [ ] Coverage ≥ **90 %**: `composer ci:test:php:unit:coverage`
- [ ] JSCPD (Duplikate = 0): `composer ci:test:php:cpd`
- [ ] Sammellauf: `composer ci:test` (sollte grün sein; enthält Lint, PHPStan, Rector-Dry-Run, CS-Dry-Run, Unit)

**Inhaltliche/Code-Guidelines:**
- [ ] **Keine** `mixed`-Signaturen • **kein** `empty()` • **keine** verschachtelten Ternaries
- [ ] Fully-qualified native functions (`\\strlen`, `\\count`, …) und sinnvolle `use`-Imports
- [ ] **Keine** dynamischen Aufrufe statischer Methoden
- [ ] Sinnvolle **Interfaces** verwendet (wo Verträge sinnvoll sind)
- [ ] Typisierte Klassenkonstanten; redundante Casts/Default-Argumente entfernt
- [ ] Klassen als `readonly`, wo passend; keine redundanten `readonly`-Mods
- [ ] **Eine Klasse je Datei** • Test-Namespaces spiegeln `src/`-Struktur
- [ ] Englische PHPDocs & englische Inline-Kommentare an komplexen Stellen
- [ ] Sinnvolle Namen für Variablen/Konstanten; Magic Numbers/Strings vermieden
- [ ] `array_find` / `array_any` / `array_all` gezielt statt trivialer `foreach` verwendet (wo es die Lesbarkeit verbessert)

---

## EXIF / TIFF / ISOBMFF / XMP Guardrails
- **EXIF-Versionen:** 1.x, 2.x (2.1/2.2/2.21/2.3/2.31/2.32), 3.0 — kompatible Änderungen; falls Tags betroffen: Coverage-Test grün.
- **TIFF/BigTIFF:** Endianness korrekt (`0x2A` / `0x2B`), Inline-Werte-Grenzen, `RATIONAL/SRATIONAL` korrekt.
- **GPS:** Vorzeichen über Ref-Tags (S/W negativ); `0/0`-Kantenfälle robust.
- **Preview/IFD1:** Nur beschreiben (Offsets/Längen/Compression), kein Rendering.
- **ISOBMFF/QuickTime:** Box-Size ≥ Header, 32/64-bit-Größen korrekt; `iloc`-Extents summiert; `data_reference_index ≠ 0` → skip; keine Remote-Refs.
- **XMP:** JPEG APP1-Präfix / ISOBMFF `uuid`; Parser mit `LIBXML_NONET`, keine DTD/Entities; `Alt/Bag/Seq` → Arrays.
- **Fehlerbehandlung:** ausschließlich `ParseError` oder `BoundsError`; keine Warnings/Notices als Kontrollfluss.

---

## Tests
- **Neue/angepasste Tests:** Enum mapping rejects reserved ResolutionUnit value; default PlanarConfiguration/ResolutionUnit expectations reflect EXIF 3.0 sections.
- **Negative Cases:** ResolutionUnit reserved value rejected; YCbCrSubSampling legal set unchanged.
- **Fixtures/Streams:** Synthetic fixtures only; no new binaries added.

---

### Additional Compliance Notes
- EXIF 3.0 §§4.6.5.1.10–4.6.5.1.12 defaults and reserved-value handling reflected in enums, parsers, and tests.

## M# Sweep — Verify compliance for this milestone
Bitte **alles** verifizieren und kurz die Ergebnisse notieren:
- [ ] `composer ci:test` **grün** (Lint, PHPStan, Rector-Dry-Run, CS-Dry-Run, Unit)
- [ ] `composer ci:test:php:cpd` **0 Duplikate** (JSCPD, Konfig: `.build/.jscpd.json`)
- [ ] `composer ci:test:php:unit:coverage` **≥ 90 %**
- [ ] **ExifCoverageTest** (falls vorhanden): 0 fehlende Tags/Getters (gegen `resources/exif-map.yaml`)
- [ ] Für **jede** Klasse existiert ein Test (Namespace-Spiegelung)

---

## Breaking Changes / Risk / Rollback
- **Breaking changes:** <!-- falls ja: welche und warum notwendig -->
- **Risiken:** <!-- Parser-Sensitivität, Performance, Abhängigkeiten -->
- **Rollback-Plan:** <!-- einfache Revert-Strategie / Feature-Flag falls nötig -->

---

## Changelog
<!-- Kurz und im Stil der Conventional Commits zusammenfassen. -->

---

## References (Specs & Docs)
<!-- Liste der relevanten Kapitel/Abschnitte, jeweils aktuellste Fassung + abweichende ältere, falls relevant -->
- EXIF 3.0 §… ; ggf. EXIF 2.32 §… ; EXIF 2.31 §…
- TIFF 6.0 §…
- ISOBMFF/QuickTime §…
- XMP (Adobe XMP Packet) §…

Docs im Repo:
- `docs/EXIF-210.pdf`, `docs/EXIF-220.pdf`, `docs/EXIF-230.pdf`, `docs/EXIF-231.pdf`, `docs/EXIF-232.pdf`, `docs/EXIF-300.pdf`
- `docs/TIFF6.pdf`

---

## Review Roles (tick what you covered)
- [ ] Planner (Scope/Non-Goals/Guardrails definiert)
- [ ] Spec Writer (AC/Tests präzisiert)
- [ ] Test Agent (RED zuerst)
- [ ] Implementer (GREEN minimal & im Datei-Scope)
- [ ] Static/QA (Stan/CS/Rector/JSCPD clean)
- [ ] Security (Bounds, Offsets, XML-Flags)
- [ ] Reviewer (Minimalität, DX, Spec-Refs, Enums)
- [ ] Release (PR-Text, Labels, Milestone, „Closes #…")


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69381aeb17208323b0557c572ed9eea1)