### PR TITLE
fix(jpeg): avoid mixed in MPF rational guard

### DIFF
--- a/src/Parse/Jpeg/MpfParser.php
+++ b/src/Parse/Jpeg/MpfParser.php
@@ -495,7 +495,7 @@ final class MpfParser
 
         return !array_any(
             $value,
-            fn (mixed $item): bool => !is_array($item) || !$this->isRational($item)
+            fn (int|string|array $item): bool => !is_array($item) || !$this->isRational($item)
         );
     }
 


### PR DESCRIPTION
### Motivation
- Tighten a closure parameter type to comply with the repository coding guideline that forbids `mixed` signatures.

### Description
- Replace the `mixed` parameter in the MPF rational-list guard closure with a concrete union type (`int|string|array`) in `src/Parse/Jpeg/MpfParser.php` (around lines 490–499) to make the intent explicit and satisfy static analysis.

### Testing
- No automated tests were executed for this trivial annotation change; recommend running `composer ci:test` (or at least `composer ci:test:php:phpstan` and `composer ci:test:php:unit`) before merging.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e79631ccc832387380e8ac506cb4f)