### PR TITLE
M#: Centralize XMP value accumulation — XMP

### DIFF
--- a/src/Model/Xmp/XmpDocument.php
+++ b/src/Model/Xmp/XmpDocument.php
@@ -11,6 +11,8 @@ declare(strict_types=1);
 
 namespace MagicSunday\ImageMeta\Model\Xmp;
 
+use MagicSunday\ImageMeta\Model\Xmp\XmpValueAccumulator;
+
 use function array_filter;
 use function array_find;
 use function array_key_exists;
@@ -88,34 +90,7 @@ final readonly class XmpDocument
      */
     private static function accumulateValue(array &$data, string $key, array|string $value): void
     {
-        if (!array_key_exists($key, $data)) {
-            $data[$key] = $value;
-
-            return;
-        }
-
-        $existing = $data[$key];
-
-        if (is_array($existing)) {
-            if (is_array($value)) {
-                $data[$key] = [...$existing, ...$value];
-
-                return;
-            }
-
-            $existing[] = $value;
-            $data[$key] = $existing;
-
-            return;
-        }
-
-        if (is_array($value)) {
-            $data[$key] = [$existing, ...$value];
-
-            return;
-        }
-
-        $data[$key] = [$existing, $value];
+        XmpValueAccumulator::merge($data, $key, $value);
     }
 
     /**

--- a/src/Model/Xmp/XmpValueAccumulator.php
+++ b/src/Model/Xmp/XmpValueAccumulator.php
@@ -1,0 +1,57 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\ImageMeta\Model\Xmp;
+
+use function array_key_exists;
+use function is_array;
+
+/**
+ * Provides the shared merge semantics for XMP values.
+ */
+final class XmpValueAccumulator
+{
+    /**
+     * Merges an XMP value into the provided data map.
+     *
+     * @param array<string, string|array<int, string>> $data
+     * @param array<int, string>|string                $value
+     */
+    public static function merge(array &$data, string $key, array|string $value): void
+    {
+        if (!array_key_exists($key, $data)) {
+            $data[$key] = $value;
+
+            return;
+        }
+
+        $existing = $data[$key];
+
+        if (is_array($existing)) {
+            if (is_array($value)) {
+                $data[$key] = [...$existing, ...$value];
+            } else {
+                $existing[] = $value;
+                $data[$key] = $existing;
+            }
+
+            return;
+        }
+
+        if (is_array($value)) {
+            $data[$key] = [$existing, ...$value];
+
+            return;
+        }
+
+        $data[$key] = [$existing, $value];
+    }
+}

--- a/src/Parse/Xmp/XmpParser.php
+++ b/src/Parse/Xmp/XmpParser.php
@@ -12,13 +12,13 @@ declare(strict_types=1);
 namespace MagicSunday\ImageMeta\Parse\Xmp;
 
 use MagicSunday\ImageMeta\Model\Xmp\XmpDocument;
+use MagicSunday\ImageMeta\Model\Xmp\XmpValueAccumulator;
 use XMLReader;
 
 use function array_filter;
 use function array_key_exists;
 use function array_values;
 use function in_array;
-use function is_array;
 use function sprintf;
 use function trim;
 
@@ -322,32 +322,7 @@ final class XmpParser
      */
     private function storeValue(array &$data, string $key, array|string $value): void
     {
-        if (!array_key_exists($key, $data)) {
-            $data[$key] = $value;
-
-            return;
-        }
-
-        $existing = $data[$key];
-
-        if (is_array($existing)) {
-            if (is_array($value)) {
-                $data[$key] = [...$existing, ...$value];
-            } else {
-                $existing[] = $value;
-                $data[$key] = $existing;
-            }
-
-            return;
-        }
-
-        if (is_array($value)) {
-            $data[$key] = [$existing, ...$value];
-
-            return;
-        }
-
-        $data[$key] = [$existing, $value];
+        XmpValueAccumulator::merge($data, $key, $value);
     }
 
     /**


### PR DESCRIPTION
### Motivation
- Remove duplicated XMP merge logic present in `XmpParser::storeValue()` and `XmpDocument::accumulateValue()` by centralizing the semantics in a single helper to reduce duplication and simplify maintenance.

### Description
- Add `src/Model/Xmp/XmpValueAccumulator.php` with a static `merge(array &$data, string $key, array|string $value): void` implementing the existing merge semantics.
- Replace `XmpParser::storeValue()` (in `src/Parse/Xmp/XmpParser.php`) and `XmpDocument::accumulateValue()` (in `src/Model/Xmp/XmpDocument.php`) to delegate to `XmpValueAccumulator::merge()`.
- No behavior changes to the merge semantics; this is a refactor to centralize duplicated logic.

### Testing
- No automated tests were executed as part of this change; please run `composer ci:test` (including `composer ci:test:php:unit` and `composer ci:test:php:phpstan`) to verify CI and coverage before merging.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e4a8773648323ac0099ae31ad1e81)