### PR TITLE
GH-2319: Adopt the shared branch-and-pull-request workflow

### DIFF
--- a/.github/ISSUE_TEMPLATE/agent-task.yml
+++ b/.github/ISSUE_TEMPLATE/agent-task.yml
@@ -13,9 +13,9 @@ body:
               If you would need to guess, expand scope, or relax guards: **STOP** and ask.
 
               **TDD workflow:** Write a failing test first, then implement the minimal code to make it pass.
-              **Commit workflow:** commit directly to `main`
-              **Commit message:** `GH-<issue-number>: <Message starting with capital letter>`
-              **Close rule:** if `ci:test` is fully green → close this issue immediately.
+              **Commit workflow:** work on a branch named `GH-<issue-number>` and open a pull request — never commit directly to `main`
+              **Commit message:** `GH-<issue-number>: <Message starting with capital letter>` for work on this issue; see `AGENTS.md` §1.4 for the full rule
+              **Close rule:** put `Closes #<issue-number>` in the pull-request body; the issue closes when the PR merges, which requires `ci:test` fully green.
 
     - type: textarea
       id: goal

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -18,5 +18,5 @@ for a bug fix, say how you confirmed the test fails without the fix.
 -->
 
 - [ ] `composer ci:test` is green
-- [ ] A failing test was written first (see `AGENTS.md` §1.7)
+- [ ] A failing test was written first — or N/A for docs, refactoring and CGL-only changes (see `AGENTS.md` §1.7)
 - [ ] No `Co-Authored-By:` trailer or other AI attribution

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,22 @@
+Closes #
+
+<!--
+The `Closes #<number>` line above is what closes the issue on merge — the
+`GH-<number>: ` commit subject prefix is not a GitHub link and closes nothing.
+Delete the line if this pull request is not tied to an issue.
+-->
+
+## What changes
+
+<!-- Scope and motivation. What a reviewer needs to judge the diff. -->
+
+## How it was verified
+
+<!--
+`composer ci:test` green is the mandatory gate. Name anything else you ran, and
+for a bug fix, say how you confirmed the test fails without the fix.
+-->
+
+- [ ] `composer ci:test` is green
+- [ ] A failing test was written first (see `AGENTS.md` §1.7)
+- [ ] No `Co-Authored-By:` trailer or other AI attribution

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,7 +58,7 @@ If unsure → **STOP and ask**. Never guess.
 
 ### 1.4 Git Rules
 
-* Work happens on a branch named exactly `GH-<number>` and reaches `main` through a **pull request** — never a direct commit
+* Work happens on a branch named exactly `GH-<number>` and reaches `main` through a **pull request** — never a direct commit. `main` requires the `build (8.4)` check but no review, so this is convention rather than something the platform enforces
 * A subject starting with `GH-` must match `^GH-\d+: [A-ZÄÖÜ]`; every other subject must match `^[A-ZÄÖÜ]` — a capitalised imperative either way. The patterns check only the leading capital; two starts are banned whatever their case: **conventional-commit prefixes** (`feat:`, `Fix:`, `chore:` …) and path-like starts (`src/Reader.php: …`, `Src/Reader.php: …`)
     * The two patterns are deliberately kept separate: `^(GH-\d+: )?[A-ZÄÖÜ]` (wrong) stops enforcing the capital *after* the prefix, because the optional group can be skipped and the `G` of `GH-` then satisfies `[A-ZÄÖÜ]` on its own — `GH-12: fix typo` would pass. Keying on the subject rather than on the branch also keeps this check decidable for commits already on `main`, where the issue branch no longer exists.
     * The same two patterns apply to the **pull-request title**, which under squash-merge is the subject that reaches `main`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,13 +58,13 @@ If unsure → **STOP and ask**. Never guess.
 
 ### 1.4 Git Rules
 
