### PR TITLE
fix(tiff): validate fixed-length EXIF tag counts

### DIFF
--- a/src/Parse/Tiff/TiffExifReader.php
+++ b/src/Parse/Tiff/TiffExifReader.php
@@ -92,6 +92,46 @@ final class TiffExifReader implements ExifReaderInterface
         ExifTag::JPEG_INTERCHANGE_FORMAT,
     ];
 
+    /**
+     * Fixed-length tags that must contain exactly four bytes.
+     *
+     * EXIF 3.0 §4.6.6.1.1 (ExifVersion), §4.6.6.1.2 (FlashpixVersion),
+     * §4.6.6.1.3 (ComponentsConfiguration), and §4.6.8 (GPSVersionID) mandate
+     * four-byte payloads. The requirements are unchanged in EXIF 2.32 for these tags.
+     *
+     * @var array<int, array{name: string, count: int, type: int, typeName: string, spec: string}>
+     */
+    private const array FIXED_LENGTH_TAGS = [
+        ExifTag::EXIF_VERSION => [
+            'name' => 'ExifVersion',
+            'count' => 4,
+            'type' => TiffConst::TYPE_ASCII,
+            'typeName' => 'ASCII',
+            'spec' => 'EXIF 3.0 §4.6.6.1.1; EXIF 2.32 §4.6.6.1.1',
+        ],
+        ExifTag::FLASHPIX_VERSION => [
+            'name' => 'FlashpixVersion',
+            'count' => 4,
+            'type' => TiffConst::TYPE_ASCII,
+            'typeName' => 'ASCII',
+            'spec' => 'EXIF 3.0 §4.6.6.1.2; EXIF 2.32 §4.6.6.1.2',
+        ],
+        ExifTag::COMPONENTS_CONFIGURATION => [
+            'name' => 'ComponentsConfiguration',
+            'count' => 4,
+            'type' => TiffConst::TYPE_UNDEFINED,
+            'typeName' => 'UNDEFINED',
+            'spec' => 'EXIF 3.0 §4.6.6.1.3; EXIF 2.32 §4.6.6.1.3',
+        ],
+        ExifTag::GPS_VERSION_ID => [
+            'name' => 'GPSVersionID',
+            'count' => 4,
+            'type' => TiffConst::TYPE_BYTE,
+            'typeName' => 'BYTE',
+            'spec' => 'EXIF 3.0 §4.6.8; EXIF 2.32 §4.6.8',
+        ],
+    ];
+
     private const int ASCII_PRINTABLE_MIN = 0x20;
 
     private const int ASCII_PRINTABLE_MAX = 0x7E;
@@ -348,6 +388,8 @@ final class TiffExifReader implements ExifReaderInterface
         $type = $this->readU16();
         $cnt  = $this->bigTiff ? $this->readU64()->toInt('directory entry value count') : $this->readU32();
 
+        $this->validateFixedLengthTagLayout($tag, $type, $cnt);
+
         if ($this->bigTiff) {
             // BigTIFF stores the inline value/offset field as an 8- or 16-byte
             // quantity (EXIF 3.0 §4.5.2 BigTIFF note) with inline payloads padded
@@ -379,6 +421,36 @@ final class TiffExifReader implements ExifReaderInterface
         }
 
         return [$tag => new IfdEntry($tag, $type, $cnt, $value)];
