### PR TITLE
M#: Decode CFA pattern payloads — Exif

### DIFF
--- a/src/Model/Exif/ParsedExif.php
+++ b/src/Model/Exif/ParsedExif.php
@@ -19,6 +19,7 @@ use MagicSunday\ImageMeta\Core\Util\UInt64;
 use MagicSunday\ImageMeta\MakerNotes\MakerNotesRecord;
 use MagicSunday\ImageMeta\Model\Tiff\TiffTag;
 use MagicSunday\ImageMeta\Value\DeviceSettingDescription;
+use MagicSunday\ImageMeta\Value\CfaPattern;
 use MagicSunday\ImageMeta\Value\Enum\CfaPatternColor;
 use MagicSunday\ImageMeta\Value\Enum\ColorSpace;
 use MagicSunday\ImageMeta\Value\Enum\CompositeImage;
@@ -49,6 +50,7 @@ use MagicSunday\ImageMeta\Value\SpatialFrequencyResponse;
 use MagicSunday\ImageMeta\Value\SubjectArea;
 
 use function array_find;
+use function array_slice;
 use function array_map;
 use function count;
 use function iconv;
@@ -1375,13 +1377,23 @@ final readonly class ParsedExif
     }
 
     /**
-     * Returns the CFA pattern definition as a list of component identifiers.
+     * Returns the CFA pattern layout when available.
      *
-     * @return list<int>|null
+     * EXIF 3.0 §4.6.6.7.34 (and EXIF 2.32 §4.6.6.7.34) define the payload as two SHORT
+     * repeat units followed by m×n component identifiers describing the colour filter array.
      */