-* Branching is **not used**
-* Commit directly on `main`
-* Commit message **must** match exactly:
-
-```
-GH-<number>: <Message starting with capital letter>
-```
+* Work happens on a branch named exactly `GH-<number>` and reaches `main` through a **pull request** — never a direct commit
+* A subject starting with `GH-` must match `^GH-\d+: [A-ZÄÖÜ]`; every other subject must match `^[A-ZÄÖÜ]` — a capitalised imperative either way. The patterns check only the leading capital; two starts are banned whatever their case: **conventional-commit prefixes** (`feat:`, `Fix:`, `chore:` …) and path-like starts (`src/Reader.php: …`, `Src/Reader.php: …`)
+    * The two patterns are deliberately kept separate: `^(GH-\d+: )?[A-ZÄÖÜ]` (wrong) stops enforcing the capital *after* the prefix, because the optional group can be skipped and the `G` of `GH-` then satisfies `[A-ZÄÖÜ]` on its own — `GH-12: fix typo` would pass. Keying on the subject rather than on the branch also keeps this check decidable for commits already on `main`, where the issue branch no longer exists.
+    * The same two patterns apply to the **pull-request title**, which under squash-merge is the subject that reaches `main`.
+    * The normative definition lives in `magicsunday/.github/.github/workflows/commit-convention.yml@main`, which self-tests a decision table before applying it. No workflow here calls that gate, so the rule in this repository is documentation only; wherever it is wired, the workflow is authoritative and this text is what gets fixed.
+* The `GH-<number>: ` prefix marks work that belongs to the issue — a commit on that branch whose concern is something else (a drive-by lint fix, a dependency bump) keeps its own unprefixed subject. Merge and revert commits keep the subject git generates. Not every git-written subject is exempt, though: `fixup!` and `squash!` start lowercase and violate the rule, so autosquash them before opening the PR.
+* Never add a `Co-Authored-By:` trailer or any other AI attribution
 
 Example:
 
@@ -74,11 +74,10 @@ GH-421: Fix BigTIFF SRATIONAL sign handling
 
 ### 1.5 Ticket Handling (Hard Rule)
 
-* If a commit references a GitHub issue (`GH-<number>`)
-* **and** `ci:test` completes fully green
-* the referenced ticket **must be closed immediately**
+* The pull-request body closes the issue with a `Closes #<number>` keyword — the `GH-<number>: ` subject prefix is not a GitHub link and closes nothing
+* The ticket closes when the pull request merges, which requires `ci:test` fully green
 
-No follow-up commits, no deferred closure, no “left open for review”.
+No follow-up commits, no deferred closure, no “left open for review”: a merged pull request leaves nothing to tidy up afterwards.
 
 ### 1.6 CI Dry-Run Changes (Hard Rule)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,9 +8,9 @@
 **Scope:** This file defines **hard technical rules**. It is not process documentation.
 
 **Workflow:**
-✔ Commits are made **directly on `main`**
-✔ Commit message format is mandatory
-✔ Tickets are closed automatically after successful CI (see §1.5)
+✔ Work happens on a `GH-<number>` branch and reaches `main` by **pull request**
+✔ Commit message format is mandatory (see §1.4)
+✔ Tickets close on merge via `Closes #<number>` in the PR body (see §1.5)
 
 **Issue Authority:**
 Issues created via `.github/ISSUE_TEMPLATE/agent-task.yml`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-<!-- Managed by agent: keep sections and order; edit content, not structure. Last updated: 2026-03-20 -->
+<!-- Managed by agent: keep sections and order; edit content, not structure. Last updated: 2026-07-20 -->
 
 # AGENTS.md — MagicSunday/ImageMeta
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,8 @@ All code style, architecture, testing, git, and specification rules are defined 
 
 Key rules to remember:
 - **TDD is mandatory** — failing test first, then implementation
-- **Commit directly on `main`** — format: `GH-<number>: <Message starting with capital letter>`
+- **Branch `GH-<number>`, merge by pull request** — never commit directly on `main`
+- **Subject format** — `GH-<number>: <Capital>` when the commit belongs to an issue, otherwise a capitalised imperative; see `AGENTS.md` §1.4 for the full rule
 - **No `Co-Authored-By` trailers** in commit messages
 - **CGL alignment fixes in separate commits** from feature changes
 - **Each review finding gets its own commit** — not bundled

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,13 +19,13 @@
 
 ## 3. Pull requests
 
-- Open a PR from a branch in your fork.
+- Open a PR from a branch — in your fork if you do not have push access, otherwise in this repository.
 - Describe scope, motivation, and validation steps.
 - Follow `.github/pull_request_template.md`.
 - Before requesting review, run the mandatory checks locally:
   - `composer ci:test`
 - Include tests for new behavior and regression tests for fixes.
-- This workflow applies to everyone. Maintainers and agents use the same branch-and-pull-request flow; they differ only in the stricter branch name (`GH-<number>`) and subject format that `AGENTS.md` §1.4 requires.
+- This workflow applies to everyone. Maintainers and agents use the same branch-and-pull-request flow; they differ only in branching inside this repository rather than a fork, and in the stricter branch name (`GH-<number>`) and subject format that `AGENTS.md` §1.4 requires.
 
 ## 4. Development setup (minimal)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,7 @@
 - Before requesting review, run the mandatory checks locally:
   - `composer ci:test`
 - Include tests for new behavior and regression tests for fixes.
-- This pull-request workflow applies to regular external contributor submissions.
+- This workflow applies to everyone. Maintainers and agents use the same branch-and-pull-request flow; they differ only in the stricter branch name (`GH-<number>`) and subject format that `AGENTS.md` §1.4 requires.
 
 ## 4. Development setup (minimal)
 
