### PR TITLE
Centralize AppleMakerNotes::empty() factory — Curate

### DIFF
--- a/src/Curate/Exif/SubFactory/MotionFactory.php
+++ b/src/Curate/Exif/SubFactory/MotionFactory.php
@@ -36,7 +36,7 @@ final readonly class MotionFactory
         $apple = $metadata->makerNotes?->apple;
 
         if (!$apple instanceof AppleMakerNotes) {
-            $apple = $this->emptyAppleMakerNotes();
+            $apple = AppleMakerNotes::empty();
         }
 
         return $this->buildMotion($exif, $apple);
@@ -74,37 +74,5 @@ final readonly class MotionFactory
             $accelZ,
         );
     }
-
-    private function emptyAppleMakerNotes(): AppleMakerNotes
-    {
-        /** @var AppleMakerNotes|null $empty */
-        static $empty = null;
-
-        if ($empty === null) {
-            $empty = new AppleMakerNotes(
-                contentIdentifier: null,
-                cameraType: null,
-                hdrHeadroom: null,
-                hdrGain: null,
-                snr: null,
-                aeStable: null,
-                aeTarget: null,
-                aeAverage: null,
-                afStable: null,
-                afPerformance: null,
-                signalToNoiseRatioType: null,
-                luminanceNoiseAmplitude: null,
-                focusPosition: null,
-                livePhotoIndex: null,
-                colorTemperature: null,
-                semanticStylePreset: null,
-                semanticStyleWarmth: null,
-                semanticStyleTone: null,
-                flags: [],
-                accelerationVector: null,
-            );
-        }
-
-        return $empty;
-    }
 }
+

--- a/src/Curate/Exif/SubFactory/SceneFactory.php
+++ b/src/Curate/Exif/SubFactory/SceneFactory.php
@@ -42,7 +42,7 @@ final readonly class SceneFactory
         $appleMakerNote = $metadata->makerNotes?->apple;
 
         if (!$appleMakerNote instanceof AppleMakerNotes) {
-            $appleMakerNote = $this->emptyAppleMakerNotes();
+            $appleMakerNote = AppleMakerNotes::empty();
         }
 
         return $this->buildScene($exif, $quickTime, $appleMakerNote, $faceCount);
@@ -139,37 +139,5 @@ final readonly class SceneFactory
     {
         return $flags[$key] ?? null;
     }
-
-    private function emptyAppleMakerNotes(): AppleMakerNotes
-    {
-        /** @var AppleMakerNotes|null $empty */
-        static $empty = null;
-
-        if ($empty === null) {
-            $empty = new AppleMakerNotes(
-                contentIdentifier: null,
-                cameraType: null,
-                hdrHeadroom: null,
-                hdrGain: null,
-                snr: null,
-                aeStable: null,
-                aeTarget: null,
-                aeAverage: null,
-                afStable: null,
-                afPerformance: null,
-                signalToNoiseRatioType: null,
-                luminanceNoiseAmplitude: null,
-                focusPosition: null,
-                livePhotoIndex: null,
-                colorTemperature: null,
-                semanticStylePreset: null,
-                semanticStyleWarmth: null,
-                semanticStyleTone: null,
-                flags: [],
-                accelerationVector: null,
-            );
-        }
-
-        return $empty;
-    }
 }
+

--- a/src/Curate/Exif/ValueFactory.php
+++ b/src/Curate/Exif/ValueFactory.php
@@ -253,7 +253,7 @@ final readonly class ValueFactory implements ValueFactoryInterface
             cameraElevationAngleDeg: $exifDocument?->cameraElevationAngleDeg(),
         );
 
-        $apple = $appleMakerNotes ?? $this->emptyAppleMakerNotes();
+        $apple = $appleMakerNotes ?? AppleMakerNotes::empty();
         $xmp   = new Xmp($xmpDocument);
 
         $file = new File(
@@ -493,39 +493,6 @@ final readonly class ValueFactory implements ValueFactoryInterface
         }
 
         return $count > 0 ? $count : null;
-    }
-
-    private function emptyAppleMakerNotes(): AppleMakerNotes
-    {
-        /** @var AppleMakerNotes|null $empty */
-        static $empty = null;
-
-        if ($empty === null) {
-            $empty = new AppleMakerNotes(
-                contentIdentifier: null,
-                cameraType: null,
-                hdrHeadroom: null,
-                hdrGain: null,
-                snr: null,
-                aeStable: null,
-                aeTarget: null,
-                aeAverage: null,
-                afStable: null,
-                afPerformance: null,
-                signalToNoiseRatioType: null,
-                luminanceNoiseAmplitude: null,
-                focusPosition: null,
-                livePhotoIndex: null,
-                colorTemperature: null,
-                semanticStylePreset: null,
-                semanticStyleWarmth: null,
-                semanticStyleTone: null,
-                flags: [],
-                accelerationVector: null,
-            );
-        }
-
-        return $empty;
     }
 
     /**

--- a/src/MakerNotes/Apple/AppleMakerNotes.php
+++ b/src/MakerNotes/Apple/AppleMakerNotes.php
@@ -18,6 +18,39 @@ use MagicSunday\ImageMeta\Value\RunTime;
  */
 final readonly class AppleMakerNotes
 {
+    public static function empty(): self
+    {
+        /** @var self|null $empty */
+        static $empty = null;
+
+        if ($empty === null) {
+            $empty = new self(
+                contentIdentifier: null,
+                cameraType: null,
+                hdrHeadroom: null,
+                hdrGain: null,
+                snr: null,
+                aeStable: null,
+                aeTarget: null,
+                aeAverage: null,
+                afStable: null,
+                afPerformance: null,
+                signalToNoiseRatioType: null,
+                luminanceNoiseAmplitude: null,
+                focusPosition: null,
+                livePhotoIndex: null,
+                colorTemperature: null,
+                semanticStylePreset: null,
+                semanticStyleWarmth: null,
+                semanticStyleTone: null,
+                flags: [],
+                accelerationVector: null,
+            );
+        }
+
+        return $empty;
+    }
+
     /**
      * @param string|null         $contentIdentifier       Unique content identifier assigned by Apple platforms.
      * @param string|int|null     $cameraType              Describes the hardware camera (e.g. "Wide", "Tele").


### PR DESCRIPTION
### Motivation
- Reduce duplication and ensure a single cached empty Apple maker-notes instance is used across the Curate/Exif factories.

### Description
- Add a cached static factory `AppleMakerNotes::empty(): self` that constructs and returns the same default instance used previously by local helpers.
- Replace local `emptyAppleMakerNotes()` helpers with calls to `AppleMakerNotes::empty()` in `MotionFactory`, `SceneFactory` and `ValueFactory` and remove the duplicated helper methods.
- Changes are limited to `src/MakerNotes/Apple/AppleMakerNotes.php`, `src/Curate/Exif/SubFactory/MotionFactory.php`, `src/Curate/Exif/SubFactory/SceneFactory.php` and `src/Curate/Exif/ValueFactory.php` and introduce no behavioral changes beyond centralizing the empty instance.

### Testing
- No automated tests were executed for this refactor-only change (no behavior change expected); CI/test run was not requested in this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e4a5bee8c83239297813fc2b50e67)