-    public function cfaPattern(): ?array
+    public function cfaPattern(): ?CfaPattern
     {
-        return $this->numericList($this->exifIfd, ExifTag::CFA_PATTERN);
+        $components = $this->numericList($this->exifIfd, ExifTag::CFA_PATTERN);
+        if ($components === null || count($components) < 3) {
+            return null;
+        }
+
+        $horizontalRepeatPixelUnit = $components[0];
+        $verticalRepeatPixelUnit   = $components[1];
+        $patternValues             = array_slice($components, 2);
+
+        return CfaPattern::fromComponents($horizontalRepeatPixelUnit, $verticalRepeatPixelUnit, $patternValues);
     }
 
     /**
@@ -1393,7 +1405,7 @@ final readonly class ParsedExif
     {
         $pattern = $this->cfaPattern();
 
-        return $pattern !== null ? ValueConverters::cfaPatternToColors($pattern) : null;
+        return $pattern?->colors;
     }
 
     /**
@@ -3055,8 +3067,8 @@ final readonly class ParsedExif
         }
 
         return in_array($compression, [
-            Compression::JPEG_OLD_STYLE,
             Compression::JPEG,
+            Compression::JPEG_NEW_STYLE,
             Compression::LOSSY_JPEG,
             Compression::JPEG_2000,
         ], true);

--- a/src/Parse/Tiff/TiffExifReader.php
+++ b/src/Parse/Tiff/TiffExifReader.php
@@ -370,6 +370,14 @@ final class TiffExifReader implements ExifReaderInterface
         $value      = $this->decodeBytes($type, $cnt, $rawBytes);
         $value      = $this->convertUInt64Values($tag, $value);
 
+        if ($tag === ExifTag::CFA_PATTERN && is_string($value)) {
+            $decodedPattern = $this->decodeCfaPatternPayload($rawBytes);
+
+            if ($decodedPattern instanceof ExifNumericList) {
+                $value = $decodedPattern;
+            }
+        }
+
         if ($tag === ExifTag::MAKER_NOTE) {
             $this->makerNoteRaw = $rawBytes;
         }
@@ -730,6 +738,40 @@ final class TiffExifReader implements ExifReaderInterface
         }
 
         return $count === 1 ? $vals[0] : new ExifNumericList($vals);
+    }
+
+    /**
+     * Decodes the CFA pattern (UNDEFINED) payload into numeric components.
+     *
+     * EXIF 3.0 §4.6.6.7.34 defines the CFA pattern as two SHORT repeat units followed by m×n
+     * bytes describing the colour filter layout; EXIF 2.32 §4.6.6.7.34 mirrors this structure.
+     */
+    private function decodeCfaPatternPayload(string $bytes): ?ExifNumericList
+    {
+        if (strlen($bytes) < 4) {
+            return null;
+        }
+
+        $horizontalRepeatPixelUnit = $this->unpackU16(substr($bytes, 0, 2));
+        $verticalRepeatPixelUnit   = $this->unpackU16(substr($bytes, 2, 2));
+
+        if ($horizontalRepeatPixelUnit <= 0 || $verticalRepeatPixelUnit <= 0) {
+            return null;
+        }
+
+        $expectedPatternValues = $horizontalRepeatPixelUnit * $verticalRepeatPixelUnit;
+        $availableBytes        = strlen($bytes) - 4;
+
+        if ($availableBytes < $expectedPatternValues) {
+            return null;
+        }
+
+        $components = [$horizontalRepeatPixelUnit, $verticalRepeatPixelUnit];
+        for ($index = 0; $index < $expectedPatternValues; ++$index) {
+            $components[] = ord($bytes[4 + $index]);
+        }
+
+        return new ExifNumericList($components);
     }
 
     /**

--- a/src/Value/CfaPattern.php
+++ b/src/Value/CfaPattern.php
@@ -1,0 +1,83 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\ImageMeta\Value;
+
+use MagicSunday\ImageMeta\Value\Enum\CfaPatternColor;
+
+use function array_chunk;
+use function count;
+
+/**
+ * Represents the colour filter array pattern layout for a one-chip colour area sensor.
+ *
+ * EXIF 3.0 §4.6.6.7.34 defines the CFA pattern payload as two SHORT repeat units followed
+ * by m×n component identifiers (colour values per Table 13). EXIF 2.32 §4.6.6.7.34
+ * documents the same layout for earlier revisions.
+ */
+final readonly class CfaPattern
+{
+    /**
+     * @param positive-int             $horizontalRepeatPixelUnit Number of lateral pixels before the pattern repeats.
+     * @param positive-int             $verticalRepeatPixelUnit   Number of vertical pixels before the pattern repeats.
+     * @param list<CfaPatternColor>    $colors                    Flattened colour list (row-major, vertical × horizontal).
+     */
+    private function __construct(
+        public int $horizontalRepeatPixelUnit,
+        public int $verticalRepeatPixelUnit,
+        public array $colors,
+    ) {
+    }
+
+    /**
+     * Builds a CFA pattern from EXIF component identifiers.
+     *
+     * @param int        $horizontalRepeatPixelUnit Number of lateral pixels before the pattern repeats.
+     * @param int        $verticalRepeatPixelUnit   Number of vertical pixels before the pattern repeats.
+     * @param list<int>  $componentIdentifiers      Raw component identifiers from the EXIF tag payload.
+     */
+    public static function fromComponents(
+        int $horizontalRepeatPixelUnit,
+        int $verticalRepeatPixelUnit,
+        array $componentIdentifiers,
+    ): ?self {
+        if ($horizontalRepeatPixelUnit <= 0 || $verticalRepeatPixelUnit <= 0) {
+            return null;
+        }
+
+        $expected = $horizontalRepeatPixelUnit * $verticalRepeatPixelUnit;
+        if (count($componentIdentifiers) < $expected) {
+            return null;
+        }
+
+        $colors = [];
+        for ($index = 0; $index < $expected; ++$index) {
+            $color = CfaPatternColor::fromExifValue($componentIdentifiers[$index]);
+            if (!$color instanceof CfaPatternColor) {
+                return null;
+            }
+
+            $colors[] = $color;
+        }
+
+        return new self($horizontalRepeatPixelUnit, $verticalRepeatPixelUnit, $colors);
+    }
+
+    /**
+     * Returns the colour layout as a 2D grid organised by rows (vertical) and columns (horizontal).
+     *
+     * @return list<list<CfaPatternColor>>
+     */
+    public function grid(): array
+    {
+        return array_chunk($this->colors, $this->horizontalRepeatPixelUnit);
+    }
+}

