### PR TITLE
M#: Map XMP creator contact info — Curate/Exif

### DIFF
--- a/src/Curate/Exif/SubFactory/ImageFactory.php
+++ b/src/Curate/Exif/SubFactory/ImageFactory.php
@@ -13,6 +13,7 @@ namespace MagicSunday\ImageMeta\Curate\Exif\SubFactory;
 
 use MagicSunday\ImageMeta\Model\Exif\ParsedExif;
 use MagicSunday\ImageMeta\Model\Metadata;
+use MagicSunday\ImageMeta\Model\Xmp\XmpDocument;
 use MagicSunday\ImageMeta\Value\Enum\ColorSpace;
 use MagicSunday\ImageMeta\Value\Image;
 
@@ -27,11 +28,12 @@ final readonly class ImageFactory
     /**
      * Creates an Image value object from EXIF metadata.
      *
-     * @param Metadata $metadata Metadata container with decoded EXIF, XMP and QuickTime data.
+     * @param Metadata         $metadata    Metadata container with decoded EXIF, XMP and QuickTime data.
+     * @param XmpDocument|null $xmpDocument Parsed XMP document for title/description overrides.
      *
      * @return Image Normalised image metadata aggregate.
      */
-    public function create(Metadata $metadata): Image
+    public function create(Metadata $metadata, ?XmpDocument $xmpDocument = null): Image
     {
         $exifDocument = $metadata->exifDoc;
 
@@ -39,6 +41,10 @@ final readonly class ImageFactory
         $height        = $exifDocument?->imageHeight() ?? $metadata->jpegFrameHeight;
         $orientation   = $exifDocument?->orientation();
         $bitsPerSample = $exifDocument?->bitsPerSample() ?? $metadata->jpegBitsPerSample;
+
+        $xmpTitle       = $xmpDocument?->string('http://purl.org/dc/elements/1.1/', 'title');
+        $xmpHeadline    = $xmpDocument?->string('http://ns.adobe.com/photoshop/1.0/', 'Headline');
+        $xmpDescription = $xmpDocument?->string('http://purl.org/dc/elements/1.1/', 'description');
 
         return new Image(
             width: $width,
@@ -48,8 +54,8 @@ final readonly class ImageFactory
             colorSpace: $this->normalizedColorSpace($exifDocument),
             imageUniqueId: $exifDocument?->imageUniqueId(),
             documentName: $exifDocument?->documentName(),
-            description: $exifDocument?->imageDescription(),
-            title: $exifDocument?->imageTitle(),
+            description: $xmpDescription ?? $exifDocument?->imageDescription(),
+            title: $xmpTitle ?? $xmpHeadline ?? $exifDocument?->imageTitle(),
             componentsConfiguration: $exifDocument?->componentsConfiguration(),
             compressedBitsPerPixel: $exifDocument?->compressedBitsPerPixel(),
             userComment: $exifDocument?->userComment(),

--- a/src/Curate/Exif/ValueFactory.php
+++ b/src/Curate/Exif/ValueFactory.php
@@ -126,7 +126,7 @@ final readonly class ValueFactory implements ValueFactoryInterface
         $exposure     = $this->exposureFactory->create($metadata);
         $sensor       = $this->sensorFactory->create($metadata);
         $device       = $this->deviceFactory->create($metadata);
-        $image        = $this->imageFactory->create($metadata);
+        $image        = $this->imageFactory->create($metadata, $xmpDocument);
         $motion       = $this->motionFactory->create($metadata);
         $temporal     = $this->temporalFactory->create($metadata);
         $regions      = $this->regionsFactory->create($metadata);
@@ -347,11 +347,20 @@ final readonly class ValueFactory implements ValueFactoryInterface
             creditLine: $xmpDocument?->string('http://ns.adobe.com/photoshop/1.0/', 'Credit'),
         );
 
+        $iptcNamespace = 'http://iptc.org/std/Iptc4xmpCore/1.0/xmlns/';
+
         $author = new Author(
             artist: $exifDocument?->artist(),
             ownerName: $exifDocument?->ownerName(),
             creator: $this->firstListValue($xmpDocument?->stringList('http://purl.org/dc/elements/1.1/', 'creator') ?? []),
-            creatorEmail: $xmpDocument?->string('http://iptc.org/std/Iptc4xmpCore/1.0/xmlns/', 'CreatorContactInfo/Iptc4xmpCore:CiEmailWork'),
+            creatorEmail: $xmpDocument?->string($iptcNamespace, 'CiEmailWork'),
+            creatorPhone: $xmpDocument?->string($iptcNamespace, 'CiTelWork'),
+            creatorAddress: $xmpDocument?->string($iptcNamespace, 'CiAdrExtadr'),
+            creatorCity: $xmpDocument?->string($iptcNamespace, 'CiAdrCity'),
+            creatorRegion: $xmpDocument?->string($iptcNamespace, 'CiAdrRegion'),
+            creatorPostalCode: $xmpDocument?->string($iptcNamespace, 'CiAdrPcode'),
+            creatorCountry: $xmpDocument?->string($iptcNamespace, 'CiAdrCtry'),
+            creatorUrl: $xmpDocument?->string($iptcNamespace, 'CiUrlWork'),
             photographer: $exifDocument?->photographer(),
             imageEditor: $exifDocument?->imageEditor(),
         );

--- a/src/Value/Author.php
+++ b/src/Value/Author.php
@@ -19,18 +19,32 @@ final readonly class Author
     /**
      * Creates an author/creator metadata value object.
      *
-     * @param string|null $artist       Artist or photographer name.
-     * @param string|null $ownerName    Camera owner name.
-     * @param string|null $creator      Creator attribution as declared in XMP.
-     * @param string|null $creatorEmail Contact email address for the creator.
-     * @param string|null $photographer Photographer attribution from EXIF 3.0 tags.
-     * @param string|null $imageEditor  Image editor attribution from EXIF 3.0 tags.
+     * @param string|null $artist            Artist or photographer name.
+     * @param string|null $ownerName         Camera owner name.
+     * @param string|null $creator           Creator attribution as declared in XMP.
+     * @param string|null $creatorEmail      Contact email address for the creator.
+     * @param string|null $creatorPhone      Contact phone number for the creator.
+     * @param string|null $creatorAddress    Contact street address for the creator.
+     * @param string|null $creatorCity       Contact city for the creator.
+     * @param string|null $creatorRegion     Contact region/state for the creator.
+     * @param string|null $creatorPostalCode Contact postal code for the creator.
+     * @param string|null $creatorCountry    Contact country for the creator.
+     * @param string|null $creatorUrl        Contact URL for the creator.
+     * @param string|null $photographer      Photographer attribution from EXIF 3.0 tags.
+     * @param string|null $imageEditor       Image editor attribution from EXIF 3.0 tags.
      */
     public function __construct(
         public ?string $artist,
         public ?string $ownerName,
         public ?string $creator,
         public ?string $creatorEmail,
+        public ?string $creatorPhone,
+        public ?string $creatorAddress,
+        public ?string $creatorCity,
+        public ?string $creatorRegion,
+        public ?string $creatorPostalCode,
+        public ?string $creatorCountry,
+        public ?string $creatorUrl,
         public ?string $photographer,
         public ?string $imageEditor,
     ) {

--- a/tests/Curate/Exif/ValueFactoryTest.php
+++ b/tests/Curate/Exif/ValueFactoryTest.php
@@ -16,14 +16,18 @@ use MagicSunday\ImageMeta\Curate\ExifAssembler;
 use MagicSunday\ImageMeta\Curate\StructuredMetadata;
 use MagicSunday\ImageMeta\Model\Metadata;
 use MagicSunday\ImageMeta\Parse\Xmp\XmpParser;
+use MagicSunday\ImageMeta\Value\Author;
 use MagicSunday\ImageMeta\Value\DepthMap;
+use MagicSunday\ImageMeta\Value\Image;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 
 #[CoversClass(ValueFactory::class)]
+#[UsesClass(Author::class)]
 #[UsesClass(ExifAssembler::class)]
+#[UsesClass(Image::class)]
 #[UsesClass(StructuredMetadata::class)]
 #[UsesClass(DepthMap::class)]
 final class ValueFactoryTest extends TestCase
@@ -56,5 +60,59 @@ XML;
         self::assertSame('image/png', $structured->depthMap->mime);
         self::assertSame(0.25, $structured->depthMap->near);
         self::assertSame(10.5, $structured->depthMap->far);
+    }
+
+    #[Test]
+    public function mapsXmpCreatorContactInfoAndTitles(): void
+    {
+        $xml = <<<XML
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+         xmlns:dc="http://purl.org/dc/elements/1.1/"
+         xmlns:photoshop="http://ns.adobe.com/photoshop/1.0/"
+         xmlns:Iptc4xmpCore="http://iptc.org/std/Iptc4xmpCore/1.0/xmlns/">
+  <rdf:Description>
+    <dc:title>
+      <rdf:Alt>
+        <rdf:li xml:lang="x-default">Sample Title</rdf:li>
+      </rdf:Alt>
+    </dc:title>
+    <dc:description>
+      <rdf:Alt>
+        <rdf:li xml:lang="x-default">Sample Description</rdf:li>
+      </rdf:Alt>
+    </dc:description>
+    <photoshop:Headline>Fallback Headline</photoshop:Headline>
+    <Iptc4xmpCore:CreatorContactInfo rdf:parseType="Resource">
+      <Iptc4xmpCore:CiEmailWork>jane@example.com</Iptc4xmpCore:CiEmailWork>
+      <Iptc4xmpCore:CiTelWork>+49 30 555</Iptc4xmpCore:CiTelWork>
+      <Iptc4xmpCore:CiAdrExtadr>Main Street 1</Iptc4xmpCore:CiAdrExtadr>
+      <Iptc4xmpCore:CiAdrCity>Berlin</Iptc4xmpCore:CiAdrCity>
+      <Iptc4xmpCore:CiAdrRegion>BE</Iptc4xmpCore:CiAdrRegion>
+      <Iptc4xmpCore:CiAdrPcode>10115</Iptc4xmpCore:CiAdrPcode>
+      <Iptc4xmpCore:CiAdrCtry>DE</Iptc4xmpCore:CiAdrCtry>
+      <Iptc4xmpCore:CiUrlWork>https://example.com</Iptc4xmpCore:CiUrlWork>
+    </Iptc4xmpCore:CreatorContactInfo>
+  </rdf:Description>
+</rdf:RDF>
+XML;
+
+        $metadata = new Metadata(
+            exifBlobs: [],
+            quickTime: null,
+            xmpDoc: (new XmpParser())->parse($xml),
+        );
+
+        $structured = (new ExifAssembler())->assemble($metadata);
+
+        self::assertSame('Sample Title', $structured->image->title);
+        self::assertSame('Sample Description', $structured->image->description);
+        self::assertSame('jane@example.com', $structured->author->creatorEmail);
+        self::assertSame('+49 30 555', $structured->author->creatorPhone);
+        self::assertSame('Main Street 1', $structured->author->creatorAddress);
+        self::assertSame('Berlin', $structured->author->creatorCity);
+        self::assertSame('BE', $structured->author->creatorRegion);
+        self::assertSame('10115', $structured->author->creatorPostalCode);
+        self::assertSame('DE', $structured->author->creatorCountry);
+        self::assertSame('https://example.com', $structured->author->creatorUrl);
     }
 }

