### PR TITLE
M#: Spatial frequency response directions — EXIF

### DIFF
--- a/src/Model/Exif/ParsedExif.php
+++ b/src/Model/Exif/ParsedExif.php
@@ -1321,7 +1321,7 @@ final readonly class ParsedExif
     /**
      * Returns the decoded spatial frequency response table.
      *
-     * EXIF 3.0 §4.6.3 Table 16: SFR records camera and optical system's spatial frequency
+     * EXIF 3.0 §4.6.6.7.25 Table 12: SFR records camera and optical system's spatial frequency
      * response characteristics.
      */
     public function spatialFrequencyResponse(): ?SpatialFrequencyResponse

--- a/src/Model/Exif/ValueConverters.php
+++ b/src/Model/Exif/ValueConverters.php
@@ -1035,7 +1035,7 @@ final readonly class ValueConverters
 
     /**
      * Decodes the spatial frequency response payload as defined by
-     * EXIF 3.0 §4.6.3 (figure 14) and the legacy layout retained in
+     * EXIF 3.0 §4.6.6.7.25 (figure 20, table 12) and the legacy layout retained in
      * EXIF 2.32 §4.6.3.
      *
      * @param string|null $payload Raw UNDEFINED payload captured from the EXIF tag.

--- a/src/Value/Sensor.php
+++ b/src/Value/Sensor.php
@@ -26,8 +26,8 @@ final readonly class Sensor
      * @param bool                          $ibis                     Indicates in-body image stabilisation support.
      * @param list<int>|null                $cfaPattern               Colour filter array pattern definition.
      * @param string|null                   $spectralSensitivity      Spectral sensitivity description.
-     * @param Oecf|null                     $oecf                     Opto-electronic conversion function (EXIF 3.0 §4.6.3).
-     * @param SpatialFrequencyResponse|null $spatialFrequencyResponse Spatial frequency response (EXIF 3.0 §4.6.3).
+     * @param Oecf|null                     $oecf                     Opto-electronic conversion function (EXIF 3.0 §4.6.6.7.6).
+     * @param SpatialFrequencyResponse|null $spatialFrequencyResponse Spatial frequency response (EXIF 3.0 §4.6.6.7.25).
      * @param float|null                    $focalPlaneXResolution    Focal plane X resolution.
      * @param float|null                    $focalPlaneYResolution    Focal plane Y resolution.
      * @param ResolutionUnit|null           $focalPlaneResolutionUnit Focal plane resolution unit.

--- a/src/Value/SpatialFrequencyResponse.php
+++ b/src/Value/SpatialFrequencyResponse.php
@@ -21,25 +21,29 @@ use function is_string;
  * Spatial Frequency Response (SFR) value object.
  *
  * Matches the binary layout described in EXIF 3.0 §4.6.6.7.25
- * and Figure 20 "Spatial Frequency Response Description":
+ * and Figure 20 "Spatial Frequency Response Description" as well
+ * as the legacy EXIF 2.32 §4.6.3 layout:
  *
  *  - columns (n): number of spatial frequency columns
- *  - rows    (m): number of SFR rows
+ *  - rows    (m): number of SFR rows (directions/colour planes)
  *  - column item names: spatial frequency labels
+ *  - row item names: direction labels (width/height/diagonal)
  *  - m×n RATIONAL values: SFR[row][column]
  */
 final readonly class SpatialFrequencyResponse
 {
     /**
-     * @param int                $columns            Number of frequency columns (n).
-     * @param int                $rows               Number of SFR rows (m).
-     * @param list<string>       $spatialFrequencies Column item names (spatial frequencies).
-     * @param array<list<float>> $values             SFR values matrix [row][column].
+     * @param int                                  $columns            Number of frequency columns (n).
+     * @param int                                  $rows               Number of SFR rows (m).
+     * @param list<string>                         $spatialFrequencies Column item names (spatial frequencies).
+     * @param list<string>                         $directions         Row item names (directions/colour planes).
+     * @param array<int, array<int, float|null>>   $values             SFR values matrix [row][column].
      */
     public function __construct(
         public int $columns,
         public int $rows,
         public array $spatialFrequencies,
+        public array $directions,
         public array $values,
     ) {
     }
@@ -54,8 +58,9 @@ final readonly class SpatialFrequencyResponse
      *     'rows'    => int,                          // m
      *     'labels'  => [
      *         'columns' => list<string>,             // column item names
+     *         'rows'    => list<string>,             // row item names
      *     ],
-     *     'values'  => array<list<float>> // SFR[row][column]
+     *     'values'  => array<list<float|null>>       // SFR[row][column]
      * ]
      *
      * @param array<string, mixed>|null $matrix
