### PR TITLE
M#: Add ISO BMFF iref item references — IsoBmff

### DIFF
--- a/src/MetadataReader.php
+++ b/src/MetadataReader.php
@@ -177,7 +177,7 @@ final readonly class MetadataReader
         ?string $digestSha1,
         ?string $digestMd5,
     ): Metadata {
-        [$exifBlobs, $xmpBlobs, $qt] = (new IsoBmffExtractor($stream))->extract();
+        [$exifBlobs, $xmpBlobs, $qt, $isoBmffItemReferences] = (new IsoBmffExtractor($stream))->extract();
 
         $exifDoc    = null;
         $xmpDoc     = null;
@@ -220,6 +220,7 @@ final readonly class MetadataReader
             $extension,
             $digestSha1,
             $digestMd5,
+            isoBmffItemReferences: $isoBmffItemReferences,
         );
     }
 

--- a/src/Model/IsoBmff/IsoBmffItemReference.php
+++ b/src/Model/IsoBmff/IsoBmffItemReference.php
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\ImageMeta\Model\IsoBmff;
+
+/**
+ * Represents a single ISO BMFF item reference entry.
+ */
+final readonly class IsoBmffItemReference
+{
+    /**
+     * @param string $relation Four-character item reference type.
+     * @param int    $toItemId Target item identifier.
+     */
+    public function __construct(
+        public string $relation,
+        public int $toItemId,
+    ) {
+    }
+}

--- a/src/Model/IsoBmff/IsoBmffItemReferenceMap.php
+++ b/src/Model/IsoBmff/IsoBmffItemReferenceMap.php
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\ImageMeta\Model\IsoBmff;
+
+use function array_keys;
+
+/**
+ * Holds ISO BMFF item references keyed by source item id.
+ */
+final readonly class IsoBmffItemReferenceMap
+{
+    /**
+     * @param array<int, list<IsoBmffItemReference>> $references
+     */
+    public function __construct(public array $references)
+    {
+    }
+
+    /**
+     * Returns all source item identifiers with registered references.
+     *
+     * @return list<int>
+     */
+    public function fromItemIds(): array
+    {
+        return array_keys($this->references);
+    }
+
+    /**
+     * Returns references that originate from the given item id.
+     *
+     * @return list<IsoBmffItemReference>
+     */
+    public function referencesFor(int $fromItemId): array
+    {
+        return $this->references[$fromItemId] ?? [];
+    }
+
+    /**
+     * Reports whether any item references are available.
+     */
+    public function isEmpty(): bool
+    {
+        return $this->references === [];
+    }
+}

--- a/src/Model/Metadata.php
+++ b/src/Model/Metadata.php
@@ -14,6 +14,7 @@ namespace MagicSunday\ImageMeta\Model;
 use MagicSunday\ImageMeta\Curate\StructuredMetadata;
 use MagicSunday\ImageMeta\MakerNotes\MakerNotesRecord;
 use MagicSunday\ImageMeta\Model\Exif\ParsedExif;
+use MagicSunday\ImageMeta\Model\IsoBmff\IsoBmffItemReferenceMap;
 use MagicSunday\ImageMeta\Model\Jpeg\JpegAudioStream;
 use MagicSunday\ImageMeta\Model\Mpf\MpfDocument;
 use MagicSunday\ImageMeta\Model\Xmp\XmpDocument;
@@ -51,6 +52,7 @@ final readonly class Metadata
      * @param string|null                                          $extension                Lowercase file extension extracted from the path.
      * @param string|null                                          $digestSha1               Lowercase hexadecimal SHA-1 digest of the payload.
      * @param string|null                                          $digestMd5                Lowercase hexadecimal MD5 digest of the payload.
+     * @param IsoBmffItemReferenceMap|null                         $isoBmffItemReferences    ISO BMFF item references extracted from metadata boxes.
      */
     public function __construct(
         public array $exifBlobs,
@@ -74,6 +76,7 @@ final readonly class Metadata
         public ?string $digestMd5 = null,
         public ?int $jpegFrameWidth = null,
         public ?int $jpegFrameHeight = null,
+        public ?IsoBmffItemReferenceMap $isoBmffItemReferences = null,
     ) {
         $this->structuredCache = new StructuredMetadataCache();
     }