+    }
+
+    /**
+     * Validates tag layouts with fixed byte counts mandated by EXIF.
+     */
+    private function validateFixedLengthTagLayout(int $tag, int $type, int $count): void
+    {
+        if (!isset(self::FIXED_LENGTH_TAGS[$tag])) {
+            return;
+        }
+
+        $rule = self::FIXED_LENGTH_TAGS[$tag];
+
+        if ($count !== $rule['count']) {
+            throw new ParseError(sprintf(
+                '%s must contain exactly %d bytes per %s.',
+                $rule['name'],
+                $rule['count'],
+                $rule['spec'],
+            ));
+        }
+
+        if ($type !== $rule['type']) {
+            throw new ParseError(sprintf(
+                '%s must use TIFF type %s per %s.',
+                $rule['name'],
+                $rule['typeName'],
+                $rule['spec'],
+            ));
+        }
     }
 
     /**

--- a/tests/Parse/Tiff/TiffExifReaderFixedLengthTest.php
+++ b/tests/Parse/Tiff/TiffExifReaderFixedLengthTest.php
@@ -1,0 +1,154 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\ImageMeta\Tests\Parse\Tiff;
+
+use MagicSunday\ImageMeta\Core\BitMask;
+use MagicSunday\ImageMeta\Core\Endian;
+use MagicSunday\ImageMeta\Core\MemoryBuffer;
+use MagicSunday\ImageMeta\Core\ParseError;
+use MagicSunday\ImageMeta\Core\Util\UInt64;
+use MagicSunday\ImageMeta\Core\Util\Unpack;
+use MagicSunday\ImageMeta\Model\Exif\ExifNumericList;
+use MagicSunday\ImageMeta\Model\Exif\ExifRational;
+use MagicSunday\ImageMeta\Model\Exif\ExifRationalList;
+use MagicSunday\ImageMeta\Model\Exif\ExifTag;
+use MagicSunday\ImageMeta\Model\Exif\Ifd;
+use MagicSunday\ImageMeta\Model\Exif\IfdEntry;
+use MagicSunday\ImageMeta\Model\Exif\ParsedExif;
+use MagicSunday\ImageMeta\Parse\Tiff\TiffConst;
+use MagicSunday\ImageMeta\Parse\Tiff\TiffExifReader;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\UsesClass;
+use PHPUnit\Framework\TestCase;
+
+use function pack;
+use function strlen;
+use function str_pad;
+use function substr;
+
+#[CoversClass(TiffExifReader::class)]
+#[UsesClass(MemoryBuffer::class)]
+#[UsesClass(BitMask::class)]
+#[UsesClass(Endian::class)]
+#[UsesClass(UInt64::class)]
+#[UsesClass(Unpack::class)]
+#[UsesClass(ParseError::class)]
+#[UsesClass(ExifRational::class)]
+#[UsesClass(ExifRationalList::class)]
+#[UsesClass(ExifNumericList::class)]
+#[UsesClass(Ifd::class)]
+#[UsesClass(IfdEntry::class)]
+#[UsesClass(ParsedExif::class)]
+#[UsesClass(TiffConst::class)]
+final class TiffExifReaderFixedLengthTest extends TestCase
+{
+    #[Test]
+    #[DataProvider('validFixedLengthTagProvider')]
+    public function acceptsFixedLengthTagsWithValidCounts(
+        int $tag,
+        int $type,
+        int $count,
+        string $valueBytes,
+    ): void {
+        $blob = $this->buildClassicTiffWithEntry($tag, $type, $count, $valueBytes);
+
+        $reader = new TiffExifReader();
+
+        $reader->parseFromBlob($blob);
+
+        $this->addToAssertionCount(1);
+    }
+
+    /**
+     * @return array<string, array{0:int,1:int,2:int,3:string}>
+     */
+    public static function validFixedLengthTagProvider(): array
+    {
+        return [
+            'ExifVersion count 4' => [
+                ExifTag::EXIF_VERSION,
+                TiffConst::TYPE_ASCII,
+                4,
+                '0300',
+            ],
+            'FlashpixVersion count 4' => [
+                ExifTag::FLASHPIX_VERSION,
+                TiffConst::TYPE_ASCII,
+                4,
+                '0100',
+            ],
+            'ComponentsConfiguration count 4' => [
+                ExifTag::COMPONENTS_CONFIGURATION,
+                TiffConst::TYPE_UNDEFINED,
+                4,
+                "\x01\x02\x03\x00",
+            ],
+            'GPSVersionID count 4' => [
+                ExifTag::GPS_VERSION_ID,
+                TiffConst::TYPE_BYTE,
+                4,
+                "\x02\x03\x00\x00",
+            ],
+        ];
+    }
+
+    private function buildClassicTiffWithEntry(int $tag, int $type, int $count, string $valueBytes): string
+    {
+        $ifdOffset = 8;
+        $blob      = 'II'
+            . pack('v', TiffConst::MAGIC_CLASSIC)
+            . pack('V', $ifdOffset);
+
+        $blob .= pack('v', 1);
+
+        $componentSize = $this->bytesPerComponent($type);
+        $dataSize      = $componentSize * $count;
+
+        if (strlen($valueBytes) < $dataSize) {
+            $valueBytes = str_pad($valueBytes, $dataSize, "\0");
+        }
+
+        if ($dataSize <= 4) {
+            $inlineBytes = str_pad(substr($valueBytes, 0, $dataSize), 4, "\0");
+
+            $blob .= pack('v', $tag)
+                . pack('v', $type)
+                . pack('V', $count)
+                . $inlineBytes
+                . pack('V', 0);
+
+            return $blob;
+        }
+
+        $valueOffset = $ifdOffset + 2 + 12 + 4;
+
+        $blob .= pack('v', $tag)
+            . pack('v', $type)
+            . pack('V', $count)
+            . pack('V', $valueOffset)
+            . pack('V', 0);
+
+        return $blob . substr($valueBytes, 0, $dataSize);
+    }
+
+    private function bytesPerComponent(int $type): int
+    {
+        return match ($type) {
+            TiffConst::TYPE_ASCII,
+            TiffConst::TYPE_BYTE,
+            TiffConst::TYPE_UNDEFINED => 1,
+            default => 1,
+        };
+    }
+}

