### PR TITLE
M?: SubjectArea compliance — EXIF

### DIFF
--- a/src/Model/Exif/ParsedExif.php
+++ b/src/Model/Exif/ParsedExif.php
@@ -2584,8 +2584,8 @@ final readonly class ParsedExif
     /**
      * Returns the EXIF subject area as a structured value object.
      *
-     * EXIF 3.0 §4.6.6: SubjectArea tag 0x9214 indicates the location and area of the main subject
-     * in the overall scene.
+     * EXIF 3.0 §4.6.6.7.22: SubjectArea tag 0x9214 indicates the location and area of the main
+     * subject in the overall scene.
      */
     public function subjectArea(): ?SubjectArea
     {

--- a/src/Model/Exif/ValueConverters.php
+++ b/src/Model/Exif/ValueConverters.php
@@ -20,8 +20,10 @@ use MagicSunday\ImageMeta\Core\BitMask;
 use MagicSunday\ImageMeta\Core\Util\UInt64;
 use MagicSunday\ImageMeta\Value\Enum\CfaPatternColor;
 use MagicSunday\ImageMeta\Value\Enum\CharacterEncoding;
+use MagicSunday\ImageMeta\Value\Enum\SubjectAreaType;
 use MagicSunday\ImageMeta\Value\ExifFlash;
 use MagicSunday\ImageMeta\Value\FlashInfo;
+use MagicSunday\ImageMeta\Value\SubjectArea;
 use Throwable;
 
 use function abs;
@@ -271,59 +273,45 @@ final readonly class ValueConverters
     /**
      * Normalises EXIF subject area representations into a rectangle map.
      *
-     * EXIF 3.0 §4.6.3 (SubjectArea) keeps the EXIF 2.32 §4.6.3 encoding rules for point,
-     * circular and rectangular focus areas.
+     * EXIF 3.0 §4.6.6.7.22 (SubjectArea) defines Count = 2 (point), Count = 3 (circle),
+     * and Count = 4 (rectangle) using unsigned SHORT components prior to rotation processing.
      *
      * @param array<int, int|float|string> $values Subject area values as extracted from metadata.
      *
-     * @return array{x:?int,y:?int,w:?int,h:?int}|null
+     * @return array{x:int,y:int,w:int|null,h:int|null}|null
      */
     public static function subjectAreaToRect(array $values): ?array
     {
-        $values = array_values($values);
-        $count  = count($values);
+        $subjectArea = SubjectArea::fromComponents(array_values($values));
 
-        if ($count >= 4) {
-            if (!is_numeric($values[0]) || !is_numeric($values[1]) || !is_numeric($values[2]) || !is_numeric($values[3])) {
-                return null;
-            }
-
-            return [
-                'x' => (int) $values[0],
-                'y' => (int) $values[1],
-                'w' => (int) $values[2],
-                'h' => (int) $values[3],
-            ];
+        if ($subjectArea === null) {
+            return null;
         }
 
-        if ($count === 3) {
-            if (!is_numeric($values[0]) || !is_numeric($values[1]) || !is_numeric($values[2])) {
-                return null;
-            }
-
-            $radius = (int) $values[2];
-
-            if ($radius < 0) {
-                return null;
-            }
-
-            return [
-                'x' => (int) $values[0] - $radius,
-                'y' => (int) $values[1] - $radius,
-                'w' => $radius * 2,
-                'h' => $radius * 2,
-            ];
-        }
-
-        if ($count === 2) {
-            if (!is_numeric($values[0]) || !is_numeric($values[1])) {
-                return null;
-            }
-
-            return ['x' => (int) $values[0], 'y' => (int) $values[1], 'w' => null, 'h' => null];
-        }
-
-        return null;
+        return match ($subjectArea->type) {
+            SubjectAreaType::Point => [
+                'x' => $subjectArea->centerX,
+                'y' => $subjectArea->centerY,
+                'w' => null,
+                'h' => null,
+            ],
+            SubjectAreaType::Circle => $subjectArea->diameter === null
+                ? null
+                : [
+                    'x' => $subjectArea->centerX,
+                    'y' => $subjectArea->centerY,
+                    'w' => $subjectArea->diameter,
+                    'h' => $subjectArea->diameter,
+                ],
+            SubjectAreaType::Rectangle => ($subjectArea->width === null || $subjectArea->height === null)
+                ? null
+                : [
+                    'x' => $subjectArea->centerX,
+                    'y' => $subjectArea->centerY,
+                    'w' => $subjectArea->width,
+                    'h' => $subjectArea->height,
+                ],
+        };
     }
 
     /**

--- a/src/Value/Enum/SubjectAreaType.php
+++ b/src/Value/Enum/SubjectAreaType.php
@@ -12,10 +12,10 @@ declare(strict_types=1);
 namespace MagicSunday\ImageMeta\Value\Enum;
 
 /**
- * Subject area types as defined by EXIF 3.0 §4.6.6.
+ * Subject area types as defined by EXIF 3.0 §4.6.6.7.22.
  *
- * EXIF 3.0 §4.6.6: SubjectArea tag 0x9214 indicates the location and area of the main subject
- * in the overall scene. The area is expressed as:
+ * EXIF 3.0 §4.6.6.7.22: SubjectArea tag 0x9214 indicates the location and area of the main
+ * subject in the overall scene. The area is expressed as:
  * - Point (2 values): center coordinates
  * - Circle (3 values): center coordinates and diameter
  * - Rectangle (4 values): center coordinates, width, and height

--- a/src/Value/SubjectArea.php
+++ b/src/Value/SubjectArea.php
@@ -13,16 +13,21 @@ namespace MagicSunday\ImageMeta\Value;
 
 use MagicSunday\ImageMeta\Value\Enum\SubjectAreaType;
 
+use function array_any;
+use function array_map;
+use function array_values;
 use function count;
+use function is_numeric;
 
 /**
  * Represents the subject area location and dimensions.
  *
- * EXIF 3.0 §4.6.6: The SubjectArea tag indicates the location and area of the main subject
- * in the overall scene. It can be:
- * - A point (2 values: x, y)
- * - A circle (3 values: x, y, diameter)
- * - A rectangle (4 values: x, y, width, height)
+ * EXIF 3.0 §4.6.6.7.22 (SubjectArea) defines tag 0x9214 as an unsigned SHORT
+ * vector that expresses the location and area of the main subject prior to any
+ * rotation processing. It can be:
+ * - A point (2 values: X coordinate, Y coordinate)
+ * - A circle (3 values: center X coordinate, center Y coordinate, diameter)
+ * - A rectangle (4 values: center X coordinate, center Y coordinate, width, height)
  */
 final readonly class SubjectArea
 {
@@ -30,11 +35,11 @@ final readonly class SubjectArea
      * Creates a subject area value object.
      *
      * @param SubjectAreaType $type     Type of subject area (point, circle, or rectangle).
-     * @param int             $centerX  X coordinate of the center point.
-     * @param int             $centerY  Y coordinate of the center point.
-     * @param int|null        $diameter Diameter for circular areas.
-     * @param int|null        $width    Width for rectangular areas.
-     * @param int|null        $height   Height for rectangular areas.
+     * @param int             $centerX  X coordinate of the center point (origin: top-left).
+     * @param int             $centerY  Y coordinate of the center point (origin: top-left).
+     * @param int|null        $diameter Diameter for circular areas (SHORT, Count = 3).
+     * @param int|null        $width    Width for rectangular areas (SHORT, Count = 4).
+     * @param int|null        $height   Height for rectangular areas (SHORT, Count = 4).
      */
     public function __construct(
         public SubjectAreaType $type,
@@ -49,29 +54,46 @@ final readonly class SubjectArea
     /**
      * Creates a SubjectArea from component array.
      *
-     * EXIF 3.0 §4.6.6: SubjectArea format depends on component count:
+     * EXIF 3.0 §4.6.6.7.22: SubjectArea format depends on component count:
      * - 2 values: center point (x, y)
      * - 3 values: circle (x, y, diameter)
      * - 4 values: rectangle (x, y, width, height)
      *
-     * @param list<int>|null $components Array of subject area components.
+     * @param array<int, int|float|string>|null $components Array of subject area components.
      *
      * @return self|null SubjectArea value object or null if components are invalid.
      */
     public static function fromComponents(?array $components): ?self
     {
-        if ($components === null || count($components) < 2 || count($components) > 4) {
+        if ($components === null) {
             return null;
         }
 
-        $x = $components[0];
-        $y = $components[1];
+        $values = array_values($components);
+        $count  = count($values);
 
-        return match (count($components)) {
-            2       => new self(SubjectAreaType::Point, $x, $y),
-            3       => new self(SubjectAreaType::Circle, $x, $y, diameter: $components[2]),
-            4       => new self(SubjectAreaType::Rectangle, $x, $y, width: $components[2], height: $components[3]),
-            default => null,
+        if (($count < 2) || ($count > 4)) {
+            return null;
+        }
+
+        if (array_any($values, static fn (mixed $component): bool => !is_numeric($component))) {
+            return null;
+        }
+
+        /** @var list<int> $values */
+        $values = array_map(static fn (int|float|string $component): int => (int) $component, $values);
+
+        if (array_any($values, static fn (int $component): bool => $component < 0)) {
+            return null;
+        }
+
+        $x = $values[0];
+        $y = $values[1];
+
+        return match ($count) {
+            2 => new self(SubjectAreaType::Point, $x, $y),
+            3 => new self(SubjectAreaType::Circle, $x, $y, diameter: $values[2]),
+            4 => new self(SubjectAreaType::Rectangle, $x, $y, width: $values[2], height: $values[3]),
         };
     }
 }

--- a/tests/Model/Exif/ValueConvertersTest.php
+++ b/tests/Model/Exif/ValueConvertersTest.php
@@ -896,7 +896,7 @@ final class ValueConvertersTest extends TestCase
             ValueConverters::subjectAreaToRect([10, 20]),
         );
         self::assertSame(
-            ['x' => 75, 'y' => 95, 'w' => 50, 'h' => 50],
+            ['x' => 100, 'y' => 120, 'w' => 25, 'h' => 25],
             ValueConverters::subjectAreaToRect([100, 120, 25]),
         );
         self::assertSame(
@@ -906,6 +906,7 @@ final class ValueConvertersTest extends TestCase
         self::assertNull(ValueConverters::subjectAreaToRect([10]));
         self::assertNull(ValueConverters::subjectAreaToRect([10, 20, -5]));
         self::assertNull(ValueConverters::subjectAreaToRect(['a', 'b']));
+        self::assertNull(ValueConverters::subjectAreaToRect([1, 2, 3, 4, 5]));
     }
 
     #[Test]

--- a/tests/Value/SubjectAreaTest.php
+++ b/tests/Value/SubjectAreaTest.php
@@ -20,7 +20,7 @@ use PHPUnit\Framework\TestCase;
 /**
  * Tests for SubjectArea value object.
  *
- * EXIF 3.0 §4.6.6 defines SubjectArea tag 0x9214 formats:
+ * EXIF 3.0 §4.6.6.7.22 defines SubjectArea tag 0x9214 formats:
  * - 2 values: center point (x, y)
  * - 3 values: circle (center x, y, diameter)
  * - 4 values: rectangle (center x, y, width, height)
@@ -85,5 +85,13 @@ final class SubjectAreaTest extends TestCase
     public function nullInputReturnsNull(): void
     {
         self::assertNull(SubjectArea::fromComponents(null));
+    }
+
+    #[Test]
+    public function rejectsNegativeOrNonNumericValues(): void
+    {
+        self::assertNull(SubjectArea::fromComponents([-1, 10]));
+        self::assertNull(SubjectArea::fromComponents([10, 20, -5]));
+        self::assertNull(SubjectArea::fromComponents(['a', 'b']));
     }
 }


### PR DESCRIPTION
## Summary
- Align SubjectArea parsing and normalisation with EXIF 3.0 §4.6.6.7.22 (validation, diameter semantics).
- Extend SubjectArea unit coverage for negative/non-numeric components and updated rectangle conversion.

**Issue/Milestone:** Closes #N/A • Milestone M?
**Scope (allowed files only):** src/Model/Exif/ParsedExif.php; src/Model/Exif/ValueConverters.php; src/Value/SubjectArea.php; src/Value/Enum/SubjectAreaType.php; tests/Model/Exif/ValueConvertersTest.php; tests/Value/SubjectAreaTest.php
**Non-Goals:** Changes to other EXIF tags or parsers.

---

## Implementation Notes
- Runtime: PHP 8.4, `declare(strict_types=1);`, PSR-12.
- **Streaming only** (Core\Stream/StreamWindow) — keine Ganzdatei-Reads.
- Keine externen Binaries/Extensions; **kein** `exif_read_data()`.
- Value Objects (chainable) nur für EXIF-Ausgabe; kein Rendering.
- **Enums** für gängige Kodierungen genutzt/ergänzt (Encoding/Endianness/IFD/XMP/...).
- **Spec-References** im Code ergänzt/aktualisiert (siehe „References“).

---

## Always Checklist (must be green)
**Composer-Tasks (deine CI-Skripte):**
- [ ] Lint: `composer ci:test:php:lint`
- [ ] PHPStan: `composer ci:test:php:phpstan`
- [ ] Rector (dry-run): `composer ci:test:php:rector`
- [ ] Coding-Style: `composer ci::cgl`
- [ ] PHPUnit: `composer ci:test:php:unit`
- [ ] Coverage ≥ **90 %**: `composer ci:test:php:unit:coverage`
- [ ] JSCPD (Duplikate = 0): `composer ci:test:php:cpd`
- [ ] Sammellauf: `composer ci:test` (sollte grün sein; enthält Lint, PHPStan, Rector-Dry-Run, CS-Dry-Run, Unit)

**Inhaltliche/Code-Guidelines:**
- [ ] **Keine** `mixed`-Signaturen • **kein** `empty()` • **keine** verschachtelten Ternaries
- [ ] Fully-qualified native functions (`\strlen`, `\count`, …) und sinnvolle `use`-Imports
- [ ] **Keine** dynamischen Aufrufe statischer Methoden
- [ ] Sinnvolle **Interfaces** verwendet (wo Verträge sinnvoll sind)
- [ ] Typisierte Klassenkonstanten; redundante Casts/Default-Argumente entfernt
- [ ] Klassen als `readonly`, wo passend; keine redundanten `readonly`-Mods
- [ ] **Eine Klasse je Datei** • Test-Namespaces spiegeln `src/`-Struktur
- [ ] Englische PHPDocs & englische Inline-Kommentare an komplexen Stellen
- [ ] Sinnvolle Namen für Variablen/Konstanten; Magic Numbers/Strings vermieden
- [ ] `array_find` / `array_any` / `array_all` gezielt statt trivialer `foreach` verwendet (wo es die Lesbarkeit verbessert)

---

## EXIF / TIFF / ISOBMFF / XMP Guardrails
- **EXIF-Versionen:** 1.x, 2.x (2.1/2.2/2.21/2.3/2.31/2.32), 3.0 — kompatible Änderungen; falls Tags betroffen: Coverage-Test grün.
- **TIFF/BigTIFF:** Endianness korrekt (`0x2A` / `0x2B`), Inline-Werte-Grenzen, `RATIONAL/SRATIONAL` korrekt.
- **GPS:** Vorzeichen über Ref-Tags (S/W negativ); `0/0`-Kantenfälle robust.
- **Preview/IFD1:** Nur beschreiben (Offsets/Längen/Compression), kein Rendering.
- **ISOBMFF/QuickTime:** Box-Size ≥ Header, 32/64-bit-Größen korrekt; `iloc`-Extents summiert; `data_reference_index ≠ 0` → skip; keine Remote-Refs.
- **XMP:** JPEG APP1-Präfix / ISOBMFF `uuid`; Parser mit `LIBXML_NONET`, keine DTD/Entities; `Alt/Bag/Seq` → Arrays.
- **Fehlerbehandlung:** ausschließlich `ParseError` oder `BoundsError`; keine Warnings/Notices als Kontrollfluss.

---

## Tests
- .build/bin/phpunit tests/Model/Exif/ValueConvertersTest.php tests/Value/SubjectAreaTest.php
- .build/bin/phpstan analyse --configuration phpstan.neon --memory-limit=-1 --no-progress src/Value/SubjectArea.php src/Model/Exif/ValueConverters.php tests/Value/SubjectAreaTest.php tests/Model/Exif/ValueConvertersTest.php

---

## PR Notes
- SubjectArea handling now enforces the EXIF 3.0 §4.6.6.7.22 component counts and diameter semantics for Count = 3 values.

## M# Sweep — Verify compliance for this milestone
Bitte **alles** verifizieren und kurz die Ergebnisse notieren:
- [ ] `composer ci:test` **grün** (Lint, PHPStan, Rector-Dry-Run, CS-Dry-Run, Unit)
- [ ] `composer ci:test:php:cpd` **0 Duplikate** (JSCPD, Konfig: `.build/.jscpd.json`)
- [ ] `composer ci:test:php:unit:coverage` **≥ 90 %**
- [ ] **ExifCoverageTest** (falls vorhanden): 0 fehlende Tags/Getters (gegen `resources/exif-map.yaml`)
- [ ] Für **jede** Klasse existiert ein Test (Namespace-Spiegelung)

---

## Breaking Changes / Risk / Rollback
- **Breaking changes:** <!-- falls ja: welche und warum notwendig -->
- **Risiken:** <!-- Parser-Sensitivität, Performance, Abhängigkeiten -->
- **Rollback-Plan:** <!-- einfache Revert-Strategie / Feature-Flag falls nötig -->

---

## Changelog
<!-- Kurz und im Stil der Conventional Commits zusammenfassen. -->

---

## References (Specs & Docs)
<!-- Liste der relevanten Kapitel/Abschnitte, jeweils aktuellste Fassung + abweichende ältere, falls relevant -->
- EXIF 3.0 §… ; ggf. EXIF 2.32 §… ; EXIF 2.31 §…
- TIFF 6.0 §…
- ISOBMFF/QuickTime §…
- XMP (Adobe XMP Packet) §…

Docs im Repo:
- `docs/EXIF-210.pdf`, `docs/EXIF-220.pdf`, `docs/EXIF-230.pdf`, `docs/EXIF-231.pdf`, `docs/EXIF-232.pdf`, `docs/EXIF-300.pdf`
- `docs/TIFF6.pdf`

---

## Review Roles (tick what you covered)
- [ ] Planner (Scope/Non-Goals/Guardrails definiert)
- [ ] Spec Writer (AC/Tests präzisiert)
- [ ] Test Agent (RED zuerst)
- [ ] Implementer (GREEN minimal & im Datei-Scope)
- [ ] Static/QA (Stan/CS/Rector/JSCPD clean)
- [ ] Security (Bounds, Offsets, XML-Flags)
- [ ] Reviewer (Minimalität, DX, Spec-Refs, Enums)
- [ ] Release (PR-Text, Labels, Milestone, „Closes #…“)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6939290556b48323ab3145ec9b0fc1e9)