### PR TITLE
feat(value): add shared matrix validator

### DIFF
--- a/src/Value/MatrixParts.php
+++ b/src/Value/MatrixParts.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\ImageMeta\Value;
+
+/**
+ * Normalized matrix parts used by value objects.
+ *
+ * @param int                                $columns      Column count.
+ * @param int                                $rows         Row count.
+ * @param list<string>                       $columnLabels Column labels.
+ * @param list<string>|null                  $rowLabels    Optional row labels.
+ * @param array<int, array<int, float|null>> $values       Matrix values.
+ */
+final readonly class MatrixParts
+{
+    /**
+     * @param int                                $columns      Column count.
+     * @param int                                $rows         Row count.
+     * @param list<string>                       $columnLabels Column labels.
+     * @param list<string>|null                  $rowLabels    Optional row labels.
+     * @param array<int, array<int, float|null>> $values       Matrix values.
+     */
+    public function __construct(
+        public int $columns,
+        public int $rows,
+        public array $columnLabels,
+        public ?array $rowLabels,
+        public array $values,
+    ) {
+    }
+}

--- a/src/Value/MatrixValidator.php
+++ b/src/Value/MatrixValidator.php
@@ -1,0 +1,147 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\ImageMeta\Value;
+
+use function count;
+use function is_array;
+use function is_float;
+use function is_int;
+use function is_string;
+
+/**
+ * Validates and normalizes decoded matrix structures.
+ */
+final class MatrixValidator
+{
+    /**
+     * @param array<string, array|int>|null $matrix            Decoded matrix payload.
+     * @param bool                          $requireRowLabels  Whether row labels are mandatory.
+     * @param bool                          $allowNullValues   Whether null values are permitted.
+     *
+     * @return MatrixParts|null Normalized matrix parts or null when invalid.
+     */
+    public static function validateMatrix(
+        ?array $matrix,
+        bool $requireRowLabels,
+        bool $allowNullValues
+    ): ?MatrixParts {
+        if ($matrix === null) {
+            return null;
+        }
+
+        $columns = $matrix['columns'] ?? null;
+        $rows    = $matrix['rows'] ?? null;
+        $labels  = $matrix['labels'] ?? null;
+        $values  = $matrix['values'] ?? null;
+
+        if (
+            !is_int($columns)
+            || !is_int($rows)
+            || !is_array($labels)
+            || !is_array($values)
+        ) {
+            return null;
+        }
+
+        if (($columns <= 0) || ($rows <= 0)) {
+            return null;
+        }
+
+        $columnLabels = $labels['columns'] ?? null;
+        if (!is_array($columnLabels)) {
+            return null;
+        }
+
+        $rowLabels = $labels['rows'] ?? null;
+        if (
+            ($rowLabels === null)
+            && $requireRowLabels
+        ) {
+            return null;
+        }
+
+        if (
+            ($rowLabels !== null)
+            && !is_array($rowLabels)
+        ) {
+            return null;
+        }
+
+        $normalizedColumnLabels = [];
+        foreach ($columnLabels as $label) {
+            if (!is_string($label)) {
+                return null;
+            }
+
+            $normalizedColumnLabels[] = $label;
+        }
+
+        if (count($normalizedColumnLabels) !== $columns) {
+            return null;
+        }
+
+        $normalizedRowLabels = null;
+        if ($rowLabels !== null) {
+            $normalizedRowLabels = [];
+            foreach ($rowLabels as $label) {
+                if (!is_string($label)) {
+                    return null;
+                }
+
+                $normalizedRowLabels[] = $label;
+            }
+
+            if (count($normalizedRowLabels) !== $rows) {
+                return null;
+            }
+        }
+
+        if (count($values) !== $rows) {
+            return null;
+        }
+
+        $normalizedValues = [];
+        foreach ($values as $row) {
+            if (!is_array($row)) {
+                return null;
+            }
+
+            $normalizedRow = [];
+            foreach ($row as $cell) {
+                if (!is_float($cell)) {
+                    if ($allowNullValues && ($cell === null)) {
+                        $normalizedRow[] = null;
+                        continue;
+                    }
+
+                    return null;
+                }
+
+                $normalizedRow[] = $cell;
+            }
+
+            if (count($normalizedRow) !== $columns) {
+                return null;
+            }
+
+            $normalizedValues[] = $normalizedRow;
+        }
+
+        return new MatrixParts(
+            $columns,
+            $rows,
+            $normalizedColumnLabels,
+            $normalizedRowLabels,
+            $normalizedValues
+        );
+    }
+}

