### PR TITLE
M#: SensitivityType mapping — Exif

### DIFF
--- a/src/Model/Exif/ParsedExif.php
+++ b/src/Model/Exif/ParsedExif.php
@@ -911,7 +911,10 @@ final readonly class ParsedExif
     }
 
     /**
-     * Returns the declared EXIF sensitivity type as defined by EXIF 3.0 §4.6.5.1.6 Table 10.
+     * Returns the declared EXIF sensitivity type as defined by EXIF 3.0 §4.6.6.7.7 Table 14.
+     *
+     * EXIF 2.32 §4.6.6.7.7 introduces SensitivityType to signal which ISO 12232
+     * parameter the PhotographicSensitivity tag represents.
      */
     public function sensitivityType(): ?SensitivityType
     {
@@ -926,6 +929,11 @@ final readonly class ParsedExif
 
     /**
      * Returns the ISO sensitivity value if present.
+     *
+     * EXIF 3.0 §4.6.6.7.7 Table 14 defines how SensitivityType maps the
+     * PhotographicSensitivity tag to ISO 12232 parameters and combinations.
+     * When declared, the photographic sensitivity value must be prioritised for
+     * the selected parameter(s) before falling back to legacy individual tags.
      *
      * @return int|null
      */
@@ -1060,8 +1068,12 @@ final readonly class ParsedExif
     private function sensitivityTagPriority(SensitivityType $type): array
     {
         return match ($type) {
-            SensitivityType::STANDARD_OUTPUT_SENSITIVITY => [ExifTag::STANDARD_OUTPUT_SENSITIVITY],
+            SensitivityType::STANDARD_OUTPUT_SENSITIVITY => [
+                ExifTag::PHOTOGRAPHIC_SENSITIVITY,
+                ExifTag::STANDARD_OUTPUT_SENSITIVITY,
+            ],
             SensitivityType::RECOMMENDED_EXPOSURE_INDEX  => [
+                ExifTag::PHOTOGRAPHIC_SENSITIVITY,
                 ExifTag::RECOMMENDED_EXPOSURE_INDEX,
                 ExifTag::EXPOSURE_INDEX,
             ],
@@ -1070,26 +1082,27 @@ final readonly class ParsedExif
                 ExifTag::ISO_SPEED,
             ],
             SensitivityType::SOS_AND_REI => [
+                ExifTag::PHOTOGRAPHIC_SENSITIVITY,
                 ExifTag::STANDARD_OUTPUT_SENSITIVITY,
                 ExifTag::RECOMMENDED_EXPOSURE_INDEX,
                 ExifTag::EXPOSURE_INDEX,
             ],
             SensitivityType::SOS_AND_ISO => [
-                ExifTag::STANDARD_OUTPUT_SENSITIVITY,
                 ExifTag::PHOTOGRAPHIC_SENSITIVITY,
+                ExifTag::STANDARD_OUTPUT_SENSITIVITY,
                 ExifTag::ISO_SPEED,
             ],
             SensitivityType::REI_AND_ISO => [
+                ExifTag::PHOTOGRAPHIC_SENSITIVITY,
                 ExifTag::RECOMMENDED_EXPOSURE_INDEX,
                 ExifTag::EXPOSURE_INDEX,
-                ExifTag::PHOTOGRAPHIC_SENSITIVITY,
                 ExifTag::ISO_SPEED,
             ],
             SensitivityType::SOS_AND_REI_AND_ISO => [
+                ExifTag::PHOTOGRAPHIC_SENSITIVITY,
                 ExifTag::STANDARD_OUTPUT_SENSITIVITY,
                 ExifTag::RECOMMENDED_EXPOSURE_INDEX,
                 ExifTag::EXPOSURE_INDEX,
-                ExifTag::PHOTOGRAPHIC_SENSITIVITY,
                 ExifTag::ISO_SPEED,
             ],
             SensitivityType::UNKNOWN => [],

--- a/src/Value/Enum/SensitivityType.php
+++ b/src/Value/Enum/SensitivityType.php
@@ -16,9 +16,10 @@ use MagicSunday\ImageMeta\Exif\Support\EnumFromIntStringNullable;
 /**
  * Sensitivity type enumeration for ISO sensitivity values.
  *
- * EXIF 3.0 §4.6.4 Table 10 defines the SensitivityType tag which indicates
- * which ISO sensitivity value (if any) is valid and what type it represents.
- * EXIF 2.3 §4.6.6 introduced this tag to disambiguate ISO speed representations.
+ * EXIF 3.0 §4.6.6.7.7 Table 14 defines the SensitivityType tag which indicates
+ * which ISO 12232 parameter is encoded by the PhotographicSensitivity tag.
+ * EXIF 2.32 §4.6.6.7.7 introduced this mapping to disambiguate ISO speed
+ * representations when multiple parameters share identical values.
  *
  * @see \MagicSunday\ImageMeta\Model\Exif\ExifTag::SENSITIVITY_TYPE
  * @see \MagicSunday\ImageMeta\Model\Exif\ExifTag::PHOTOGRAPHIC_SENSITIVITY
@@ -32,49 +33,49 @@ enum SensitivityType: int
 
     /**
      * Unknown sensitivity type.
-     * EXIF 3.0 §4.6.4 Table 10.
+     * EXIF 3.0 §4.6.6.7.7 Table 14.
      */
     case UNKNOWN = 0;
 
     /**
      * Standard output sensitivity (SOS).
-     * EXIF 3.0 §4.6.4 Table 10.
+     * EXIF 3.0 §4.6.6.7.7 Table 14.
      */
     case STANDARD_OUTPUT_SENSITIVITY = 1;
 
     /**
      * Recommended exposure index (REI).
-     * EXIF 3.0 §4.6.4 Table 10.
+     * EXIF 3.0 §4.6.6.7.7 Table 14.
      */
     case RECOMMENDED_EXPOSURE_INDEX = 2;
 
     /**
      * ISO speed.
-     * EXIF 3.0 §4.6.4 Table 10.
+     * EXIF 3.0 §4.6.6.7.7 Table 14.
      */
     case ISO_SPEED = 3;
 
     /**
      * Standard output sensitivity and recommended exposure index.
-     * EXIF 3.0 §4.6.4 Table 10.
+     * EXIF 3.0 §4.6.6.7.7 Table 14.
      */
     case SOS_AND_REI = 4;
 
     /**
      * Standard output sensitivity and ISO speed.
-     * EXIF 3.0 §4.6.4 Table 10.
+     * EXIF 3.0 §4.6.6.7.7 Table 14.
      */
     case SOS_AND_ISO = 5;
 
     /**
      * Recommended exposure index and ISO speed.
-     * EXIF 3.0 §4.6.4 Table 10.
+     * EXIF 3.0 §4.6.6.7.7 Table 14.
      */
     case REI_AND_ISO = 6;
 
     /**
      * Standard output sensitivity, recommended exposure index, and ISO speed.
-     * EXIF 3.0 §4.6.4 Table 10.
+     * EXIF 3.0 §4.6.6.7.7 Table 14.
      */
     case SOS_AND_REI_AND_ISO = 7;
 }

--- a/tests/Model/Exif/ParsedExifSensitivityTest.php
+++ b/tests/Model/Exif/ParsedExifSensitivityTest.php
@@ -85,31 +85,33 @@ final class ParsedExifSensitivityTest extends TestCase
         yield 'standard output sensitivity' => [
             'sensitivityType' => SensitivityType::STANDARD_OUTPUT_SENSITIVITY,
             'tagValues'       => [
+                ExifTag::PHOTOGRAPHIC_SENSITIVITY    => 640,
                 ExifTag::STANDARD_OUTPUT_SENSITIVITY => 100,
                 ExifTag::RECOMMENDED_EXPOSURE_INDEX  => 200,
                 ExifTag::ISO_SPEED                   => 300,
             ],
-            'expected' => 100,
+            'expected' => 640,
         ];
 
         yield 'recommended exposure index' => [
             'sensitivityType' => SensitivityType::RECOMMENDED_EXPOSURE_INDEX,
             'tagValues'       => [
+                ExifTag::PHOTOGRAPHIC_SENSITIVITY    => 125,
                 ExifTag::STANDARD_OUTPUT_SENSITIVITY => 100,
                 ExifTag::RECOMMENDED_EXPOSURE_INDEX  => 200,
                 ExifTag::ISO_SPEED                   => 300,
                 ExifTag::EXPOSURE_INDEX              => 250,
             ],
-            'expected' => 200,
+            'expected' => 125,
         ];
 
         yield 'iso speed' => [
             'sensitivityType' => SensitivityType::ISO_SPEED,
             'tagValues'       => [
+                ExifTag::PHOTOGRAPHIC_SENSITIVITY    => 320,
                 ExifTag::STANDARD_OUTPUT_SENSITIVITY => 100,
                 ExifTag::RECOMMENDED_EXPOSURE_INDEX  => 200,
                 ExifTag::ISO_SPEED                   => 300,
-                ExifTag::PHOTOGRAPHIC_SENSITIVITY    => 320,
             ],
             'expected' => 320,
         ];
@@ -117,47 +119,48 @@ final class ParsedExifSensitivityTest extends TestCase
         yield 'sos and rei' => [
             'sensitivityType' => SensitivityType::SOS_AND_REI,
             'tagValues'       => [
+                ExifTag::PHOTOGRAPHIC_SENSITIVITY    => 80,
                 ExifTag::STANDARD_OUTPUT_SENSITIVITY => 100,
                 ExifTag::RECOMMENDED_EXPOSURE_INDEX  => 200,
                 ExifTag::ISO_SPEED                   => 300,
                 ExifTag::EXPOSURE_INDEX              => 250,
             ],
-            'expected' => 100,
+            'expected' => 80,
         ];
 
         yield 'sos and iso' => [
             'sensitivityType' => SensitivityType::SOS_AND_ISO,
             'tagValues'       => [
+                ExifTag::PHOTOGRAPHIC_SENSITIVITY    => 400,
                 ExifTag::STANDARD_OUTPUT_SENSITIVITY => 100,
                 ExifTag::RECOMMENDED_EXPOSURE_INDEX  => 200,
                 ExifTag::ISO_SPEED                   => 300,
-                ExifTag::PHOTOGRAPHIC_SENSITIVITY    => 320,
             ],
-            'expected' => 100,
+            'expected' => 400,
         ];
 
         yield 'rei and iso' => [
             'sensitivityType' => SensitivityType::REI_AND_ISO,
             'tagValues'       => [
+                ExifTag::PHOTOGRAPHIC_SENSITIVITY    => 250,
                 ExifTag::STANDARD_OUTPUT_SENSITIVITY => 100,
                 ExifTag::RECOMMENDED_EXPOSURE_INDEX  => 200,
                 ExifTag::ISO_SPEED                   => 300,
-                ExifTag::PHOTOGRAPHIC_SENSITIVITY    => 320,
                 ExifTag::EXPOSURE_INDEX              => 250,
             ],
-            'expected' => 200,
+            'expected' => 250,
         ];
 
         yield 'sos and rei and iso' => [
             'sensitivityType' => SensitivityType::SOS_AND_REI_AND_ISO,
             'tagValues'       => [
+                ExifTag::PHOTOGRAPHIC_SENSITIVITY    => 160,
                 ExifTag::STANDARD_OUTPUT_SENSITIVITY => 100,
                 ExifTag::RECOMMENDED_EXPOSURE_INDEX  => 200,
                 ExifTag::ISO_SPEED                   => 300,
-                ExifTag::PHOTOGRAPHIC_SENSITIVITY    => 320,
                 ExifTag::EXPOSURE_INDEX              => 250,
             ],
-            'expected' => 100,
+            'expected' => 160,
         ];
 
         yield 'unknown sensitivity type' => [


### PR DESCRIPTION
## Summary
- Prioritise PhotographicSensitivity according to SensitivityType when deriving ISO values.
- Update SensitivityType documentation to reference EXIF 3.0 §4.6.6.7.7 / Table 14.
- Expand sensitivity priority tests to cover photographic sensitivity combinations.

**Issue/Milestone:** Closes #<ID> • Milestone M#
**Scope (allowed files only):** src/Model/Exif/ParsedExif.php; src/Value/Enum/SensitivityType.php; tests/Model/Exif/ParsedExifSensitivityTest.php
**Non-Goals:** Broader ISO derivation heuristics or unrelated EXIF tags.

---

## Implementation Notes
- Runtime: PHP 8.4, `declare(strict_types=1);`, PSR-12.
- **Streaming only** (Core\Stream/StreamWindow) — keine Ganzdatei-Reads.
- Keine externen Binaries/Extensions; **kein** `exif_read_data()`.
- Value Objects (chainable) nur für EXIF-Ausgabe; kein Rendering.
- **Enums** für gängige Kodierungen genutzt/ergänzt (Encoding/Endianness/IFD/XMP/...).
- **Spec-References** im Code ergänzt/aktualisiert (siehe „References“).

---

## Always Checklist (must be green)
**Composer-Tasks (deine CI-Skripte):**
- [ ] Lint: `composer ci:test:php:lint`
- [ ] PHPStan: `composer ci:test:php:phpstan`
- [ ] Rector (dry-run): `composer ci:test:php:rector`
- [ ] Coding-Style: `composer ci::cgl`
- [ ] PHPUnit: `composer ci:test:php:unit`
- [ ] Coverage ≥ **90 %**: `composer ci:test:php:unit:coverage`
- [ ] JSCPD (Duplikate = 0): `composer ci:test:php:cpd`
- [ ] Sammellauf: `composer ci:test` (sollte grün sein; enthält Lint, PHPStan, Rector-Dry-Run, CS-Dry-Run, Unit)

**Inhaltliche/Code-Guidelines:**
- [ ] **Keine** `mixed`-Signaturen • **kein** `empty()` • **keine** verschachtelten Ternaries
- [ ] Fully-qualified native functions (`\\strlen`, `\\count`, …) und sinnvolle `use`-Imports
- [ ] **Keine** dynamischen Aufrufe statischer Methoden
- [ ] Sinnvolle **Interfaces** verwendet (wo Verträge sinnvoll sind)
- [ ] Typisierte Klassenkonstanten; redundante Casts/Default-Argumente entfernt
- [ ] Klassen als `readonly`, wo passend; keine redundanten `readonly`-Mods
- [ ] **Eine Klasse je Datei** • Test-Namespaces spiegeln `src/`-Struktur
- [ ] Englische PHPDocs & englische Inline-Kommentare an komplexen Stellen
- [ ] Sinnvolle Namen für Variablen/Konstanten; Magic Numbers/Strings vermieden
- [ ] `array_find` / `array_any` / `array_all` gezielt statt trivialer `foreach` verwendet (wo es die Lesbarkeit verbessert)

---

## EXIF / TIFF / ISOBMFF / XMP Guardrails
- **EXIF-Versionen:** 1.x, 2.x (2.1/2.2/2.21/2.3/2.31/2.32), 3.0 — kompatible Änderungen; falls Tags betroffen: Coverage-Test grün.
- **TIFF/BigTIFF:** Endianness korrekt (`0x2A` / `0x2B`), Inline-Werte-Grenzen, `RATIONAL/SRATIONAL` korrekt.
- **GPS:** Vorzeichen über Ref-Tags (S/W negativ); `0/0`-Kantenfälle robust.
- **Preview/IFD1:** Nur beschreiben (Offsets/Längen/Compression), kein Rendering.
- **ISOBMFF/QuickTime:** Box-Size ≥ Header, 32/64-bit-Größen korrekt; `iloc`-Extents summiert; `data_reference_index ≠ 0` → skip; keine Remote-Refs.
- **XMP:** JPEG APP1-Präfix / ISOBMFF `uuid`; Parser mit `LIBXML_NONET`, keine DTD/Entities; `Alt/Bag/Seq` → Arrays.
- **Fehlerbehandlung:** ausschließlich `ParseError` oder `BoundsError`; keine Warnings/Notices als Kontrollfluss.

---

## Tests
- **Neue/angepasste Tests:** SensitivityType-derived ISO priority combinations, numeric-string handling.
- **Negative Cases:** SensitivityType=Unknown still falls back to photographic sensitivity value.
- **Fixtures/Streams:** Synthetic IFD entries only; no external binaries.

---

## Notes
- SensitivityType priorities now prefer PhotographicSensitivity for the declared ISO 12232 parameter per EXIF 3.0 §4.6.6.7.7.
- Full suite currently reports pre-existing JPEG compression enum errors; targeted sensitivity tests pass.

## M# Sweep — Verify compliance for this milestone
Bitte **alles** verifizieren und kurz die Ergebnisse notieren:
- [ ] `composer ci:test` **grün** (Lint, PHPStan, Rector-Dry-Run, CS-Dry-Run, Unit)
- [ ] `composer ci:test:php:cpd` **0 Duplikate** (JSCPD, Konfig: `.build/.jscpd.json`)
- [ ] `composer ci:test:php:unit:coverage` **≥ 90 %**
- [ ] **ExifCoverageTest** (falls vorhanden): 0 fehlende Tags/Getters (gegen `resources/exif-map.yaml`)
- [ ] Für **jede** Klasse existiert ein Test (Namespace-Spiegelung)

---

## Breaking Changes / Risk / Rollback
- **Breaking changes:** None.
- **Risiken:** Minimal; ISO derivation now honours photographic sensitivity before legacy tags.
- **Rollback-Plan:** Revert commit if regressions are observed.

---

## Changelog
- fix(exif): align sensitivity type handling with EXIF 3.0 mapping

---

## References (Specs & Docs)
- EXIF 3.0 §4.6.6.7.7; EXIF 2.32 §4.6.6.7.7.
- `docs/EXIF-210.pdf`, `docs/EXIF-220.pdf`, `docs/EXIF-230.pdf`, `docs/EXIF-231.pdf`, `docs/EXIF-232.pdf`, `docs/EXIF-300.pdf`
- `docs/TIFF6.pdf`

---

## Review Roles (tick what you covered)
- [ ] Planner (Scope/Non-Goals/Guardrails definiert)
- [ ] Spec Writer (AC/Tests präzisiert)
- [ ] Test Agent (RED zuerst)
- [ ] Implementer (GREEN minimal & im Datei-Scope)
- [ ] Static/QA (Stan/CS/Rector/JSCPD clean)
- [ ] Security (Bounds, Offsets, XML-Flags)
- [ ] Reviewer (Minimalität, DX, Spec-Refs, Enums)
- [ ] Release (PR-Text, Labels, Milestone, „Closes #…“)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693928684370832394542ac609ce0bcd)