--- a/tests/Value/AuthorTest.php
+++ b/tests/Value/AuthorTest.php
@@ -30,6 +30,13 @@ final class AuthorTest extends TestCase
             ownerName: null,
             creator: null,
             creatorEmail: null,
+            creatorPhone: null,
+            creatorAddress: null,
+            creatorCity: null,
+            creatorRegion: null,
+            creatorPostalCode: null,
+            creatorCountry: null,
+            creatorUrl: null,
             photographer: null,
             imageEditor: null,
         );
@@ -45,6 +52,13 @@ final class AuthorTest extends TestCase
             ownerName: 'Camera Owner',
             creator: 'J. Smith',
             creatorEmail: 'jane@example.com',
+            creatorPhone: '+49 30 555',
+            creatorAddress: 'Main Street 1',
+            creatorCity: 'Berlin',
+            creatorRegion: 'BE',
+            creatorPostalCode: '10115',
+            creatorCountry: 'DE',
+            creatorUrl: 'https://example.com',
             photographer: 'Jane Smith Photography',
             imageEditor: 'Jane Smith',
         );
@@ -53,6 +67,13 @@ final class AuthorTest extends TestCase
         self::assertSame('Camera Owner', $author->ownerName);
         self::assertSame('J. Smith', $author->creator);
         self::assertSame('jane@example.com', $author->creatorEmail);
