### PR TITLE
M1: Add Samsung maker note decoder — MakerNotes

### DIFF
--- a/src/MakerNotes/Apple/AppleMakerNotesMerger.php
+++ b/src/MakerNotes/Apple/AppleMakerNotesMerger.php
@@ -53,6 +53,7 @@ final class AppleMakerNotesMerger
                 $makerNotes->length,
                 $makerNotes->sha1,
                 $apple,
+                $makerNotes->samsung,
             );
         }
 
@@ -61,7 +62,8 @@ final class AppleMakerNotesMerger
                 'Apple',
                 0,
                 str_repeat('0', 40),
-                $apple
+                $apple,
+                null,
             );
         }
 

--- a/src/MakerNotes/MakerNotesRecord.php
+++ b/src/MakerNotes/MakerNotesRecord.php
@@ -13,6 +13,7 @@ namespace MagicSunday\ImageMeta\MakerNotes;
 
 use InvalidArgumentException;
 use MagicSunday\ImageMeta\MakerNotes\Apple\AppleMakerNotes;
+use MagicSunday\ImageMeta\MakerNotes\Samsung\SamsungMakerNotes;
 
 use function preg_match;
 
@@ -22,16 +23,18 @@ use function preg_match;
 final readonly class MakerNotesRecord
 {
     /**
-     * @param string               $vendor Vendor responsible for the maker note payload. Must not be empty.
-     * @param int                  $length Number of bytes contained in the payload. Must be zero or positive.
-     * @param string               $sha1   Lowercase hexadecimal SHA-1 digest of the payload. Must be 40 characters long.
-     * @param AppleMakerNotes|null $apple  Additional Apple specific maker note data.
+     * @param string                 $vendor  Vendor responsible for the maker note payload. Must not be empty.
+     * @param int                    $length  Number of bytes contained in the payload. Must be zero or positive.
+     * @param string                 $sha1    Lowercase hexadecimal SHA-1 digest of the payload. Must be 40 characters long.
+     * @param AppleMakerNotes|null   $apple   Additional Apple specific maker note data.
+     * @param SamsungMakerNotes|null $samsung Additional Samsung specific maker note data.
      */
     public function __construct(
         public string $vendor,
         public int $length,
         public string $sha1,
         public ?AppleMakerNotes $apple = null,
+        public ?SamsungMakerNotes $samsung = null,
     ) {
         if ($this->vendor === '') {
             throw new InvalidArgumentException('The vendor must not be empty.');

--- a/src/MakerNotes/RegistryFactory.php
+++ b/src/MakerNotes/RegistryFactory.php
@@ -26,6 +26,7 @@ final class RegistryFactory
         $appleDecoder = new AppleDecoder();
         $canonDecoder = new CanonDecoder();
         $nikonDecoder = new NikonDecoder();
+        $samsungDecoder = new SamsungDecoder();
         $sonyDecoder  = new SonyDecoder();
 
         $registry->register('Apple', $appleDecoder);
@@ -34,6 +35,9 @@ final class RegistryFactory
         $registry->register('Canon Inc.', $canonDecoder);
         $registry->register('Nikon', $nikonDecoder);
         $registry->register('Nikon Corporation', $nikonDecoder);
+        $registry->register('Samsung', $samsungDecoder);
+        $registry->register('SAMSUNG', $samsungDecoder);
+        $registry->register('Samsung Electronics', $samsungDecoder);
         $registry->register('Sony', $sonyDecoder);
         $registry->register('Sony Corporation', $sonyDecoder);
 

--- a/src/MakerNotes/Samsung/SamsungMakerNotes.php
+++ b/src/MakerNotes/Samsung/SamsungMakerNotes.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\ImageMeta\MakerNotes\Samsung;
+
+/**
+ * Represents curated maker note data extracted from Samsung devices.
+ *
+ * Fields are based on documented Samsung maker note tags from ExifTool.
+ */
+final readonly class SamsungMakerNotes
+{
+    /**
+     * @param string|null $makerNoteVersion Maker note version reported by Samsung devices.
+     * @param string|null $deviceType       Device type string reported in the maker note.
+     * @param int|null    $modelId          Numeric model identifier reported by Samsung devices.
+     */
+    public function __construct(
+        public ?string $makerNoteVersion,
+        public ?string $deviceType,
+        public ?int $modelId,
+    ) {
+    }
+}

--- a/src/MakerNotes/SamsungDecoder.php
+++ b/src/MakerNotes/SamsungDecoder.php
@@ -1,0 +1,267 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\ImageMeta\MakerNotes;
+
+use MagicSunday\ImageMeta\Core\Endian;
+use MagicSunday\ImageMeta\Core\ParseError;
+use MagicSunday\ImageMeta\Core\Util\Unpack;
+use MagicSunday\ImageMeta\MakerNotes\Samsung\SamsungMakerNotes;
+
+use function rtrim;
+use function sha1;
+use function str_starts_with;
+use function strlen;
+use function substr;
+use function trim;
+
+/**
+ * Decoder that extracts structured metadata from Samsung maker note payloads.
+ *
+ * Samsung maker note tags are documented by ExifTool and stored as a TIFF-style
+ * IFD payload, optionally prefixed with the ASCII string "SAMSUNG\\0".
+ */
+final class SamsungDecoder implements MakerNotesDecoderInterface
+{
+    private const int TIFF_MAGIC = 0x2A;
+    private const string SAMSUNG_SIGNATURE = "SAMSUNG\0";
+
+    private const int TAG_MAKER_NOTE_VERSION = 0x0001;
+    private const int TAG_DEVICE_TYPE = 0x0002;
+    private const int TAG_MODEL_ID = 0x0003;
+
+    private const int TYPE_ASCII = 2;
+    private const int TYPE_SHORT = 3;
+    private const int TYPE_LONG = 4;
+
+    /**
+     * Creates a metadata value object describing the Samsung maker note payload.
+     *
+     * @param string      $raw   Raw maker note data stream captured from the image file.
+     * @param string      $make  Reported camera make string.
+     * @param string|null $model Optional camera model identifier for the payload.
+     */
+    public function decode(string $raw, string $make, ?string $model): MakerNotesRecord
+    {
+        $samsungData = $this->parseSamsungData($raw);
+
+        return new MakerNotesRecord(
+            'Samsung',
+            strlen($raw),
+            sha1($raw),
+            null,
+            $samsungData,
+        );
+    }
+
+    /**
+     * Parses the raw Samsung maker note payload into a structured representation.
+     */
+    private function parseSamsungData(string $raw): ?SamsungMakerNotes
+    {
+        $length = strlen($raw);
+        if ($length < 8) {
+            return null;
+        }
+
+        $headerOffset = 0;
+        if (str_starts_with($raw, self::SAMSUNG_SIGNATURE)) {
+            $headerOffset = strlen(self::SAMSUNG_SIGNATURE);
+        }
+
+        if ($length < $headerOffset + 8) {
+            return null;
+        }
+
+        $endian = $this->resolveEndian(substr($raw, $headerOffset, 2));
+        if (!$endian instanceof Endian) {
+            return null;
+        }
+
+        try {
+            $magic = $this->readU16($raw, $headerOffset + 2, $endian, 'Samsung TIFF magic');
+            if ($magic !== self::TIFF_MAGIC) {
+                return null;
+            }
+
+            $ifdOffset = $this->readU32($raw, $headerOffset + 4, $endian, 'Samsung IFD offset');
+            $ifdStart  = $headerOffset + $ifdOffset;
+
+            if ($ifdOffset < 8 || $ifdStart + 2 > $length) {
+                return null;
+            }
+
+            $entryCount = $this->readU16($raw, $ifdStart, $endian, 'Samsung IFD entry count');
+            $entriesEnd = $ifdStart + 2 + ($entryCount * 12);
+
+            if ($entriesEnd > $length) {
+                return null;
+            }
+
+            $makerNoteVersion = null;
+            $deviceType = null;
+            $modelId = null;
+
+            for ($index = 0; $index < $entryCount; ++$index) {
+                $entryOffset = $ifdStart + 2 + ($index * 12);
+                $tag = $this->readU16($raw, $entryOffset, $endian, 'Samsung IFD tag');
+                $type = $this->readU16($raw, $entryOffset + 2, $endian, 'Samsung IFD type');
+                $count = $this->readU32($raw, $entryOffset + 4, $endian, 'Samsung IFD count');
+                $valueOffset = $this->readU32($raw, $entryOffset + 8, $endian, 'Samsung IFD value offset');
+
+                $valueBytes = $this->resolveValueBytes(
+                    $raw,
+                    $headerOffset,
+                    $entryOffset + 8,
+                    $type,
+                    $count,
+                    $valueOffset,
+                    $length,
+                );
+
+                if ($valueBytes === null) {
+                    continue;
+                }
+
+                switch ($tag) {
+                    case self::TAG_MAKER_NOTE_VERSION:
+                        $makerNoteVersion = $this->parseAscii($valueBytes);
+                        break;
+                    case self::TAG_DEVICE_TYPE:
+                        $deviceType = $this->parseAscii($valueBytes);
+                        break;
+                    case self::TAG_MODEL_ID:
+                        $modelId = $this->parseInt($valueBytes, $type, $endian);
+                        break;
+                    default:
+                        break;
+                }
+            }
+        } catch (ParseError) {
+            return null;
+        }
+
+        if ($makerNoteVersion === null && $deviceType === null && $modelId === null) {
+            return null;
+        }
+
+        return new SamsungMakerNotes($makerNoteVersion, $deviceType, $modelId);
+    }
+
+    /**
+     * Resolves the endian marker for Samsung maker note payloads.
+     */
+    private function resolveEndian(string $endian): ?Endian
+    {
+        return match ($endian) {
+            Endian::Little->value => Endian::Little,
+            Endian::Big->value => Endian::Big,
+            default => null,
+        };
+    }
+
+    /**
+     * Reads an unsigned 16-bit integer using the supplied byte order.
+     */
+    private function readU16(string $raw, int $offset, Endian $endian, string $context): int
+    {
+        $bytes = substr($raw, $offset, 2);
+
+        return Unpack::int($endian === Endian::Little ? 'v' : 'n', $bytes, $context);
+    }
+
+    /**
+     * Reads an unsigned 32-bit integer using the supplied byte order.
+     */
+    private function readU32(string $raw, int $offset, Endian $endian, string $context): int
+    {
+        $bytes = substr($raw, $offset, 4);
+
+        return Unpack::int($endian === Endian::Little ? 'V' : 'N', $bytes, $context);
+    }
+
+    /**
+     * Resolves the bytes representing a tag value.
+     */
+    private function resolveValueBytes(
+        string $raw,
+        int $headerOffset,
+        int $inlineOffset,
+        int $type,
+        int $count,
+        int $valueOffset,
+        int $length,
+    ): ?string {
+        $typeSize = $this->typeSize($type);
+        if ($typeSize === 0 || $count < 1) {
+            return null;
+        }
+
+        $dataSize = $typeSize * $count;
+        if ($dataSize <= 4) {
+            return substr($raw, $inlineOffset, $dataSize);
+        }
+
+        $dataOffset = $headerOffset + $valueOffset;
+        if ($dataOffset < 0 || $dataOffset + $dataSize > $length) {
+            return null;
+        }
+
+        return substr($raw, $dataOffset, $dataSize);
+    }
+
+    /**
+     * Returns the byte width for a TIFF type used in Samsung maker notes.
+     */
+    private function typeSize(int $type): int
+    {
+        return match ($type) {
+            self::TYPE_ASCII => 1,
+            self::TYPE_SHORT => 2,
+            self::TYPE_LONG => 4,
+            default => 0,
+        };
+    }
+
+    /**
+     * Parses an ASCII-encoded value and normalises it.
+     */
+    private function parseAscii(string $valueBytes): ?string
+    {
+        $value = trim(rtrim($valueBytes, "\0"));
+
+        return $value === '' ? null : $value;
+    }
+
+    /**
+     * Parses an integer value from the supplied bytes.
+     */
+    private function parseInt(string $valueBytes, int $type, Endian $endian): ?int
+    {
+        if ($type === self::TYPE_SHORT) {
+            if (strlen($valueBytes) < 2) {
+                return null;
+            }
+
+            return Unpack::int($endian === Endian::Little ? 'v' : 'n', substr($valueBytes, 0, 2), 'Samsung SHORT');
+        }
+
+        if ($type === self::TYPE_LONG) {
+            if (strlen($valueBytes) < 4) {
+                return null;
+            }
+
+            return Unpack::int($endian === Endian::Little ? 'V' : 'N', substr($valueBytes, 0, 4), 'Samsung LONG');
+        }
+
+        return null;
+    }
+}

--- a/src/Parse/Tiff/TiffExifReader.php
+++ b/src/Parse/Tiff/TiffExifReader.php
@@ -1090,6 +1090,7 @@ final class TiffExifReader implements ExifReaderInterface
             $metadata->length,
             $metadata->sha1,
             $metadata->apple,
+            $metadata->samsung,
         );
     }
 

--- a/tests/MakerNotes/MakerNotesRecordTest.php
+++ b/tests/MakerNotes/MakerNotesRecordTest.php
@@ -36,6 +36,7 @@ final class MakerNotesRecordTest extends TestCase
         self::assertSame(123, $metadata->length);
         self::assertSame('0123456789abcdef0123456789abcdef01234567', $metadata->sha1);
         self::assertNull($metadata->apple);
+        self::assertNull($metadata->samsung);
     }
 
     /**

--- a/tests/MakerNotes/RegistryTest.php
+++ b/tests/MakerNotes/RegistryTest.php
@@ -17,6 +17,7 @@ use MagicSunday\ImageMeta\MakerNotes\MakerNotesRecord;
 use MagicSunday\ImageMeta\MakerNotes\NikonDecoder;
 use MagicSunday\ImageMeta\MakerNotes\Registry;
 use MagicSunday\ImageMeta\MakerNotes\RegistryFactory;
+use MagicSunday\ImageMeta\MakerNotes\SamsungDecoder;
 use MagicSunday\ImageMeta\MakerNotes\SonyDecoder;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -110,6 +111,7 @@ final class RegistryTest extends TestCase
 
         self::assertInstanceOf(CanonDecoder::class, $registry->find('Canon Inc.'));
         self::assertInstanceOf(NikonDecoder::class, $registry->find('Nikon Corporation'));
+        self::assertInstanceOf(SamsungDecoder::class, $registry->find('SAMSUNG'));
         self::assertInstanceOf(SonyDecoder::class, $registry->find('Sony Corporation'));
     }
 }

--- a/tests/MakerNotes/SamsungDecoderTest.php
+++ b/tests/MakerNotes/SamsungDecoderTest.php
@@ -1,0 +1,85 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\ImageMeta\Tests\MakerNotes;
+
+use MagicSunday\ImageMeta\MakerNotes\Samsung\SamsungMakerNotes;
+use MagicSunday\ImageMeta\MakerNotes\SamsungDecoder;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\UsesClass;
+use PHPUnit\Framework\TestCase;
+
+use function implode;
+use function pack;
+use function strlen;
+
+/**
+ * Validates decoding Samsung maker note payloads.
+ */
+#[CoversClass(SamsungDecoder::class)]
+#[UsesClass(SamsungMakerNotes::class)]
+final class SamsungDecoderTest extends TestCase
+{
+    #[Test]
+    public function decodeExtractsSamsungFieldsFromMakerNote(): void
+    {
+        $raw = 'SAMSUNG' . "\0" . $this->buildSamsungMakerNote();
+
+        $decoder = new SamsungDecoder();
+        $record = $decoder->decode($raw, 'SAMSUNG', 'Galaxy S24');
+
+        self::assertSame('Samsung', $record->vendor);
+        self::assertInstanceOf(SamsungMakerNotes::class, $record->samsung);
+        self::assertSame('0100', $record->samsung->makerNoteVersion);
+        self::assertSame('Phone', $record->samsung->deviceType);
+        self::assertSame(0x1234, $record->samsung->modelId);
+    }
+
+    #[Test]
+    public function decodeReturnsNullSamsungNotesForInvalidPayload(): void
+    {
+        $decoder = new SamsungDecoder();
+        $record = $decoder->decode('invalid', 'SAMSUNG', null);
+
+        self::assertNull($record->samsung);
+    }
+
+    private function buildSamsungMakerNote(): string
+    {
+        $entries = [];
+        $data = '';
+
+        $version = "0100\0";
+        $deviceType = "Phone\0";
+
+        $versionOffset = 8 + 2 + (3 * 12) + 4;
+        $deviceOffset = $versionOffset + strlen($version);
+
+        $entries[] = $this->buildEntry(0x0001, 2, strlen($version), $versionOffset);
+        $entries[] = $this->buildEntry(0x0002, 2, strlen($deviceType), $deviceOffset);
+        $entries[] = $this->buildEntry(0x0003, 3, 1, 0x1234, true);
+
+        $data .= $version;
+        $data .= $deviceType;
+
+        $ifd = pack('v', 3) . implode('', $entries) . pack('V', 0);
+
+        return 'II' . pack('v', 0x2A) . pack('V', 8) . $ifd . $data;
+    }
+
+    private function buildEntry(int $tag, int $type, int $count, int $value, bool $inline = false): string
+    {
+        $valueBytes = $inline ? pack('v', $value) . "\0\0" : pack('V', $value);
+
+        return pack('v', $tag) . pack('v', $type) . pack('V', $count) . $valueBytes;
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide vendor-specific parsing for Samsung MakerNotes so structured fields (MakerNoteVersion, DeviceType, ModelID) are available to consumers.
- Ensure MakerNotes registry can resolve Samsung make strings and that decoded Samsung data is preserved alongside existing Apple maker note data.

### Description
- Add `SamsungDecoder` to parse a TIFF-style IFD (optionally prefixed with `"SAMSUNG\0"`) and extract MakerNoteVersion, DeviceType and ModelID into a new VO `SamsungMakerNotes` (`src/MakerNotes/SamsungDecoder.php`, `src/MakerNotes/Samsung/SamsungMakerNotes.php`).
- Extend `MakerNotesRecord` to carry an optional `SamsungMakerNotes` instance and preserve this field through safety/merge paths in `TiffExifReader` and `AppleMakerNotesMerger` (`src/MakerNotes/MakerNotesRecord.php`, `src/Parse/Tiff/TiffExifReader.php`, `src/MakerNotes/Apple/AppleMakerNotesMerger.php`).
- Register Samsung make prefixes in the default registry so common make strings map to the new decoder (`src/MakerNotes/RegistryFactory.php`).
- Add unit tests validating decoding and registry mapping: `tests/MakerNotes/SamsungDecoderTest.php`, update `tests/MakerNotes/RegistryTest.php`, and update `tests/MakerNotes/MakerNotesRecordTest.php`.

### Testing
- No automated test suite was executed as part of this change; the PR adds unit tests but they were not run locally in the rollout.
- New/updated PHPUnit tests: `SamsungDecoderTest`, `RegistryTest` (registry mapping for `SAMSUNG`), and `MakerNotesRecordTest` (ensures `samsung` field defaults to null).
- To validate the change run the project CI commands, e.g. `composer ci:test` and `composer ci:test:php:unit` (expected to run the added tests and full verification).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f4f33940c83238441596048a68514)