### PR TITLE
M#: Add depth map XMP curation — Curate/Exif

### DIFF
--- a/src/Curate/Exif/ValueFactory.php
+++ b/src/Curate/Exif/ValueFactory.php
@@ -39,6 +39,7 @@ use MagicSunday\ImageMeta\Value\ColorProfile as ValueColorProfile;
 use MagicSunday\ImageMeta\Value\CompositeImageInfo;
 use MagicSunday\ImageMeta\Value\Container;
 use MagicSunday\ImageMeta\Value\Derived;
+use MagicSunday\ImageMeta\Value\DepthMap;
 use MagicSunday\ImageMeta\Value\Device;
 use MagicSunday\ImageMeta\Value\Exposure;
 use MagicSunday\ImageMeta\Value\File as ValueFile;
@@ -112,7 +113,7 @@ final readonly class ValueFactory implements ValueFactoryInterface
      *
      * @param Metadata $metadata Metadata container with decoded EXIF, XMP and QuickTime data.
      *
-     * @return array{audio: ValueAudio, author: Author, camera: Camera, capture: Capture, colorProfile: ValueColorProfile, composite: CompositeImageInfo, container: Container, derived: Derived, device: Device, embeddedAudio: AudioClips, exposure: Exposure, file: ValueFile, flashPix: FlashPix, focus: Focus, gps: Gps, image: Image, integrity: Integrity, interop: ValueInterop, keywords: Keywords, lens: Lens, motion: Motion, multiPicture: MultiPicture, processing: ValueProcessingSettings, regions: Regions, related: RelatedAssets, rights: Rights, scene: Scene, sensor: Sensor, standards: ValueStandards, temporal: Temporal, thumbnail: Thumbnail, tiff: TiffData, video: Video, whiteBalance: WhiteBalanceDetails, xmp: ValueXmp, makerNotesApple: AppleMakerNotes|null}
+     * @return array{audio: ValueAudio, author: Author, camera: Camera, capture: Capture, colorProfile: ValueColorProfile, composite: CompositeImageInfo, container: Container, derived: Derived, depthMap: DepthMap, device: Device, embeddedAudio: AudioClips, exposure: Exposure, file: ValueFile, flashPix: FlashPix, focus: Focus, gps: Gps, image: Image, integrity: Integrity, interop: ValueInterop, keywords: Keywords, lens: Lens, motion: Motion, multiPicture: MultiPicture, processing: ValueProcessingSettings, regions: Regions, related: RelatedAssets, rights: Rights, scene: Scene, sensor: Sensor, standards: ValueStandards, temporal: Temporal, thumbnail: Thumbnail, tiff: TiffData, video: Video, whiteBalance: WhiteBalanceDetails, xmp: ValueXmp, makerNotesApple: AppleMakerNotes|null}
      */
     public function createComponents(Metadata $metadata): array
     {
@@ -389,6 +390,14 @@ final readonly class ValueFactory implements ValueFactoryInterface
             relatedSoundFile: $exifDocument?->relatedSoundFile(),
         );
 
