### PR TITLE
M?: Align composite and subject distance enums — EXIF

### DIFF
--- a/src/Model/Exif/ParsedExif.php
+++ b/src/Model/Exif/ParsedExif.php
@@ -1334,6 +1334,9 @@ final readonly class ParsedExif
 
     /**
      * Returns the composite image classification when available.
+     *
+     * EXIF 3.0 §4.6.6.7.47 (also EXIF 2.32 §4.6.6.7.47) defines the
+     * CompositeImage tag with four enumerated states, reserving all others.
      */
     public function compositeImage(): ?CompositeImage
     {
@@ -2533,6 +2536,9 @@ final readonly class ParsedExif
 
     /**
      * Returns the subject distance range enum when provided.
+     *
+     * EXIF 3.0 §4.6.6.7.46 (retained from EXIF 2.32 §4.6.6.7.46) provides the
+     * four valid SubjectDistanceRange codes; other values are reserved.
      */
     public function subjectDistanceRange(): ?SubjectDistanceRange
     {

--- a/src/Value/Enum/CompositeImage.php
+++ b/src/Value/Enum/CompositeImage.php
@@ -15,8 +15,11 @@ use MagicSunday\ImageMeta\Exif\Support\EnumFromIntStringNullable;
 
 /**
  * Enumerates the composite image classifications defined for the CompositeImage
- * tag in EXIF 3.0 §4.6.3 (shooting conditions), continuing the set introduced
- * in EXIF 2.32 §4.6.3.
+ * tag.
+ *
+ * EXIF 3.0 §4.6.6.7.47 defines 0 = Unknown, 1 = Non-composite image, 2 =
+ * General composite image, 3 = Composite image captured when shooting. EXIF
+ * 2.32 §4.6.6.7.47 retains the same numeric encodings and reserved range.
  */
 enum CompositeImage: int
 {

--- a/src/Value/Enum/SubjectDistanceRange.php
+++ b/src/Value/Enum/SubjectDistanceRange.php
@@ -15,8 +15,11 @@ use MagicSunday\ImageMeta\Exif\Support\EnumFromIntStringNullable;
 
 /**
  * Enumerates the subject distance range classifications assigned to the
- * SubjectDistanceRange tag in EXIF 3.0 §4.6.3 (shooting conditions), retained
- * from EXIF 2.32 §4.6.3.
+ * SubjectDistanceRange tag.
+ *
+ * EXIF 3.0 §4.6.6.7.46 codifies the four allowed values (0 = unknown, 1 =
+ * Macro, 2 = Close view, 3 = Distant view). EXIF 2.32 §4.6.6.7.46 retains the
+ * same value set and reserved handling.
  */
 enum SubjectDistanceRange: int
 {

--- a/tests/Value/Enum/EnumMappingTest.php
+++ b/tests/Value/Enum/EnumMappingTest.php
@@ -134,6 +134,26 @@ final class EnumMappingTest extends TestCase
     }
 
     /**
+     * Rejects reserved subject distance range codes outside the defined set.
+     */
+    #[Test]
+    public function returnsNullForReservedSubjectDistanceRanges(): void
+    {
+        self::assertNull(SubjectDistanceRange::fromExifValue(4));
+        self::assertNull(SubjectDistanceRange::fromExifValue('9'));
+    }
+
+    /**
+     * Rejects composite image codes outside the enumerated EXIF range.
+     */
+    #[Test]
+    public function returnsNullForReservedCompositeImageCodes(): void
+    {
+        self::assertNull(CompositeImage::fromExifValue(4));
+        self::assertNull(CompositeImage::fromExifValue('7'));
+    }
+
+    /**
      * Rejects reserved photometric interpretations outside the EXIF allowed set.
      *
      * EXIF 3.0 §4.6.5.1.5 limits PhotometricInterpretation to RGB (2) and YCbCr (6).


### PR DESCRIPTION
## Summary
Refines EXIF enum handling for composite and subject distance tags and adds guard-rail tests.

**Issue/Milestone:** Closes #N/A • Milestone M?
**Scope (allowed files only):** src/Model/Exif/ParsedExif.php; src/Value/Enum/CompositeImage.php; src/Value/Enum/SubjectDistanceRange.php; tests/Value/Enum/EnumMappingTest.php
**Non-Goals:** No additional EXIF tag mappings beyond CompositeImage and SubjectDistanceRange.

---

## Implementation Notes
- Runtime: PHP 8.4, `declare(strict_types=1);`, PSR-12.
- **Streaming only** (Core\Stream/StreamWindow) — keine Ganzdatei-Reads.
- Keine externen Binaries/Extensions; **kein** `exif_read_data()`.
- Value Objects (chainable) nur für EXIF-Ausgabe; kein Rendering.
- **Enums** für gängige Kodierungen genutzt/ergänzt (Encoding/Endianness/IFD/XMP/...).
- **Spec-References** im Code ergänzt/aktualisiert (siehe „References“).

---

## Always Checklist (must be green)
**Composer-Tasks (deine CI-Skripte):**
- [ ] Lint: `composer ci:test:php:lint`
- [ ] PHPStan: `composer ci:test:php:phpstan`
- [ ] Rector (dry-run): `composer ci:test:php:rector`
- [ ] Coding-Style: `composer ci::cgl`
- [ ] PHPUnit: `composer ci:test:php:unit`
- [ ] Coverage ≥ **90 %**: `composer ci:test:php:unit:coverage`
- [ ] JSCPD (Duplikate = 0): `composer ci:test:php:cpd`
- [ ] Sammellauf: `composer ci:test` (sollte grün sein; enthält Lint, PHPStan, Rector-Dry-Run, CS-Dry-Run, Unit)

**Inhaltliche/Code-Guidelines:**
- [ ] **Keine** `mixed`-Signaturen • **kein** `empty()` • **keine** verschachtelten Ternaries
- [ ] Fully-qualified native functions (`\strlen`, `\count`, …) und sinnvolle `use`-Imports
- [ ] **Keine** dynamischen Aufrufe statischer Methoden
- [ ] Sinnvolle **Interfaces** verwendet (wo Verträge sinnvoll sind)
- [ ] Typisierte Klassenkonstanten; redundante Casts/Default-Argumente entfernt
- [ ] Klassen als `readonly`, wo passend; keine redundanten `readonly`-Mods
- [ ] **Eine Klasse je Datei** • Test-Namespaces spiegeln `src/`-Struktur
- [ ] Englische PHPDocs & englische Inline-Kommentare an komplexen Stellen
- [ ] Sinnvolle Namen für Variablen/Konstanten; Magic Numbers/Strings vermieden
- [ ] `array_find` / `array_any` / `array_all` gezielt statt trivialer `foreach` verwendet (wo es die Lesbarkeit verbessert)

---

## EXIF / TIFF / ISOBMFF / XMP Guardrails
- **EXIF-Versionen:** 1.x, 2.x (2.1/2.2/2.21/2.3/2.31/2.32), 3.0 — kompatible Änderungen; falls Tags betroffen: Coverage-Test grün.
- **TIFF/BigTIFF:** Endianness korrekt (`0x2A` / `0x2B`), Inline-Werte-Grenzen, `RATIONAL/SRATIONAL` korrekt.
- **GPS:** Vorzeichen über Ref-Tags (S/W negativ); `0/0`-Kantenfälle robust.
- **Preview/IFD1:** Nur beschreiben (Offsets/Längen/Compression), kein Rendering.
- **ISOBMFF/QuickTime:** Box-Size ≥ Header, 32/64-bit-Größen korrekt; `iloc`-Extents summiert; `data_reference_index ≠ 0` → skip; keine Remote-Refs.
- **XMP:** JPEG APP1-Präfix / ISOBMFF `uuid`; Parser mit `LIBXML_NONET`, keine DTD/Entities; `Alt/Bag/Seq` → Arrays.
- **Fehlerbehandlung:** ausschließlich `ParseError` oder `BoundsError`; keine Warnings/Notices als Kontrollfluss.

---

## Tests
- **Neue/angepasste Tests:** EnumMappingTest coverage for CompositeImage and SubjectDistanceRange reserved values
- **Negative Cases:** Reserved EXIF codes for composite and subject distance range return null
- **Fixtures/Streams:** None added (logic-only enum validation)

---

## Additional Notes
- PHPUnit (`composer ci:test:php:unit`) currently fails in the base branch with undefined `Compression::JPEG_OLD_STYLE` and a GPS BigTIFF expectation; see test output for details.

---

## M# Sweep — Verify compliance for this milestone
Bitte **alles** verifizieren und kurz die Ergebnisse notieren:
- [ ] `composer ci:test` **grün** (Lint, PHPStan, Rector-Dry-Run, CS-Dry-Run, Unit)
- [ ] `composer ci:test:php:cpd` **0 Duplikate** (JSCPD, Konfig: `.build/.jscpd.json`)
- [ ] `composer ci:test:php:unit:coverage` **≥ 90 %**
- [ ] **ExifCoverageTest** (falls vorhanden): 0 fehlende Tags/Getters (gegen `resources/exif-map.yaml`)
- [ ] Für **jede** Klasse existiert ein Test (Namespace-Spiegelung)

---

## Breaking Changes / Risk / Rollback
- **Breaking changes:** None
- **Risiken:** None beyond existing CI failures on base branch
- **Rollback-Plan:** Revert commit

---

## Changelog
- chore(exif): align composite and subject distance enums with EXIF value constraints

---

## References (Specs & Docs)
- EXIF 3.0 §4.6.6.7.46; EXIF 2.32 §4.6.6.7.46
- EXIF 3.0 §4.6.6.7.47; EXIF 2.32 §4.6.6.7.47

Docs im Repo:
- `docs/EXIF-210.pdf`, `docs/EXIF-220.pdf`, `docs/EXIF-230.pdf`, `docs/EXIF-231.pdf`, `docs/EXIF-232.pdf`, `docs/EXIF-300.pdf`
- `docs/TIFF6.pdf`

---

## Review Roles (tick what you covered)
- [ ] Planner (Scope/Non-Goals/Guardrails definiert)
- [ ] Spec Writer (AC/Tests präzisiert)
- [ ] Test Agent (RED zuerst)
- [ ] Implementer (GREEN minimal & im Datei-Scope)
- [ ] Static/QA (Stan/CS/Rector/JSCPD clean)
- [ ] Security (Bounds, Offsets, XML-Flags)
- [ ] Reviewer (Minimalität, DX, Spec-Refs, Enums)
- [ ] Release (PR-Text, Labels, Milestone, „Closes #…“)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693929f6e8548323b1a8acf7395b98ca)