@@ -85,13 +90,13 @@ final readonly class SpatialFrequencyResponse
         }
 
         $columnLabels = $labels['columns'] ?? null;
-        if (!is_array($columnLabels)) {
+        $rowLabels    = $labels['rows'] ?? null;
+        if (!is_array($columnLabels) || !is_array($rowLabels)) {
             return null;
         }
 
         // Validate and normalize column item names to list<string>
         $frequencies = [];
-
         foreach ($columnLabels as $label) {
             if (!is_string($label)) {
                 return null;
@@ -100,11 +105,21 @@ final readonly class SpatialFrequencyResponse
             $frequencies[] = $label;
         }
 
-        if (count($frequencies) !== $columns) {
+        // Validate and normalize row item names to list<string>
+        $directions = [];
+        foreach ($rowLabels as $label) {
+            if (!is_string($label)) {
+                return null;
+            }
+
+            $directions[] = $label;
+        }
+
+        if (count($frequencies) !== $columns || count($directions) !== $rows) {
             return null;
         }
 
-        // Validate that values form an exact m×n matrix of float RATIONALs
+        // Validate that values form an exact m×n matrix of RATIONALs (null if denominator was zero)
         if (count($values) !== $rows) {
             return null;
         }
@@ -119,8 +134,8 @@ final readonly class SpatialFrequencyResponse
             $typedRow = [];
 
             foreach ($row as $cell) {
-                // Spec: RATIONAL ⇒ always a numeric value, null is not allowed
-                if (!is_float($cell)) {
+                // Spec: RATIONAL ⇒ numeric value; decoder maps zero denominators to null
+                if (!is_float($cell) && ($cell !== null)) {
                     return null;
                 }
 
@@ -138,6 +153,7 @@ final readonly class SpatialFrequencyResponse
             $columns,
             $rows,
             $frequencies,
+            $directions,
             $typedValues
         );
     }

--- a/tests/Value/SpatialFrequencyResponseTest.php
+++ b/tests/Value/SpatialFrequencyResponseTest.php
@@ -19,11 +19,11 @@ use PHPUnit\Framework\TestCase;
 /**
  * Tests for SpatialFrequencyResponse value object.
  *
- * EXIF 3.0 §4.6.3 Table 16 defines SFR structure:
+ * EXIF 3.0 §4.6.6.7.25 Figure 20/Table 12 defines the SFR structure:
  * - columns: number of spatial frequency columns
- * - rows: number of SFR value rows
+ * - rows: number of SFR value rows (directions/colour planes)
  * - columnLabels: frequency values
- * - rowLabels: direction/color labels
+ * - rowLabels: direction labels
  * - values: matrix of RATIONAL response values
  */
 #[CoversClass(SpatialFrequencyResponse::class)]
@@ -37,6 +37,7 @@ final class SpatialFrequencyResponseTest extends TestCase
             'rows'    => 2,
             'labels'  => [
                 'columns' => ['0.1', '0.2', '0.3'],
+                'rows'    => ['Width', 'Height'],
             ],
             'values' => [
                 [1.00, 0.90, 0.80],
@@ -50,6 +51,7 @@ final class SpatialFrequencyResponseTest extends TestCase
         self::assertSame(3, $sfr->columns);
         self::assertSame(2, $sfr->rows);
         self::assertSame(['0.1', '0.2', '0.3'], $sfr->spatialFrequencies);
+        self::assertSame(['Width', 'Height'], $sfr->directions);
         self::assertSame(
             [
                 [1.00, 0.90, 0.80],
@@ -57,6 +59,27 @@ final class SpatialFrequencyResponseTest extends TestCase
             ],
             $sfr->values
         );
+    }
+
+    #[Test]
+    public function acceptsNullValuesWhenDenominatorMissing(): void
+    {
+        $matrix = [
+            'columns' => 2,
+            'rows'    => 1,
+            'labels'  => [
+                'columns' => ['0.1', '0.2'],
+                'rows'    => ['Diagonal'],
+            ],
+            'values' => [
+                [0.5, null],
+            ],
+        ];
+
+        $sfr = SpatialFrequencyResponse::fromMatrix($matrix);
+
+        self::assertNotNull($sfr);
+        self::assertSame([[0.5, null]], $sfr->values);
     }
 
     #[Test]
@@ -86,13 +109,14 @@ final class SpatialFrequencyResponseTest extends TestCase
             'rows'    => 1,
             'labels'  => [
                 'columns' => ['10'],
+                'rows'    => ['Along Image Width', 'Along Image Height'],
             ],
             'values' => [
                 [1.0, 0.9],
             ],
         ];
 
-        // Column count mismatch (labels has 1, but columns says 2)
+        // Column/row count mismatch compared to declared dimensions
         self::assertNull(SpatialFrequencyResponse::fromMatrix($matrix));
     }
 }


