### PR TITLE
M#: Resolve idat item extents in ISO BMFF meta parsing

### DIFF
--- a/src/Parse/IsoBmff/IsoBmffExtractor.php
+++ b/src/Parse/IsoBmff/IsoBmffExtractor.php
@@ -103,6 +103,11 @@ final readonly class IsoBmffExtractor
     private const string BOX_ILOC = 'iloc';
 
     /**
+     * FourCC for item data box.
+     */
+    private const string BOX_IDAT = 'idat';
+
+    /**
      * FourCC for primary item box.
      */
     private const string BOX_PITM = 'pitm';
@@ -792,6 +797,7 @@ final readonly class IsoBmffExtractor
         $payloads = $this->collectDirectPayloads($meta);
         $itemReferences = $this->mergeItemReferences($itemReferences, $payloads['itemReferences']);
         $dataReferences = $this->mergeDataReferences($dataReferences, $payloads['dataReferences']);
+        $idatPayload    = $payloads['idatPayload'];
 
         foreach ($payloads['directExif'] as $blob) {
             $exifBlobs[] = $blob;
@@ -802,12 +808,12 @@ final readonly class IsoBmffExtractor
         // Resolve EXIF item payloads and normalize leading headers.
         // EXIF 3.0 §4.8 notes that item payloads omit the APP1 signature; some
         // encoders still include it, so we normalise accordingly.
-        foreach ($this->resolveQueuedItems($exifItemIds, $payloads['locations'], $this->normalizeExifBlob(...), $payloads['dataReferences'], $unresolvedItems) as $blob) {
+        foreach ($this->resolveQueuedItems($exifItemIds, $payloads['locations'], $this->normalizeExifBlob(...), $payloads['dataReferences'], $idatPayload, $unresolvedItems) as $blob) {
             $exifBlobs[] = $blob;
         }
 
         // Resolve referenced XMP payloads in declared priority order.
-        foreach ($this->resolveQueuedItems($xmpItemIds, $payloads['locations'], null, $payloads['dataReferences'], $unresolvedItems) as $blob) {
+        foreach ($this->resolveQueuedItems($xmpItemIds, $payloads['locations'], null, $payloads['dataReferences'], $idatPayload, $unresolvedItems) as $blob) {
             $this->appendUniqueXmp($xmpBlobs, $xmpHashes, $blob);
         }
 
@@ -832,6 +838,7 @@ final readonly class IsoBmffExtractor
      *     directXmp: list<string>,
      *     uuidXmp: list<string>,
      *     directExif: list<string>,
+     *     idatPayload: ?string,
      *     keysMaps: list<array<int, string>>,
      *     ilstBoxes: list<BoxDescriptor>
      * }
@@ -848,8 +855,9 @@ final readonly class IsoBmffExtractor
         $dataReferences = [];
         $primaryItemId  = null;
         $directXmp      = [];
-        $uuidXmp       = [];
-        $directExif    = [];
+        $uuidXmp        = [];
+        $directExif     = [];
+        $idatPayload    = null;
         /** @var list<array<int, string>> $keysMaps */
         $keysMaps = [];
         /** @var list<BoxDescriptor> $ilstBoxes */
@@ -870,6 +878,16 @@ final readonly class IsoBmffExtractor
                     break;
                 case self::BOX_ILOC:
                     $locations = $this->parseIloc($child);
+                    break;
+                case self::BOX_IDAT:
+                    if ($idatPayload === null) {
+                        if ($child->contentSize > self::MAX_ITEM_PAYLOAD_SIZE) {
+                            throw new ParseError('idat payload exceeds configured limit');
+                        }
+
+                        $idatPayload = $this->readAll($child->window);
+                    }
+
                     break;
                 case self::BOX_PITM:
                     $primaryItemId = $this->parsePitm($child);
@@ -905,10 +923,11 @@ final readonly class IsoBmffExtractor
             'dataReferences' => $dataReferences,
             'primaryItemId'  => $primaryItemId,
             'directXmp'      => $directXmp,
-            'uuidXmp'       => $uuidXmp,
-            'directExif'    => $directExif,
-            'keysMaps'      => $keysMaps,
-            'ilstBoxes'     => $ilstBoxes,
+            'uuidXmp'        => $uuidXmp,
+            'directExif'     => $directExif,
+            'idatPayload'    => $idatPayload,
+            'keysMaps'       => $keysMaps,
+            'ilstBoxes'      => $ilstBoxes,
         ];
     }
 
