### PR TITLE
Tighten value-object typing — Contracts/MakerNotes/Exif

### DIFF
--- a/src/Contracts/ValueFactoryInterface.php
+++ b/src/Contracts/ValueFactoryInterface.php
@@ -11,7 +11,43 @@ declare(strict_types=1);
 
 namespace MagicSunday\ImageMeta\Contracts;
 
+use MagicSunday\ImageMeta\MakerNotes\Apple\AppleMakerNotes;
 use MagicSunday\ImageMeta\Model\Metadata;
+use MagicSunday\ImageMeta\Value\Audio;
+use MagicSunday\ImageMeta\Value\AudioClips;
+use MagicSunday\ImageMeta\Value\Author;
+use MagicSunday\ImageMeta\Value\Camera;
+use MagicSunday\ImageMeta\Value\Capture;
+use MagicSunday\ImageMeta\Value\ColorProfile;
+use MagicSunday\ImageMeta\Value\CompositeImageInfo;
+use MagicSunday\ImageMeta\Value\Container;
+use MagicSunday\ImageMeta\Value\Derived;
+use MagicSunday\ImageMeta\Value\Device;
+use MagicSunday\ImageMeta\Value\Exposure;
+use MagicSunday\ImageMeta\Value\File;
+use MagicSunday\ImageMeta\Value\FlashPix;
+use MagicSunday\ImageMeta\Value\Focus;
+use MagicSunday\ImageMeta\Value\Gps;
+use MagicSunday\ImageMeta\Value\Image;
+use MagicSunday\ImageMeta\Value\Integrity;
+use MagicSunday\ImageMeta\Value\Interop;
+use MagicSunday\ImageMeta\Value\Keywords;
+use MagicSunday\ImageMeta\Value\Lens;
+use MagicSunday\ImageMeta\Value\Motion;
+use MagicSunday\ImageMeta\Value\MultiPicture;
+use MagicSunday\ImageMeta\Value\ProcessingSettings;
+use MagicSunday\ImageMeta\Value\Regions;
+use MagicSunday\ImageMeta\Value\RelatedAssets;
+use MagicSunday\ImageMeta\Value\Rights;
+use MagicSunday\ImageMeta\Value\Scene;
+use MagicSunday\ImageMeta\Value\Sensor;
+use MagicSunday\ImageMeta\Value\Standards;
+use MagicSunday\ImageMeta\Value\Temporal;
+use MagicSunday\ImageMeta\Value\Thumbnail;
+use MagicSunday\ImageMeta\Value\TiffData;
+use MagicSunday\ImageMeta\Value\Video;
+use MagicSunday\ImageMeta\Value\WhiteBalanceDetails;
+use MagicSunday\ImageMeta\Value\Xmp;
 
 /**
  * Factory contract for building value-object aggregates from metadata structures.
@@ -23,7 +59,7 @@ interface ValueFactoryInterface
      *
      * @param Metadata $metadata Aggregated metadata extracted from the source image.
      *
-     * @return array<string, mixed> Associative map of component identifiers to their value objects.
+     * @return array{audio: Audio, author: Author, camera: Camera, capture: Capture, colorProfile: ColorProfile, composite: CompositeImageInfo, container: Container, derived: Derived, device: Device, embeddedAudio: AudioClips, exposure: Exposure, file: File, flashPix: FlashPix, focus: Focus, gps: Gps, image: Image, integrity: Integrity, interop: Interop, keywords: Keywords, lens: Lens, motion: Motion, multiPicture: MultiPicture, processing: ProcessingSettings, regions: Regions, related: RelatedAssets, rights: Rights, scene: Scene, sensor: Sensor, standards: Standards, temporal: Temporal, thumbnail: Thumbnail, tiff: TiffData, video: Video, whiteBalance: WhiteBalanceDetails, xmp: Xmp, makerNotesApple: AppleMakerNotes|null} Associative map of component identifiers to their value objects.
      */
     public function createComponents(Metadata $metadata): array;
 }

--- a/src/MakerNotes/AppleDecoder.php
+++ b/src/MakerNotes/AppleDecoder.php
@@ -55,6 +55,9 @@ use function trim;
 
 /**
  * Decoder that extracts structured metadata from Apple maker note payloads.
+ *
+ * @phpstan-type NativePlistValue array<string, NativePlistValue>|array<int, NativePlistValue>|bool|float|int|string|null
+ * @phpstan-type NativePlistDictionary array<string, NativePlistValue>
  */
 final class AppleDecoder implements MakerNotesDecoderInterface
 {
@@ -95,7 +98,7 @@ final class AppleDecoder implements MakerNotesDecoderInterface
             return null;
         }
 