### PR DESCRIPTION
## Summary
- Add row label support to spatial frequency response values per EXIF 3.0 §4.6.6.7.25.
- Permit null SFR cells for zero denominators and expose direction labels in the value object.
- Refresh PHPDocs to reference the current EXIF sections for SFR handling.

**Issue/Milestone:** Closes #N/A • Milestone M#
**Scope (allowed files only):** src/Value/SpatialFrequencyResponse.php, src/Model/Exif/ValueConverters.php, src/Model/Exif/ParsedExif.php, src/Value/Sensor.php, tests/Value/SpatialFrequencyResponseTest.php
**Non-Goals:** Behaviour changes to other EXIF tags or stream parsers.

---

## Implementation Notes
- Runtime: PHP 8.4, `declare(strict_types=1);`, PSR-12.
- **Streaming only** (Core\\Stream/StreamWindow) — keine Ganzdatei-Reads.
- Keine externen Binaries/Extensions; **kein** `exif_read_data()`.
- Value Objects (chainable) nur für EXIF-Ausgabe; kein Rendering.
- **Enums** für gängige Kodierungen genutzt/ergänzt (Encoding/Endianness/IFD/XMP/...).
- **Spec-References** im Code ergänzt/aktualisiert (siehe „References“).

---

## Always Checklist (must be green)
**Composer-Tasks (deine CI-Skripte):**
- [ ] Lint: `composer ci:test:php:lint`
- [ ] PHPStan: `composer ci:test:php:phpstan`
- [ ] Rector (dry-run): `composer ci:test:php:rector`
- [ ] Coding-Style: `composer ci::cgl`
- [ ] PHPUnit: `composer ci:test:php:unit`
- [ ] Coverage ≥ **90 %**: `composer ci:test:php:unit:coverage`
- [ ] JSCPD (Duplikate = 0): `composer ci:test:php:cpd`
- [ ] Sammellauf: `composer ci:test` (sollte grün sein; enthält Lint, PHPStan, Rector-Dry-Run, CS-Dry-Run, Unit)

**Inhaltliche/Code-Guidelines:**
- [ ] **Keine** `mixed`-Signaturen • **kein** `empty()` • **keine** verschachtelten Ternaries
- [ ] Fully-qualified native functions (`\\strlen`, `\\count`, …) und sinnvolle `use`-Imports
- [ ] **Keine** dynamischen Aufrufe statischer Methoden
- [ ] Sinnvolle **Interfaces** verwendet (wo Verträge sinnvoll sind)
- [ ] Typisierte Klassenkonstanten; redundante Casts/Default-Argumente entfernt
- [ ] Klassen als `readonly`, wo passend; keine redundanten `readonly`-Mods
- [ ] **Eine Klasse je Datei** • Test-Namespaces spiegeln `src/`-Struktur
- [ ] Englische PHPDocs & englische Inline-Kommentare an komplexen Stellen
- [ ] Sinnvolle Namen für Variablen/Konstanten; Magic Numbers/Strings vermieden
- [ ] `array_find` / `array_any` / `array_all` gezielt statt trivialer `foreach` verwendet (wo es die Lesbarkeit verbessert)