+        $depthMapNamespace = 'http://ns.google.com/photos/1.0/depthmap/';
+        $depthMap          = new DepthMap(
+            data: $xmpDocument?->string($depthMapNamespace, 'Data'),
+            mime: $xmpDocument?->string($depthMapNamespace, 'Mime'),
+            near: $xmpDocument?->float($depthMapNamespace, 'Near'),
+            far: $xmpDocument?->float($depthMapNamespace, 'Far'),
+        );
+
         $hasHistory = $xmpDocument?->has('http://ns.adobe.com/xap/1.0/mm/', 'History') ?? false;
 
         $integrity = new Integrity(
@@ -407,6 +416,7 @@ final readonly class ValueFactory implements ValueFactoryInterface
             'composite'       => $composite,
             'container'       => $container,
             'derived'         => $derived,
+            'depthMap'        => $depthMap,
             'device'          => $device,
             'embeddedAudio'   => $embeddedAudio,
             'exposure'        => $exposure,

--- a/src/Curate/ExifAssembler.php
+++ b/src/Curate/ExifAssembler.php
@@ -43,6 +43,7 @@ final readonly class ExifAssembler implements StructuredAssemblerInterface
             composite: $components['composite'],
             container: $components['container'],
             derived: $components['derived'],
+            depthMap: $components['depthMap'],
             device: $components['device'],
             exposure: $components['exposure'],
             file: $components['file'],

--- a/src/Curate/StructuredMetadata.php
+++ b/src/Curate/StructuredMetadata.php
@@ -21,6 +21,7 @@ use MagicSunday\ImageMeta\Value\ColorProfile;
 use MagicSunday\ImageMeta\Value\CompositeImageInfo;
 use MagicSunday\ImageMeta\Value\Container;
 use MagicSunday\ImageMeta\Value\Derived;
+use MagicSunday\ImageMeta\Value\DepthMap;
 use MagicSunday\ImageMeta\Value\Device;
 use MagicSunday\ImageMeta\Value\Exposure;
 use MagicSunday\ImageMeta\Value\File;
@@ -63,6 +64,7 @@ final readonly class StructuredMetadata
         public CompositeImageInfo $composite,
         public Container $container,
         public Derived $derived,
+        public DepthMap $depthMap,
         public Device $device,
         public Exposure $exposure,
         public File $file,

--- a/src/Value/DepthMap.php
+++ b/src/Value/DepthMap.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\ImageMeta\Value;
+
+/**
+ * Represents depth map metadata embedded in XMP packets.
+ */
+final readonly class DepthMap
+{
+    /**
+     * Creates a depth map metadata value object.
+     *
+     * @param string|null $data Base64-encoded depth map payload.
+     * @param string|null $mime Mime type of the depth map payload.
+     * @param float|null  $near Nearest depth value reported by the map.
+     * @param float|null  $far  Farthest depth value reported by the map.
+     */
+    public function __construct(
+        public ?string $data,
+        public ?string $mime,
+        public ?float $near,
+        public ?float $far,
+    ) {
+    }
+}

--- a/tests/Curate/Exif/ValueFactoryTest.php
+++ b/tests/Curate/Exif/ValueFactoryTest.php
@@ -1,0 +1,60 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/imagemeta.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\ImageMeta\Tests\Curate\Exif;
+
+use MagicSunday\ImageMeta\Curate\Exif\ValueFactory;
+use MagicSunday\ImageMeta\Curate\ExifAssembler;
+use MagicSunday\ImageMeta\Curate\StructuredMetadata;
+use MagicSunday\ImageMeta\Model\Metadata;
+use MagicSunday\ImageMeta\Parse\Xmp\XmpParser;
+use MagicSunday\ImageMeta\Value\DepthMap;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\UsesClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(ValueFactory::class)]
+#[UsesClass(ExifAssembler::class)]
+#[UsesClass(StructuredMetadata::class)]
+#[UsesClass(DepthMap::class)]
+final class ValueFactoryTest extends TestCase
+{
+    #[Test]
+    public function assemblesDepthMapFromXmpPacket(): void
+    {
+        $xml = <<<XML
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+         xmlns:GDepth="http://ns.google.com/photos/1.0/depthmap/">
+  <rdf:Description
+    GDepth:Data="ZGVwdGg="
+    GDepth:Mime="image/png"
+    GDepth:Near="0.25"
+    GDepth:Far="10.5"
+  />
+</rdf:RDF>
+XML;
+
+        $metadata = new Metadata(
+            exifBlobs: [],
+            quickTime: null,
+            xmpDoc: (new XmpParser())->parse($xml),
+        );
+
+        $structured = (new ExifAssembler())->assemble($metadata);
+
+        self::assertInstanceOf(DepthMap::class, $structured->depthMap);
+        self::assertSame('ZGVwdGg=', $structured->depthMap->data);
+        self::assertSame('image/png', $structured->depthMap->mime);
+        self::assertSame(0.25, $structured->depthMap->near);
+        self::assertSame(10.5, $structured->depthMap->far);
+    }
+}

--- a/tests/Parse/Xmp/XmpParserTest.php
+++ b/tests/Parse/Xmp/XmpParserTest.php
@@ -506,4 +506,33 @@ XML;
         self::assertArrayHasKey(self::DC_NS, $document->namespacePrefixes);
         self::assertSame('dc', $document->namespacePrefixes[self::DC_NS]);
     }
+
+    /**
+     * Ensures depth map properties from the Google depthmap namespace are parsed.
+     */
+    #[Test]
+    public function parseExtractsDepthMapProperties(): void
+    {
+        $xml = <<<XML
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+         xmlns:GDepth="http://ns.google.com/photos/1.0/depthmap/">
+  <rdf:Description
+    GDepth:Data="ZGVwdGg="
+    GDepth:Mime="image/png"
+    GDepth:Near="0.25"
+    GDepth:Far="10.5"
+  />
+</rdf:RDF>
+XML;
+
+        $parser   = new XmpParser();
+        $document = $parser->parse($xml);
+
+        $depthNs = 'http://ns.google.com/photos/1.0/depthmap/';
+
+        self::assertSame('ZGVwdGg=', $document->get($depthNs, 'Data'));
+        self::assertSame('image/png', $document->get($depthNs, 'Mime'));
+        self::assertSame('0.25', $document->get($depthNs, 'Near'));
+        self::assertSame('10.5', $document->get($depthNs, 'Far'));
+    }
 }


### PR DESCRIPTION
### Motivation
- Surface Google depthmap XMP properties (`GDepth:Data`, `GDepth:Mime`, `GDepth:Near`, `GDepth:Far`) in the structured metadata so consumers can access embedded depth information.

### Description
- Add `DepthMap` value object in `src/Value/DepthMap.php` to represent base64 payload, mime type and near/far floats. 
- Extract the `http://ns.google.com/photos/1.0/depthmap/` properties inside `src/Curate/Exif/ValueFactory.php` and construct a `DepthMap` instance returned in the components array. 
- Expose the new `depthMap` property on the curated aggregate by adding it to `src/Curate/StructuredMetadata.php` and by passing `depthMap` through `src/Curate/ExifAssembler.php`. 
- Add unit tests covering parsing and curation with synthetic XMP packets in `tests/Parse/Xmp/XmpParserTest.php` and `tests/Curate/Exif/ValueFactoryTest.php`.

### Testing
- New PHPUnit tests were added: `XmpParserTest::parseExtractsDepthMapProperties` and `ValueFactoryTest::assemblesDepthMapFromXmpPacket` but the test suite was not executed during this rollout. 
- Static analysis and coding-style checks (`PHPStan`, `PHPCS`, `Rector`) were not run as part of this change set in the current environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f533845888323b4b277336c470c66)