### PR TITLE
M#: Flash tag reserved bit handling — Value

### DIFF
--- a/src/Model/Exif/ValueConverters.php
+++ b/src/Model/Exif/ValueConverters.php
@@ -1364,7 +1364,7 @@ final readonly class ValueConverters
 
     /**
      * Converts the EXIF flash bit field into a typed value object per
-     * EXIF 2.32 §4.6.4 / EXIF 3.0 §4.6.4 (Flash tag bit layout).
+     * EXIF 3.0 §4.6.6.7.21 (Flash) and EXIF 2.32 §4.6.4 (Flash tag bit layout).
      *
      * @param ExifScalar $value Flash tag value representation.
      */

--- a/src/Value/Enum/FlashFunction.php
+++ b/src/Value/Enum/FlashFunction.php
@@ -15,7 +15,7 @@ use MagicSunday\ImageMeta\Exif\Support\EnumFromIntStringNullable;
 
 /**
  * Describes whether the flash function is present on the camera as specified in
- * EXIF 3.0 §4.6.4 (flash information), consistent with EXIF 2.32 §4.6.4.
+ * EXIF 3.0 §4.6.6.7.21 (Flash), consistent with EXIF 2.32 §4.6.4.
  */
 enum FlashFunction: int
 {

--- a/src/Value/Enum/FlashMode.php
+++ b/src/Value/Enum/FlashMode.php
@@ -15,8 +15,7 @@ use MagicSunday\ImageMeta\Exif\Support\EnumFromIntStringNullable;
 
 /**
  * Enumerates the flash mode bits carried in the Flash tag according to EXIF 3.0
- * §4.6.4 (flash information), keeping the interpretations from EXIF 2.32
- * §4.6.4.
+ * §4.6.6.7.21 (Flash), keeping the interpretations from EXIF 2.32 §4.6.4.
  */
 enum FlashMode: int
 {

--- a/src/Value/Enum/FlashReturn.php
+++ b/src/Value/Enum/FlashReturn.php
@@ -15,13 +15,14 @@ use MagicSunday\ImageMeta\Exif\Support\EnumFromIntStringNullable;
 
 /**
  * Indicates the strobe return detection status encoded in the Flash tag per
- * EXIF 3.0 §4.6.4 (flash information), unchanged from EXIF 2.32 §4.6.4.
+ * EXIF 3.0 §4.6.6.7.21 (Flash) and EXIF 2.32 §4.6.4.
  */
 enum FlashReturn: int
 {
     use EnumFromIntStringNullable;
 
     case NO_STROBE_DETECTION = 0;
+    case RESERVED             = 1;
     case RETURN_NOT_DETECTED = 2;
     case RETURN_DETECTED     = 3;
 }

--- a/src/Value/ExifFlash.php
+++ b/src/Value/ExifFlash.php
@@ -43,6 +43,10 @@ final class ExifFlash
     /**
      * Creates a FlashInfo instance from the numeric EXIF Flash tag value.
      *
+     * EXIF 3.0 §4.6.6.7.21 (Flash) and EXIF 2.32 §4.6.4 define the grouped bit fields decoded here:
+     * bit 0 (fired), bits 1-2 (return detection), bits 3-4 (mode), bit 5 (function presence),
+     * bit 6 (red-eye reduction support).
+     *
      * @param int|string|null $value Raw EXIF Flash tag encoding the capture state.
      *
      * @return FlashInfo|null Structured flash details or null when no information is provided.
@@ -55,8 +59,7 @@ final class ExifFlash
 
         $flashBits = is_int($value) ? $value : (int) $value;
 
-        // EXIF 2.32 §4.6.4 and EXIF 3.0 §4.6.4 define the Flash tag bit layout decoded below.
-        // Extract the grouped bit fields encoded within the EXIF Flash tag.
+        // EXIF 3.0 §4.6.6.7.21 and EXIF 2.32 §4.6.4 define the grouped Flash tag bit layout decoded below.
         $returnBits  = ($flashBits >> self::RETURN_SHIFT) & self::TWO_BIT_MASK;
         $modeBits    = ($flashBits >> self::MODE_SHIFT) & self::TWO_BIT_MASK;
         $functionBit = ($flashBits >> self::FUNCTION_SHIFT) & self::ONE_BIT_MASK;

--- a/tests/Value/ExifFlashTest.php
+++ b/tests/Value/ExifFlashTest.php
@@ -42,6 +42,22 @@ final class ExifFlashTest extends TestCase
     }
 
     /**
+     * Ensures reserved return bits are surfaced instead of discarded.
+     */
+    #[Test]
+    public function exposesReservedReturnDetection(): void
+    {
+        $info = ExifFlash::fromExifValue(2);
+
+        self::assertNotNull($info);
+        self::assertFalse($info->fired);
+        self::assertSame(FlashMode::UNKNOWN, $info->mode);
+        self::assertSame(FlashReturn::RESERVED, $info->returnDetection);
+        self::assertSame(FlashFunction::PRESENT, $info->functionPresence);
+        self::assertFalse($info->redEyeReduction);
+    }
+
+    /**
      * Ensures null is returned when no value is supplied.
      */
     #[Test]


### PR DESCRIPTION
## Summary
Updated EXIF flash decoding to surface all documented bit states and align PHPDocs with the latest spec numbering.

**Issue/Milestone:** Closes #N/A • Milestone M?
**Scope (allowed files only):** src/Value/ExifFlash.php; src/Value/Enum/FlashReturn.php; src/Value/Enum/FlashMode.php; src/Value/Enum/FlashFunction.php; src/Model/Exif/ValueConverters.php; tests/Value/ExifFlashTest.php
**Non-Goals:** Broader EXIF parsing changes beyond the Flash tag.

---

## Implementation Notes
- Runtime: PHP 8.4, `declare(strict_types=1);`, PSR-12.
- **Streaming only** (Core\\Stream/StreamWindow) — keine Ganzdatei-Reads.
- Keine externen Binaries/Extensions; **kein** `exif_read_data()`.
- Value Objects (chainable) nur für EXIF-Ausgabe; kein Rendering.
- **Enums** für gängige Kodierungen genutzt/ergänzt (Encoding/Endianness/IFD/XMP/...).
- **Spec-References** im Code ergänzt/aktualisiert (siehe „References“).

---

## Always Checklist (must be green)
**Composer-Tasks (deine CI-Skripte):**
- [ ] Lint: `composer ci:test:php:lint`
- [ ] PHPStan: `composer ci:test:php:phpstan`
- [ ] Rector (dry-run): `composer ci:test:php:rector`
- [ ] Coding-Style: `composer ci::cgl`
- [ ] PHPUnit: `composer ci:test:php:unit`
- [ ] Coverage ≥ **90 %**: `composer ci:test:php:unit:coverage`
- [ ] JSCPD (Duplikate = 0): `composer ci:test:php:cpd`
- [ ] Sammellauf: `composer ci:test` (sollte grün sein; enthält Lint, PHPStan, Rector-Dry-Run, CS-Dry-Run, Unit)

**Inhaltliche/Code-Guidelines:**
- [ ] **Keine** `mixed`-Signaturen • **kein** `empty()` • **keine** verschachtelten Ternaries
- [ ] Fully-qualified native functions (`\\strlen`, `\\count`, …) und sinnvolle `use`-Imports
- [ ] **Keine** dynamischen Aufrufe statischer Methoden
- [ ] Sinnvolle **Interfaces** verwendet (wo Verträge sinnvoll sind)
- [ ] Typisierte Klassenkonstanten; redundante Casts/Default-Argumente entfernt
- [ ] Klassen als `readonly`, wo passend; keine redundanten `readonly`-Mods
- [ ] **Eine Klasse je Datei** • Test-Namespaces spiegeln `src/`-Struktur
- [ ] Englische PHPDocs & englische Inline-Kommentare an komplexen Stellen
- [ ] Sinnvolle Namen für Variablen/Konstanten; Magic Numbers/Strings vermieden
- [ ] `array_find` / `array_any` / `array_all` gezielt statt trivialer `foreach` verwendet (wo es die Lesbarkeit verbessert)

---

## EXIF / TIFF / ISOBMFF / XMP Guardrails
- **EXIF-Versionen:** 1.x, 2.x (2.1/2.2/2.21/2.3/2.31/2.32), 3.0 — kompatible Änderungen; falls Tags betroffen: Coverage-Test grün.
- **TIFF/BigTIFF:** Endianness korrekt (`0x2A` / `0x2B`), Inline-Werte-Grenzen, `RATIONAL/SRATIONAL` korrekt.
- **GPS:** Vorzeichen über Ref-Tags (S/W negativ); `0/0`-Kantenfälle robust.
- **Preview/IFD1:** Nur beschreiben (Offsets/Längen/Compression), kein Rendering.
- **ISOBMFF/QuickTime:** Box-Size ≥ Header, 32/64-bit-Größen korrekt; `iloc`-Extents summiert; `data_reference_index ≠ 0` → skip; keine Remote-Refs.
- **XMP:** JPEG APP1-Präfix / ISOBMFF `uuid`; Parser mit `LIBXML_NONET`, keine DTD/Entities; `Alt/Bag/Seq` → Arrays.
- **Fehlerbehandlung:** ausschließlich `ParseError` oder `BoundsError`; keine Warnings/Notices als Kontrollfluss.

---

## Tests
- **Neue/angepasste Tests:** ExifFlash reserved return decoding; red-eye and mode assertions remain covered.
- **Negative Cases:** Reserved return bit surfaced without nulling the value.
- **Fixtures/Streams:** Synthetic flash bit fields.

---

## Pre-Sweep Notes
- phpunit currently fails on this branch because `Compression::JPEG_OLD_STYLE` is undefined in unrelated code paths.

## M# Sweep — Verify compliance for this milestone
Bitte **alles** verifizieren und kurz die Ergebnisse notieren:
- [ ] `composer ci:test` **grün** (Lint, PHPStan, Rector-Dry-Run, CS-Dry-Run, Unit)
- [ ] `composer ci:test:php:cpd` **0 Duplikate** (JSCPD, Konfig: `.build/.jscpd.json`)
- [ ] `composer ci:test:php:unit:coverage` **≥ 90 %**
- [ ] **ExifCoverageTest** (falls vorhanden): 0 fehlende Tags/Getters (gegen `resources/exif-map.yaml`)
- [ ] Für **jede** Klasse existiert ein Test (Namespace-Spiegelung)

---

## Breaking Changes / Risk / Rollback
- **Breaking changes:** None; Flash enum expanded to capture reserved return bits.
- **Risiken:** Minimal; consumer code gains deterministic enum for reserved return bit combinations.
- **Rollback-Plan:** Revert this PR.

---

## Changelog
- fix(value): decode reserved flash return bit combinations per EXIF spec.

---

## References (Specs & Docs)
- EXIF 3.0 §4.6.6.7.21; EXIF 2.32 §4.6.4
- TIFF 6.0 §…
- ISOBMFF/QuickTime §…
- XMP (Adobe XMP Packet) §…

Docs im Repo:
- `docs/EXIF-210.pdf`, `docs/EXIF-220.pdf`, `docs/EXIF-230.pdf`, `docs/EXIF-231.pdf`, `docs/EXIF-232.pdf`, `docs/EXIF-300.pdf`
- `docs/TIFF6.pdf`

---

## Review Roles (tick what you covered)
- [ ] Planner (Scope/Non-Goals/Guardrails definiert)
- [ ] Spec Writer (AC/Tests präzisiert)
- [ ] Test Agent (RED zuerst)
- [ ] Implementer (GREEN minimal & im Datei-Scope)
- [ ] Static/QA (Stan/CS/Rector/JSCPD clean)
- [ ] Security (Bounds, Offsets, XML-Flags)
- [ ] Reviewer (Minimalität, DX, Spec-Refs, Enums)
- [ ] Release (PR-Text, Labels, Milestone, „Closes #…“)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693928dda6ac8323ae07b52eccfa510c)