### PR TITLE
fix(exif): require ISO speed for ISO latitude

### DIFF
--- a/src/Model/Exif/ParsedExif.php
+++ b/src/Model/Exif/ParsedExif.php
@@ -1187,6 +1187,10 @@ final readonly class ParsedExif
             return null;
         }
 
+        if ($this->isoSpeedValue() === null) {
+            return null;
+        }
+
         if ($this->isoSpeedLatitudeZzz() === null) {
             return null;
         }

--- a/tests/Model/Exif/ParsedExifSensitivityTest.php
+++ b/tests/Model/Exif/ParsedExifSensitivityTest.php
@@ -140,6 +140,7 @@ final class ParsedExifSensitivityTest extends TestCase
     public function returnsIsoLatitudeValues(): void
     {
         $exifIfd = new Ifd([
+            ExifTag::ISO_SPEED              => new IfdEntry(ExifTag::ISO_SPEED, 4, 1, 200),
             ExifTag::ISO_SPEED_LATITUDE_YYY => new IfdEntry(ExifTag::ISO_SPEED_LATITUDE_YYY, 4, 1, 90),
             ExifTag::ISO_SPEED_LATITUDE_ZZZ => new IfdEntry(ExifTag::ISO_SPEED_LATITUDE_ZZZ, 4, 1, 100),
         ]);


### PR DESCRIPTION
### Motivation

- A unit test exposed that `isoSpeedLatitudeYyy()` returned a value without its required related tags, so the behavior was tightened to match EXIF expectations.
- The change aligns the accessor with the EXIF spec requirement for ISO latitude pairing (EXIF 3.0 §4.6.6.7.11) and prevents misleading results when `ISO_SPEED` is absent.

### Description

- Require presence of `ISO_SPEED` by checking `isoSpeedValue()` before returning `isoSpeedLatitudeYyy()` in `src/Model/Exif/ParsedExif.php`.
- Update the test `ParsedExifSensitivityTest::returnsIsoLatitudeValues` to include an `ISO_SPEED` entry so the positive case remains covered (`tests/Model/Exif/ParsedExifSensitivityTest.php`).

### Testing

- Ran the unit test suite with `composer ci:test:php:unit`, which completed successfully and reported `OK (760 tests, 2340 assertions)`.
- The adjusted test that previously failed now passes and the full test run is green.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e44f37d9c832390998a8962c7e22b)