+        self::assertSame('+49 30 555', $author->creatorPhone);
+        self::assertSame('Main Street 1', $author->creatorAddress);
+        self::assertSame('Berlin', $author->creatorCity);
+        self::assertSame('BE', $author->creatorRegion);
+        self::assertSame('10115', $author->creatorPostalCode);
+        self::assertSame('DE', $author->creatorCountry);
+        self::assertSame('https://example.com', $author->creatorUrl);
         self::assertSame('Jane Smith Photography', $author->photographer);
         self::assertSame('Jane Smith', $author->imageEditor);
     }
@@ -65,6 +86,13 @@ final class AuthorTest extends TestCase
             ownerName: null,
             creator: null,
             creatorEmail: null,
+            creatorPhone: null,
+            creatorAddress: null,
+            creatorCity: null,
+            creatorRegion: null,
+            creatorPostalCode: null,
+            creatorCountry: null,
+            creatorUrl: null,
             photographer: null,
             imageEditor: null,
         );
@@ -73,6 +101,13 @@ final class AuthorTest extends TestCase
         self::assertNull($author->ownerName);
         self::assertNull($author->creator);
         self::assertNull($author->creatorEmail);
+        self::assertNull($author->creatorPhone);
+        self::assertNull($author->creatorAddress);
+        self::assertNull($author->creatorCity);
+        self::assertNull($author->creatorRegion);
+        self::assertNull($author->creatorPostalCode);
+        self::assertNull($author->creatorCountry);
+        self::assertNull($author->creatorUrl);
         self::assertNull($author->photographer);
         self::assertNull($author->imageEditor);
     }


