### PR TITLE
M#: Fix CI checks — Curate/Value

### DIFF
--- a/docs/compliance-report.json
+++ b/docs/compliance-report.json
@@ -1,5 +1,5 @@
 {
-    "generated": "2025-12-07T12:44:43+00:00",
+    "generated": "2026-01-19T16:47:48+00:00",
     "summary": {
         "total_spec_tags": 227,
         "implemented": 227,
@@ -590,6 +590,7 @@
                 "constant_defined": true,
                 "getter_method_exists": true,
                 "getter_methods": [
+                    "software",
                     "rawDevelopingSoftware",
                     "imageEditingSoftware",
                     "metadataEditingSoftware"
@@ -1438,6 +1439,7 @@
                 "constant_defined": true,
                 "getter_method_exists": true,
                 "getter_methods": [
+                    "software",
                     "rawDevelopingSoftware",
                     "imageEditingSoftware",
                     "metadataEditingSoftware"
@@ -2501,6 +2503,7 @@
                 "constant_defined": true,
                 "getter_method_exists": true,
                 "getter_methods": [
+                    "recommendedExposureIndex",
                     "exposureIndex"
                 ],
                 "notes": []

--- a/docs/compliance-report.yaml
+++ b/docs/compliance-report.yaml
@@ -1,4 +1,4 @@
-generated: '2025-12-07T12:44:43+00:00'
+generated: '2026-01-19T16:47:48+00:00'
 summary:
   total_spec_tags: 227
   implemented: 227
@@ -462,7 +462,7 @@ categories:
       status: implemented
       constant_defined: true
       getter_method_exists: true
-      getter_methods: [rawDevelopingSoftware, imageEditingSoftware, metadataEditingSoftware]
+      getter_methods: [software, rawDevelopingSoftware, imageEditingSoftware, metadataEditingSoftware]
       notes: {  }
     306:
       tag_id: '0x0132'
@@ -1123,7 +1123,7 @@ categories:
       status: implemented
       constant_defined: true
       getter_method_exists: true
-      getter_methods: [rawDevelopingSoftware, imageEditingSoftware, metadataEditingSoftware]
+      getter_methods: [software, rawDevelopingSoftware, imageEditingSoftware, metadataEditingSoftware]
       notes: {  }
     306:
       tag_id: '0x0132'
@@ -1939,7 +1939,7 @@ categories:
       status: implemented
       constant_defined: true
       getter_method_exists: true
-      getter_methods: [exposureIndex]
+      getter_methods: [recommendedExposureIndex, exposureIndex]
       notes: {  }
     41495:
       tag_id: '0xA217'

--- a/src/Convenience/ExifConvenience.php
+++ b/src/Convenience/ExifConvenience.php
@@ -227,8 +227,8 @@ final class ExifConvenience
     /**
      * Checks if the parts array contains an equivalent focal length string.
      *
-     * @param list<string> $parts      Array of lens descriptor parts.
-     * @param int          $equivalent Equivalent focal length value to search for.
+     * @param list<string|int> $parts      Array of lens descriptor parts.
+     * @param int              $equivalent Equivalent focal length value to search for.
      *
      * @return bool True if the equivalent focal length is found.
      */
@@ -236,7 +236,7 @@ final class ExifConvenience
     {
         $needle = sprintf('%d mm eq', $equivalent);
 
-        return array_any($parts, fn ($part): bool => strcasecmp($part, $needle) === 0);
+        return array_any($parts, fn ($part): bool => strcasecmp((string) $part, $needle) === 0);
     }
 
     private static function formatExposureTime(float $seconds): string

--- a/src/Curate/Exif/SubFactory/MotionFactory.php
+++ b/src/Curate/Exif/SubFactory/MotionFactory.php
@@ -75,4 +75,3 @@ final readonly class MotionFactory
         );
     }
 }
-

--- a/src/Curate/Exif/SubFactory/SceneFactory.php
+++ b/src/Curate/Exif/SubFactory/SceneFactory.php
@@ -140,4 +140,3 @@ final readonly class SceneFactory
         return $flags[$key] ?? null;
     }
 }