--- a/tests/Parse/Tiff/TiffExifReaderNegativeTest.php
+++ b/tests/Parse/Tiff/TiffExifReaderNegativeTest.php
@@ -28,11 +28,15 @@ use MagicSunday\ImageMeta\Model\Exif\ParsedExif;
 use MagicSunday\ImageMeta\Parse\Tiff\TiffConst;
 use MagicSunday\ImageMeta\Parse\Tiff\TiffExifReader;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 
 use function pack;
+use function strlen;
+use function str_pad;
+use function substr;
 
 /**
  * Negative tests for TiffExifReader focusing on malformed and corrupted TIFF/EXIF data.
@@ -322,6 +326,31 @@ final class TiffExifReaderNegativeTest extends TestCase
     }
 
     /**
+     * Ensures fixed-length EXIF tags reject invalid counts.
+     *
+     * EXIF 3.0 §4.6.6.1.1-§4.6.6.1.3 and §4.6.8 require four-byte payloads for
+     * ExifVersion, FlashpixVersion, ComponentsConfiguration, and GPSVersionID.
+     */
+    #[Test]
+    #[DataProvider('invalidFixedLengthTagProvider')]
+    public function rejectsFixedLengthTagsWithInvalidCounts(
+        int $tag,
+        int $type,
+        int $count,
+        string $valueBytes,
+        string $expectedMessage,
+    ): void {
+        $blob = $this->buildClassicTiffWithEntry($tag, $type, $count, $valueBytes);
+
+        $reader = new TiffExifReader();
+
+        $this->expectException(ParseError::class);
+        $this->expectExceptionMessage($expectedMessage);
+
+        $reader->parseFromBlob($blob);
+    }
+
+    /**
      * Builds a minimal valid TIFF blob with a RATIONAL value.
      *
      * @param int $numerator   Numerator for the rational.
@@ -446,5 +475,91 @@ final class TiffExifReaderNegativeTest extends TestCase
         $blob .= pack('V', 0);  // Next IFD
 
         return $blob;
+    }
+
+    /**
+     * @return array<string, array{0:int,1:int,2:int,3:string,4:string}>
+     */
+    public static function invalidFixedLengthTagProvider(): array
+    {
+        return [
+            'ExifVersion expects 4 ASCII bytes' => [
+                ExifTag::EXIF_VERSION,
+                TiffConst::TYPE_ASCII,
+                3,
+                '010',
+                'ExifVersion must contain exactly 4 bytes per EXIF 3.0 §4.6.6.1.1; EXIF 2.32 §4.6.6.1.1.',
+            ],
+            'FlashpixVersion expects 4 ASCII bytes' => [
+                ExifTag::FLASHPIX_VERSION,
+                TiffConst::TYPE_ASCII,
+                3,
+                '010',
+                'FlashpixVersion must contain exactly 4 bytes per EXIF 3.0 §4.6.6.1.2; EXIF 2.32 §4.6.6.1.2.',
+            ],
+            'ComponentsConfiguration expects 4 bytes' => [
+                ExifTag::COMPONENTS_CONFIGURATION,
+                TiffConst::TYPE_UNDEFINED,
+                3,
+                "\x01\x02\x03",
+                'ComponentsConfiguration must contain exactly 4 bytes per EXIF 3.0 §4.6.6.1.3; EXIF 2.32 §4.6.6.1.3.',
+            ],
+            'GPSVersionID expects 4 bytes' => [
+                ExifTag::GPS_VERSION_ID,
+                TiffConst::TYPE_BYTE,
+                3,
+                "\x02\x03\x00",
+                'GPSVersionID must contain exactly 4 bytes per EXIF 3.0 §4.6.8; EXIF 2.32 §4.6.8.',
+            ],
+        ];
+    }
+
+    private function buildClassicTiffWithEntry(int $tag, int $type, int $count, string $valueBytes): string
+    {
+        $ifdOffset = 8;
+        $blob      = 'II'
+            . pack('v', TiffConst::MAGIC_CLASSIC)
+            . pack('V', $ifdOffset);
+
+        $blob .= pack('v', 1);
+
+        $componentSize = $this->bytesPerComponent($type);
+        $dataSize      = $componentSize * $count;
+
+        if (strlen($valueBytes) < $dataSize) {
+            $valueBytes = str_pad($valueBytes, $dataSize, "\0");
+        }
+
+        if ($dataSize <= 4) {
+            $inlineBytes = str_pad(substr($valueBytes, 0, $dataSize), 4, "\0");
+
+            $blob .= pack('v', $tag)
+                . pack('v', $type)
+                . pack('V', $count)
+                . $inlineBytes
+                . pack('V', 0);
+
+            return $blob;
+        }
+
+        $valueOffset = $ifdOffset + 2 + 12 + 4;
+
+        $blob .= pack('v', $tag)
+            . pack('v', $type)
+            . pack('V', $count)
+            . pack('V', $valueOffset)
+            . pack('V', 0);
+
+        return $blob . substr($valueBytes, 0, $dataSize);
+    }
+
+    private function bytesPerComponent(int $type): int
+    {
+        return match ($type) {
+            TiffConst::TYPE_ASCII,
+            TiffConst::TYPE_BYTE,
+            TiffConst::TYPE_UNDEFINED => 1,
+            default => 1,
+        };
     }
 }