--- a/src/Value/Oecf.php
+++ b/src/Value/Oecf.php
@@ -11,12 +11,6 @@ declare(strict_types=1);
 
 namespace MagicSunday\ImageMeta\Value;
 
-use function count;
-use function is_array;
-use function is_float;
-use function is_int;
-use function is_string;
-
 /**
  * Opto-Electronic Conversion Function (OECF) data structure.
  *
@@ -53,105 +47,27 @@ final readonly class Oecf
      * EXIF 3.0 §4.6.6.7.6 (Figure 16, Table 11): OECF matrix format with dimensions, labels,
      * and SRATIONAL values.
      *
-     * @param array<string, mixed>|null $matrix Decoded OECF matrix. OECF matrix.
+     * @param array<string, array|int>|null $matrix Decoded OECF matrix. OECF matrix.
      *
      * @return self|null OECF value object or null if matrix is invalid.
      */
     public static function fromMatrix(?array $matrix): ?self
     {
-        if ($matrix === null) {
+        $parts = MatrixValidator::validateMatrix($matrix, true, true);
+        if ($parts === null) {
             return null;
         }
 
-        $columns = $matrix['columns'] ?? null;
-        $rows    = $matrix['rows'] ?? null;
-        $labels  = $matrix['labels'] ?? null;
-        $values  = $matrix['values'] ?? null;
-
-        if (
-            !is_int($columns)
-            || !is_int($rows)
-            || !is_array($labels)
-            || !is_array($values)
-        ) {
-            return null;
-        }
-
-        if ($columns <= 0 || $rows <= 0) {
-            return null;
-        }
-
-        $columnLabels = $labels['columns'] ?? null;
-        $rowLabels    = $labels['rows'] ?? null;
-
-        if (
-            !is_array($columnLabels)
-            || !is_array($rowLabels)
-        ) {
-            return null;
-        }
-
-        // Validate dimensions match label counts
-        $normalizedColumnLabels = [];
-        foreach ($columnLabels as $label) {
-            if (!is_string($label)) {
-                return null;
-            }
-
-            $normalizedColumnLabels[] = $label;
-        }
-
-        $normalizedRowLabels = [];
-        foreach ($rowLabels as $label) {
-            if (!is_string($label)) {
-                return null;
-            }
-
-            $normalizedRowLabels[] = $label;
-        }
-
-        $normalizedValues = [];
-        foreach ($values as $row) {
-            if (!is_array($row)) {
-                return null;
-            }
-
-            $normalizedRow = [];
-            foreach ($row as $cell) {
-                if (
-                    !is_float($cell)
-                    && ($cell !== null)
-                ) {
-                    return null;
-                }
-
-                $normalizedRow[] = $cell;
-            }
-
-            if (count($normalizedRow) !== $columns) {
-                return null;
-            }
-
-            $normalizedValues[] = $normalizedRow;
-        }
-
-        if (
-            (count($normalizedColumnLabels) !== $columns)
-            || (count($normalizedRowLabels) !== $rows)
-        ) {
-            return null;
-        }
-
-        if (count($normalizedValues) !== $rows) {
+        if ($parts->rowLabels === null) {
             return null;
         }
 
         return new self(
-            $columns,
-            $rows,
-            $normalizedColumnLabels,
-            $normalizedRowLabels,
-            $normalizedValues
+            $parts->columns,
+            $parts->rows,
+            $parts->columnLabels,
+            $parts->rowLabels,
+            $parts->values
         );
     }
 }

--- a/src/Value/SpatialFrequencyResponse.php
+++ b/src/Value/SpatialFrequencyResponse.php
@@ -11,12 +11,6 @@ declare(strict_types=1);
 
 namespace MagicSunday\ImageMeta\Value;
 
-use function count;
-use function is_array;
-use function is_float;
-use function is_int;
-use function is_string;
-
 /**
  * Spatial Frequency Response (SFR) value object.
  *
@@ -58,87 +52,22 @@ final readonly class SpatialFrequencyResponse
      *     'values'  => array<list<float>> // SFR[row][column]
      * ]
      *
-     * @param array<string, mixed>|null $matrix
+     * @param array<string, array|int>|null $matrix
      *
      * @return self|null
      */
     public static function fromMatrix(?array $matrix): ?self
     {
-        if ($matrix === null) {
+        $parts = MatrixValidator::validateMatrix($matrix, false, false);
+        if ($parts === null) {
             return null;
-        }
-
-        $columns = $matrix['columns'] ?? null;
-        $rows    = $matrix['rows'] ?? null;
-        $labels  = $matrix['labels'] ?? null;
-        $values  = $matrix['values'] ?? null;
-
-        if (
-            !is_int($columns)
-            || ($columns <= 0)
-            || !is_int($rows)
-            || ($rows <= 0)
-            || !is_array($labels)
-            || !is_array($values)
-        ) {
-            return null;
-        }
-
-        $columnLabels = $labels['columns'] ?? null;
-        if (!is_array($columnLabels)) {
-            return null;
-        }
-
-        // Validate and normalize column item names to list<string>
-        $frequencies = [];
-
-        foreach ($columnLabels as $label) {
-            if (!is_string($label)) {
-                return null;
-            }
-
-            $frequencies[] = $label;
-        }
-
-        if (count($frequencies) !== $columns) {
-            return null;
-        }
-
-        // Validate that values form an exact m×n matrix of float RATIONALs
-        if (count($values) !== $rows) {
-            return null;
-        }
-
-        $typedValues = [];
-
-        foreach ($values as $rowIndex => $row) {
-            if (!is_array($row)) {
-                return null;
-            }
-
-            $typedRow = [];
-
-            foreach ($row as $cell) {
-                // Spec: RATIONAL ⇒ always a numeric value, null is not allowed
-                if (!is_float($cell)) {
-                    return null;
-                }
-
-                $typedRow[] = $cell;
-            }
-
-            if (count($typedRow) !== $columns) {
-                return null;
-            }
-
-            $typedValues[$rowIndex] = $typedRow;
         }
 
         return new self(
-            $columns,
-            $rows,
-            $frequencies,
-            $typedValues
+            $parts->columns,
+            $parts->rows,
+            $parts->columnLabels,
+            $parts->values
         );
     }
 }

--- a/tests/Value/MatrixValidatorTest.php
+++ b/tests/Value/MatrixValidatorTest.php
@@ -1,0 +1,132 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\ImageMeta\Tests\Value;
+
+use MagicSunday\ImageMeta\Value\MatrixParts;
+use MagicSunday\ImageMeta\Value\MatrixValidator;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(MatrixValidator::class)]
+#[CoversClass(MatrixParts::class)]
+final class MatrixValidatorTest extends TestCase
+{
+    #[Test]
+    public function validateMatrixWithRequiredRowLabels(): void
+    {
+        $matrix = [
+            'columns' => 2,
+            'rows'    => 2,
+            'labels'  => [
+                'columns' => ['Input1', 'Input2'],
+                'rows'    => ['Output1', 'Output2'],
+            ],
+            'values' => [
+                [0.0, 0.5],
+                [0.5, 1.0],
+            ],
+        ];
+
+        $parts = MatrixValidator::validateMatrix($matrix, true, true);
+
+        self::assertNotNull($parts);
+        self::assertSame(2, $parts->columns);
+        self::assertSame(2, $parts->rows);
+        self::assertSame(['Input1', 'Input2'], $parts->columnLabels);
+        self::assertSame(['Output1', 'Output2'], $parts->rowLabels);
+        self::assertSame(
+            [
+                [0.0, 0.5],
+                [0.5, 1.0],
+            ],
+            $parts->values
+        );
+    }
+
+    #[Test]
+    public function validateMatrixAllowsMissingRowLabelsWhenOptional(): void
+    {
+        $matrix = [
+            'columns' => 1,
+            'rows'    => 2,
+            'labels'  => [
+                'columns' => ['0.1'],
+            ],
+            'values' => [
+                [0.9],
+                [0.8],
+            ],
+        ];
+
+        $parts = MatrixValidator::validateMatrix($matrix, false, false);
+
+        self::assertNotNull($parts);
+        self::assertNull($parts->rowLabels);
+        self::assertSame([[0.9], [0.8]], $parts->values);
+    }
+
+    #[Test]
+    public function validateMatrixRejectsNullValuesWhenNotAllowed(): void
+    {
+        $matrix = [
+            'columns' => 1,
+            'rows'    => 1,
+            'labels'  => [
+                'columns' => ['Col1'],
+            ],
+            'values' => [
+                [null],
+            ],
+        ];
+
+        self::assertNull(MatrixValidator::validateMatrix($matrix, false, false));
+    }
+
+    #[Test]
+    public function validateMatrixAllowsNullValuesWhenConfigured(): void
+    {
+        $matrix = [
+            'columns' => 1,
+            'rows'    => 1,
+            'labels'  => [
+                'columns' => ['Col1'],
+                'rows'    => ['Row1'],
+            ],
+            'values' => [
+                [null],
+            ],
+        ];
+
+        $parts = MatrixValidator::validateMatrix($matrix, true, true);
+
+        self::assertNotNull($parts);
+        self::assertSame([[null]], $parts->values);
+    }
+
+    #[Test]
+    public function validateMatrixRequiresRowLabelsWhenConfigured(): void
+    {
+        $matrix = [
+            'columns' => 1,
+            'rows'    => 1,
+            'labels'  => [
+                'columns' => ['Col1'],
+            ],
+            'values' => [
+                [0.1],
+            ],
+        ];
+
+        self::assertNull(MatrixValidator::validateMatrix($matrix, true, true));
+    }
+}


