### PR TITLE
refactor(exif): narrow callback parameter types

### DIFF
--- a/src/Model/Exif/ValueConverters.php
+++ b/src/Model/Exif/ValueConverters.php
@@ -794,7 +794,7 @@ final readonly class ValueConverters
             return null;
         }
 
-        if (array_any($bytes, static fn (mixed $byte): bool => !is_int($byte))) {
+        if (array_any($bytes, static fn (int|float|string $byte): bool => !is_int($byte))) {
             return null;
         }
 

--- a/src/Value/SubjectArea.php
+++ b/src/Value/SubjectArea.php
@@ -76,7 +76,7 @@ final readonly class SubjectArea
             return null;
         }
 
-        if (array_any($values, static fn (mixed $component): bool => !is_numeric($component))) {
+        if (array_any($values, static fn (int|float|string $component): bool => !is_numeric($component))) {
             return null;
         }
 


### PR DESCRIPTION
### Motivation
- Improve static typing and PHPStan friendliness by narrowing anonymous callback parameter types from `mixed` to `int|float|string` without changing runtime validation.

### Description
- Change `array_any($bytes, static fn (mixed $byte) ...)` to `static fn (int|float|string $byte) ...` in `ValueConverters::tiffEpStandardId()` while preserving the existing `is_int` guard and formatting logic.
- Change `array_any($values, static fn (mixed $component) ...)` to `static fn (int|float|string $component) ...` in `SubjectArea::fromComponents()` while keeping the numeric guard and mapping flow intact.
- Files modified: `src/Model/Exif/ValueConverters.php`, `src/Value/SubjectArea.php`; no behavioural changes intended, only tighter callback type hints.

### Testing
- No automated tests were executed in this change; this is a type-hint-only refactor and existing test-suite should be run in CI (recommended commands: `composer ci:test:php:phpstan`, `composer ci:test:php:unit`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e68a96220832390dffe7c388a2dfc)