@@ -958,18 +977,19 @@ final readonly class IsoBmffExtractor
      * @param array<int, array{dataReferenceIndex:int, constructionMethod:int, baseOffset:int, extents:list<array{offset:int,length:int}>}> $locations       Item location metadata.
      * @param (callable(string):string)|null                                                                                                $transform       Optional transform function.
      * @param array<int, IsoBmffDataReference>                                                                                               $dataReferences  Parsed data references for the current meta box.
+     * @param string|null                                                                                                                    $idatPayload     Cached idat payload for construction_method=1 extents.
      * @param list<IsoBmffUnresolvedItem>                                                                                                    $unresolvedItems Accumulator for unresolved item payloads.
      *
      * @return list<string> List of resolved item payloads.
      */
-    private function resolveQueuedItems(array $itemIds, array $locations, ?callable $transform, array $dataReferences, array &$unresolvedItems): array
+    private function resolveQueuedItems(array $itemIds, array $locations, ?callable $transform, array $dataReferences, ?string $idatPayload, array &$unresolvedItems): array
     {
         /** @var list<string> $resolved */
         $resolved = [];
 
         // Pull data for each referenced item and optionally transform the payload.
         foreach ($itemIds as $itemId) {
-            $data = $this->resolveItemData($itemId, $locations, $dataReferences, $unresolvedItems);
+            $data = $this->resolveItemData($itemId, $locations, $dataReferences, $idatPayload, $unresolvedItems);
             if ($data !== null) {
                 $resolved[] = $transform !== null ? $transform($data) : $data;
             }
@@ -1194,68 +1214,116 @@ final readonly class IsoBmffExtractor
      * @param int                                                                                                                           $itemId         Identifier of the item to resolve.
      * @param array<int, array{dataReferenceIndex:int, constructionMethod:int, baseOffset:int, extents:list<array{offset:int,length:int}>}> $locations
      * @param array<int, IsoBmffDataReference>                                                                                               $dataReferences
+     * @param string|null                                                                                                                    $idatPayload
      * @param list<IsoBmffUnresolvedItem>                                                                                                    $unresolvedItems
      *
      * @return string|null
      */
-    private function resolveItemData(int $itemId, array $locations, array $dataReferences, array &$unresolvedItems): ?string
+    private function resolveItemData(int $itemId, array $locations, array $dataReferences, ?string $idatPayload, array &$unresolvedItems): ?string
     {
         if (!isset($locations[$itemId])) {
             return null;
         }
 
         $location = $locations[$itemId];
-        // EXIF 3.0 Annex A.2.4 confines Exif item data to self-contained payloads
-        // (`construction_method = 0`, `data_reference_index = 0`). When files
-        // reference external payloads we keep a record of the unresolved item.
-        if ($location['constructionMethod'] !== ConstructionMethod::FileOffset->value) {
-            $this->registerUnresolvedItem($itemId, $location, $dataReferences, $unresolvedItems);
-            return null;
-        }
-
+        // EXIF 3.0 Annex A.2.4 confines Exif item data to self-contained payloads.
+        // We only resolve items with local data references; other sources are tracked
+        // as unresolved for the caller to decide how to handle them.
         if ($location['dataReferenceIndex'] !== 0) {
             $this->registerUnresolvedItem($itemId, $location, $dataReferences, $unresolvedItems);
             return null;
         }
 
-        $blob     = '';
-        $total    = 0;
-        $fileSize = $this->stream->size();
-        foreach ($location['extents'] as $extent) {
-            $length = $extent['length'];
-            if ($length === 0) {
-                continue;
+        if ($location['constructionMethod'] === ConstructionMethod::FileOffset->value) {
+            $blob     = '';
+            $total    = 0;
+            $fileSize = $this->stream->size();
+            foreach ($location['extents'] as $extent) {
+                $length = $extent['length'];
+                if ($length === 0) {
+                    continue;
+                }
+
+                if ($length > self::MAX_ITEM_PAYLOAD_SIZE - $total) {
+                    throw new ParseError('iloc item payload exceeds configured limit');
+                }
+
+                if ($length > $fileSize - $total) {
+                    throw new ParseError('iloc extent length exceeds file size');
+                }
+
+                $total += $length;
+
+                $baseOffset   = $location['baseOffset'];
+                $extentOffset = $extent['offset'];
+                if ($baseOffset < 0 || $extentOffset < 0) {
+                    throw new ParseError('iloc negative offset');
+                }
+
+                if ($baseOffset > PHP_INT_MAX - $extentOffset) {
+                    throw new ParseError('iloc offset overflow');
+                }
+
+                $offset = $baseOffset + $extentOffset;
+                if ($offset > $fileSize - $length) {
+                    throw new ParseError('iloc extent outside file');
+                }
+
+                $blob .= $this->readAll($this->stream->window($offset, $length));
             }
 
-            if ($length > self::MAX_ITEM_PAYLOAD_SIZE - $total) {
-                throw new ParseError('iloc item payload exceeds configured limit');
-            }
-
-            if ($length > $fileSize - $total) {
-                throw new ParseError('iloc extent length exceeds file size');
-            }
-
-            $total += $length;
-
-            $baseOffset   = $location['baseOffset'];
-            $extentOffset = $extent['offset'];
-            if ($baseOffset < 0 || $extentOffset < 0) {
-                throw new ParseError('iloc negative offset');
-            }
-
-            if ($baseOffset > PHP_INT_MAX - $extentOffset) {
-                throw new ParseError('iloc offset overflow');
-            }
-
-            $offset = $baseOffset + $extentOffset;
-            if ($offset > $fileSize - $length) {
-                throw new ParseError('iloc extent outside file');
-            }
-
-            $blob .= $this->readAll($this->stream->window($offset, $length));
+            return $blob === '' ? null : $blob;
         }
 
-        return $blob === '' ? null : $blob;
+        if ($location['constructionMethod'] === ConstructionMethod::IdatOffset->value) {
+            if ($idatPayload === null) {
+                $this->registerUnresolvedItem($itemId, $location, $dataReferences, $unresolvedItems);
+                return null;
+            }
+
+            // ISO/IEC 14496-12 §8.11.3.2 defines construction_method=1 offsets as idat-relative.
+            $blob     = '';
+            $total    = 0;
+            $idatSize = strlen($idatPayload);
+            foreach ($location['extents'] as $extent) {
+                $length = $extent['length'];
+                if ($length === 0) {
+                    continue;
+                }
+
+                if ($length > self::MAX_ITEM_PAYLOAD_SIZE - $total) {
+                    throw new ParseError('iloc item payload exceeds configured limit');
+                }
+
+                if ($length > $idatSize - $total) {
+                    throw new ParseError('iloc extent length exceeds idat payload');
+                }
+
+                $total += $length;
+
+                $baseOffset   = $location['baseOffset'];
+                $extentOffset = $extent['offset'];
+                if ($baseOffset < 0 || $extentOffset < 0) {
+                    throw new ParseError('iloc negative offset');
+                }
+
+                if ($baseOffset > PHP_INT_MAX - $extentOffset) {
+                    throw new ParseError('iloc offset overflow');
+                }
+
+                $offset = $baseOffset + $extentOffset;
+                if ($offset > $idatSize - $length) {
+                    throw new ParseError('iloc extent outside idat payload');
+                }
+
+                $blob .= substr($idatPayload, $offset, $length);
+            }
+
+            return $blob === '' ? null : $blob;
+        }
+
+        $this->registerUnresolvedItem($itemId, $location, $dataReferences, $unresolvedItems);
+        return null;
     }
 
     /**


### PR DESCRIPTION
## Summary
- Cache `idat` payloads during meta parsing and resolve item extents for `construction_method=1` relative to the payload.
- Apply bounds checks and payload size limits consistent with the file-offset path.

**Issue/Milestone:** Closes #N/A • Milestone M#  
**Scope (allowed files only):** `src/Parse/IsoBmff/IsoBmffExtractor.php`  
**Non-Goals:** Tests/CI updates; broader refactors.

---

## Implementation Notes
- Runtime: PHP 8.4, `declare(strict_types=1);`, PSR-12.
- **Streaming only** (Core\Stream/StreamWindow) — keine Ganzdatei-Reads.
- Keine externen Binaries/Extensions; **kein** `exif_read_data()`.
- Value Objects (chainable) nur für EXIF-Ausgabe; kein Rendering.
- **Enums** für gängige Kodierungen genutzt/ergänzt (Encoding/Endianness/IFD/XMP/...).
- **Spec-References** im Code ergänzt/aktualisiert (siehe „References“).

---

## Always Checklist (must be green)
**Composer-Tasks (deine CI-Skripte):**
- [ ] Lint: `composer ci:test:php:lint`
- [ ] PHPStan: `composer ci:test:php:phpstan`
- [ ] Rector (dry-run): `composer ci:test:php:rector`
- [ ] Coding-Style: `composer ci::cgl`
- [ ] PHPUnit: `composer ci:test:php:unit`
- [ ] Coverage ≥ **90 %**: `composer ci:test:php:unit:coverage`
- [ ] JSCPD (Duplikate = 0): `composer ci:test:php:cpd`
- [ ] Sammellauf: `composer ci:test` (sollte grün sein; enthält Lint, PHPStan, Rector-Dry-Run, CS-Dry-Run, Unit)

**Inhaltliche/Code-Guidelines:**
- [ ] **Keine** `mixed`-Signaturen • **kein** `empty()` • **keine** verschachtelten Ternaries
- [ ] Fully-qualified native functions (`\strlen`, `\count`, …) und sinnvolle `use`-Imports
- [ ] **Keine** dynamischen Aufrufe statischer Methoden
- [ ] Sinnvolle **Interfaces** verwendet (wo Verträge sinnvoll sind)
- [ ] Typisierte Klassenkonstanten; redundante Casts/Default-Argumente entfernt
- [ ] Klassen als `readonly`, wo passend; keine redundanten `readonly`-Mods
- [ ] **Eine Klasse je Datei** • Test-Namespaces spiegeln `src/`-Struktur
- [ ] Englische PHPDocs & englische Inline-Kommentare an komplexen Stellen
- [ ] Sinnvolle Namen für Variablen/Konstanten; Magic Numbers/Strings vermieden
- [ ] `array_find` / `array_any` / `array_all` gezielt statt trivialer `foreach` verwendet (wo es die Lesbarkeit verbessert)

---

## EXIF / TIFF / ISOBMFF / XMP Guardrails
- **EXIF-Versionen:** 1.x, 2.x (2.1/2.2/2.21/2.3/2.31/2.32), 3.0 — kompatible Änderungen; falls Tags betroffen: Coverage-Test grün.
- **TIFF/BigTIFF:** Endianness korrekt (`0x2A` / `0x2B`), Inline-Werte-Grenzen, `RATIONAL/SRATIONAL` korrekt.
- **GPS:** Vorzeichen über Ref-Tags (S/W negativ); `0/0`-Kantenfälle robust.
- **Preview/IFD1:** Nur beschreiben (Offsets/Längen/Compression), kein Rendering.
- **ISOBMFF/QuickTime:** Box-Size ≥ Header, 32/64-bit-Größen korrekt; `iloc`-Extents summiert; `data_reference_index ≠ 0` → skip; keine Remote-Refs.
- **XMP:** JPEG APP1-Präfix / ISOBMFF `uuid`; Parser mit `LIBXML_NONET`, keine DTD/Entities; `Alt/Bag/Seq` → Arrays.
- **Fehlerbehandlung:** ausschließlich `ParseError` oder `BoundsError`; keine Warnings/Notices als Kontrollfluss.

---

## Tests
- **Neue/angepasste Tests:** Not added.
- **Negative Cases:** Not added.
- **Fixtures/Streams:** Not added.

---

## M# Sweep — Preflight Notes
- Not run in this change set.

---

## M# Sweep — Verify compliance for this milestone
Bitte **alles** verifizieren und kurz die Ergebnisse notieren:
- [ ] `composer ci:test` **grün** (Lint, PHPStan, Rector-Dry-Run, CS-Dry-Run, Unit)
- [ ] `composer ci:test:php:cpd` **0 Duplikate** (JSCPD, Konfig: `.build/.jscpd.json`)
- [ ] `composer ci:test:php:unit:coverage` **≥ 90 %**
- [ ] **ExifCoverageTest** (falls vorhanden): 0 fehlende Tags/Getters (gegen `resources/exif-map.yaml`)
- [ ] Für **jede** Klasse existiert ein Test (Namespace-Spiegelung)

---

## Breaking Changes / Risk / Rollback
- **Breaking changes:** None.
- **Risiken:** Minimal; new idat resolution may surface malformed offsets as ParseError.
- **Rollback-Plan:** Revert this commit.

---

## Changelog
- feat(isobmff): resolve idat item extents

---

## References (Specs & Docs)
- EXIF 3.0 Annex A.2.4
- ISOBMFF/QuickTime ISO/IEC 14496-12 §8.11.3.2

Docs im Repo:
- `docs/EXIF-210.pdf`, `docs/EXIF-220.pdf`, `docs/EXIF-230.pdf`, `docs/EXIF-231.pdf`, `docs/EXIF-232.pdf`, `docs/EXIF-300.pdf`
- `docs/TIFF6.pdf`

---

## Review Roles (tick what you covered)
- [ ] Planner (Scope/Non-Goals/Guardrails definiert)
- [ ] Spec Writer (AC/Tests präzisiert)
- [ ] Test Agent (RED zuerst)
- [ ] Implementer (GREEN minimal & im Datei-Scope)
- [ ] Static/QA (Stan/CS/Rector/JSCPD clean)
- [ ] Security (Bounds, Offsets, XML-Flags)
- [ ] Reviewer (Minimalität, DX, Spec-Refs, Enums)
- [ ] Release (PR-Text, Labels, Milestone, „Closes #…")

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f33ddf7488323825b3539ecc4147e)