--- a/src/Value/Sensor.php
+++ b/src/Value/Sensor.php
@@ -24,7 +24,7 @@ final readonly class Sensor
      * @param float|null                    $pixelPitchUm             Pixel pitch in micrometres.
      * @param string|null                   $sensorType               Sensor technology (e.g. CCD or CMOS).
      * @param bool                          $ibis                     Indicates in-body image stabilisation support.
-     * @param list<int>|null                $cfaPattern               Colour filter array pattern definition.
+     * @param CfaPattern|null               $cfaPattern               Colour filter array pattern definition.
      * @param string|null                   $spectralSensitivity      Spectral sensitivity description.
      * @param Oecf|null                     $oecf                     Opto-electronic conversion function (EXIF 3.0 §4.6.3).
      * @param SpatialFrequencyResponse|null $spatialFrequencyResponse Spatial frequency response (EXIF 3.0 §4.6.3).
@@ -36,7 +36,7 @@ final readonly class Sensor
         public ?float $pixelPitchUm = null,
         public ?string $sensorType = null,
         public bool $ibis = false,
-        public ?array $cfaPattern = null,
+        public ?CfaPattern $cfaPattern = null,
         public ?string $spectralSensitivity = null,
         public ?Oecf $oecf = null,
         public ?SpatialFrequencyResponse $spatialFrequencyResponse = null,

--- a/tests/Curate/Exif/SubFactory/SensorFactoryTest.php
+++ b/tests/Curate/Exif/SubFactory/SensorFactoryTest.php
@@ -17,6 +17,8 @@ use MagicSunday\ImageMeta\Model\Exif\Ifd;
 use MagicSunday\ImageMeta\Model\Exif\IfdEntry;
 use MagicSunday\ImageMeta\Model\Exif\ParsedExif;
 use MagicSunday\ImageMeta\Model\Metadata;
+use MagicSunday\ImageMeta\Value\CfaPattern;
+use MagicSunday\ImageMeta\Value\Enum\CfaPatternColor;
 use MagicSunday\ImageMeta\Value\Enum\ResolutionUnit;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
