### PR TITLE
M#: Subject distance sentinels — EXIF

### DIFF
--- a/src/Model/Exif/ParsedExif.php
+++ b/src/Model/Exif/ParsedExif.php
@@ -1201,6 +1201,9 @@ final readonly class ParsedExif
     /**
      * Returns the metering mode enumeration if present.
      *
+     * EXIF 3.0 §4.6.6.7.19 (MeteringMode) retains the EXIF 2.32
+     * §4.6.6.7.19 catalogue of camera metering algorithms.
+     *
      * @return MeteringMode|null
      */
     public function meteringMode(): ?MeteringMode
@@ -1252,6 +1255,10 @@ final readonly class ParsedExif
 
     /**
      * Returns the maximum aperture value (APEX) if present.
+     *
+     * EXIF 3.0 §4.6.6.7.17 (MaxApertureValue) preserves the EXIF 2.32
+     * §4.6.6.7.17 encoding of a single RATIONAL representing the lens's
+     * smallest F number expressed as an APEX value.
      *
      * @return float|null
      */
@@ -2509,6 +2516,10 @@ final readonly class ParsedExif
     /**
      * Returns the light source enum describing the scene illumination.
      *
+     * EXIF 3.0 §4.6.6.7.20 (LightSource) keeps the EXIF 2.32
+     * §4.6.6.7.20 mapping of coded illuminants and their default value of 0
+     * for unknown light sources.
+     *
      * @return LightSource|null
      */
     public function lightSource(): ?LightSource