### PR DESCRIPTION
### Motivation
- Enforce EXIF fixed-length requirements for tags that must be exactly four bytes to avoid accepting malformed payloads and to follow the spec strictly.
- Prevent subtle parsing/normalisation bugs by failing early with a `ParseError` when counts or types deviate from the EXIF/TIFF expectations.
- Align the TIFF EXIF reader behaviour with EXIF 3.0 (and applicable EXIF 2.32) references for `ExifVersion`, `FlashpixVersion`, `ComponentsConfiguration`, and `GPSVersionID`.
- Provide targeted unit tests (positive and negative) to codify the expected strict behaviour.

### Description
- Added `FIXED_LENGTH_TAGS` mapping in `src/Parse/Tiff/TiffExifReader.php` with tag name, expected `count`, `type`, `typeName` and spec reference for each fixed-length tag.
- Introduced `validateFixedLengthTagLayout()` and invoked it from `readDirEntry()` to raise `ParseError` when `count` or `type` does not match the rule (messages include the spec reference and expected values).
- Added negative test cases in `tests/Parse/Tiff/TiffExifReaderNegativeTest.php` (`rejectsFixedLengthTagsWithInvalidCounts`) that construct malformed IFD entries and assert the thrown `ParseError` and message.
- Added positive tests in `tests/Parse/Tiff/TiffExifReaderFixedLengthTest.php` to confirm valid four-byte layouts are accepted by the reader.

### Testing
- New unit tests added: `tests/Parse/Tiff/TiffExifReaderFixedLengthTest.php` (positive) and `tests/Parse/Tiff/TiffExifReaderNegativeTest.php::rejectsFixedLengthTagsWithInvalidCounts` (negative).
- No automated test suite was executed during this rollout; tests were authored and committed but not run here.
- Recommend running `composer ci:test:php:unit` (or `composer ci:test`) and `composer ci:test:php:phpstan` in CI to verify behaviour and static checks.
- Error messages thrown by the reader include the corresponding EXIF spec clause (e.g. `EXIF 3.0 §4.6.6.1.1`) to aid review and traceability.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69578d57b05c832398413fe1ebfdd346)