--- a/src/Parse/IsoBmff/IsoBmffExtractor.php
+++ b/src/Parse/IsoBmff/IsoBmffExtractor.php
@@ -16,6 +16,8 @@ use MagicSunday\ImageMeta\Core\ParseError;
 use MagicSunday\ImageMeta\Core\Stream;
 use MagicSunday\ImageMeta\Core\StreamWindow;
 use MagicSunday\ImageMeta\Core\Util\Unpack;
+use MagicSunday\ImageMeta\Model\IsoBmff\IsoBmffItemReference;
+use MagicSunday\ImageMeta\Model\IsoBmff\IsoBmffItemReferenceMap;
 use MagicSunday\ImageMeta\Model\QuickTimeMeta;
 use MagicSunday\ImageMeta\Value\Enum\ConstructionMethod;
 
@@ -101,6 +103,11 @@ final readonly class IsoBmffExtractor
      * FourCC for primary item box.
      */
     private const string BOX_PITM = 'pitm';
+
+    /**
+     * FourCC for item reference box.
+     */
+    private const string BOX_IREF = 'iref';
 
     /**
      * FourCC for embedded XMP metadata box.
@@ -228,6 +235,11 @@ final readonly class IsoBmffExtractor
     private const int MAX_IINF_ENTRIES = 10000;
 
     /**
+     * Maximum number of item references allowed per iref entry.
+     */
+    private const int MAX_IREF_REFERENCES = 10000;
+
+    /**
      * Maximum number of keys in a keys box to prevent DoS attacks.
      */
     private const int MAX_KEYS_ENTRIES = 1000;
@@ -258,23 +270,24 @@ final readonly class IsoBmffExtractor
     /**
      * Extracts EXIF blobs, XMP packets, and QuickTime metadata from the stream.
      *
-     * @return array{0: list<string>, 1: list<string>, 2: ?QuickTimeMeta}
+     * @return array{0: list<string>, 1: list<string>, 2: ?QuickTimeMeta, 3: ?IsoBmffItemReferenceMap}
      */
     public function extract(): array
     {
-        $exifBlobs     = [];
-        $xmpBlobs      = [];
-        $qtKeys        = [];
-        $queuedUuidXmp = [];
-        $xmpHashes     = [];
+        $exifBlobs       = [];
+        $xmpBlobs        = [];
+        $qtKeys          = [];
+        $queuedUuidXmp   = [];
+        $xmpHashes       = [];
+        $itemReferences  = [];
 
         foreach ($this->walkTopLevelBoxes() as $box) {
             if ($box->type === self::BOX_FTYP) {
                 $qtKeys = $this->mergeAssociative($qtKeys, $this->parseFtyp($box));
             } elseif ($box->type === self::BOX_META) {
-                $this->parseMetaBox($box, $exifBlobs, $xmpBlobs, $qtKeys, $xmpHashes);
+                $this->parseMetaBox($box, $exifBlobs, $xmpBlobs, $qtKeys, $itemReferences, $xmpHashes);
             } elseif ($box->type === self::BOX_MOOV) {
-                $this->parseMoovBox($box, $exifBlobs, $xmpBlobs, $qtKeys, $xmpHashes);
+                $this->parseMoovBox($box, $exifBlobs, $xmpBlobs, $qtKeys, $itemReferences, $xmpHashes);
             } elseif ($box->type === self::BOX_UUID && $box->userType === self::XMP_UUID) {
                 $queuedUuidXmp[] = $this->readAll($box->window);
             }
@@ -284,9 +297,10 @@ final readonly class IsoBmffExtractor
             $this->appendUniqueXmp($xmpBlobs, $xmpHashes, $blob);
         }
 
-        $qt = $qtKeys === [] ? null : new QuickTimeMeta($qtKeys);
+        $qt                 = $qtKeys === [] ? null : new QuickTimeMeta($qtKeys);
+        $itemReferenceMap = $itemReferences === [] ? null : new IsoBmffItemReferenceMap($itemReferences);
 
-        return [$exifBlobs, $xmpBlobs, $qt];
+        return [$exifBlobs, $xmpBlobs, $qt, $itemReferenceMap];
     }
 
     /**
@@ -315,17 +329,18 @@ final readonly class IsoBmffExtractor
      *
      * @param BoxDescriptor       $moov      Box descriptor for the movie box.
      * @param list<string>        $exifBlobs
-     * @param list<string>        $xmpBlobs
-     * @param array<string, bool> $xmpHashes
-     * @param QuickTimeKeyMap     $qtKeys
+     * @param list<string>                             $xmpBlobs
+     * @param array<int, list<IsoBmffItemReference>>     $itemReferences
+     * @param array<string, bool>                        $xmpHashes
+     * @param QuickTimeKeyMap                            $qtKeys
      */