@@ -2575,10 +2586,31 @@ final readonly class ParsedExif
 
     /**
      * Returns the subject distance in metres when provided.
+     *
+     * EXIF 3.0 §4.6.6.7.18 (SubjectDistance) states that a numerator of
+     * 0xFFFFFFFF indicates infinity, while a numerator of 0 indicates an
+     * unknown distance; both conventions originate from EXIF 2.32
+     * §4.6.6.7.18.
      */
     public function subjectDistance(): ?float
     {
-        return $this->rational($this->exifIfd, ExifTag::SUBJECT_DISTANCE);
+        $value = $this->normalisedValue($this->exifIfd, ExifTag::SUBJECT_DISTANCE);
+
+        if ($value === null) {
+            return null;
+        }
+
+        $numerator = $this->subjectDistanceNumerator($value);
+
+        if ($numerator === 0) {
+            return null;
+        }
+
+        if ($numerator === 0xFFFFFFFF || $numerator === -1) {
+            return INF;
+        }
+
+        return ValueConverters::rationalToFloat($value);
     }
 
     /**
@@ -2644,6 +2676,40 @@ final readonly class ParsedExif
         $value = $this->normalisedValue($ifd, $tag);
 
         return $this->coerceIntValue($value);
+    }
+
+    private function subjectDistanceNumerator(
+        int|float|string|ExifRational|ExifRationalList|ExifNumericList|null $value,
+    ): ?int {
+        if ($value instanceof ExifRational) {
+            return $value->numerator;
+        }
+
+        if ($value instanceof ExifRationalList) {
+            $first = $value->values[0] ?? null;
+
+            if ($first instanceof ExifRational) {
+                return $first->numerator;
+            }
+
+            return null;
+        }
+
+        if ($value instanceof ExifNumericList) {
+            $first = $value->values[0] ?? null;
+
+            if (is_int($first) || is_float($first)) {
+                return (int) $first;
+            }
+
+            return null;
+        }
+
+        if (is_int($value) || is_float($value)) {
+            return (int) $value;
+        }
+
+        return null;
     }
 
     /**

--- a/tests/Model/Exif/ParsedExifSubjectDistanceTest.php
+++ b/tests/Model/Exif/ParsedExifSubjectDistanceTest.php
@@ -39,4 +39,38 @@ final class ParsedExifSubjectDistanceTest extends TestCase
 
         self::assertSame(2.0, $parsedExif->subjectDistance());
     }
+
+    #[Test]
+    public function returnsInfinityWhenSubjectDistanceRecordsInfinity(): void
+    {
+        $exifIfd = new Ifd([
+            ExifTag::SUBJECT_DISTANCE => new IfdEntry(
+                ExifTag::SUBJECT_DISTANCE,
+                5,
+                1,
+                new ExifRational(0xFFFFFFFF, 1),
+            ),
+        ]);
+
+        $parsedExif = new ParsedExif(new Ifd([]), $exifIfd, null, null, null);
+
+        self::assertSame(INF, $parsedExif->subjectDistance());
+    }
+
+    #[Test]
+    public function returnsNullWhenSubjectDistanceIsUnknown(): void
+    {
+        $exifIfd = new Ifd([
+            ExifTag::SUBJECT_DISTANCE => new IfdEntry(
+                ExifTag::SUBJECT_DISTANCE,
+                5,
+                1,
+                new ExifRational(0, 10),
+            ),
+        ]);
+
+        $parsedExif = new ParsedExif(new Ifd([]), $exifIfd, null, null, null);
+
+        self::assertNull($parsedExif->subjectDistance());
+    }
 }


### PR DESCRIPTION
## Summary
- Added EXIF 3.0/2.32 references for MaxApertureValue, MeteringMode and LightSource accessors.
- Normalised SubjectDistance handling to honour infinity/unknown sentinels before converting to floats.
- Extended subject distance parsing tests to cover spec-defined boundary cases.

**Issue/Milestone:** Closes #0 • Milestone M#
**Scope (allowed files only):** src/Model/Exif/ParsedExif.php; tests/Model/Exif/ParsedExifSubjectDistanceTest.php
**Non-Goals:** Broader EXIF tag refactors or CI remediation beyond the scoped accessors/tests.

---

## Implementation Notes
- Runtime: PHP 8.4, `declare(strict_types=1);`, PSR-12.
- **Streaming only** (Core\\Stream/StreamWindow) — keine Ganzdatei-Reads.
- Keine externen Binaries/Extensions; **kein** `exif_read_data()`.
- Value Objects (chainable) nur für EXIF-Ausgabe; kein Rendering.
- **Enums** für gängige Kodierungen genutzt/ergänzt (Encoding/Endianness/IFD/XMP/...).
- **Spec-References** im Code ergänzt/aktualisiert (siehe „References“).

---

## Always Checklist (must be green)
**Composer-Tasks (deine CI-Skripte):**
- [ ] Lint: `composer ci:test:php:lint`
- [ ] PHPStan: `composer ci:test:php:phpstan`
- [ ] Rector (dry-run): `composer ci:test:php:rector`
- [ ] Coding-Style: `composer ci::cgl`
- [ ] PHPUnit: `composer ci:test:php:unit` (fails: Undefined constant Compression::JPEG_OLD_STYLE; GPS reference expectation mismatch)
- [ ] Coverage ≥ **90 %**: `composer ci:test:php:unit:coverage`
- [ ] JSCPD (Duplikate = 0): `composer ci:test:php:cpd`
- [ ] Sammellauf: `composer ci:test` (sollte grün sein; enthält Lint, PHPStan, Rector-Dry-Run, CS-Dry-Run, Unit)

**Inhaltliche/Code-Guidelines:**
- [ ] **Keine** `mixed`-Signaturen • **kein** `empty()` • **keine** verschachtelten Ternaries
- [ ] Fully-qualified native functions (`\\strlen`, `\\count`, …) und sinnvolle `use`-Imports
- [ ] **Keine** dynamischen Aufrufe statischer Methoden
- [ ] Sinnvolle **Interfaces** verwendet (wo Verträge sinnvoll sind)
- [ ] Typisierte Klassenkonstanten; redundante Casts/Default-Argumente entfernt
- [ ] Klassen als `readonly`, wo passend; keine redundanten `readonly`-Mods
- [ ] **Eine Klasse je Datei** • Test-Namespaces spiegeln `src/`-Struktur
- [ ] Englische PHPDocs & englische Inline-Kommentare an komplexen Stellen
- [ ] Sinnvolle Namen für Variablen/Konstanten; Magic Numbers/Strings vermieden
- [ ] `array_find` / `array_any` / `array_all` gezielt statt trivialer `foreach` verwendet (wo es die Lesbarkeit verbessert)

---

## EXIF / TIFF / ISOBMFF / XMP Guardrails
- **EXIF-Versionen:** 1.x, 2.x (2.1/2.2/2.21/2.3/2.31/2.32), 3.0 — kompatible Änderungen; falls Tags betroffen: Coverage-Test grün.
- **TIFF/BigTIFF:** Endianness korrekt (`0x2A` / `0x2B`), Inline-Werte-Grenzen, `RATIONAL/SRATIONAL` korrekt.
- **GPS:** Vorzeichen über Ref-Tags (S/W negativ); `0/0`-Kantenfälle robust.
- **Preview/IFD1:** Nur beschreiben (Offsets/Längen/Compression), kein Rendering.
- **ISOBMFF/QuickTime:** Box-Size ≥ Header, 32/64-bit-Größen korrekt; `iloc`-Extents summiert; `data_reference_index ≠ 0` → skip; keine Remote-Refs.
- **XMP:** JPEG APP1-Präfix / ISOBMFF `uuid`; Parser mit `LIBXML_NONET`, keine DTD/Entities; `Alt/Bag/Seq` → Arrays.
- **Fehlerbehandlung:** ausschließlich `ParseError` oder `BoundsError`; keine Warnings/Notices als Kontrollfluss.

---

## Tests
- **Neue/angepasste Tests:** ParsedExifSubjectDistanceTest covering infinity/unknown cases for SubjectDistance.
- **Negative Cases:** SubjectDistance unknown sentinel handling.
- **Fixtures/Streams:** Synthetic ExifRational inputs via IfdEntry builders.

### Execution Notes
- composer ci:test:php:unit (fails: Undefined constant Compression::JPEG_OLD_STYLE; existing GPS reference expectation mismatch)

---

## M# Sweep — Verify compliance for this milestone
Bitte **alles** verifizieren und kurz die Ergebnisse notieren:
- [ ] `composer ci:test` **grün** (Lint, PHPStan, Rector-Dry-Run, CS-Dry-Run, Unit)
- [ ] `composer ci:test:php:cpd` **0 Duplikate** (JSCPD, Konfig: `.build/.jscpd.json`)
- [ ] `composer ci:test:php:unit:coverage` **≥ 90 %**
- [ ] **ExifCoverageTest** (falls vorhanden): 0 fehlende Tags/Getters (gegen `resources/exif-map.yaml`)
- [ ] Für **jede** Klasse existiert ein Test (Namespace-Spiegelung)

---

## Breaking Changes / Risk / Rollback
- **Breaking changes:** None.
- **Risiken:** None beyond existing CI failures noted above.
- **Rollback-Plan:** Revert commit.

---

## Changelog
- fix: honour SubjectDistance sentinel values and document EXIF tag references.

---

## References (Specs & Docs)
- EXIF 3.0 §4.6.6.7.17; EXIF 2.32 §4.6.6.7.17
- EXIF 3.0 §4.6.6.7.18; EXIF 2.32 §4.6.6.7.18
- EXIF 3.0 §4.6.6.7.19; EXIF 2.32 §4.6.6.7.19
- EXIF 3.0 §4.6.6.7.20; EXIF 2.32 §4.6.6.7.20

Docs im Repo:
- `docs/EXIF-210.pdf`, `docs/EXIF-220.pdf`, `docs/EXIF-230.pdf`, `docs/EXIF-231.pdf`, `docs/EXIF-232.pdf`, `docs/EXIF-300.pdf`
- `docs/TIFF6.pdf`

---

## Review Roles (tick what you covered)
- [ ] Planner (Scope/Non-Goals/Guardrails definiert)
- [ ] Spec Writer (AC/Tests präzisiert)
- [ ] Test Agent (RED zuerst)
- [ ] Implementer (GREEN minimal & im Datei-Scope)
- [ ] Static/QA (Stan/CS/Rector/JSCPD clean)
- [ ] Security (Bounds, Offsets, XML-Flags)
- [ ] Reviewer (Minimalität, DX, Spec-Refs, Enums)
- [ ] Release (PR-Text, Labels, Milestone, „Closes #…“)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693928b2ea5c8323a404f2bab509e981)