### PR TITLE
M?: Align shooting condition tags — EXIF

### DIFF
--- a/resources/exif-spec-tags.yaml
+++ b/resources/exif-spec-tags.yaml
@@ -1689,7 +1689,7 @@ exif_tags:
     name: GainControl
     tag: 41991
     hex: A407
-    type: RATIONAL
+    type: SHORT
     count: 1
     ifd: ExifIFD
     category: II

--- a/src/Model/Exif/ParsedExif.php
+++ b/src/Model/Exif/ParsedExif.php
@@ -1432,6 +1432,8 @@ final readonly class ParsedExif
 
     /**
      * Returns the in-camera contrast setting.
+     *
+     * EXIF 3.0 §4.6.6.7.42; EXIF 2.32 §4.6.3.
      */
     public function contrast(): ?Contrast
     {
@@ -1442,6 +1444,8 @@ final readonly class ParsedExif
 
     /**
      * Returns the in-camera saturation setting.
+     *
+     * EXIF 3.0 §4.6.6.7.43; EXIF 2.32 §4.6.3.
      */
     public function saturation(): ?Saturation
     {
@@ -1452,6 +1456,8 @@ final readonly class ParsedExif
 
     /**
      * Returns the in-camera sharpness setting.
+     *
+     * EXIF 3.0 §4.6.6.7.44; EXIF 2.32 §4.6.3.
      */
     public function sharpness(): ?Sharpness
     {
@@ -2454,6 +2460,8 @@ final readonly class ParsedExif
 
     /**
      * Returns the gain control enum describing in-camera amplification.
+     *
+     * EXIF 3.0 §4.6.6.7.41; EXIF 2.32 §4.6.3.
      */
     public function gainControl(): ?GainControl
     {

--- a/src/Value/Enum/Contrast.php
+++ b/src/Value/Enum/Contrast.php
@@ -15,8 +15,8 @@ use MagicSunday\ImageMeta\Exif\Support\EnumFromIntStringNullable;
 
 /**
  * Enumerates the in-camera contrast processing levels described for the
- * Contrast tag in EXIF 3.0 §4.6.3 (shooting conditions), consistent with EXIF
- * 2.32 §4.6.3.
+ * Contrast tag in EXIF 3.0 §4.6.6.7.42 (shooting conditions), consistent with
+ * EXIF 2.32 §4.6.3.
  */
 enum Contrast: int
 {

--- a/src/Value/Enum/GainControl.php
+++ b/src/Value/Enum/GainControl.php
@@ -15,7 +15,7 @@ use MagicSunday\ImageMeta\Exif\Support\EnumFromIntStringNullable;
 
 /**
  * Enumerates the gain control adjustments described for the GainControl tag in
- * EXIF 3.0 §4.6.3 (shooting conditions), mirroring EXIF 2.32 §4.6.3.
+ * EXIF 3.0 §4.6.6.7.41 (shooting conditions), mirroring EXIF 2.32 §4.6.3.
  */
 enum GainControl: int
 {

--- a/src/Value/Enum/Saturation.php
+++ b/src/Value/Enum/Saturation.php
@@ -15,7 +15,7 @@ use MagicSunday\ImageMeta\Exif\Support\EnumFromIntStringNullable;
 
 /**
  * Enumerates the saturation processing levels associated with the Saturation
- * tag in EXIF 3.0 §4.6.3 (shooting conditions), identical to EXIF 2.32
+ * tag in EXIF 3.0 §4.6.6.7.43 (shooting conditions), identical to EXIF 2.32
  * §4.6.3.
  */
 enum Saturation: int

--- a/src/Value/Enum/Sharpness.php
+++ b/src/Value/Enum/Sharpness.php
@@ -15,7 +15,7 @@ use MagicSunday\ImageMeta\Exif\Support\EnumFromIntStringNullable;
 
 /**
  * Enumerates the sharpness processing levels described for the Sharpness tag in
- * EXIF 3.0 §4.6.3 (shooting conditions), consistent with EXIF 2.32 §4.6.3.
+ * EXIF 3.0 §4.6.6.7.44 (shooting conditions), consistent with EXIF 2.32 §4.6.3.
  */
 enum Sharpness: int
 {


### PR DESCRIPTION
## Summary
- GainControl tag marked as SHORT per EXIF 3.0 and kept count at one.
- Added EXIF 3.0 §4.6.6.7 references for gain control, contrast, saturation, and sharpness accessors.
- Updated shooting-condition enums to cite the latest specification sections.

**Issue/Milestone:** Closes #N/A • Milestone M?
**Scope (allowed files only):** resources/exif-spec-tags.yaml; src/Model/Exif/ParsedExif.php; src/Value/Enum
**Non-Goals:** Broader parser changes or new features.

---

## Implementation Notes
- Runtime: PHP 8.4, `declare(strict_types=1);`, PSR-12.
- **Streaming only** (Core\\Stream/StreamWindow) — keine Ganzdatei-Reads.
- Keine externen Binaries/Extensions; **kein** `exif_read_data()`.
- Value Objects (chainable) nur für EXIF-Ausgabe; kein Rendering.
- **Enums** für gängige Kodierungen genutzt/ergänzt (Encoding/Endianness/IFD/XMP/...).
- **Spec-References** im Code ergänzt/aktualisiert (siehe „References“).

---

## Always Checklist (must be green)
**Composer-Tasks (deine CI-Skripte):**
- [ ] Lint: `composer ci:test:php:lint`
- [ ] PHPStan: `composer ci:test:php:phpstan`
- [ ] Rector (dry-run): `composer ci:test:php:rector`
- [ ] Coding-Style: `composer ci::cgl`
- [ ] PHPUnit: `composer ci:test:php:unit`
- [ ] Coverage ≥ **90 %**: `composer ci:test:php:unit:coverage`
- [ ] JSCPD (Duplikate = 0): `composer ci:test:php:cpd`
- [ ] Sammellauf: `composer ci:test` (sollte grün sein; enthält Lint, PHPStan, Rector-Dry-Run, CS-Dry-Run, Unit)

**Inhaltliche/Code-Guidelines:**
- [ ] **Keine** `mixed`-Signaturen • **kein** `empty()` • **keine** verschachtelten Ternaries
- [ ] Fully-qualified native functions (`\\strlen`, `\\count`, …) und sinnvolle `use`-Imports
- [ ] **Keine** dynamischen Aufrufe statischer Methoden
- [ ] Sinnvolle **Interfaces** verwendet (wo Verträge sinnvoll sind)
- [ ] Typisierte Klassenkonstanten; redundante Casts/Default-Argumente entfernt
- [ ] Klassen als `readonly`, wo passend; keine redundanten `readonly`-Mods
- [ ] **Eine Klasse je Datei** • Test-Namespaces spiegeln `src/`-Struktur
- [ ] Englische PHPDocs & englische Inline-Kommentare an komplexen Stellen
- [ ] Sinnvolle Namen für Variablen/Konstanten; Magic Numbers/Strings vermieden
- [ ] `array_find` / `array_any` / `array_all` gezielt statt trivialer `foreach` verwendet (wo es die Lesbarkeit verbessert)

---

## EXIF / TIFF / ISOBMFF / XMP Guardrails
- **EXIF-Versionen:** 1.x, 2.x (2.1/2.2/2.21/2.3/2.31/2.32), 3.0 — kompatible Änderungen; falls Tags betroffen: Coverage-Test grün.
- **TIFF/BigTIFF:** Endianness korrekt (`0x2A` / `0x2B`), Inline-Werte-Grenzen, `RATIONAL/SRATIONAL` korrekt.
- **GPS:** Vorzeichen über Ref-Tags (S/W negativ); `0/0`-Kantenfälle robust.
- **Preview/IFD1:** Nur beschreiben (Offsets/Längen/Compression), kein Rendering.
- **ISOBMFF/QuickTime:** Box-Size ≥ Header, 32/64-bit-Größen korrekt; `iloc`-Extents summiert; `data_reference_index ≠ 0` → skip; keine Remote-Refs.
- **XMP:** JPEG APP1-Präfix / ISOBMFF `uuid`; Parser mit `LIBXML_NONET`, keine DTD/Entities; `Alt/Bag/Seq` → Arrays.
- **Fehlerbehandlung:** ausschließlich `ParseError` oder `BoundsError`; keine Warnings/Notices als Kontrollfluss.

---

## Tests
- **Neue/angepasste Tests:** PHPDocs for shooting-condition accessors and enums adjusted to reference EXIF 3.0 §§4.6.6.7.41–44.
- **Negative Cases:** Not added; enum mapping still returns null for reserved codes.
- **Fixtures/Streams:** None.

---

### CI status
- `composer ci:test:php:unit` currently red on baseline due to missing `Compression::JPEG_OLD_STYLE` constant and an existing GPS reference expectation; no new test regressions introduced.

---

## M# Sweep — Verify compliance for this milestone
Bitte **alles** verifizieren und kurz die Ergebnisse notieren:
- [ ] `composer ci:test` **grün** (Lint, PHPStan, Rector-Dry-Run, CS-Dry-Run, Unit)
- [ ] `composer ci:test:php:cpd` **0 Duplikate** (JSCPD, Konfig: `.build/.jscpd.json`)
- [ ] `composer ci:test:php:unit:coverage` **≥ 90 %**
- [ ] **ExifCoverageTest** (falls vorhanden): 0 fehlende Tags/Getters (gegen `resources/exif-map.yaml`)
- [ ] Für **jede** Klasse existiert ein Test (Namespace-Spiegelung)

---

## Breaking Changes / Risk / Rollback
- **Breaking changes:** None.
- **Risiken:** None beyond existing baseline test failures.
- **Rollback-Plan:** Revert commit.

---

## Changelog
- fix(exif): align shooting condition tags with EXIF 3.0 sections and types.

---

## References (Specs & Docs)
- EXIF 3.0 §§4.6.6.7.41–44; EXIF 2.32 §4.6.3
- `docs/EXIF-210.pdf`, `docs/EXIF-220.pdf`, `docs/EXIF-230.pdf`, `docs/EXIF-231.pdf`, `docs/EXIF-232.pdf`, `docs/EXIF-300.pdf`
- `docs/TIFF6.pdf`

---

## Review Roles (tick what you covered)
- [ ] Planner (Scope/Non-Goals/Guardrails definiert)
- [ ] Spec Writer (AC/Tests präzisiert)
- [ ] Test Agent (RED zuerst)
- [ ] Implementer (GREEN minimal & im Datei-Scope)
- [ ] Static/QA (Stan/CS/Rector/JSCPD clean)
- [ ] Security (Bounds, Offsets, XML-Flags)
- [ ] Reviewer (Minimalität, DX, Spec-Refs, Enums)
- [ ] Release (PR-Text, Labels, Milestone, „Closes #…“)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693929d07db8832393c2d6a503e03f11)