-    private function parseMoovBox(BoxDescriptor $moov, array &$exifBlobs, array &$xmpBlobs, array &$qtKeys, array &$xmpHashes): void
+    private function parseMoovBox(BoxDescriptor $moov, array &$exifBlobs, array &$xmpBlobs, array &$qtKeys, array &$itemReferences, array &$xmpHashes): void
     {
         foreach ($this->walkChildren($moov) as $child) {
             if ($child->type === self::BOX_META) {
-                $this->parseMetaBox($child, $exifBlobs, $xmpBlobs, $qtKeys, $xmpHashes);
+                $this->parseMetaBox($child, $exifBlobs, $xmpBlobs, $qtKeys, $itemReferences, $xmpHashes);
             } elseif ($child->type === self::BOX_UDTA) {
-                $this->parseUdtaBox($child, $exifBlobs, $xmpBlobs, $qtKeys, $xmpHashes);
+                $this->parseUdtaBox($child, $exifBlobs, $xmpBlobs, $qtKeys, $itemReferences, $xmpHashes);
             } elseif ($child->type === self::BOX_TRAK) {
                 $qtKeys = $this->mergeAssociative($qtKeys, $this->parseTrak($child));
             }
@@ -368,15 +383,16 @@ final readonly class IsoBmffExtractor
      *
      * @param BoxDescriptor       $udta      Box descriptor for the user data box.
      * @param list<string>        $exifBlobs
-     * @param list<string>        $xmpBlobs
-     * @param array<string, bool> $xmpHashes
-     * @param QuickTimeKeyMap     $qtKeys
+     * @param list<string>                             $xmpBlobs
+     * @param array<int, list<IsoBmffItemReference>>     $itemReferences
+     * @param array<string, bool>                        $xmpHashes
+     * @param QuickTimeKeyMap                            $qtKeys
      */
-    private function parseUdtaBox(BoxDescriptor $udta, array &$exifBlobs, array &$xmpBlobs, array &$qtKeys, array &$xmpHashes): void
+    private function parseUdtaBox(BoxDescriptor $udta, array &$exifBlobs, array &$xmpBlobs, array &$qtKeys, array &$itemReferences, array &$xmpHashes): void
     {
         foreach ($this->walkChildren($udta) as $child) {
             if ($child->type === self::BOX_META) {
-                $this->parseMetaBox($child, $exifBlobs, $xmpBlobs, $qtKeys, $xmpHashes);
+                $this->parseMetaBox($child, $exifBlobs, $xmpBlobs, $qtKeys, $itemReferences, $xmpHashes);
             }
         }
     }
@@ -722,11 +738,12 @@ final readonly class IsoBmffExtractor
      *
      * @param BoxDescriptor       $meta      Box descriptor for the metadata box.
      * @param list<string>        $exifBlobs
-     * @param list<string>        $xmpBlobs
-     * @param array<string, bool> $xmpHashes
-     * @param QuickTimeKeyMap     $qtKeys
+     * @param list<string>                             $xmpBlobs
+     * @param array<int, list<IsoBmffItemReference>>     $itemReferences
+     * @param array<string, bool>                        $xmpHashes
+     * @param QuickTimeKeyMap                            $qtKeys
      */
-    private function parseMetaBox(BoxDescriptor $meta, array &$exifBlobs, array &$xmpBlobs, array &$qtKeys, array &$xmpHashes): void
+    private function parseMetaBox(BoxDescriptor $meta, array &$exifBlobs, array &$xmpBlobs, array &$qtKeys, array &$itemReferences, array &$xmpHashes): void
     {
         if ($meta->contentSize < 4) {
             throw new ParseError('meta box truncated');
@@ -736,6 +753,7 @@ final readonly class IsoBmffExtractor
         // direct Exif boxes, UUID-wrapped payloads and item references, so we collect each
         // channel before normalising the referenced data.
         $payloads = $this->collectDirectPayloads($meta);
+        $itemReferences = $this->mergeItemReferences($itemReferences, $payloads['itemReferences']);
 
         foreach ($payloads['directExif'] as $blob) {
             $exifBlobs[] = $blob;
@@ -770,6 +788,7 @@ final readonly class IsoBmffExtractor
      * @return array{
      *     itemInfos: array<int, array{id: int, itemType: ?string, name: ?string, contentType: ?string}>,
      *     locations: array<int, array{dataReferenceIndex:int, constructionMethod:int, baseOffset:int, extents:list<array{offset:int,length:int}>}>,
+     *     itemReferences: array<int, list<IsoBmffItemReference>>,
      *     primaryItemId: ?int,
      *     directXmp: list<string>,
      *     uuidXmp: list<string>,
@@ -783,9 +802,11 @@ final readonly class IsoBmffExtractor
         /** @var array<int, array{id: int, itemType: ?string, name: ?string, contentType: ?string}> $itemInfos */
         $itemInfos = [];
         /** @var array<int, array{dataReferenceIndex:int, constructionMethod:int, baseOffset:int, extents:list<array{offset:int,length:int}>}> $locations */
-        $locations     = [];
-        $primaryItemId = null;
-        $directXmp     = [];
+        $locations      = [];
+        /** @var array<int, list<IsoBmffItemReference>> $itemReferences */
+        $itemReferences = [];
+        $primaryItemId  = null;
+        $directXmp      = [];
         $uuidXmp       = [];
         $directExif    = [];
         /** @var list<array<int, string>> $keysMaps */
@@ -812,6 +833,9 @@ final readonly class IsoBmffExtractor
                 case self::BOX_PITM:
                     $primaryItemId = $this->parsePitm($child);
                     break;
+                case self::BOX_IREF:
+                    $itemReferences = $this->mergeItemReferences($itemReferences, $this->parseIref($child));
+                    break;
                 case self::BOX_XMP:
                     $directXmp[] = $this->readAll($child->window);
                     break;
@@ -831,10 +855,11 @@ final readonly class IsoBmffExtractor
         }
 
         return [
-            'itemInfos'     => $itemInfos,
-            'locations'     => $locations,
-            'primaryItemId' => $primaryItemId,
-            'directXmp'     => $directXmp,
+            'itemInfos'      => $itemInfos,
+            'locations'      => $locations,
+            'itemReferences' => $itemReferences,
+            'primaryItemId'  => $primaryItemId,
+            'directXmp'      => $directXmp,
             'uuidXmp'       => $uuidXmp,
             'directExif'    => $directExif,
             'keysMaps'      => $keysMaps,
@@ -948,6 +973,30 @@ final readonly class IsoBmffExtractor
         // Merge all ilst entries into the cumulative QuickTime metadata set.
         foreach ($ilstBoxes as $ilst) {
             $existing = $this->mergeAssociative($existing, $this->parseIlst($ilst, $keyIndex));
+        }
+
+        return $existing;
+    }
+
+    /**
+     * Merges ISO BMFF item reference mappings.
+     *
+     * @param array<int, list<IsoBmffItemReference>> $existing
+     * @param array<int, list<IsoBmffItemReference>> $incoming
+     *
+     * @return array<int, list<IsoBmffItemReference>>
+     */
+    private function mergeItemReferences(array $existing, array $incoming): array
+    {
+        foreach ($incoming as $fromId => $references) {
+            if (!isset($existing[$fromId])) {
+                $existing[$fromId] = $references;
+                continue;
+            }
+
+            foreach ($references as $reference) {
+                $existing[$fromId][] = $reference;
+            }
         }
 
         return $existing;
@@ -1235,6 +1284,103 @@ final readonly class IsoBmffExtractor
         $this->readUInt24($win);
 
         return $version === 0 ? $win->readU16BE() : $win->readU32BE();
+    }
+
+    /**
+     * Parses an item reference box (`iref`) and returns the referenced item ids.
+     *
+     * ISO/IEC 14496-12 §8.11.12 defines the structure of item reference
+     * collections and their single-item reference entries.
+     *
+     * @param BoxDescriptor $iref Box descriptor containing item references.
+     *
+     * @return array<int, list<IsoBmffItemReference>>
+     */
+    private function parseIref(BoxDescriptor $iref): array
+    {
+        $win = $iref->window;
+        $win->seek(0);
+
+        if ($iref->contentSize < 4) {
+            throw new ParseError('iref box truncated');
+        }
+
+        $version = $win->readU8();
+        $this->readUInt24($win); // flags
+
+        if ($version !== 0 && $version !== 1) {
+            throw new ParseError('unsupported iref box version');
+        }
+
+        $references = [];
+
+        foreach ($this->walkChildren($iref, 4) as $child) {
+            $entry = $this->parseSingleItemReference($child);
+            $references = $this->mergeItemReferences($references, [
+                $entry['fromItemId'] => $entry['references'],
+            ]);
+        }
+
+        return $references;
+    }
+
+    /**
+     * Parses a single item reference box inside an `iref` container.
+     *
+     * @param BoxDescriptor $entry Box descriptor describing the reference entry.
+     *
+     * @return array{fromItemId:int, references:list<IsoBmffItemReference>}
+     */
+    private function parseSingleItemReference(BoxDescriptor $entry): array
+    {
+        $win = $entry->window;
+        $win->seek(0);
+
+        if ($entry->contentSize < 6) {
+            throw new ParseError('iref entry truncated');
+        }
+
+        $version = $win->readU8();
+        $this->readUInt24($win); // flags
+
+        if ($version !== 0 && $version !== 1) {
+            throw new ParseError('unsupported iref entry version');
+        }
+
+        $idSize = $version === 0 ? 2 : 4;
+
+        if ($entry->contentSize < 4 + $idSize + 2) {
+            throw new ParseError('iref entry truncated');
+        }
+
+        $fromItemId = $idSize === 2 ? $win->readU16BE() : $win->readU32BE();
+        $referenceCount = $win->readU16BE();
+
+        if ($referenceCount > self::MAX_IREF_REFERENCES) {
+            throw new ParseError('iref reference count exceeds maximum allowed');
+        }
+
+        $remaining = $entry->contentSize - $win->tell();
+        $expected = $referenceCount * $idSize;
+        if ($remaining < $expected) {
+            throw new ParseError('iref entry truncated');
+        }
+
+        $relation = $this->normaliseFourcc($entry->type);
+        $references = [];
+        for ($i = 0; $i < $referenceCount; ++$i) {
+            $toItemId = $idSize === 2 ? $win->readU16BE() : $win->readU32BE();
+            $references[] = new IsoBmffItemReference($relation, $toItemId);
+        }
+
+        if ($win->tell() !== $entry->contentSize) {
+            throw new ParseError('iref entry size mismatch');
+        }
+
+        return [
+            'fromItemId' => $fromItemId,
+            'references' => $references,
+        ];
     }
 
     /**

--- a/tests/MetadataReaderTest.php
+++ b/tests/MetadataReaderTest.php
@@ -39,6 +39,8 @@ use MagicSunday\ImageMeta\Model\Exif\Ifd;
 use MagicSunday\ImageMeta\Model\Exif\IfdEntry;
 use MagicSunday\ImageMeta\Model\Exif\ParsedExif;
 use MagicSunday\ImageMeta\Model\Exif\ValueConverters;
+use MagicSunday\ImageMeta\Model\IsoBmff\IsoBmffItemReference;
+use MagicSunday\ImageMeta\Model\IsoBmff\IsoBmffItemReferenceMap;
 use MagicSunday\ImageMeta\Model\Metadata;
 use MagicSunday\ImageMeta\Model\QuickTimeMeta;
 use MagicSunday\ImageMeta\Model\StructuredMetadataCache;
@@ -132,6 +134,8 @@ use function unlink;
 #[UsesClass(IfdEntry::class)]
 #[UsesClass(ParsedExif::class)]
 #[UsesClass(ValueConverters::class)]
+#[UsesClass(IsoBmffItemReference::class)]
+#[UsesClass(IsoBmffItemReferenceMap::class)]
 #[UsesClass(Metadata::class)]
 #[UsesClass(QuickTimeMeta::class)]
 #[UsesClass(StructuredMetadataCache::class)]
@@ -344,9 +348,11 @@ final class MetadataReaderTest extends TestCase
             . '</x:xmpmeta>';
         $identifier = 'qt-meta-identifier';
 
-        $ftyp       = $this->box('ftyp', 'isom');
-        $meta       = $this->fullBox('meta', $this->box('Exif', self::EXIF_SIGNATURE . $tiff) . $this->box('XMP ', $xmp));
-        $moov       = $this->quickTimeMoov($identifier);
+        $ftyp      = $this->box('ftyp', 'isom');
+        $irefEntry = $this->fullBox('cdsc', pack('n', 2) . pack('n', 1) . pack('n', 3));
+        $iref      = $this->fullBox('iref', $irefEntry);
+        $meta      = $this->fullBox('meta', $this->box('Exif', self::EXIF_SIGNATURE . $tiff) . $this->box('XMP ', $xmp) . $iref);
+        $moov      = $this->quickTimeMoov($identifier);
         $isoPayload = $ftyp . $meta . $moov;
 
         $path = $this->writeTempFile($isoPayload);
@@ -361,6 +367,11 @@ final class MetadataReaderTest extends TestCase
         self::assertSame([$xmp], $metadata->xmpBlobs);
         self::assertInstanceOf(QuickTimeMeta::class, $metadata->quickTime);
         self::assertSame($identifier, $metadata->quickTime->contentIdentifier());
+        self::assertInstanceOf(IsoBmffItemReferenceMap::class, $metadata->isoBmffItemReferences);
+        $itemReferences = $metadata->isoBmffItemReferences->referencesFor(2);
+        self::assertCount(1, $itemReferences);
+        self::assertSame('cdsc', $itemReferences[0]->relation);
+        self::assertSame(3, $itemReferences[0]->toItemId);
         self::assertInstanceOf(ParsedExif::class, $metadata->exifDoc);
         self::assertInstanceOf(XmpDocument::class, $metadata->xmpDoc);
         self::assertInstanceOf(MakerNotesRecord::class, $metadata->makerNotes);

--- a/tests/Model/IsoBmff/IsoBmffItemReferenceMapTest.php
+++ b/tests/Model/IsoBmff/IsoBmffItemReferenceMapTest.php
@@ -1,0 +1,44 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\ImageMeta\Tests\Model\IsoBmff;
+
+use MagicSunday\ImageMeta\Model\IsoBmff\IsoBmffItemReference;
+use MagicSunday\ImageMeta\Model\IsoBmff\IsoBmffItemReferenceMap;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(IsoBmffItemReference::class)]
+#[CoversClass(IsoBmffItemReferenceMap::class)]
+final class IsoBmffItemReferenceMapTest extends TestCase
+{
+    #[Test]
+    public function mapProvidesReferencesBySourceId(): void
+    {
+        $reference = new IsoBmffItemReference('cdsc', 12);
+        $map       = new IsoBmffItemReferenceMap([5 => [$reference]]);
+
+        self::assertSame([5], $map->fromItemIds());
+        self::assertSame([$reference], $map->referencesFor(5));
+        self::assertSame([], $map->referencesFor(9));
+        self::assertFalse($map->isEmpty());
+    }
+
+    #[Test]
+    public function emptyMapReportsNoReferences(): void
+    {
+        $map = new IsoBmffItemReferenceMap([]);
+
+        self::assertSame([], $map->fromItemIds());
+        self::assertTrue($map->isEmpty());
+    }
+}

--- a/tests/Model/MetadataTest.php
+++ b/tests/Model/MetadataTest.php
@@ -23,6 +23,8 @@ use MagicSunday\ImageMeta\Model\Exif\Ifd;
 use MagicSunday\ImageMeta\Model\Exif\IfdEntry;
 use MagicSunday\ImageMeta\Model\Exif\ParsedExif;
 use MagicSunday\ImageMeta\Model\Exif\ValueConverters;
+use MagicSunday\ImageMeta\Model\IsoBmff\IsoBmffItemReference;
+use MagicSunday\ImageMeta\Model\IsoBmff\IsoBmffItemReferenceMap;
 use MagicSunday\ImageMeta\Model\Metadata;
 use MagicSunday\ImageMeta\Model\QuickTimeMeta;
 use MagicSunday\ImageMeta\Model\StructuredMetadataCache;
@@ -78,6 +80,8 @@ use PHPUnit\Framework\TestCase;
 #[UsesClass(Ifd::class)]
 #[UsesClass(IfdEntry::class)]
 #[UsesClass(QuickTimeMeta::class)]
+#[UsesClass(IsoBmffItemReference::class)]
+#[UsesClass(IsoBmffItemReferenceMap::class)]
 #[UsesClass(XmpDocument::class)]
 #[UsesClass(XmpParser::class)]
 #[UsesClass(ExifCapabilities::class)]
@@ -156,6 +160,10 @@ final class MetadataTest extends TestCase
             '{http://ns.adobe.com/photoshop/1.0/}DateCreated' => '2024-05-01',
         ]);
 
+        $itemReferences = new IsoBmffItemReferenceMap([
+            1 => [new IsoBmffItemReference('cdsc', 2)],
+        ]);
+
         $iccProfile  = 'icc-profile';
         $iccSegments = ['seg-1', 'seg-2'];
         $sampling    = [
@@ -184,6 +192,7 @@ final class MetadataTest extends TestCase
             digestMd5: 'def456',
             jpegFrameWidth: 4096,
             jpegFrameHeight: 2730,
+            isoBmffItemReferences: $itemReferences,
         );
 
         self::assertSame($exifBlobs, $metadata->exifBlobs);
@@ -203,6 +212,7 @@ final class MetadataTest extends TestCase
         self::assertSame('def456', $metadata->digestMd5);
         self::assertSame(4096, $metadata->jpegFrameWidth);
         self::assertSame(2730, $metadata->jpegFrameHeight);
+        self::assertSame($itemReferences, $metadata->isoBmffItemReferences);
     }
 
     /**
@@ -218,6 +228,7 @@ final class MetadataTest extends TestCase
         self::assertNull($metadata->exifDoc);
         self::assertSame([], $metadata->xmpBlobs);
         self::assertNull($metadata->xmpDoc);
+        self::assertNull($metadata->isoBmffItemReferences);
         self::assertNull($metadata->jpegBitsPerSample);
         self::assertNull($metadata->jpegFrameSamplingFactors);
         self::assertNull($metadata->jpegYCbCrSubSampling);


### PR DESCRIPTION
### Motivation
- Support item-to-item relations embedded in ISO BMFF containers so downstream features (Exif/XMP/Depth) can resolve referenced payloads; this follows ISOBMFF §8.11.12.
- Surface parsed `iref` mappings through the existing metadata aggregate so consumers can access reference graphs without re-parsing boxes.

### Description
- Implemented `iref` parsing in `src/Parse/IsoBmff/IsoBmffExtractor.php` including `parseIref` and `parseSingleItemReference`, added guarding (`MAX_IREF_REFERENCES`) and merging logic (`mergeItemReferences`).
- Added model types `MagicSunday\ImageMeta\Model\IsoBmff\IsoBmffItemReference` and `IsoBmffItemReferenceMap` and wired the map into the metadata pipeline by extending `IsoBmffExtractor::extract()` to return the map and adding `isoBmffItemReferences` to `Metadata` and `MetadataReader`.
- Updated and added unit tests to cover exposure and basic behavior: `tests/Model/IsoBmff/IsoBmffItemReferenceMapTest.php`, adjusted assertions in `tests/MetadataReaderTest.php`, and `tests/Model/MetadataTest.php` to include the new map in the aggregate.

### Testing
- Unit tests added: `tests/Model/IsoBmff/IsoBmffItemReferenceMapTest.php` and updates to `tests/MetadataReaderTest.php` and `tests/Model/MetadataTest.php` to assert presence and content of the reference map.
- No automated test suite was executed as part of this rollout (no `composer ci:test:*` or `phpunit` run was performed), so test pass/fail status is not available.
- Static/quality checks (PHPStan/CS/Rectors) were not run in this change set; CI checklist entries remain to be executed by the integrator.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f29861bdc8323b492d8518f7bf93c)