-

--- a/src/Curate/Exif/ValueFactory.php
+++ b/src/Curate/Exif/ValueFactory.php
@@ -30,7 +30,42 @@ use MagicSunday\ImageMeta\Model\Exif\ValueConverters;
 use MagicSunday\ImageMeta\Model\Metadata;
 use MagicSunday\ImageMeta\Model\QuickTimeMeta;
 use MagicSunday\ImageMeta\Parse\Icc\IccDecoder;
-use MagicSunday\ImageMeta\Value as Value;
+use MagicSunday\ImageMeta\Value\Audio as ValueAudio;
+use MagicSunday\ImageMeta\Value\AudioClips;
+use MagicSunday\ImageMeta\Value\Author;
+use MagicSunday\ImageMeta\Value\Camera;
+use MagicSunday\ImageMeta\Value\Capture;
+use MagicSunday\ImageMeta\Value\ColorProfile as ValueColorProfile;
+use MagicSunday\ImageMeta\Value\CompositeImageInfo;
+use MagicSunday\ImageMeta\Value\Container;
+use MagicSunday\ImageMeta\Value\Derived;
+use MagicSunday\ImageMeta\Value\Device;
+use MagicSunday\ImageMeta\Value\Exposure;
+use MagicSunday\ImageMeta\Value\File as ValueFile;
+use MagicSunday\ImageMeta\Value\FlashPix;
+use MagicSunday\ImageMeta\Value\Focus;
+use MagicSunday\ImageMeta\Value\Gps;
+use MagicSunday\ImageMeta\Value\Image;
+use MagicSunday\ImageMeta\Value\Integrity;
+use MagicSunday\ImageMeta\Value\Interop as ValueInterop;
+use MagicSunday\ImageMeta\Value\Keywords;
+use MagicSunday\ImageMeta\Value\Lens;
+use MagicSunday\ImageMeta\Value\Motion;
+use MagicSunday\ImageMeta\Value\MultiPicture;
+use MagicSunday\ImageMeta\Value\ProcessingSettings as ValueProcessingSettings;
+use MagicSunday\ImageMeta\Value\Regions;
+use MagicSunday\ImageMeta\Value\Regions\RegionType;
+use MagicSunday\ImageMeta\Value\RelatedAssets;
+use MagicSunday\ImageMeta\Value\Rights;
+use MagicSunday\ImageMeta\Value\Scene;
+use MagicSunday\ImageMeta\Value\Sensor;
+use MagicSunday\ImageMeta\Value\Standards as ValueStandards;
+use MagicSunday\ImageMeta\Value\Temporal;
+use MagicSunday\ImageMeta\Value\Thumbnail;
+use MagicSunday\ImageMeta\Value\TiffData;
+use MagicSunday\ImageMeta\Value\Video;
+use MagicSunday\ImageMeta\Value\WhiteBalanceDetails;
+use MagicSunday\ImageMeta\Value\Xmp as ValueXmp;
 
 use function count;
 
@@ -77,44 +112,7 @@ final readonly class ValueFactory implements ValueFactoryInterface
      *
      * @param Metadata $metadata Metadata container with decoded EXIF, XMP and QuickTime data.
      *