@@ -50,4 +50,4 @@ This repository has explicit agent rules. Do not duplicate or reinterpret them i
 - Test-scope agent rules: `tests/AGENTS.md`
 
 If a contribution is prepared or modified by an LLM/agent, it must comply with those files.
-Where agent rules define a different workflow, the AGENTS files take precedence.
+The AGENTS files do not define a different workflow — they add the branch-naming and commit-subject requirements on top of this one, and take precedence where they are stricter.

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -1,4 +1,4 @@
-<!-- Managed by agent: keep sections and order; edit content, not structure. Last updated: 2026-03-20 -->
+<!-- Managed by agent: keep sections and order; edit content, not structure. Last updated: 2026-07-20 -->
 
 # AGENTS.md — MagicSunday/ImageMeta (tests)
 

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -42,9 +42,8 @@ If production code changes are required → **STOP**.
 
 The git flow and the commit-subject rule are the repository-wide ones in the root
 `AGENTS.md` §1.4 — work on a `GH-<number>` branch, merge by pull request, and use
-the prefix for issue-tied work. They are **not** restated here: this file used to
-carry its own copy, which drifted into demanding the prefix on every commit while
-its own example (`Add coverage for truncated IFD entries`) carried none.
+the prefix for issue-tied work. They are deliberately **not** restated here; a
+second copy is how the two drift apart.
 
 Test-only work adds nothing to that flow beyond the scope rule above.
 

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -40,24 +40,19 @@ If production code changes are required → **STOP**.
 
 ### 1.2 Git Rules
 
-* Commit directly on `main`
-* Commit message **must** match exactly:
+The git flow and the commit-subject rule are the repository-wide ones in the root
+`AGENTS.md` §1.4 — work on a `GH-<number>` branch, merge by pull request, and use
+the prefix for issue-tied work. They are **not** restated here: this file used to
+carry its own copy, which drifted into demanding the prefix on every commit while
+its own example (`Add coverage for truncated IFD entries`) carried none.
 
-```
-GH-<number>: <Message starting with capital letter>
-```
-
-Example:
-
-```
-Add coverage for truncated IFD entries
-```
+Test-only work adds nothing to that flow beyond the scope rule above.
 
 ### 1.3 Ticket Handling (Hard Rule)
 
-* If a commit references a GitHub issue (`GH-<number>`)
-* **and** `ci:test` completes fully green
-* the referenced ticket **must be closed immediately**
+As in the root `AGENTS.md` §1.5: the pull-request body closes the issue with a
+`Closes #<number>` keyword, and the ticket closes when the pull request merges,
+which requires `ci:test` fully green.
 
 No follow-up commits, no deferred closure, no “left open for review”.
 


### PR DESCRIPTION
Closes #2319.

This pull request is itself the first use of the flow it documents — branch `GH-2319`, reviewable diff, merge tied to the issue.

## What changes

**§1.4** replaces "Branching is **not used** / Commit directly on `main`" with the shared convention: work on a `GH-<number>` branch, reach `main` through a pull request, and follow the same commit-subject rule as the sibling repositories.

**§1.5** follows from it. Immediate ticket closure once `ci:test` is green becomes `Closes #<number>` in the pull-request body, which GitHub applies on merge.

## The commit rule had to change either way

The documented pattern demanded the `GH-<number>: ` prefix on every commit. Measured against the last 60 subjects on `main`:

| Rule | violations in 60 |
| --- | --- |
| the one documented here | **22** |
| the shared one | **0** |

The 22 are not edge cases — Dependabot bumps, `Pin the action version comments to the exact released tag`, and ordinary work like `Extract a parseIptcBlobs() helper in MetadataReader`. The practice in this repository already *was* the shared convention; only the text said otherwise, and a rule contradicted 22 times in 60 commits teaches an agent to ignore it rather than follow it.

## The branching half is a real change

Direct commits were the actual habit: 3 of the last 60 arrived by pull request, and all three were Dependabots. But `main` already requires the `build (8.4)` status check, so the direct-commit model was only partly real, and it gave up what the siblings get from the pull-request flow — a reviewable diff, the bot review pass, and a merge tied to its issue.

## Detail worth knowing

The counter-example regex sits on one line with a `(wrong)` marker, so a repository-wide sweep for the broken pattern does not match files that have already been corrected. That mattered during the rollout: an earlier sweep flagged four already-fixed repositories because the counter-example was wrapped onto its own line.

Part of `magicsunday/webtrees-fan-chart#254`, which tracks one commit-subject rule in one wording across all eight repositories.