-        /** @var array<int|string, mixed> $dictionary */
+        /** @var NativePlistDictionary $dictionary */
         $dictionary = $decoded;
 
         $decoded = $this->resolveKeyedArchiveDictionary($dictionary);
@@ -111,7 +114,7 @@ final class AppleDecoder implements MakerNotesDecoderInterface
      *
      * @param string $raw Raw maker note data stream.
      *
-     * @return array<int|string, mixed>|bool|float|int|string|null
+     * @return NativePlistValue
      */
     private function decodeBinaryPropertyList(string $raw): array|string|int|float|bool|null
     {
@@ -141,7 +144,7 @@ final class AppleDecoder implements MakerNotesDecoderInterface
      *
      * @param string $raw Raw maker note data stream.
      *
-     * @return array<int|string, mixed>|null
+     * @return NativePlistDictionary|null
      */
     private function parseRawDictionaryPayload(string $raw): ?array
     {
@@ -170,7 +173,7 @@ final class AppleDecoder implements MakerNotesDecoderInterface
     /**
      * Parses a dictionary section from the textual representation.
      *
-     * @return array<int|string, mixed>
+     * @return NativePlistDictionary
      */
     private function parseDictionary(string $raw, int &$offset, int $length): array
     {
@@ -234,7 +237,7 @@ final class AppleDecoder implements MakerNotesDecoderInterface
     /**
      * Parses a single value from the textual dictionary representation.
      *
-     * @return array<int|string, mixed>|bool|float|int|string|null
+     * @return NativePlistValue
      */
     private function parseValue(string $raw, int &$offset, int $length): array|bool|float|int|string|null
     {
@@ -292,9 +295,9 @@ final class AppleDecoder implements MakerNotesDecoderInterface
      * @param int    $offset Current parsing offset (modified by reference).
      * @param int    $length Total payload length.
      *
-     * @return array<int, array<int|string, mixed>|bool|float|int|string|null> Parsed array values.
+     * @return array<int, NativePlistValue> Parsed array values.
      *
-     * @phpstan-return array<int, array<int|string, mixed>|bool|float|int|string|null>
+     * @phpstan-return array<int, NativePlistValue>
      *
      * @throws ParseError If array syntax is invalid.
      */
@@ -305,7 +308,7 @@ final class AppleDecoder implements MakerNotesDecoderInterface
         }
 
         ++$offset;
-        /** @var array<int, array<int|string, mixed>|bool|float|int|string|null> $values */
+        /** @var array<int, NativePlistValue> $values */
         $values = [];
 
         while (true) {
@@ -337,7 +340,7 @@ final class AppleDecoder implements MakerNotesDecoderInterface
             }
         }
 
-        /** @var array<int, array<int|string, mixed>|bool|float|int|string|null> $values */
+        /** @var array<int, NativePlistValue> $values */
         return $values;
     }
 
@@ -574,9 +577,9 @@ final class AppleDecoder implements MakerNotesDecoderInterface
     /**
      * Unarchives a normalized keyed archive dictionary.
      *
-     * @param array<int|string, mixed> $dictionary Normalized keyed archive structure.
+     * @param NativePlistDictionary $dictionary Normalized keyed archive structure.
      *
-     * @return array<int|string, mixed>|null Unarchived dictionary or null if invalid.
+     * @return NativePlistDictionary|null Unarchived dictionary or null if invalid.
      */
     private function unarchiveNormalisedKeyedArchive(array $dictionary): ?array
     {
@@ -598,7 +601,7 @@ final class AppleDecoder implements MakerNotesDecoderInterface
     /**
      * Converts a property list value into native PHP types.
      *
-     * @return array<int|string, mixed>|bool|float|int|string|null
+     * @return NativePlistValue
      */
     private function plistValueToPhp(ApplePlistValue $value): array|string|int|float|bool|null
     {
@@ -625,7 +628,10 @@ final class AppleDecoder implements MakerNotesDecoderInterface
         throw new ParseError('Unsupported property list value.');
     }
 
-    private function nativeToPlistValue(mixed $value): ApplePlistValue
+    /**
+     * @param NativePlistValue $value
+     */
+    private function nativeToPlistValue(array|bool|float|int|string|null $value): ApplePlistValue
     {
         if (!is_array($value)) {
             if (is_bool($value) || is_int($value) || is_float($value) || is_string($value) || $value === null) {
@@ -659,9 +665,9 @@ final class AppleDecoder implements MakerNotesDecoderInterface
     /**
      * Normalizes a keyed archive dictionary to standard structure.
      *
-     * @param array<int|string, mixed> $dictionary Raw keyed archive dictionary.
+     * @param NativePlistDictionary $dictionary Raw keyed archive dictionary.
      *
-     * @return array<int|string, mixed>|null Normalized structure or null if invalid.
+     * @return NativePlistDictionary|null Normalized structure or null if invalid.
      */
     private function normaliseKeyedArchive(array $dictionary): ?array
     {
@@ -710,7 +716,7 @@ final class AppleDecoder implements MakerNotesDecoderInterface
     /**
      * Returns the first existing key from a prioritized list.
      *
-     * @param array<int|string, mixed> $dictionary Dictionary to search.
+     * @param NativePlistDictionary $dictionary Dictionary to search.
      * @param string                   ...$keys    Priority-ordered keys to check.
      *
      * @return string|null First matching key or null if none exist.
@@ -726,15 +732,15 @@ final class AppleDecoder implements MakerNotesDecoderInterface
     /**
      * Builds an AppleMakerNotes value object from decoded dictionary.
      *
-     * @param array<int|string, mixed> $dictionary Decoded maker notes dictionary.
+     * @param NativePlistDictionary $dictionary Decoded maker notes dictionary.
      *
-     * @phpstan-param array<int|string, mixed> $dictionary
+     * @phpstan-param NativePlistDictionary $dictionary
      *
      * @return AppleMakerNotes|null Apple maker notes object or null if invalid.
      */
     private function buildAppleMakerNotes(array $dictionary): ?AppleMakerNotes
     {
-        /** @var array<int|string, mixed> $dictionary */
+        /** @var NativePlistDictionary $dictionary */
         $semanticStyleCompact = null;
         if (
             !array_key_exists('SemanticStylePreset', $dictionary)

--- a/src/Model/Exif/ExifNumericList.php
+++ b/src/Model/Exif/ExifNumericList.php
@@ -31,8 +31,6 @@ final readonly class ExifNumericList
     /**
      * @param list<int|float|UInt64> $values Ordered list of numeric components.
      *
-     * @phpstan-param array<int, mixed> $values Ordered list of numeric components.
-     *
      * @psalm-param list<int|float|UInt64> $values
      */
     public function __construct(array $values)
@@ -70,11 +68,9 @@ final readonly class ExifNumericList
     }
 
     /**
-     * @param list<mixed> $values
+     * @param list<int|float|UInt64> $values
      *
-     * @phpstan-param array<int, mixed> $values
-     *
-     * @phpstan-assert list<mixed> $values
+     * @phpstan-assert list<int|float|UInt64> $values
      */
     private function assertList(array $values): void
     {


### PR DESCRIPTION
### Motivation
- Remove `mixed` from public contracts and internal PHPDoc to improve static typing, PHPStan diagnostics and caller ergonomics.
- Make Apple plist/native value shapes explicit so `nativeToPlistValue()` and related code declare the accepted scalar/array shapes instead of `mixed`.

### Description
- Replaced the loose `array<string,mixed>` return with a precise associative shape in `ValueFactoryInterface::createComponents()` and added the corresponding `use` imports for the concrete value object types (file: `src/Contracts/ValueFactoryInterface.php`).
- Introduced `@phpstan-type NativePlistValue` and `NativePlistDictionary` and updated `AppleDecoder` to use explicit unions for native plist shapes, adjusted `nativeToPlistValue()` signature and related PHPDoc/return annotations (file: `src/MakerNotes/AppleDecoder.php`).
- Tightened `ExifNumericList` PHPDoc and phpstan assertions to `list<int|float|UInt64>` and removed prior `mixed` annotations (file: `src/Model/Exif/ExifNumericList.php`).
- These are typing/refactor changes only and preserve runtime behavior; no parsing logic was altered.

### Testing
- No automated tests were executed as part of this rollout; PHPUnit, PHPStan and other CI tasks were not run here.
- Recommend running the project CI locally or in CI using `composer ci:test` and `composer ci:test:php:phpstan` to validate typing and static checks.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e689def8c83239ca4ae6e38af5b88)