-     * @return array{
-     *     audio: Value\Audio,
-     *     author: Value\Author,
-     *     camera: Value\Camera,
-     *     capture: Value\Capture,
-     *     colorProfile: Value\ColorProfile,
-     *     composite: Value\CompositeImageInfo,
-     *     container: Value\Container,
-     *     derived: Value\Derived,
-     *     device: Value\Device,
-     *     embeddedAudio: Value\AudioClips,
-     *     exposure: Value\Exposure,
-     *     file: Value\File,
-     *     flashPix: Value\FlashPix,
-     *     focus: Value\Focus,
-     *     gps: Value\Gps,
-     *     image: Value\Image,
-     *     integrity: Value\Integrity,
-     *     interop: Value\Interop,
-     *     keywords: Value\Keywords,
-     *     lens: Value\Lens,
-     *     motion: Value\Motion,
-     *     multiPicture: Value\MultiPicture,
-     *     processing: Value\ProcessingSettings,
-     *     regions: Value\Regions,
-     *     related: Value\RelatedAssets,
-     *     rights: Value\Rights,
-     *     scene: Value\Scene,
-     *     sensor: Value\Sensor,
-     *     standards: Value\Standards,
-     *     temporal: Value\Temporal,
-     *     thumbnail: Value\Thumbnail,
-     *     tiff: Value\TiffData,
-     *     video: Value\Video,
-     *     whiteBalance: Value\WhiteBalanceDetails,
-     *     xmp: Value\Xmp,
-     *     makerNotesApple: AppleMakerNotes|null,
-     * }
+     * @return array{audio: ValueAudio, author: Author, camera: Camera, capture: Capture, colorProfile: ValueColorProfile, composite: CompositeImageInfo, container: Container, derived: Derived, device: Device, embeddedAudio: AudioClips, exposure: Exposure, file: ValueFile, flashPix: FlashPix, focus: Focus, gps: Gps, image: Image, integrity: Integrity, interop: ValueInterop, keywords: Keywords, lens: Lens, motion: Motion, multiPicture: MultiPicture, processing: ValueProcessingSettings, regions: Regions, related: RelatedAssets, rights: Rights, scene: Scene, sensor: Sensor, standards: ValueStandards, temporal: Temporal, thumbnail: Thumbnail, tiff: TiffData, video: Video, whiteBalance: WhiteBalanceDetails, xmp: ValueXmp, makerNotesApple: AppleMakerNotes|null}
      */
     public function createComponents(Metadata $metadata): array
     {
@@ -139,7 +137,7 @@ final readonly class ValueFactory implements ValueFactoryInterface
         $quickTimeLookup = new QuickTimeLookup($quickTimeMeta);
         $appleMakerNotes = $metadata->makerNotes?->apple;
 
-        $interop = new Value\Interop(
+        $interop = new ValueInterop(
             index: $exifDocument?->interopIndex(),
         );
 
@@ -163,7 +161,7 @@ final readonly class ValueFactory implements ValueFactoryInterface
             }
         }
 