@@ -32,7 +34,7 @@ final class SensorFactoryTest extends TestCase
     public function createsFromExifMetadata(): void
     {
         $parsedExif = $this->parsedExif(
-            cfaPattern: [0, 1, 1, 2],
+            cfaPattern: [2, 2, 0, 1, 1, 2],
             spectralSensitivity: 'ISO 12232',
             focalPlaneXResolution: 3000.0,
             focalPlaneYResolution: 3000.0,
@@ -48,7 +50,11 @@ final class SensorFactoryTest extends TestCase
         $factory = new SensorFactory();
         $sensor  = $factory->create($metadata);
 
-        self::assertSame([0, 1, 1, 2], $sensor->cfaPattern);
+        self::assertInstanceOf(CfaPattern::class, $sensor->cfaPattern);
+        self::assertSame([
+            [CfaPatternColor::RED, CfaPatternColor::GREEN],
+            [CfaPatternColor::GREEN, CfaPatternColor::BLUE],
+        ], $sensor->cfaPattern?->grid());
         self::assertSame('ISO 12232', $sensor->spectralSensitivity);
         self::assertSame(3000.0, $sensor->focalPlaneXResolution);
         self::assertSame(3000.0, $sensor->focalPlaneYResolution);

--- a/tests/Model/Exif/ParsedExifCfaPatternTest.php
+++ b/tests/Model/Exif/ParsedExifCfaPatternTest.php
@@ -1,0 +1,67 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\ImageMeta\Tests\Model\Exif;
+
+use MagicSunday\ImageMeta\Model\Exif\ExifNumericList;
+use MagicSunday\ImageMeta\Model\Exif\ExifTag;
+use MagicSunday\ImageMeta\Model\Exif\Ifd;
+use MagicSunday\ImageMeta\Model\Exif\IfdEntry;
+use MagicSunday\ImageMeta\Model\Exif\ParsedExif;
+use MagicSunday\ImageMeta\Value\CfaPattern;
+use MagicSunday\ImageMeta\Value\Enum\CfaPatternColor;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(ParsedExif::class)]
+final class ParsedExifCfaPatternTest extends TestCase
+{
+    #[Test]
+    public function parsesCfaPatternWithRepeatUnits(): void
+    {
+        $cfaPattern = new IfdEntry(
+            ExifTag::CFA_PATTERN,
+            7,
+            6,
+            new ExifNumericList([2, 2, 0, 1, 2, 1]),
+        );
+
+        $exifIfd   = new Ifd([ExifTag::CFA_PATTERN => $cfaPattern]);
+        $parsedExif = new ParsedExif(new Ifd([]), $exifIfd, null, null, null);
+
+        $pattern = $parsedExif->cfaPattern();
+
+        self::assertInstanceOf(CfaPattern::class, $pattern);
+        self::assertSame(2, $pattern->horizontalRepeatPixelUnit);
+        self::assertSame(2, $pattern->verticalRepeatPixelUnit);
+        self::assertSame([
+            [CfaPatternColor::RED, CfaPatternColor::GREEN],
+            [CfaPatternColor::BLUE, CfaPatternColor::GREEN],
+        ], $pattern->grid());
+    }
+
+    #[Test]
+    public function returnsNullWhenPatternIsIncomplete(): void
+    {
+        $cfaPattern = new IfdEntry(
+            ExifTag::CFA_PATTERN,
+            7,
+            4,
+            new ExifNumericList([2, 2, 0, 1]),
+        );
+
+        $exifIfd   = new Ifd([ExifTag::CFA_PATTERN => $cfaPattern]);
+        $parsedExif = new ParsedExif(new Ifd([]), $exifIfd, null, null, null);
+
+        self::assertNull($parsedExif->cfaPattern());
+    }
+}

--- a/tests/Parse/Tiff/TiffExifReaderGpsReferenceTest.php
+++ b/tests/Parse/Tiff/TiffExifReaderGpsReferenceTest.php
@@ -177,6 +177,7 @@ final class TiffExifReaderGpsReferenceTest extends TestCase
             . $ifd0NextOffset;
         $gpsIfdLength   = strlen($gpsIfdPlaceholder);
         $gpsDataOffset  = strlen($header . $ifd0) + $gpsIfdLength;
+        $lonOffset      = $gpsDataOffset + (3 * 8);
 
         $gpsIfd = $gpsEntryCount
             // GPSLatitudeRef = "S" (inline)

--- a/tests/Value/SensorTest.php
+++ b/tests/Value/SensorTest.php
@@ -12,6 +12,8 @@ declare(strict_types=1);
 namespace MagicSunday\ImageMeta\Tests\Value;
 
 use MagicSunday\ImageMeta\Value\Enum\ResolutionUnit;
+use MagicSunday\ImageMeta\Value\Enum\CfaPatternColor;
+use MagicSunday\ImageMeta\Value\CfaPattern;
 use MagicSunday\ImageMeta\Value\Sensor;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
@@ -40,7 +42,18 @@ final class SensorTest extends TestCase
     #[Test]
     public function constructsWithCFAPattern(): void
     {
-        $cfaPattern = [0, 1, 1, 2]; // Bayer RGGB pattern
+        $cfaPattern = CfaPattern::fromComponents(
+            horizontalRepeatPixelUnit: 2,
+            verticalRepeatPixelUnit: 2,
+            componentIdentifiers: [
+                CfaPatternColor::RED->value,
+                CfaPatternColor::GREEN->value,
+                CfaPatternColor::GREEN->value,
+                CfaPatternColor::BLUE->value,
+            ],
+        );
+
+        self::assertInstanceOf(CfaPattern::class, $cfaPattern);
 
         $sensor = new Sensor(
             pixelPitchUm: null,
@@ -50,6 +63,7 @@ final class SensorTest extends TestCase
         );
 
         self::assertSame($cfaPattern, $sensor->cfaPattern);
+        self::assertSame(CfaPatternColor::RED, $cfaPattern->colors[0]);
     }
 
     #[Test]


### PR DESCRIPTION
<!--
PR-Titel-Empfehlung:
M#: <kurze Beschreibung> — <Bereich>
Beispiel: M1: Unify binary readers — Core/Stream
-->

## Summary
<!-- Kurzbeschreibung der Änderung und des Ziels. -->

**Issue/Milestone:** Closes #<ID> • Milestone M#
**Scope (allowed files only):** <!-- Liste der Dateien/Verzeichnisse, die in diesem PR geändert werden dürfen. -->
**Non-Goals:** <!-- Was explizit NICHT Bestandteil ist. -->

---

## Implementation Notes
- Runtime: PHP 8.4, `declare(strict_types=1);`, PSR-12.
- **Streaming only** (Core\Stream/StreamWindow) — keine Ganzdatei-Reads.
- Keine externen Binaries/Extensions; **kein** `exif_read_data()`.
- Value Objects (chainable) nur für EXIF-Ausgabe; kein Rendering.
- **Enums** für gängige Kodierungen genutzt/ergänzt (Encoding/Endianness/IFD/XMP/...).
- **Spec-References** im Code ergänzt/aktualisiert (siehe „References“).

---

## Always Checklist (must be green)
**Composer-Tasks (deine CI-Skripte):**
- [ ] Lint: `composer ci:test:php:lint`
- [ ] PHPStan: `composer ci:test:php:phpstan`
- [ ] Rector (dry-run): `composer ci:test:php:rector`
- [ ] Coding-Style: `composer ci::cgl`
- [ ] PHPUnit: `composer ci:test:php:unit`
- [ ] Coverage ≥ **90 %**: `composer ci:test:php:unit:coverage`
- [ ] JSCPD (Duplikate = 0): `composer ci:test:php:cpd`
- [ ] Sammellauf: `composer ci:test` (sollte grün sein; enthält Lint, PHPStan, Rector-Dry-Run, CS-Dry-Run, Unit)

**Inhaltliche/Code-Guidelines:**
- [ ] **Keine** `mixed`-Signaturen • **kein** `empty()` • **keine** verschachtelten Ternaries
- [ ] Fully-qualified native functions (`\strlen`, `\count`, …) und sinnvolle `use`-Imports
- [ ] **Keine** dynamischen Aufrufe statischer Methoden
- [ ] Sinnvolle **Interfaces** verwendet (wo Verträge sinnvoll sind)
- [ ] Typisierte Klassenkonstanten; redundante Casts/Default-Argumente entfernt
- [ ] Klassen als `readonly`, wo passend; keine redundanten `readonly`-Mods
- [ ] **Eine Klasse je Datei** • Test-Namespaces spiegeln `src/`-Struktur
- [ ] Englische PHPDocs & englische Inline-Kommentare an komplexen Stellen
- [ ] Sinnvolle Namen für Variablen/Konstanten; Magic Numbers/Strings vermieden
- [ ] `array_find` / `array_any` / `array_all` gezielt statt trivialer `foreach` verwendet (wo es die Lesbarkeit verbessert)

---

## EXIF / TIFF / ISOBMFF / XMP Guardrails
- **EXIF-Versionen:** 1.x, 2.x (2.1/2.2/2.21/2.3/2.31/2.32), 3.0 — kompatible Änderungen; falls Tags betroffen: Coverage-Test grün.
- **TIFF/BigTIFF:** Endianness korrekt (`0x2A` / `0x2B`), Inline-Werte-Grenzen, `RATIONAL/SRATIONAL` korrekt.
- **GPS:** Vorzeichen über Ref-Tags (S/W negativ); `0/0`-Kantenfälle robust.
- **Preview/IFD1:** Nur beschreiben (Offsets/Längen/Compression), kein Rendering.
- **ISOBMFF/QuickTime:** Box-Size ≥ Header, 32/64-bit-Größen korrekt; `iloc`-Extents summiert; `data_reference_index ≠ 0` → skip; keine Remote-Refs.
- **XMP:** JPEG APP1-Präfix / ISOBMFF `uuid`; Parser mit `LIBXML_NONET`, keine DTD/Entities; `Alt/Bag/Seq` → Arrays.
- **Fehlerbehandlung:** ausschließlich `ParseError` oder `BoundsError`; keine Warnings/Notices als Kontrollfluss.

---

## Tests
- **Neue/angepasste Tests:** <!-- Auflisten: Klassen/Methoden/Edge-Cases -->
- **Negative Cases:** <!-- Welche Fehlerbilder werden abgedeckt? -->
- **Fixtures/Streams:** <!-- Synthetische Blobs bevorzugt; große Binärdateien vermeiden. -->

---

Summary of changes:
- Parsed EXIF CFA pattern payloads into structured repeat units and colour grids.
- Decoded CFA pattern UNDEFINED data with TIFF endianness handling during parsing.
- Updated sensor aggregation/tests and corrected the BigTIFF GPS fixture offsets.

## M# Sweep — Verify compliance for this milestone
Bitte **alles** verifizieren und kurz die Ergebnisse notieren:
- [ ] `composer ci:test` **grün** (Lint, PHPStan, Rector-Dry-Run, CS-Dry-Run, Unit)
- [ ] `composer ci:test:php:cpd` **0 Duplikate** (JSCPD, Konfig: `.build/.jscpd.json`)
- [ ] `composer ci:test:php:unit:coverage` **≥ 90 %**
- [ ] **ExifCoverageTest** (falls vorhanden): 0 fehlende Tags/Getters (gegen `resources/exif-map.yaml`)
- [ ] Für **jede** Klasse existiert ein Test (Namespace-Spiegelung)

---

## Breaking Changes / Risk / Rollback
- **Breaking changes:** <!-- falls ja: welche und warum notwendig -->
- **Risiken:** <!-- Parser-Sensitivität, Performance, Abhängigkeiten -->
- **Rollback-Plan:** <!-- einfache Revert-Strategie / Feature-Flag falls nötig -->

---

## Changelog
<!-- Kurz und im Stil der Conventional Commits zusammenfassen. -->

---

## References (Specs & Docs)
<!-- Liste der relevanten Kapitel/Abschnitte, jeweils aktuellste Fassung + abweichende ältere, falls relevant -->
- EXIF 3.0 §… ; ggf. EXIF 2.32 §… ; EXIF 2.31 §…
- TIFF 6.0 §…
- ISOBMFF/QuickTime §…
- XMP (Adobe XMP Packet) §…

Docs im Repo:
- `docs/EXIF-210.pdf`, `docs/EXIF-220.pdf`, `docs/EXIF-230.pdf`, `docs/EXIF-231.pdf`, `docs/EXIF-232.pdf`, `docs/EXIF-300.pdf`
- `docs/TIFF6.pdf`

---

## Review Roles (tick what you covered)
- [ ] Planner (Scope/Non-Goals/Guardrails definiert)
- [ ] Spec Writer (AC/Tests präzisiert)
- [ ] Test Agent (RED zuerst)
- [ ] Implementer (GREEN minimal & im Datei-Scope)
- [ ] Static/QA (Stan/CS/Rector/JSCPD clean)
- [ ] Security (Bounds, Offsets, XML-Flags)
- [ ] Reviewer (Minimalität, DX, Spec-Refs, Enums)
- [ ] Release (PR-Text, Labels, Milestone, „Closes #…")

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6939299955008323bce88a490cb23101)