### PR TITLE
M#: Validate composite source counts — EXIF

### DIFF
--- a/src/Model/Exif/ParsedExif.php
+++ b/src/Model/Exif/ParsedExif.php
@@ -1345,17 +1345,32 @@ final readonly class ParsedExif
     /**
      * Returns the number of source images contributing to the composite result.
      *
+     * EXIF 3.0 §4.6.6.7.48 (EXIF 2.32 §4.6.6.7.48) records both the total number of
+     * captured source images and how many were actually used to assemble the
+     * composite. Figure 24 requires two SHORT values where both counters are at
+     * least two and the used count cannot exceed the captured total.
+     *
      * @return array{0:int,1:int}|null
      */
     public function sourceImageNumberOfCompositeImage(): ?array
     {
         $values = $this->numericList($this->exifIfd, ExifTag::SOURCE_IMAGE_NUMBER_OF_COMPOSITE_IMAGE);
 
-        if ($values === null || count($values) !== 2) {
+        if (($values === null) || (count($values) !== 2)) {
             return null;
         }
 
-        return [$values[0], $values[1]];
+        [$capturedCount, $usedCount] = $values;
+
+        if (($capturedCount < 2) || ($usedCount < 2)) {
+            return null;
+        }
+
+        if ($usedCount > $capturedCount) {
+            return null;
+        }
+
+        return [$capturedCount, $usedCount];
     }
 
     /**

--- a/src/Value/CompositeImageInfo.php
+++ b/src/Value/CompositeImageInfo.php
@@ -22,7 +22,7 @@ final readonly class CompositeImageInfo
      * Creates a composite image information metadata value object.
      *
      * @param CompositeImage|null     $type               Composite image classification.
-     * @param array{0:int,1:int}|null $counts             Pair of [sourceCount, usedCount].
+     * @param array{0:int,1:int}|null $counts             Pair of [capturedTotal, usedForComposite].
      * @param list<float>|null        $exposureTimesTotal Exposure times for contributing frames.
      */
     public function __construct(

--- a/tests/Model/Exif/ParsedExifCompositeImageTest.php
+++ b/tests/Model/Exif/ParsedExifCompositeImageTest.php
@@ -1,0 +1,82 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\ImageMeta\Tests\Model\Exif;
+
+use MagicSunday\ImageMeta\Model\Exif\ExifTag;
+use MagicSunday\ImageMeta\Model\Exif\Ifd;
+use MagicSunday\ImageMeta\Model\Exif\IfdEntry;
+use MagicSunday\ImageMeta\Model\Exif\ParsedExif;
+use MagicSunday\ImageMeta\Parse\Tiff\TiffConst;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for composite image source count decoding.
+ */
+#[CoversClass(ParsedExif::class)]
+final class ParsedExifCompositeImageTest extends TestCase
+{
+    #[Test]
+    public function returnsCountsWhenValuesMeetSpecRequirements(): void
+    {
+        $ifd0    = new Ifd([]);
+        $exifIfd = new Ifd([
+            ExifTag::SOURCE_IMAGE_NUMBER_OF_COMPOSITE_IMAGE => new IfdEntry(
+                ExifTag::SOURCE_IMAGE_NUMBER_OF_COMPOSITE_IMAGE,
+                TiffConst::TYPE_SHORT,
+                2,
+                [6, 4],
+            ),
+        ]);
+
+        $parsedExif = new ParsedExif($ifd0, $exifIfd, null, null, null);
+
+        self::assertSame([6, 4], $parsedExif->sourceImageNumberOfCompositeImage());
+    }
+
+    #[Test]
+    public function returnsNullWhenCountsAreBelowMinimum(): void
+    {
+        $ifd0    = new Ifd([]);
+        $exifIfd = new Ifd([
+            ExifTag::SOURCE_IMAGE_NUMBER_OF_COMPOSITE_IMAGE => new IfdEntry(
+                ExifTag::SOURCE_IMAGE_NUMBER_OF_COMPOSITE_IMAGE,
+                TiffConst::TYPE_SHORT,
+                2,
+                [1, 0],
+            ),
+        ]);
+
+        $parsedExif = new ParsedExif($ifd0, $exifIfd, null, null, null);
+
+        self::assertNull($parsedExif->sourceImageNumberOfCompositeImage());
+    }
+
+    #[Test]
+    public function returnsNullWhenUsedCountExceedsCapturedTotal(): void
+    {
+        $ifd0    = new Ifd([]);
+        $exifIfd = new Ifd([
+            ExifTag::SOURCE_IMAGE_NUMBER_OF_COMPOSITE_IMAGE => new IfdEntry(
+                ExifTag::SOURCE_IMAGE_NUMBER_OF_COMPOSITE_IMAGE,
+                TiffConst::TYPE_SHORT,
+                2,
+                [3, 5],
+            ),
+        ]);
+
+        $parsedExif = new ParsedExif($ifd0, $exifIfd, null, null, null);
+
+        self::assertNull($parsedExif->sourceImageNumberOfCompositeImage());
+    }
+}


### PR DESCRIPTION
## Summary
- Validate composite source image counts against EXIF Figure 24 requirements and ignore invalid pairs.
- Add unit coverage for SourceImageNumberOfCompositeImage edge cases.

**Issue/Milestone:** Closes #N/A • Milestone M#
**Scope (allowed files only):** src/Model/Exif/ParsedExif.php; src/Value/CompositeImageInfo.php; tests/Model/Exif/ParsedExifCompositeImageTest.php
**Non-Goals:** Broader composite image metadata beyond SourceImageNumberOfCompositeImage.

---

## Implementation Notes
- Runtime: PHP 8.4, `declare(strict_types=1);`, PSR-12.
- **Streaming only** (Core\Stream/StreamWindow) — keine Ganzdatei-Reads.
- Keine externen Binaries/Extensions; **kein** `exif_read_data()`.
- Value Objects (chainable) nur für EXIF-Ausgabe; kein Rendering.
- **Enums** für gängige Kodierungen genutzt/ergänzt (Encoding/Endianness/IFD/XMP/...).
- **Spec-References** im Code ergänzt/aktualisiert (siehe „References“).

---

## Always Checklist (must be green)
**Composer-Tasks (deine CI-Skripte):**
- [ ] Lint: `composer ci:test:php:lint`
- [ ] PHPStan: `composer ci:test:php:phpstan`
- [ ] Rector (dry-run): `composer ci:test:php:rector`
- [ ] Coding-Style: `composer ci::cgl`
- [ ] PHPUnit: `composer ci:test:php:unit`
- [ ] Coverage ≥ **90 %**: `composer ci:test:php:unit:coverage`
- [ ] JSCPD (Duplikate = 0): `composer ci:test:php:cpd`
- [ ] Sammellauf: `composer ci:test` (sollte grün sein; enthält Lint, PHPStan, Rector-Dry-Run, CS-Dry-Run, Unit)

**Inhaltliche/Code-Guidelines:**
- [ ] **Keine** `mixed`-Signaturen • **kein** `empty()` • **keine** verschachtelten Ternaries
- [ ] Fully-qualified native functions (`\\strlen`, `\\count`, …) und sinnvolle `use`-Imports
- [ ] **Keine** dynamischen Aufrufe statischer Methoden
- [ ] Sinnvolle **Interfaces** verwendet (wo Verträge sinnvoll sind)
- [ ] Typisierte Klassenkonstanten; redundante Casts/Default-Argumente entfernt
- [ ] Klassen als `readonly`, wo passend; keine redundanten `readonly`-Mods
- [ ] **Eine Klasse je Datei** • Test-Namespaces spiegeln `src/`-Struktur
- [ ] Englische PHPDocs & englische Inline-Kommentare an komplexen Stellen
- [ ] Sinnvolle Namen für Variablen/Konstanten; Magic Numbers/Strings vermieden
- [ ] `array_find` / `array_any` / `array_all` gezielt statt trivialer `foreach` verwendet (wo es die Lesbarkeit verbessert)

---

## EXIF / TIFF / ISOBMFF / XMP Guardrails
- **EXIF-Versionen:** 1.x, 2.x (2.1/2.2/2.21/2.3/2.31/2.32), 3.0 — kompatible Änderungen; falls Tags betroffen: Coverage-Test grün.
- **TIFF/BigTIFF:** Endianness korrekt (`0x2A` / `0x2B`), Inline-Werte-Grenzen, `RATIONAL/SRATIONAL` korrekt.
- **GPS:** Vorzeichen über Ref-Tags (S/W negativ); `0/0`-Kantenfälle robust.
- **Preview/IFD1:** Nur beschreiben (Offsets/Längen/Compression), kein Rendering.
- **ISOBMFF/QuickTime:** Box-Size ≥ Header, 32/64-bit-Größen korrekt; `iloc`-Extents summiert; `data_reference_index ≠ 0` → skip; keine Remote-Refs.
- **XMP:** JPEG APP1-Präfix / ISOBMFF `uuid`; Parser mit `LIBXML_NONET`, keine DTD/Entities; `Alt/Bag/Seq` → Arrays.
- **Fehlerbehandlung:** ausschließlich `ParseError` oder `BoundsError`; keine Warnings/Notices als Kontrollfluss.

---

## Tests
- **Neue/angepasste Tests:** ParsedExifCompositeImageTest validates SourceImageNumberOfCompositeImage valid/invalid pairs.
- **Negative Cases:** Invalid counts below the EXIF minimum and used count exceeding captured total.
- **Fixtures/Streams:** Synthetic IFD entries defined inline.

---

## Additional Notes
- SourceImageNumberOfCompositeImage is validated against EXIF Figure 24 minimum counts before being exposed.

## M# Sweep — Verify compliance for this milestone
Bitte **alles** verifizieren und kurz die Ergebnisse notieren:
- [ ] `composer ci:test` **grün** (Lint, PHPStan, Rector-Dry-Run, CS-Dry-Run, Unit)
- [ ] `composer ci:test:php:cpd` **0 Duplikate** (JSCPD, Konfig: `.build/.jscpd.json`)
- [ ] `composer ci:test:php:unit:coverage` **≥ 90 %**
- [ ] **ExifCoverageTest** (falls vorhanden): 0 fehlende Tags/Getters (gegen `resources/exif-map.yaml`)
- [ ] Für **jede** Klasse existiert ein Test (Namespace-Spiegelung)

---

## Breaking Changes / Risk / Rollback
- **Breaking changes:**
- **Risiken:**
- **Rollback-Plan:**

---

## Changelog

---

## References (Specs & Docs)
- EXIF 3.0 §4.6.6.7.48; EXIF 2.32 §4.6.6.7.48
- TIFF 6.0 §…
- ISOBMFF/QuickTime §…
- XMP (Adobe XMP Packet) §…

Docs im Repo:
- `docs/EXIF-210.pdf`, `docs/EXIF-220.pdf`, `docs/EXIF-230.pdf`, `docs/EXIF-231.pdf`, `docs/EXIF-232.pdf`, `docs/EXIF-300.pdf`
- `docs/TIFF6.pdf`

---

## Review Roles (tick what you covered)
- [ ] Planner (Scope/Non-Goals/Guardrails definiert)
- [ ] Spec Writer (AC/Tests präzisiert)
- [ ] Test Agent (RED zuerst)
- [ ] Implementer (GREEN minimal & im Datei-Scope)
- [ ] Static/QA (Stan/CS/Rector/JSCPD clean)
- [ ] Security (Bounds, Offsets, XML-Flags)
- [ ] Reviewer (Minimalität, DX, Spec-Refs, Enums)
- [ ] Release (PR-Text, Labels, Milestone, „Closes #…“)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69392a0b0bd08323b183f09f41dcc788)