-        $tiff = new Value\TiffData(
+        $tiff = new TiffData(
             samplesPerPixel: $exifDocument?->samplesPerPixel(),
             bitsPerSample: $bitsPerSample,
             rowsPerStrip: $exifDocument?->rowsPerStrip(),
@@ -191,7 +189,7 @@ final readonly class ValueFactory implements ValueFactoryInterface
             copyright: $exifDocument?->copyright(),
         );
 
-        $composite = new Value\CompositeImageInfo(
+        $composite = new CompositeImageInfo(
             type: $exifDocument?->compositeImage(),
             counts: $exifDocument?->sourceImageNumberOfCompositeImage(),
             sourceExposureTimes: $exifDocument?->sourceExposureTimesOfCompositeImage(),
@@ -200,15 +198,15 @@ final readonly class ValueFactory implements ValueFactoryInterface
         $exifVersion = $exifDocument?->exifVersion();
         $profile     = $exifDocument?->exifProfile() ?? 'unknown';
 
-        $standards = new Value\Standards(
+        $standards = new ValueStandards(
             exifVersion: $exifVersion,
             profile: $profile,
             flashpixVersion: $exifDocument?->flashpixVersion(),
         );
 
-        $flashPix = new Value\FlashPix($metadata->flashPixStreams);
+        $flashPix = new FlashPix($metadata->flashPixStreams);
 
-        $capture = new Value\Capture(
+        $capture = new Capture(
             dateTime: $exifDocument?->captureDateTime(),
             temperatureC: $exifDocument?->temperatureCelsius(),
             humidityPercent: $exifDocument?->humidityPercent(),
@@ -219,9 +217,9 @@ final readonly class ValueFactory implements ValueFactoryInterface
         );
 
         $apple = $appleMakerNotes ?? AppleMakerNotes::empty();
-        $xmp   = new Value\Xmp($xmpDocument);
+        $xmp   = new ValueXmp($xmpDocument);
 
-        $file = new Value\File(
+        $file = new ValueFile(
             $metadata->mimeType,
             $metadata->fileSize,
             $metadata->extension,
@@ -229,7 +227,7 @@ final readonly class ValueFactory implements ValueFactoryInterface
             $metadata->digestMd5,
         );
 
-        $container = new Value\Container(
+        $container = new Container(
             format: $quickTimeLookup->string(QuickTimeMeta::MAJOR_BRAND_KEY),
             encoder: $quickTimeLookup->string('com.apple.quicktime.encoder',
                 'Encoder',
@@ -252,7 +250,7 @@ final readonly class ValueFactory implements ValueFactoryInterface
         $thumbnailTileWidth    = $exifDocument?->thumbnailTileWidth();
         $thumbnailTileLength   = $exifDocument?->thumbnailTileLength();
 
-        $thumbnail = new Value\Thumbnail(
+        $thumbnail = new Thumbnail(
             hasThumbnail: $exifDocument?->hasThumbnail() ?? false,
             thumbnailOffset: $exifDocument?->thumbnailJpegInterchangeFormat(),
             thumbnailLength: $exifDocument?->thumbnailJpegInterchangeFormatLength(),
@@ -265,7 +263,7 @@ final readonly class ValueFactory implements ValueFactoryInterface
             thumbnailStripByteCounts: $thumbnailStripCounts,
         );
 
-        $video = new Value\Video(
+        $video = new Video(
             durationSec: $quickTimeLookup->float('com.apple.quicktime.duration'),
             frameRate: $quickTimeLookup->float('com.apple.quicktime.videoFrameRate'),
             width: $quickTimeLookup->int(QuickTimeMeta::VIDEO_WIDTH_KEY),
@@ -278,7 +276,7 @@ final readonly class ValueFactory implements ValueFactoryInterface
             colorPrimaries: $quickTimeLookup->string('com.apple.quicktime.colorPrimaries'),
         );
 
-        $audio = new Value\Audio(
+        $audio = new ValueAudio(
             channels: $quickTimeLookup->int(QuickTimeMeta::AUDIO_CHANNELS_KEY),
             sampleRate: $quickTimeLookup->int(QuickTimeMeta::AUDIO_SAMPLE_RATE_KEY),
             codec: $quickTimeLookup->string(QuickTimeMeta::AUDIO_FORMAT_KEY,
@@ -287,14 +285,14 @@ final readonly class ValueFactory implements ValueFactoryInterface
             bitDepth: $quickTimeLookup->int(QuickTimeMeta::AUDIO_BITS_PER_SAMPLE_KEY),
         );
 
-        $embeddedAudio = Value\AudioClips::fromJpegAudioStreams($metadata->jpegAudioStreams);
+        $embeddedAudio = AudioClips::fromJpegAudioStreams($metadata->jpegAudioStreams);
 
         $iccData = null;
         if ($metadata->iccProfile !== null || $metadata->iccSegments !== []) {
             $iccData = (new IccDecoder())->decode($metadata->iccProfile, $metadata->iccSegments);
         }
 
-        $colorProfile = new Value\ColorProfile(
+        $colorProfile = new ValueColorProfile(
             profileName: $iccData['description'] ?? null,
             profileVersion: $iccData['version'] ?? null,
             pcs: $iccData['pcs'] ?? null,
@@ -303,7 +301,7 @@ final readonly class ValueFactory implements ValueFactoryInterface
             profileId: $iccData['profileId'] ?? null,
         );
 
-        $processing = new Value\ProcessingSettings(
+        $processing = new ValueProcessingSettings(
             sharpness: $exifDocument?->sharpness(),
             contrast: $exifDocument?->contrast(),
             saturation: $exifDocument?->saturation(),
@@ -318,7 +316,7 @@ final readonly class ValueFactory implements ValueFactoryInterface
             $whiteBalanceKelvin = $quickTimeLookup->int('ColorTemperature');
         }
 
-        $whiteBalanceDetails = new Value\WhiteBalanceDetails(
+        $whiteBalanceDetails = new WhiteBalanceDetails(
             mode: $exposure->whiteBalance,
             kelvin: $whiteBalanceKelvin,
             rgGain: null,
@@ -327,7 +325,7 @@ final readonly class ValueFactory implements ValueFactoryInterface
 
         $subjectArea = $exifDocument?->subjectArea();
 
-        $focus = new Value\Focus(
+        $focus = new Focus(
             subjectDistanceM: $exifDocument?->subjectDistance(),
             subjectArea: $subjectArea,
             afMode: null,
@@ -336,19 +334,19 @@ final readonly class ValueFactory implements ValueFactoryInterface
         $flatKeywords         = $xmpDocument?->stringList('http://purl.org/dc/elements/1.1/', 'subject') ?? [];
         $hierarchicalKeywords = $xmpDocument?->stringList('http://ns.adobe.com/lightroom/1.0/', 'hierarchicalSubject') ?? [];
 
-        $keywords = new Value\Keywords(
+        $keywords = new Keywords(
             flat: $flatKeywords,
             hierarchical: $hierarchicalKeywords !== [] ? $hierarchicalKeywords : null,
         );
 
-        $rights = new Value\Rights(
+        $rights = new Rights(
             copyright: $exifDocument?->copyright(),
             usageTerms: $xmpDocument?->string('http://ns.adobe.com/xap/1.0/rights/', 'UsageTerms'),
             licenseUrl: $xmpDocument?->string('http://ns.adobe.com/xap/1.0/rights/', 'WebStatement'),
             creditLine: $xmpDocument?->string('http://ns.adobe.com/photoshop/1.0/', 'Credit'),
         );
 
-        $author = new Value\Author(
+        $author = new Author(
             artist: $exifDocument?->artist(),
             ownerName: $exifDocument?->ownerName(),
             creator: $this->firstListValue($xmpDocument?->stringList('http://purl.org/dc/elements/1.1/', 'creator') ?? []),
@@ -362,7 +360,7 @@ final readonly class ValueFactory implements ValueFactoryInterface
             ? ValueConverters::calcCircleOfConfusionMm($cropFactor)
             : null;
 
-        $derived = new Value\Derived(
+        $derived = new Derived(
             ev100: ValueConverters::calcEv100(
                 $exposure->exposureTimeSec,
                 $exposure->fNumber,
@@ -382,7 +380,7 @@ final readonly class ValueFactory implements ValueFactoryInterface
         );
 
         $panoramaFlag = $xmpDocument?->bool('http://ns.google.com/photos/1.0/panorama/', 'UsePanoramaViewer');
-        $related      = new Value\RelatedAssets(
+        $related      = new RelatedAssets(
             livePhotoPairId: $metadata->quickTime?->contentIdentifier(),
             burstId: $quickTimeLookup->string('BurstUUID'),
             isPrimaryInBurst: $quickTimeLookup->bool('BurstSelected') ?? false,
@@ -393,7 +391,7 @@ final readonly class ValueFactory implements ValueFactoryInterface
 
         $hasHistory = $xmpDocument?->has('http://ns.adobe.com/xap/1.0/mm/', 'History') ?? false;
 
-        $integrity = new Value\Integrity(
+        $integrity = new Integrity(
             originalFileName: $xmpDocument?->string('http://ns.adobe.com/tiff/1.0/', 'OriginalFileName'),
             originalDigest: null,
             edited: $hasHistory ? true : null,
@@ -443,16 +441,16 @@ final readonly class ValueFactory implements ValueFactoryInterface
     /**
      * Counts the number of face regions detected in the supplied region aggregate.
      *
-     * @param Value\Regions $regions Region aggregate containing detected regions.
+     * @param Regions $regions Region aggregate containing detected regions.
      *
      * @return int|null Number of face regions or null when no face region exists.
      */
-    private function countFaceRegions(Value\Regions $regions): ?int
+    private function countFaceRegions(Regions $regions): ?int
     {
         $count = 0;
 
         foreach ($regions->items as $region) {
-            if ($region->type === Value\Regions\RegionType::FACE) {
+            if ($region->type === RegionType::FACE) {
                 ++$count;
             }
         }

--- a/src/Model/Xmp/XmpDocument.php
+++ b/src/Model/Xmp/XmpDocument.php
@@ -11,8 +11,6 @@ declare(strict_types=1);
 
 namespace MagicSunday\ImageMeta\Model\Xmp;
 
-use MagicSunday\ImageMeta\Model\Xmp\XmpValueAccumulator;
-
 use function array_filter;
 use function array_find;
 use function array_key_exists;

--- a/src/Value/MatrixParts.php
+++ b/src/Value/MatrixParts.php
@@ -14,20 +14,20 @@ namespace MagicSunday\ImageMeta\Value;
 /**
  * Normalized matrix parts used by value objects.
  *
- * @param int                                $columns      Column count.
- * @param int                                $rows         Row count.
- * @param list<string>                       $columnLabels Column labels.
- * @param list<string>|null                  $rowLabels    Optional row labels.
- * @param array<int, array<int, float|null>> $values       Matrix values.
+ * @param int                    $columns      Column count.
+ * @param int                    $rows         Row count.
+ * @param list<string>           $columnLabels Column labels.
+ * @param list<string>|null      $rowLabels    Optional row labels.
+ * @param list<list<float|null>> $values       Matrix values.
  */
 final readonly class MatrixParts
 {
     /**
-     * @param int                                $columns      Column count.
-     * @param int                                $rows         Row count.
-     * @param list<string>                       $columnLabels Column labels.
-     * @param list<string>|null                  $rowLabels    Optional row labels.
-     * @param array<int, array<int, float|null>> $values       Matrix values.
+     * @param int                    $columns      Column count.
+     * @param int                    $rows         Row count.
+     * @param list<string>           $columnLabels Column labels.
+     * @param list<string>|null      $rowLabels    Optional row labels.
+     * @param list<list<float|null>> $values       Matrix values.
      */
     public function __construct(
         public int $columns,

--- a/src/Value/MatrixValidator.php
+++ b/src/Value/MatrixValidator.php
@@ -19,20 +19,22 @@ use function is_string;
 
 /**
  * Validates and normalizes decoded matrix structures.
+ *
+ * @phpstan-type DecodedMatrix array{columns?:scalar|null, rows?:scalar|null, labels?:array{columns?:array<int, scalar|null>|scalar|null, rows?:array<int, scalar|null>|scalar|null}|null, values?:array<int, array<int, scalar|null>|scalar|null>|null}|null
  */
 final class MatrixValidator
 {
     /**
-     * @param array<string, array|int>|null $matrix            Decoded matrix payload.
-     * @param bool                          $requireRowLabels  Whether row labels are mandatory.
-     * @param bool                          $allowNullValues   Whether null values are permitted.
+     * @param DecodedMatrix $matrix           Decoded matrix payload.
+     * @param bool          $requireRowLabels Whether row labels are mandatory.
+     * @param bool          $allowNullValues  Whether null values are permitted.
      *
      * @return MatrixParts|null Normalized matrix parts or null when invalid.
      */
     public static function validateMatrix(
         ?array $matrix,
         bool $requireRowLabels,
-        bool $allowNullValues
+        bool $allowNullValues,
     ): ?MatrixParts {
         if ($matrix === null) {
             return null;
@@ -77,12 +79,12 @@ final class MatrixValidator
         }
 
         $normalizedColumnLabels = [];
-        foreach ($columnLabels as $label) {
-            if (!is_string($label)) {
+        foreach ($columnLabels as $columnLabel) {
+            if (!is_string($columnLabel)) {
                 return null;
             }
 
-            $normalizedColumnLabels[] = $label;
+            $normalizedColumnLabels[] = $columnLabel;
         }
 
         if (count($normalizedColumnLabels) !== $columns) {
@@ -92,12 +94,12 @@ final class MatrixValidator
         $normalizedRowLabels = null;
         if ($rowLabels !== null) {
             $normalizedRowLabels = [];
-            foreach ($rowLabels as $label) {
-                if (!is_string($label)) {
+            foreach ($rowLabels as $rowLabel) {
+                if (!is_string($rowLabel)) {
                     return null;
                 }
 
-                $normalizedRowLabels[] = $label;
+                $normalizedRowLabels[] = $rowLabel;
             }
 
             if (count($normalizedRowLabels) !== $rows) {

--- a/src/Value/Oecf.php
+++ b/src/Value/Oecf.php
@@ -20,17 +20,19 @@ namespace MagicSunday\ImageMeta\Value;
  * - Column labels (typically input/pixel values)
  * - Row labels (typically output/luminance values)
  * - Matrix of SRATIONAL values representing the conversion function
+ *
+ * @phpstan-type DecodedMatrix array{columns?:scalar|null, rows?:scalar|null, labels?:array{columns?:array<int, scalar|null>|scalar|null, rows?:array<int, scalar|null>|scalar|null}|null, values?:array<int, array<int, scalar|null>|scalar|null>|null}|null
  */
 final readonly class Oecf
 {
     /**
      * Creates an OECF value object.
      *
-     * @param int                                $columns      Number of columns in the OECF matrix.
-     * @param int                                $rows         Number of rows in the OECF matrix.
-     * @param list<string>                       $columnLabels Labels for each column (input values).
-     * @param list<string>                       $rowLabels    Labels for each row (output values).
-     * @param array<int, array<int, float|null>> $values       Matrix of SRATIONAL conversion values.
+     * @param int                    $columns      Number of columns in the OECF matrix.
+     * @param int                    $rows         Number of rows in the OECF matrix.
+     * @param list<string>           $columnLabels Labels for each column (input values).
+     * @param list<string>           $rowLabels    Labels for each row (output values).
+     * @param list<list<float|null>> $values       Matrix of SRATIONAL conversion values.
      */
     public function __construct(
         public int $columns,
@@ -47,14 +49,14 @@ final readonly class Oecf
      * EXIF 3.0 §4.6.6.7.6 (Figure 16, Table 11): OECF matrix format with dimensions, labels,
      * and SRATIONAL values.
      *
-     * @param array<string, array|int>|null $matrix Decoded OECF matrix. OECF matrix.
+     * @param DecodedMatrix $matrix Decoded OECF matrix.
      *
      * @return self|null OECF value object or null if matrix is invalid.
      */
     public static function fromMatrix(?array $matrix): ?self
     {
         $parts = MatrixValidator::validateMatrix($matrix, true, true);
-        if ($parts === null) {
+        if (!$parts instanceof MatrixParts) {
             return null;
         }
 

--- a/src/Value/SpatialFrequencyResponse.php
+++ b/src/Value/SpatialFrequencyResponse.php
@@ -21,14 +21,16 @@ namespace MagicSunday\ImageMeta\Value;
  *  - rows    (m): number of SFR rows
  *  - column item names: spatial frequency labels
  *  - m×n RATIONAL values: SFR[row][column]
+ *
+ * @phpstan-type DecodedMatrix array{columns?:scalar|null, rows?:scalar|null, labels?:array{columns?:array<int, scalar|null>|scalar|null, rows?:array<int, scalar|null>|scalar|null}|null, values?:array<int, array<int, scalar|null>|scalar|null>|null}|null
  */
 final readonly class SpatialFrequencyResponse
 {
     /**
-     * @param int                $columns            Number of frequency columns (n).
-     * @param int                $rows               Number of SFR rows (m).
-     * @param list<string>       $spatialFrequencies Column item names (spatial frequencies).
-     * @param array<list<float>> $values             SFR values matrix [row][column].
+     * @param int               $columns            Number of frequency columns (n).
+     * @param int               $rows               Number of SFR rows (m).
+     * @param list<string>      $spatialFrequencies Column item names (spatial frequencies).
+     * @param list<list<float>> $values             SFR values matrix [row][column].
      */
     public function __construct(
         public int $columns,
@@ -49,25 +51,36 @@ final readonly class SpatialFrequencyResponse
      *     'labels'  => [
      *         'columns' => list<string>,             // column item names
      *     ],
-     *     'values'  => array<list<float>> // SFR[row][column]
+     *     'values'  => list<list<float>> // SFR[row][column]
      * ]
      *
-     * @param array<string, array|int>|null $matrix
+     * @param DecodedMatrix $matrix
      *
      * @return self|null
      */
     public static function fromMatrix(?array $matrix): ?self
     {
         $parts = MatrixValidator::validateMatrix($matrix, false, false);
-        if ($parts === null) {
+        if (!$parts instanceof MatrixParts) {
             return null;
         }
+
+        foreach ($parts->values as $row) {
+            foreach ($row as $cell) {
+                if ($cell === null) {
+                    return null;
+                }
+            }
+        }
+
+        /** @var list<list<float>> $values */
+        $values = $parts->values;
 
         return new self(
             $parts->columns,
             $parts->rows,
             $parts->columnLabels,
-            $parts->values
+            $values
         );
     }
 }


### PR DESCRIPTION
### Motivation

- Resolve CI failures from PHPStan, Rector/CS dry-runs and style checks by tightening matrix typing and harmonising imports and docblocks across value objects and the Curate flow. 
- Keep changes minimal and confined to validation/type hygiene, import alignment and small style fixes so parser behaviour remains unchanged.

### Description

- Tighten and document the decoded-matrix shape with `@phpstan-type DecodedMatrix` and rename loop variables to avoid PHPStan warnings in `src/Value/MatrixValidator.php` and unify `MatrixParts` typing. 
- Harden consumers: `Oecf::fromMatrix()` and `SpatialFrequencyResponse::fromMatrix()` now check for `MatrixParts` and validate non-null SFR cells before constructing value objects in `src/Value/Oecf.php` and `src/Value/SpatialFrequencyResponse.php`. 
- Standardise value object imports and return PHPDoc in the curator pipeline to satisfy static analysis and CS rules in `src/Curate/Exif/ValueFactory.php`. 
- Small API/safety and style fixes: cast handling for lens-equivalent matching in `src/Convenience/ExifConvenience.php`, remove an unused import in `src/Model/Xmp/XmpDocument.php`, and minor newline/formatting cleanup in motion/scene subfactories. 
- Regenerated compliance artifacts `docs/compliance-report.json` and `docs/compliance-report.yaml` after tests.

Files changed (allowed scope): `src/Value/{MatrixValidator,MatrixParts,Oecf,SpatialFrequencyResponse}.php`, `src/Curate/Exif/ValueFactory.php`, `src/Convenience/ExifConvenience.php`, `src/Model/Xmp/XmpDocument.php`, `src/Curate/Exif/SubFactory/{MotionFactory,SceneFactory}.php`, `docs/compliance-report.{json,yaml}`.

### Testing

- Ran full CI suite with `composer ci:test` and all checks passed (Lint, PHPStan, Rector dry-run, CS dry-run, JSCPD, PHPUnit).
- PHPUnit: `OK (765 tests, 2353 assertions)` (run during CI). 
- Static analysis: PHPStan produced no remaining errors for the changed files and Rector/CS dry-runs reported no outstanding fixes. 
- JSCPD/CPD: duplication check cleared (no clones above threshold).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e5b7117948323b16d5282eeabbe4b)