### PR DESCRIPTION
### Motivation

- Provide richer curated metadata by mapping common XMP properties (IPTC CreatorContactInfo fields, `photoshop:Headline`, `dc:description`, `dc:title`) into existing value objects. 
- Prefer XMP title/description/headline where present so image-level metadata reflects author-provided textual fields.

### Description

- Extend the `Author` value object with IPTC contact fields (email/phone/address/city/region/postalCode/country/url) so contact data can be carried in the curated model (`src/Value/Author.php`).
- Map `Iptc4xmpCore:CreatorContactInfo` child properties using the IPTC namespace `http://iptc.org/std/Iptc4xmpCore/1.0/xmlns/` inside `ValueFactory` and expose them on the `Author` instance (`src/Curate/Exif/ValueFactory.php`).
- Prefer `dc:title` / `dc:description` and fallback to `photoshop:Headline` when populating image `title`/`description` via the `ImageFactory` subfactory (`src/Curate/Exif/SubFactory/ImageFactory.php`).
- Add PHPUnit coverage for the mapping behavior and update the `Author` tests with the new fields (`tests/Curate/Exif/ValueFactoryTest.php`, `tests/Value/AuthorTest.php`).

### Testing

- New/updated unit tests: `ValueFactoryTest::mapsXmpCreatorContactInfoAndTitles` and updated `tests/Value/AuthorTest` were added to cover positive mapping cases and VO construction. 
- Attempting to run the PHPUnit command in the current environment failed because `vendor/bin/phpunit` is not present, so tests were not executed locally; CI (via `composer ci:test` / `composer ci:test:php:unit`) is expected to run the added tests.
- All changes were kept minimal and scoped to the specified files; CI static checks (`phpstan`, `phpcs`) should be run in CI to verify style and static analysis.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f5507743c83239ac79941d9ea9c9f)