### PR TITLE
chore(tests): replace mixed annotations

### DIFF
--- a/tests/MakerNotes/Apple/AppleDecoderKeyedArchiveTest.php
+++ b/tests/MakerNotes/Apple/AppleDecoderKeyedArchiveTest.php
@@ -42,6 +42,10 @@ use function pack;
 use function str_repeat;
 use function strlen;
 
+/**
+ * @phpstan-type NativePlistValue array<string, NativePlistValue>|array<int, NativePlistValue>|bool|float|int|string|null
+ * @phpstan-type NativePlistDictionary array<string, NativePlistValue>
+ */
 #[CoversClass(AppleDecoder::class)]
 #[UsesClass(AppleMakerNotes::class)]
 #[UsesClass(ApplePlistArray::class)]
@@ -90,7 +94,7 @@ final class AppleDecoderKeyedArchiveTest extends TestCase
         $decoder = new AppleDecoder();
         $method  = new ReflectionMethod(AppleDecoder::class, 'decodeBinaryPropertyList');
 
-        /** @var array<int|string, mixed>|bool|float|int|string|null $result */
+        /** @var NativePlistValue $result */
         $result = $method->invoke($decoder, $raw);
 
         self::assertIsArray($result);
@@ -128,7 +132,7 @@ final class AppleDecoderKeyedArchiveTest extends TestCase
             'PayloadVersion' => 1,
         ];
 
-        /** @var array<int|string, mixed>|null $result */
+        /** @var NativePlistDictionary|null $result */
         $result = $method->invoke($decoder, $wrapper);
 
         self::assertIsArray($result);

--- a/tests/MetadataReaderTest.php
+++ b/tests/MetadataReaderTest.php
@@ -233,7 +233,7 @@ final class MetadataReaderTest extends TestCase
 
         $structured = $metadata->structured();
 
-        /** @var array<string, callable(): mixed> $componentAccessors */
+        /** @var array{file: callable(): FileValue, container: callable(): Container, camera: callable(): Camera, lens: callable(): Lens, derived: callable(): Derived, exposure: callable(): Exposure, thumbnail: callable(): Thumbnail, rights: callable(): Rights} $componentAccessors */
         $componentAccessors = [
             'file'      => static fn (): FileValue => $structured->file,
             'container' => static fn (): Container => $structured->container,


### PR DESCRIPTION
### Motivation
- Replace ad-hoc `mixed` phpdoc annotations in tests with precise typed shapes and phpstan type aliases to improve static analysis accuracy and comply with repository guidelines.

### Description
- `tests/MetadataReaderTest.php`: replaced `array<string, callable(): mixed>` with an explicit array shape mapping component keys to `callable(): <ValueObject>` return types to document exact expectations.
- `tests/MakerNotes/Apple/AppleDecoderKeyedArchiveTest.php`: added `@phpstan-type NativePlistValue` and `@phpstan-type NativePlistDictionary` aliases and replaced `mixed`-based annotations with these precise aliases.

### Testing
- No automated tests were executed locally for this change; the edits are annotation-only and committed, and CI should run `composer ci:test` (including `phpunit` and `phpstan`) to validate the update.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e8eb1fecc8323a8094e31c29425e0)