### PR TITLE
Add coverage for EXIF shooting condition tags

### DIFF
--- a/src/Model/Exif/ParsedExif.php
+++ b/src/Model/Exif/ParsedExif.php
@@ -1304,6 +1304,8 @@ final readonly class ParsedExif
 
     /**
      * Returns the exposure index value.
+     *
+     * EXIF 3.0 §4.6.6.7.30 (ExposureIndex); EXIF 2.32 §4.6.6.7.30.
      */
     public function exposureIndex(): ?float
     {
@@ -1398,6 +1400,8 @@ final readonly class ParsedExif
 
     /**
      * Returns the scene type classification when present.
+     *
+     * EXIF 3.0 §4.6.6.7.33 (SceneType); EXIF 2.32 §4.6.6.7.33.
      */
     public function sceneType(): ?SceneType
     {
@@ -2464,6 +2468,8 @@ final readonly class ParsedExif
 
     /**
      * Returns the EXIF file source enum when provided.
+     *
+     * EXIF 3.0 §4.6.6.7.32 (FileSource); EXIF 2.32 §4.6.6.7.32.
      */
     public function fileSource(): ?FileSource
     {
@@ -2498,6 +2504,8 @@ final readonly class ParsedExif
 
     /**
      * Returns the EXIF sensing method enum when provided.
+     *
+     * EXIF 3.0 §4.6.6.7.31 (SensingMethod); EXIF 2.32 §4.6.6.7.31.
      */
     public function sensingMethod(): ?SensingMethod
     {

--- a/src/Value/Enum/FileSource.php
+++ b/src/Value/Enum/FileSource.php
@@ -15,8 +15,8 @@ use MagicSunday\ImageMeta\Exif\Support\EnumFromIntStringNullable;
 
 /**
  * Enumerates the image acquisition sources recorded by the FileSource tag in
- * EXIF 3.0 §4.6.3 (shooting conditions), preserving the list from EXIF 2.32
- * §4.6.3.
+ * EXIF 3.0 §4.6.6.7.32 (FileSource), preserving the list from EXIF 2.32
+ * §4.6.6.7.32 where DSC images default to 3.
  */
 enum FileSource: int
 {

--- a/src/Value/Enum/SceneType.php
+++ b/src/Value/Enum/SceneType.php
@@ -15,7 +15,8 @@ use MagicSunday\ImageMeta\Exif\Support\EnumFromIntStringNullable;
 
 /**
  * Enumerates the scene type encodings recorded by the SceneType tag in EXIF
- * 3.0 §4.6.3 (shooting conditions), preserving the EXIF 2.32 §4.6.3 meaning.
+ * 3.0 §4.6.6.7.33 (SceneType), preserving the EXIF 2.32 §4.6.6.7.33 meaning
+ * that directly photographed images use the value 1.
  */
 enum SceneType: int
 {

--- a/src/Value/Enum/SensingMethod.php
+++ b/src/Value/Enum/SensingMethod.php
@@ -15,7 +15,7 @@ use MagicSunday\ImageMeta\Exif\Support\EnumFromIntStringNullable;
 
 /**
  * Enumerates the sensor sampling methods recognised by the SensingMethod tag in
- * EXIF 3.0 §4.6.3 (shooting conditions), matching the EXIF 2.32 §4.6.3 list.
+ * EXIF 3.0 §4.6.6.7.31 (SensingMethod), matching the EXIF 2.32 §4.6.6.7.31 list.
  */
 enum SensingMethod: int
 {

--- a/tests/Model/Exif/ParsedExifShootingConditionsTest.php
+++ b/tests/Model/Exif/ParsedExifShootingConditionsTest.php
@@ -16,6 +16,9 @@ use MagicSunday\ImageMeta\Model\Exif\Ifd;
 use MagicSunday\ImageMeta\Model\Exif\IfdEntry;
 use MagicSunday\ImageMeta\Model\Exif\ParsedExif;
 use MagicSunday\ImageMeta\Value\Enum\ExposureProgram;
+use MagicSunday\ImageMeta\Value\Enum\FileSource;
+use MagicSunday\ImageMeta\Value\Enum\SceneType;
+use MagicSunday\ImageMeta\Value\Enum\SensingMethod;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -70,5 +73,65 @@ final class ParsedExifShootingConditionsTest extends TestCase
         $parsedExif = new ParsedExif(new Ifd([]), $exifIfd, null, null, null);
 
         self::assertSame(640, $parsedExif->photographicSensitivity());
+    }
+
+    #[Test]
+    public function returnsExposureIndexFromRational(): void
+    {
+        $exifIfd = new Ifd([
+            ExifTag::EXPOSURE_INDEX => new IfdEntry(ExifTag::EXPOSURE_INDEX, 5, 1, [[320, 2]]),
+        ]);
+
+        $parsedExif = new ParsedExif(new Ifd([]), $exifIfd, null, null, null);
+
+        self::assertSame(160.0, $parsedExif->exposureIndex());
+    }
+
+    #[Test]
+    public function returnsSensingMethodEnum(): void
+    {
+        $exifIfd = new Ifd([
+            ExifTag::SENSING_METHOD => new IfdEntry(ExifTag::SENSING_METHOD, 3, 1, SensingMethod::ONE_CHIP_COLOR_AREA->value),
+        ]);
+
+        $parsedExif = new ParsedExif(new Ifd([]), $exifIfd, null, null, null);
+
+        self::assertSame(SensingMethod::ONE_CHIP_COLOR_AREA, $parsedExif->sensingMethod());
+    }
+
+    #[Test]
+    public function ignoresReservedSensingMethodCodes(): void
+    {
+        $exifIfd = new Ifd([
+            ExifTag::SENSING_METHOD => new IfdEntry(ExifTag::SENSING_METHOD, 3, 1, 6),
+        ]);
+
+        $parsedExif = new ParsedExif(new Ifd([]), $exifIfd, null, null, null);
+
+        self::assertNull($parsedExif->sensingMethod());
+    }
+
+    #[Test]
+    public function returnsFileSourceFromUndefinedByte(): void
+    {
+        $exifIfd = new Ifd([
+            ExifTag::FILE_SOURCE => new IfdEntry(ExifTag::FILE_SOURCE, 7, 1, "\x03"),
+        ]);
+
+        $parsedExif = new ParsedExif(new Ifd([]), $exifIfd, null, null, null);
+
+        self::assertSame(FileSource::DIGITAL_CAMERA, $parsedExif->fileSource());
+    }
+
+    #[Test]
+    public function returnsSceneTypeFromUndefinedByte(): void
+    {
+        $exifIfd = new Ifd([
+            ExifTag::SCENE_TYPE => new IfdEntry(ExifTag::SCENE_TYPE, 7, 1, "\x01"),
+        ]);
+
+        $parsedExif = new ParsedExif(new Ifd([]), $exifIfd, null, null, null);
+
+        self::assertSame(SceneType::DIRECTLY_PHOTOGRAPHED_IMAGE, $parsedExif->sceneType());
     }
 }


### PR DESCRIPTION
## Summary
- Documented ExposureIndex, SensingMethod, FileSource, and SceneType handling against the EXIF 3.0 shooting condition sections.
- Added unit coverage for parsing ExposureIndex and enum-backed shooting condition tags from EXIF IFD payloads.

**Issue/Milestone:** Closes #0000 • Milestone M#
**Scope (allowed files only):** src/Model/Exif/ParsedExif.php, src/Value/Enum/FileSource.php, src/Value/Enum/SceneType.php, src/Value/Enum/SensingMethod.php, tests/Model/Exif/ParsedExifShootingConditionsTest.php
**Non-Goals:** Broader EXIF tag surface changes or public API adjustments.

---

## Implementation Notes
- Runtime: PHP 8.4, `declare(strict_types=1);`, PSR-12.
- **Streaming only** (Core\\Stream/StreamWindow) — keine Ganzdatei-Reads.
- Keine externen Binaries/Extensions; **kein** `exif_read_data()`.
- Value Objects (chainable) nur für EXIF-Ausgabe; kein Rendering.
- **Enums** für gängige Kodierungen genutzt/ergänzt (Encoding/Endianness/IFD/XMP/...).
- **Spec-References** im Code ergänzt/aktualisiert (siehe „References“).

---

## Always Checklist (must be green)
**Composer-Tasks (deine CI-Skripte):**
- [ ] Lint: `composer ci:test:php:lint`
- [ ] PHPStan: `composer ci:test:php:phpstan`
- [ ] Rector (dry-run): `composer ci:test:php:rector`
- [ ] Coding-Style: `composer ci::cgl`
- [ ] PHPUnit: `composer ci:test:php:unit`
- [ ] Coverage ≥ **90 %**: `composer ci:test:php:unit:coverage`
- [ ] JSCPD (Duplikate = 0): `composer ci:test:php:cpd`
- [ ] Sammellauf: `composer ci:test` (sollte grün sein; enthält Lint, PHPStan, Rector-Dry-Run, CS-Dry-Run, Unit)

**Inhaltliche/Code-Guidelines:**
- [ ] **Keine** `mixed`-Signaturen • **kein** `empty()` • **keine** verschachtelten Ternaries
- [ ] Fully-qualified native functions (`\\strlen`, `\\count`, …) und sinnvolle `use`-Imports
- [ ] **Keine** dynamischen Aufrufe statischer Methoden
- [ ] Sinnvolle **Interfaces** verwendet (wo Verträge sinnvoll sind)
- [ ] Typisierte Klassenkonstanten; redundante Casts/Default-Argumente entfernt
- [ ] Klassen als `readonly`, wo passend; keine redundanten `readonly`-Mods
- [ ] **Eine Klasse je Datei** • Test-Namespaces spiegeln `src/`-Struktur
- [ ] Englische PHPDocs & englische Inline-Kommentare an komplexen Stellen
- [ ] Sinnvolle Namen für Variablen/Konstanten; Magic Numbers/Strings vermieden
- [ ] `array_find` / `array_any` / `array_all` gezielt statt trivialer `foreach` verwendet (wo es die Lesbarkeit verbessert)

---

## EXIF / TIFF / ISOBMFF / XMP Guardrails
- **EXIF-Versionen:** 1.x, 2.x (2.1/2.2/2.21/2.3/2.31/2.32), 3.0 — kompatible Änderungen; falls Tags betroffen: Coverage-Test grün.
- **TIFF/BigTIFF:** Endianness korrekt (`0x2A` / `0x2B`), Inline-Werte-Grenzen, `RATIONAL/SRATIONAL` korrekt.
- **GPS:** Vorzeichen über Ref-Tags (S/W negativ); `0/0`-Kantenfälle robust.
- **Preview/IFD1:** Nur beschreiben (Offsets/Längen/Compression), kein Rendering.
- **ISOBMFF/QuickTime:** Box-Size ≥ Header, 32/64-bit-Größen korrekt; `iloc`-Extents summiert; `data_reference_index ≠ 0` → skip; keine Remote-Refs.
- **XMP:** JPEG APP1-Präfix / ISOBMFF `uuid`; Parser mit `LIBXML_NONET`, keine DTD/Entities; `Alt/Bag/Seq` → Arrays.
- **Fehlerbehandlung:** ausschließlich `ParseError` oder `BoundsError`; keine Warnings/Notices als Kontrollfluss.

---

## Tests
- **Neue/angepasste Tests:** ParsedExif shooting condition getters (ExposureIndex, SensingMethod, FileSource, SceneType)
- **Negative Cases:** Reserved SensingMethod code rejected.
- **Fixtures/Streams:** Synthetic IFD entries with minimal payloads.

---

## M# Sweep — Verify compliance for this milestone
Bitte **alles** verifizieren und kurz die Ergebnisse notieren:
- [ ] `composer ci:test` **grün** (Lint, PHPStan, Rector-Dry-Run, CS-Dry-Run, Unit)
- [ ] `composer ci:test:php:cpd` **0 Duplikate** (JSCPD, Konfig: `.build/.jscpd.json`)
- [ ] `composer ci:test:php:unit:coverage` **≥ 90 %**
- [ ] **ExifCoverageTest** (falls vorhanden): 0 fehlende Tags/Getters (gegen `resources/exif-map.yaml`)
- [ ] Für **jede** Klasse existiert ein Test (Namespace-Spiegelung)

---

## Breaking Changes / Risk / Rollback
- **Breaking changes:** None.
- **Risiken:** None identified beyond normal parser surface.
- **Rollback-Plan:** Revert this branch.

---

## Changelog
- test(exif): cover exposure index and sensor tags

---

## References (Specs & Docs)
- EXIF 3.0 §4.6.6.7.30–4.6.6.7.33; EXIF 2.32 §4.6.6.7.30–4.6.6.7.33
- `docs/EXIF-232.pdf`, `docs/EXIF-300.pdf`

---

## Review Roles (tick what you covered)
- [ ] Planner (Scope/Non-Goals/Guardrails definiert)
- [ ] Spec Writer (AC/Tests präzisiert)
- [ ] Test Agent (RED zuerst)
- [ ] Implementer (GREEN minimal & im Datei-Scope)
- [ ] Static/QA (Stan/CS/Rector/JSCPD clean)
- [ ] Security (Bounds, Offsets, XML-Flags)
- [ ] Reviewer (Minimalität, DX, Spec-Refs, Enums)
- [ ] Release (PR-Text, Labels, Milestone, „Closes #…")


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693929739de08323887371cf5bee70dd)