### PR DESCRIPTION
### Motivation
- Centralize and standardize validation/normalization of decoded matrix payloads used by multiple Value objects to avoid duplicated logic and mismatches. 
- Ensure consistent handling of optional row labels and nullable cell values according to the needs of different EXIF matrix-based tags (OECF vs SFR).

### Description
- Add `src/Value/MatrixValidator.php` which exposes `MatrixValidator::validateMatrix(?array $matrix, bool $requireRowLabels, bool $allowNullValues): ?MatrixParts` and performs strict normalization and checks for `columns`, `rows`, `labels`, and `values`.
- Add `src/Value/MatrixParts.php` as a small readonly VO carrying normalized parts (`columns`, `rows`, `columnLabels`, `rowLabels|null`, `values`).
- Refactor `Oecf::fromMatrix()` to call `MatrixValidator::validateMatrix($matrix, true, true)` and build the `Oecf` from the returned `MatrixParts` (row labels required, null values allowed).
- Refactor `SpatialFrequencyResponse::fromMatrix()` to call `MatrixValidator::validateMatrix($matrix, false, false)` and build the VO from the returned `MatrixParts` (row labels optional, null values disallowed).
- Add unit tests `tests/Value/MatrixValidatorTest.php` covering required/optional row labels and null-value handling.

### Testing
- Added PHPUnit tests: `tests/Value/MatrixValidatorTest.php` which exercise positive and negative cases (required row labels, optional row labels, null value acceptance/rejection).
- No CI commands were executed as part of this change in this rollout; running the full CI suite is expected via `composer ci:test` and `composer ci:test:php:unit` (not executed here).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e4ab516ec8323bb91d06aac01f3ef)