---

## EXIF / TIFF / ISOBMFF / XMP Guardrails
- **EXIF-Versionen:** 1.x, 2.x (2.1/2.2/2.21/2.3/2.31/2.32), 3.0 — kompatible Änderungen; falls Tags betroffen: Coverage-Test grün.
- **TIFF/BigTIFF:** Endianness korrekt (`0x2A` / `0x2B`), Inline-Werte-Grenzen, `RATIONAL/SRATIONAL` korrekt.
- **GPS:** Vorzeichen über Ref-Tags (S/W negativ); `0/0`-Kantenfälle robust.
- **Preview/IFD1:** Nur beschreiben (Offsets/Längen/Compression), kein Rendering.
- **ISOBMFF/QuickTime:** Box-Size ≥ Header, 32/64-bit-Größen korrekt; `iloc`-Extents summiert; `data_reference_index ≠ 0` → skip; keine Remote-Refs.
- **XMP:** JPEG APP1-Präfix / ISOBMFF `uuid`; Parser mit `LIBXML_NONET`, keine DTD/Entities; `Alt/Bag/Seq` → Arrays.
- **Fehlerbehandlung:** ausschließlich `ParseError` oder `BoundsError`; keine Warnings/Notices als Kontrollfluss.

---

## Tests
- **Neue/angepasste Tests:** SpatialFrequencyResponse value object (row labels, null values)
- **Negative Cases:** Invalid matrix dimensions, missing labels
- **Fixtures/Streams:** Synthetische Matrixdaten

---

## Pre-Sweep Notes
- `composer ci:test:php:unit` currently fails on the default branch because `Compression::JPEG_OLD_STYLE` is undefined; this change does not modify compression handling.

## M# Sweep — Verify compliance for this milestone
Bitte **alles** verifizieren und kurz die Ergebnisse notieren:
- [ ] `composer ci:test` **grün** (Lint, PHPStan, Rector-Dry-Run, CS-Dry-Run, Unit)
- [ ] `composer ci:test:php:cpd` **0 Duplikate** (JSCPD, Konfig: `.build/.jscpd.json`)
- [ ] `composer ci:test:php:unit:coverage` **≥ 90 %**
- [ ] **ExifCoverageTest** (falls vorhanden): 0 fehlende Tags/Getters (gegen `resources/exif-map.yaml`)
- [ ] Für **jede** Klasse existiert ein Test (Namespace-Spiegelung)

---

## Breaking Changes / Risk / Rollback
- **Breaking changes:** None
- **Risiken:** None beyond existing CI failures on default branch.
- **Rollback-Plan:** Revert this PR.

---

## Changelog
- fix: capture spatial frequency response directions and null SFR values

---

## References (Specs & Docs)
- EXIF 3.0 §4.6.6.7.25; EXIF 2.32 §4.6.3
- `docs/EXIF-210.pdf`, `docs/EXIF-220.pdf`, `docs/EXIF-230.pdf`, `docs/EXIF-231.pdf`, `docs/EXIF-232.pdf`, `docs/EXIF-300.pdf`
- `docs/TIFF6.pdf`

---

## Review Roles (tick what you covered)
- [ ] Planner (Scope/Non-Goals/Guardrails definiert)
- [ ] Spec Writer (AC/Tests präzisiert)
- [ ] Test Agent (RED zuerst)
- [ ] Implementer (GREEN minimal & im Datei-Scope)
- [ ] Static/QA (Stan/CS/Rector/JSCPD clean)
- [ ] Security (Bounds, Offsets, XML-Flags)
- [ ] Reviewer (Minimalität, DX, Spec-Refs, Enums)
- [ ] Release (PR-Text, Labels, Milestone, „Closes #…“)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6939293bdfd8832382e5b5d92d69c417)