### PR TITLE
GH-2323: Add the missing issue templates and repair the existing ones

### DIFF
--- a/.github/ISSUE_TEMPLATE/agent-task.yml
+++ b/.github/ISSUE_TEMPLATE/agent-task.yml
@@ -1,16 +1,25 @@
-name: "Agent Task"
+name: "Agent task"
 description: "Task for agent implementation with TDD, specs, and minimal-change rules."
-title: "<Title starting with capital letter>"
 labels:
-    - agent
-    - needs-implementation
+    - "Agent task"
+    - "Needs implementation"
 body:
     - type: markdown
       attributes:
           value: |
+              > [!WARNING]
+              > This issue is public and effectively permanent. Assume nothing you
+              > paste is private, in any field — including the issue title. If you
+              > meant to report a defect rather than commission one, the *Bug
+              > report* and *Parse error report* forms are the ones you want;
+              > [Sharing a sample file](https://github.com/magicsunday/imagemeta/blob/main/.github/SHARING-A-SAMPLE-FILE.md)
+              > explains what this library reads out of a file.
+
               ## Agent Instructions (Read First)
               This repo is governed by `CLAUDE.md`, `AGENTS.md` (and `tests/AGENTS.md` for work under `tests/`).
               If you would need to guess, expand scope, or relax guards: **STOP** and ask.
+
+              **Issue title:** a capitalised imperative, as the commit subject will be.
 
               **TDD workflow:** Write a failing test first, then implement the minimal code to make it pass.
               **Commit workflow:** work on a branch named `GH-<issue-number>` and open a pull request — never commit directly to `main`

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -76,8 +76,8 @@ body:
           description: >-
               If the defect points at a specific offset, a hex dump of roughly 256 bytes around it is usually more
               useful than the file, and far smaller — but not anonymous: read the ASCII column, and note that
-              serial numbers and QuickTime or XMP coordinates do appear there, while the EXIF GPS IFD and DJI
-              telemetry never will. [Sharing a sample file](https://github.com/magicsunday/imagemeta/blob/main/.github/SHARING-A-SAMPLE-FILE.md) says what to check besides.
+              serial numbers and QuickTime or XMP coordinates do appear there, while the coordinates in the
+              EXIF GPS IFD and in DJI telemetry never will. [Sharing a sample file](https://github.com/magicsunday/imagemeta/blob/main/.github/SHARING-A-SAMPLE-FILE.md) says what to check besides.
           render: text
       validations:
           required: false

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,124 @@
+name: "Bug report"
+description: "Report a defect so it can be reproduced and fixed."
+labels:
+    - Bug
+body:
+    - type: markdown
+      attributes:
+          value: |
+              > [!CAUTION]
+              > Stop if a crafted file can make the parser hang, exhaust memory,
+              > loop forever, read outside its buffer, return data it should not,
+              > or take absurdly long. That is a vulnerability, not a bug.
+              > Report it privately through the
+              > [security advisory form](https://github.com/magicsunday/imagemeta/security/advisories/new),
+              > and do not attach the file here — describe it there, and a
+              > maintainer will arrange a private transfer. If you are unsure whether it
+              > counts, use the private form anyway — a mistaken private report
+              > costs nothing, a public one cannot be undone.
+
+              > [!WARNING]
+              > This issue, and every file attached to it, is public and
+              > effectively permanent — deleting a comment does not retract an
+              > attachment. Metadata is what this library reads, so a sample file
+              > carries far more than the defect. Assume nothing you paste is
+              > private, in any field — including the issue title, which reporters
+              > often paste a real file name into. [Sharing a sample file](https://github.com/magicsunday/imagemeta/blob/main/.github/SHARING-A-SAMPLE-FILE.md)
+              > explains what this library reads out of a file.
+
+              If the file fails to parse at all, the *Parse error report*
+              template fits better — it asks for the failing structure directly.
+
+    - type: textarea
+      id: description
+      attributes:
+          label: "Description of the problem"
+          description: >-
+              What happened, and what did you expect instead? Redact GPS coordinates, serial numbers, person names and
+              absolute paths from any values you quote, and put dumps in a fenced code block so identifiers are not linked
+              into unrelated repositories.
+      validations:
+          required: true
+
+    - type: input
+      id: format
+      attributes:
+          label: "Metadata format and container"
+          description: "Which metadata block, in which file format, is affected?"
+          placeholder: "EXIF in HEIC / XMP in JPEG / QuickTime in MOV"
+      validations:
+          required: true
+
+    - type: textarea
+      id: reproduction
+      attributes:
+          label: "Steps to reproduce"
+          description: >-
+              The minimal steps or input that trigger the problem. Replace real file paths and file names with
+              placeholders, and put dumps in a fenced code block so identifiers are not linked into unrelated
+              repositories.
+      validations:
+          required: true
+
+    - type: textarea
+      id: reproduction_code
+      attributes:
+          label: "Reproducing code"
+          description: "A minimal script. Replace the real file path with a placeholder."
+          render: php
+      validations:
+          required: false
+
+    - type: textarea
+      id: failing_structure
+      attributes:
+          label: "Failing structure"
+          description: >-
+              If the defect points at a specific offset, a hex dump of roughly 256 bytes around it is usually more
+              useful than the file, and far smaller — but not anonymous: read the ASCII column, and note that
+              serial numbers and QuickTime or XMP coordinates do appear there, while the EXIF GPS IFD and DJI
+              telemetry never will. [Sharing a sample file](https://github.com/magicsunday/imagemeta/blob/main/.github/SHARING-A-SAMPLE-FILE.md) says what to check besides.
+          render: text
+      validations:
+          required: false
+
+    - type: textarea
+      id: sample_file
+      attributes:
+          label: "Sample file"
+          description: |
+              Attach a minimal file that reproduces the problem, or describe how to obtain one.
+
+              Only attach a file that is yours to license, that shows and names no other identifiable person, and
+              that you accept becoming a permanent public test fixture under this repository's licence.
+
+              Do not run `exiftool -all=` on it first — deleting tags rewrites the offsets the defect lives in, and
+              the file stops reproducing. [Sharing a sample file](https://github.com/magicsunday/imagemeta/blob/main/.github/SHARING-A-SAMPLE-FILE.md) explains what to overwrite instead, which
+              formats it does not work for, and what GitHub will refuse to accept.
+      validations:
+          required: false
+
+    - type: input
+      id: version
+      attributes:
+          label: "Library version"
+          description: "Which released version or commit does this occur with?"
+      validations:
+          required: true
+
+    - type: textarea
+      id: php_version
+      attributes:
+          label: "PHP version and extensions"
+          description: "Output of `php -v`, plus any relevant extensions."
+      validations:
+          required: true
+
+    - type: textarea
+      id: logs
+      attributes:
+          label: "Error output or stack trace"
+          description: "Replace absolute paths and user names with placeholders. An exception message often quotes the offending tag value — redact it if it identifies anyone."
+          render: shell
+      validations:
+          required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,2 +1,23 @@
-blank_issues_enabled: true
-contact_links: []
+# The presence of this directory suppresses the shared issue templates from the
+# `.github` repository entirely — GitHub falls back to those only when a
+# repository has no ISSUE_TEMPLATE directory of its own. Improve the templates
+# here; the shared copies are never offered for this repository.
+
+# Disabled so the web chooser always puts a form, and therefore its warnings, in
+# front of an outside reporter. This is a chooser setting only — the REST API
+# still creates issues with no template at all, so treat it as removing the easy
+# bypass rather than closing the path.
+#
+# It costs the maintainer nothing: with blank issues disabled, anyone with write
+# access still sees the blank form, marked "Maintainers only". And every one of
+# this repository's issues to date was filed by the owner, so the reports that
+# carry no template label are the maintainer's own backlog, not traffic from
+# someone who would be turned away.
+blank_issues_enabled: false
+contact_links:
+    # GitHub renders its own security row from SECURITY.md. This one is named for
+    # the symptom instead, so a reporter holding a file that crashes the parser
+    # finds it without having to think of it as a vulnerability first.
+    - name: "A crafted file crashes, hangs or exhausts memory"
+      url: "https://github.com/magicsunday/imagemeta/security/advisories/new"
+      about: "Report it privately, never as a public issue — a public report hands out a working denial-of-service against every consumer of this library."

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,67 @@
+name: "Feature request"
+description: "Suggest a capability, or an improvement to an existing one."
+labels:
+    - Enhancement
+body:
+    - type: markdown
+      attributes:
+          value: |
+              Describe the problem you are trying to solve before describing a
+              solution — the underlying need is what makes a proposal reviewable.
+
+              > [!WARNING]
+              > This issue is public and effectively permanent. Assume nothing you
+              > paste is private, in any field — including the issue title; [Sharing a sample file](https://github.com/magicsunday/imagemeta/blob/main/.github/SHARING-A-SAMPLE-FILE.md)
+              > explains what this library reads out of a file. And if you
+              > arrived here because a file made the parser hang or exhaust
+              > memory, that is a vulnerability rather than a missing feature:
+              > report it privately through the [security advisory form](https://github.com/magicsunday/imagemeta/security/advisories/new).
+
+    - type: textarea
+      id: problem
+      attributes:
+          label: "Problem or motivation"
+          description: >-
+              Which use case is not covered today, and where does the current API fall short? Redact GPS, serial numbers and
+              person names from any metadata you quote, and put dumps in a fenced code block so identifiers are not linked
+              into unrelated repositories.
+      validations:
+          required: true
+
+    - type: textarea
+      id: proposal
+      attributes:
+          label: "Proposed solution"
+          description: >-
+              What should the library do? Put dumps in a fenced code block so identifiers are not linked into unrelated repositories.
+      validations:
+          required: false
+
+    - type: textarea
+      id: proposal_code
+      attributes:
+          label: "Sketch of the call site"
+          description: >-
+              How the API would be used, if you have a shape in mind. Replace real file paths and user names
+              with placeholders.
+          render: php
+      validations:
+          required: false
+
+    - type: textarea
+      id: alternatives
+      attributes:
+          label: "Alternatives considered"
+          description: >-
+              Workarounds you tried, and why they are not sufficient. Put dumps in a fenced code block so identifiers are not linked into unrelated repositories.
+      validations:
+          required: false
+
+    - type: input
+      id: specification
+      attributes:
+          label: "Specification reference"
+          description: "For a metadata format or tag, the standard and the section that defines it."
+          placeholder: "Exif 2.32, section 4.6.5 / ISO 14496-12, section 8.11.3"
+      validations:
+          required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -13,9 +13,11 @@ body:
               > This issue is public and effectively permanent. Assume nothing you
               > paste is private, in any field — including the issue title; [Sharing a sample file](https://github.com/magicsunday/imagemeta/blob/main/.github/SHARING-A-SAMPLE-FILE.md)
               > explains what this library reads out of a file. And if you
-              > arrived here because a file made the parser hang or exhaust
-              > memory, that is a vulnerability rather than a missing feature:
-              > report it privately through the [security advisory form](https://github.com/magicsunday/imagemeta/security/advisories/new).
+              > arrived here because a crafted file can make the parser hang,
+              > exhaust memory, loop forever, read outside its buffer, return data
+              > it should not, or take absurdly long, that is a vulnerability
+              > rather than a missing feature: report it privately through the
+              > [security advisory form](https://github.com/magicsunday/imagemeta/security/advisories/new).
 
     - type: textarea
       id: problem

--- a/.github/ISSUE_TEMPLATE/parse-error.yml
+++ b/.github/ISSUE_TEMPLATE/parse-error.yml
@@ -1,15 +1,37 @@
-name: "Parse Error Report"
+name: "Parse error report"
 description: "A file cannot be parsed and the parser aborts with an error."
-title: "Parse error: <brief description>"
 labels:
-    - bug
+    - Bug
     - parse-error
 body:
     - type: markdown
       attributes:
           value: |
-              ## Parse Error Report
-              Use this template when a file fails to parse with an error message.
+              > [!CAUTION]
+              > Stop if a crafted file can make the parser hang, exhaust memory,
+              > loop forever, read outside its buffer, return data it should not,
+              > or take absurdly long. That is a vulnerability, not a parse error.
+              > Report it privately through the
+              > [security advisory form](https://github.com/magicsunday/imagemeta/security/advisories/new),
+              > and do not attach the file here — describe it there, and a
+              > maintainer will arrange a private transfer. If you are unsure whether it
+              > counts, use the private form anyway — a mistaken private report
+              > costs nothing, a public one cannot be undone.
+
+              > [!WARNING]
+              > This issue, and every file attached to it, is public and
+              > effectively permanent — deleting a comment does not retract an
+              > attachment. Metadata is what this library reads, so a sample file
+              > carries far more than the defect. Assume nothing you paste is
+              > private, in any field — including the issue title, which reporters
+              > often paste a real file name into. [Sharing a sample file](https://github.com/magicsunday/imagemeta/blob/main/.github/SHARING-A-SAMPLE-FILE.md)
+              > explains what this library reads out of a file.
+
+              The fastest report is often not the file at all: a hex window
+              around the offset named in the error, plus the box or IFD header
+              chain leading to it, is usually enough to write a fixture. It is
+              much smaller than the file — but not automatically anonymous, so
+              read its ASCII column before pasting.
 
     - type: input
       id: file_type
@@ -33,27 +55,67 @@ body:
       id: error_message
       attributes:
           label: "Error message and stack trace"
-          description: "The full error output."
+          description: "The full error output. Replace absolute paths and user names with placeholders. An exception message often quotes the offending tag value — redact it if it identifies anyone."
           render: shell
           placeholder: |
               ERROR: infe uri item_uri_type must be non-empty
-              #0 /app/src/Parse/IsoBmff/IlocBoxParser.php(231): ...
+              #0 /path/to/project/src/Parse/IsoBmff/IlocBoxParser.php(231): ...
               #1 ...
       validations:
           required: true
 
     - type: textarea
+      id: failing_structure
+      attributes:
+          label: "Failing structure"
+          description: >-
+              Required unless you attach a sample file below — a report with neither cannot be reproduced.
+              A hex dump of roughly 256 bytes around the offset the error names, plus the box or IFD header chain
+              leading to it. Usually more useful than the file, and far smaller — but not anonymous: read the ASCII
+              column, where serial numbers and QuickTime or XMP coordinates do show up — but the EXIF GPS IFD and
+              DJI telemetry never will. [Sharing a sample file](https://github.com/magicsunday/imagemeta/blob/main/.github/SHARING-A-SAMPLE-FILE.md) says what to check besides.
+          render: text
+      validations:
+          required: false
+
+    - type: textarea
       id: sample_file
       attributes:
           label: "Sample file"
-          description: "Attach a minimal sample file that reproduces the error, or describe how to obtain one. If the file contains personal data, consider stripping metadata first."
+          description: |
+              Attach a minimal file that reproduces the problem, or describe how to obtain one.
+
+              Only attach a file that is yours to license, that shows and names no other identifiable person, and
+              that you accept becoming a permanent public test fixture under this repository's licence.
+
+              Do not run `exiftool -all=` on it first — deleting tags rewrites the offsets the defect lives in, and
+              the file stops reproducing. [Sharing a sample file](https://github.com/magicsunday/imagemeta/blob/main/.github/SHARING-A-SAMPLE-FILE.md) explains what to overwrite instead, which
+              formats it does not work for, and what GitHub will refuse to accept.
       validations:
           required: false
+
+    - type: input
+      id: version
+      attributes:
+          label: "Library version"
+          description: "Which released version or commit does this occur with?"
+      validations:
+          required: true
+
+    - type: textarea
+      id: php_version
+      attributes:
+          label: "PHP version and extensions"
+          description: "Output of `php -v`, plus any relevant extensions."
+      validations:
+          required: true
 
     - type: textarea
       id: additional_context
       attributes:
           label: "Additional context"
-          description: "Any other relevant information (PHP version, library version, etc.)."
+          description: >-
+              Anything else that narrows it down. Put dumps in a fenced code block so identifiers are not linked into
+              unrelated repositories.
       validations:
           required: false

--- a/.github/ISSUE_TEMPLATE/parse-error.yml
+++ b/.github/ISSUE_TEMPLATE/parse-error.yml
@@ -72,8 +72,8 @@ body:
               Required unless you attach a sample file below — a report with neither cannot be reproduced.
               A hex dump of roughly 256 bytes around the offset the error names, plus the box or IFD header chain
               leading to it. Usually more useful than the file, and far smaller — but not anonymous: read the ASCII
-              column, where serial numbers and QuickTime or XMP coordinates do show up — but the EXIF GPS IFD and
-              DJI telemetry never will. [Sharing a sample file](https://github.com/magicsunday/imagemeta/blob/main/.github/SHARING-A-SAMPLE-FILE.md) says what to check besides.
+              column, where serial numbers and QuickTime or XMP coordinates do show up — but the coordinates in
+              the EXIF GPS IFD and in DJI telemetry never will. [Sharing a sample file](https://github.com/magicsunday/imagemeta/blob/main/.github/SHARING-A-SAMPLE-FILE.md) says what to check besides.
           render: text
       validations:
           required: false

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,0 +1,33 @@
+name: "Question or documentation issue"
+description: "Something in the documentation is wrong or missing, or you are not sure how the library is meant to behave."
+labels:
+    - Documentation
+body:
+    - type: markdown
+      attributes:
+          value: |
+              > [!WARNING]
+              > This issue is public and effectively permanent. Assume nothing you
+              > paste is private, in any field — including the issue title, which
+              > reporters often paste a real file name into.
+
+              For a defect, the *Bug report* and *Parse error report* forms ask
+              for what a fix needs. This form is for everything else, and asks
+              for nothing you would have to look up.
+
+    - type: textarea
+      id: question
+      attributes:
+          label: "What is unclear, wrong or missing?"
+          description: "Redact anything identifying from values you quote, and put dumps in a fenced code block so identifiers are not linked into unrelated repositories."
+      validations:
+          required: true
+
+    - type: input
+      id: location
+      attributes:
+          label: "Where"
+          description: "The document, section or method this concerns, if it applies to one."
+          placeholder: "README, Supported formats / MetadataReader::read()"
+      validations:
+          required: false

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -17,9 +17,10 @@ body:
 
               Do not attach a sample file here — if your question is really about
               a file that fails, use the *Parse error report* form, which explains
-              what to redact first. And if a file makes the parser hang or exhaust
-              memory, that is a vulnerability: report it through the
-              [security advisory form](https://github.com/magicsunday/imagemeta/security/advisories/new).
+              what to redact first. And if a crafted file can make the parser hang,
+              exhaust memory, loop forever, read outside its buffer, return data it
+              should not, or take absurdly long, that is a vulnerability: report it
+              through the [security advisory form](https://github.com/magicsunday/imagemeta/security/advisories/new).
 
     - type: textarea
       id: question

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -15,6 +15,12 @@ body:
               for what a fix needs. This form is for everything else, and asks
               for nothing you would have to look up.
 
+              Do not attach a sample file here — if your question is really about
+              a file that fails, use the *Parse error report* form, which explains
+              what to redact first. And if a file makes the parser hang or exhaust
+              memory, that is a vulnerability: report it through the
+              [security advisory form](https://github.com/magicsunday/imagemeta/security/advisories/new).
+
     - type: textarea
       id: question
       attributes:

--- a/.github/SHARING-A-SAMPLE-FILE.md
+++ b/.github/SHARING-A-SAMPLE-FILE.md
@@ -106,10 +106,13 @@ a lot, because much of what matters here is stored as text:
 - XMP, which is UTF-8 throughout — including `exif:GPSLatitude`;
 - the QuickTime `location.ISO6709` atom, which reads as `+51.5074-000.1278/`.
 
-An ASCII pass is necessary but **not sufficient**, because two location sources
-have no printable form at all: the EXIF GPS IFD stores latitude and longitude as
-RATIONAL triplets — raw integers — and DJI telemetry stores them as 64-bit
-floats inside protobuf. Neither shows up as anything a reader would notice.
+An ASCII pass is necessary but **not sufficient**, because the coordinates
+themselves have no printable form in two of their sources: the EXIF GPS IFD
+stores latitude and longitude as RATIONAL triplets — raw integers — and DJI
+telemetry stores them as 64-bit floats inside protobuf. Note the scope: other
+tags in that same GPS IFD, such as the N/S reference, the map datum and the date
+stamp, *are* ASCII, so seeing readable text near the coordinates proves nothing
+about the coordinates.
 
 So also check *which structure* the window covers. If it overlaps the GPS IFD, a
 QuickTime location atom, or `mdat` bytes near a `DJI` marker, either zero those
@@ -124,8 +127,9 @@ camera formats — are not among them. Rather than guess: if the upload is
 rejected, put the file in a `.zip`, which is accepted.
 
 Size is capped at 10 MB for images and 25 MB for everything else, a `.zip`
-included. A video may be allowed larger, but only when both the account owning
-this repository and your own account are on a paid plan, so do not count on it.
+included. A video is capped at 10 MB unless both this repository's owner is on a
+paid plan and you are either on one yourself or a member or collaborator here —
+so plan for 10 MB.
 
 **25 MB is the ceiling for every route.** If the smallest file that still
 reproduces the defect does not fit, do not look for a file host — send the

--- a/.github/SHARING-A-SAMPLE-FILE.md
+++ b/.github/SHARING-A-SAMPLE-FILE.md
@@ -36,12 +36,16 @@ hex editor works; so does `xxd` for locating and patching, or `bbe` if you give
 it a replacement of exactly the same length.
 
 Some of what has to go is not text at all. The embedded thumbnail, MPF
-secondary images, an embedded audio stream and a depth map are kilobytes of
-binary with nothing to type over. Each is addressed by an offset and a length —
+secondary images and an embedded audio stream are kilobytes of binary with
+nothing to type over. Each is addressed by an offset and a length —
 `ThumbnailOffset`/`ThumbnailLength` for the EXIF thumbnail, the MPF entry's
 offset and size, the APP2 segment span — so locate the payload and **zero-fill
 the whole region, keeping its byte count**. If zero-filling makes the defect
 disappear, the defect is *in* that payload: send the failing structure instead.
+
+The depth map is the exception that looks binary but is not: this library reads
+it from a Base64 value inside the XMP packet (`GDepth:Data`), so redact it as
+XMP text — overwrite that value in place, keeping its length.
 
 **Match the byte count, not the character count.** XMP is UTF-8, the Windows XP
 tags are UTF-16LE, and `UserComment` may carry a BOM-tagged UTF-16 payload — so
@@ -66,8 +70,9 @@ This library extracts more than the fields people expect. At minimum:
   Preservation Image*, which is the un-edited original before any edit.
 - Any embedded audio stream. A "sound and shot" JPEG carries seconds of recorded
   audio in an APP2 segment, and no visual or hex inspection will notice it.
-- Depth maps, and live-photo or burst identifiers that link this file to the
-  rest of your library.
+- The depth map, a Base64 blob in the XMP packet that reconstructs scene
+  geometry, and live-photo or burst identifiers that link this file to the rest
+  of your library.
 
 **Clearing the EXIF GPS tags is not sufficient.** This library also recovers
 location from the QuickTime `location.ISO6709` atom and from DJI telemetry
@@ -101,9 +106,10 @@ enough to write a test fixture.
 It is **not** anonymous by default. Read its ASCII column first — that catches
 a lot, because much of what matters here is stored as text:
 
-- names, file paths and IPTC contact details;
+- names and file paths;
 - camera and lens serial numbers, which EXIF stores as ASCII strings;
-- XMP, which is UTF-8 throughout — including `exif:GPSLatitude`;
+- XMP, which is UTF-8 throughout — including `exif:GPSLatitude` and the IPTC
+  creator contact block, so a non-ASCII address there needs the UTF-8 caveat below;
 - the QuickTime `location.ISO6709` atom, which reads as `+51.5074-000.1278/`.
 
 An ASCII pass is necessary but **not sufficient**, because the coordinates
@@ -131,6 +137,8 @@ included. A video is capped at 10 MB unless both this repository's owner is on a
 paid plan and you are either on one yourself or a member or collaborator here —
 so plan for 10 MB.
 
-**25 MB is the ceiling for every route.** If the smallest file that still
-reproduces the defect does not fit, do not look for a file host — send the
-failing structure instead.
+**Plan for 25 MB.** That is the ceiling for the `.zip` route and for anything
+that is not an image or a directly-uploadable video; an image is 10 MB, and the
+paid-plan video exception above is the only way past 25 MB. If the smallest file
+that still reproduces the defect does not fit, do not look for a file host —
+send the failing structure instead.

--- a/.github/SHARING-A-SAMPLE-FILE.md
+++ b/.github/SHARING-A-SAMPLE-FILE.md
@@ -1,0 +1,132 @@
+# Sharing a sample file
+
+A parser bug is usually easiest to fix with the file that triggers it. That file
+is also the problem: this library exists to read metadata, and metadata is where
+personal data lives. A GitHub issue is public, indexed, and effectively
+permanent — deleting a comment does not retract an attachment.
+
+This page is the long version. The issue templates link here so they can stay
+short.
+
+## The short version
+
+1. If a crafted file makes the parser hang, exhaust memory, loop forever, read
+   outside its buffer, return data it should not, or take absurdly long, do not
+   open a public issue at all. Use the
+   [security advisory form](https://github.com/magicsunday/imagemeta/security/advisories/new).
+2. Prefer sending the failing structure — a hex window — over the whole file.
+3. If you do attach a file, only attach one that is yours to license, that shows
+   and names no other identifiable person, and that you accept becoming a
+   permanent public test fixture under this repository's licence. Owning the
+   copyright in a photograph does not give you authority to publish a third
+   party's name, face or whereabouts.
+4. If none of that is workable, say so in the issue and ask for a private
+   channel. An unreproducible report is better than a disclosure you cannot take
+   back.
+
+## Do not strip the metadata
+
+The obvious move — `exiftool -all=`, or a phone's "remove location" toggle — is
+the wrong one here. Deleting tags rewrites the offsets, box sizes and index
+tables that a parser defect usually lives in. The stripped file no longer
+reproduces the bug, and you have filed a report nobody can act on.
+
+Overwrite the **values in place** instead, leaving every offset where it is. A
+hex editor works; so does `xxd` for locating and patching, or `bbe` if you give
+it a replacement of exactly the same length.
+
+Some of what has to go is not text at all. The embedded thumbnail, MPF
+secondary images, an embedded audio stream and a depth map are kilobytes of
+binary with nothing to type over. Each is addressed by an offset and a length —
+`ThumbnailOffset`/`ThumbnailLength` for the EXIF thumbnail, the MPF entry's
+offset and size, the APP2 segment span — so locate the payload and **zero-fill
+the whole region, keeping its byte count**. If zero-filling makes the defect
+disappear, the defect is *in* that payload: send the failing structure instead.
+
+**Match the byte count, not the character count.** XMP is UTF-8, the Windows XP
+tags are UTF-16LE, and `UserComment` may carry a BOM-tagged UTF-16 payload — so
+one character is often two bytes, and `José` → `XXXX` shortens the field. In an
+ExtendedXMP chain a single missing byte turns your reproducing file into a
+different error.
+
+## What to overwrite
+
+This library extracts more than the fields people expect. At minimum:
+
+- GPS coordinates, and the QuickTime and DJI location channels below.
+- Camera and lens serial numbers; owner, artist and copyright names.
+- IPTC creator contact details — e-mail, phone, street address.
+- Keyword and hierarchical-subject trees, which in practice read
+  `People/<real name>` and `Places/<home town>`.
+- Face regions, including the person names and the per-face identifiers that
+  correlate the same individual across every photo you publish.
+- The embedded EXIF thumbnail, which is frequently the **uncropped** original —
+  cropping someone out of the visible image does not remove them from it.
+- MPF secondary images: a panorama frame, a large thumbnail, or an *Original
+  Preservation Image*, which is the un-edited original before any edit.
+- Any embedded audio stream. A "sound and shot" JPEG carries seconds of recorded
+  audio in an APP2 segment, and no visual or hex inspection will notice it.
+- Depth maps, and live-photo or burst identifiers that link this file to the
+  rest of your library.
+
+**Clearing the EXIF GPS tags is not sufficient.** This library also recovers
+location from the QuickTime `location.ISO6709` atom and from DJI telemetry
+embedded in the video payload itself, neither of which is touched by clearing
+the GPS IFD.
+
+## Where overwriting in place does not work
+
+- **A file carrying a C2PA manifest** — JPEG `APP11`, or a `jumb` box in HEIC,
+  AVIF, MP4, MOV or JXL — keeps a *second copy* of the metadata inside the
+  manifest, alongside the signing certificate. Overwriting the primary copy
+  leaves that one intact.
+- **JPEG XL may store EXIF and XMP Brotli-compressed** in a `brob` box. This
+  library never decompresses one, so if your JXL fails on *metadata content* it
+  is using the uncompressed `Exif` or `xml ` boxes, and you can overwrite those
+  normally. Two caveats. A hex dump of a `brob` payload is *compressed, not
+  anonymous* — anyone can decompress it. And a malformed `brob` **header** is
+  rejected during the container walk, before any payload is read, so a defect
+  can sit on a box this library otherwise ignores: in that case send the box
+  header chain rather than the payload.
+
+For the C2PA case, send the failing structure rather than the file.
+
+## Sending the failing structure
+
+Usually the most useful thing you can send is not the file but the bytes around
+the failure: roughly 256 bytes at the offset the error names, plus the box or
+IFD header chain leading to it. It is small enough to read, and it is normally
+enough to write a test fixture.
+
+It is **not** anonymous by default. Read its ASCII column first — that catches
+a lot, because much of what matters here is stored as text:
+
+- names, file paths and IPTC contact details;
+- camera and lens serial numbers, which EXIF stores as ASCII strings;
+- XMP, which is UTF-8 throughout — including `exif:GPSLatitude`;
+- the QuickTime `location.ISO6709` atom, which reads as `+51.5074-000.1278/`.
+
+An ASCII pass is necessary but **not sufficient**, because two location sources
+have no printable form at all: the EXIF GPS IFD stores latitude and longitude as
+RATIONAL triplets — raw integers — and DJI telemetry stores them as 64-bit
+floats inside protobuf. Neither shows up as anything a reader would notice.
+
+So also check *which structure* the window covers. If it overlaps the GPS IFD, a
+QuickTime location atom, or `mdat` bytes near a `DJI` marker, either zero those
+bytes as well or simply name the structure in the issue and let a maintainer ask
+for a narrower window.
+
+## Attachment limits
+
+GitHub accepts only a fixed set of file extensions, and most of the containers
+this library reads — HEIC, HEIF, AVIF, JXL, AVI, `.m4v`, `.3gp` and the raw
+camera formats — are not among them. Rather than guess: if the upload is
+rejected, put the file in a `.zip`, which is accepted.
+
+Size is capped at 10 MB for images and 25 MB for everything else, a `.zip`
+included. A video may be allowed larger, but only when both the account owning
+this repository and your own account are on a paid plan, so do not count on it.
+
+**25 MB is the ceiling for every route.** If the smallest file that still
+reproduces the defect does not fit, do not look for a file host — send the
+failing structure instead.

--- a/.github/SHARING-A-SAMPLE-FILE.md
+++ b/.github/SHARING-A-SAMPLE-FILE.md
@@ -43,9 +43,10 @@ offset and size, the APP2 segment span — so locate the payload and **zero-fill
 the whole region, keeping its byte count**. If zero-filling makes the defect
 disappear, the defect is *in* that payload: send the failing structure instead.
 
-The depth map is the exception that looks binary but is not: this library reads
-it from a Base64 value inside the XMP packet (`GDepth:Data`), so redact it as
-XMP text — overwrite that value in place, keeping its length.
+The depth map is the exception that looks binary but is not: the one this
+library surfaces is read from a Base64 value inside the XMP packet
+(`GDepth:Data`), so redact it as XMP text — overwrite that value in place,
+keeping its length.
 
 **Match the byte count, not the character count.** XMP is UTF-8, the Windows XP
 tags are UTF-16LE, and `UserComment` may carry a BOM-tagged UTF-16 payload — so
@@ -109,7 +110,7 @@ a lot, because much of what matters here is stored as text:
 - names and file paths;
 - camera and lens serial numbers, which EXIF stores as ASCII strings;
 - XMP, which is UTF-8 throughout — including `exif:GPSLatitude` and the IPTC
-  creator contact block, so a non-ASCII address there needs the UTF-8 caveat below;
+  creator contact block, so a non-ASCII address there is covered by the byte-count caveat above, not the ASCII pass;
 - the QuickTime `location.ISO6709` atom, which reads as `+51.5074-000.1278/`.
 
 An ASCII pass is necessary but **not sufficient**, because the coordinates


### PR DESCRIPTION
Closes #2323

## What changes

The chooser offered only an *Agent task* and a *Parse error report*. Anything else — a defect that is not a file parse failure, or any feature request — fell through to the blank issue form: no structure, no label, nothing for a maintainer to work from.

This directory suppresses the shared `ISSUE_TEMPLATE` set **entirely** (GitHub falls back to the shared defaults only when a repository has no such directory of its own), so the shared bug and feature forms were already invisible here. Adding them locally is the only way to restore those entry points.

Reviewing that change surfaced further defects — some pre-existing, most of them introduced by earlier revisions of this PR and caught before merge. All are fixed here.

**`.github/SHARING-A-SAMPLE-FILE.md` (new).** The redaction advice a reporter needs is far too long for a form field, and duplicating it across two templates had already made them drift. It now lives in one document that both link.

Three of its corrections are advice that reads as safe and is not:

- *"Remove the GPS coordinates"* does not remove location. `MetadataReader.php` recovers it from DJI telemetry inside the video payload and `GpsFactory.php` from QuickTime `location.ISO6709`.
- *"Read the ASCII column"* of a hex window is necessary but not sufficient, and the boundary is not intuitive. Serial numbers are ASCII, XMP is UTF-8 throughout including `exif:GPSLatitude`, and QuickTime `location.ISO6709` reads as plain text — all visible. The *coordinates* in the EXIF GPS IFD are RATIONAL triplets and DJI telemetry stores them as 64-bit floats in protobuf — neither printable. This sentence took three revisions and two overcorrections: the first said the ASCII pass was enough, the second that coordinates never appear there at all. The second is worse than the first, because it tells a reporter not to look while their position sits in the window as text.
- *"Strip the metadata first"* destroys the reproducer: deleting tags rewrites the offsets and box sizes the defect lives in. The guide asks for an in-place value overwrite with the byte count matched (XMP is UTF-8, the XP tags are UTF-16LE), and names the two cases where that cannot work — a C2PA manifest keeps a second copy of the metadata beside the signing certificate, and a JPEG XL `brob` box is Brotli-compressed.

**New: `bug_report.yml`, `feature_request.yml`.** Prose fields are deliberately unrendered — GitHub documents that *"when this key is provided, the text area will not expand for file attachments or Markdown editing"* — so only the code, log and hex-dump fields carry a render language.

**Titles.** GitHub documents the top-level `title` key as *"a default title that will be pre-populated in the issue submission form"* — a value, not a placeholder. `agent-task.yml` pre-filled it with the literal string `<Title starting with capital letter>`, so an author who submitted without touching the title filed an issue under that string.

This took three review rounds to settle and both intermediate answers were wrong. A category prefix (`Bug: `) does not fix it either: GitHub's required-title validation only checks for non-emptiness, so the reporter files an issue called `Bug:` instead. The key is absent from all four forms now — the only rule that actually forces a title worth reading.

**`parse-error.yml` — labels.** It declared `bug` and `parse-error`. This repository has no `parse-error` label in any spelling and spells the other one `Bug`. GitHub documents that *"if a label does not already exist in the repository, it will not be automatically added to the issue"*, and does not document whether it matches case-insensitively — so the declaration rested on one label that is definitely absent and one matched at best by undocumented behaviour. GitHub records no template provenance, so whether anyone ever filed through this form cannot be established either way; no issue carries its former default title and its distinguishing label never existed, so there is no trace of one. The `parse-error` label has been created.

**`parse-error.yml` — evidence and versions.** Both evidence fields were optional and this form has no steps-to-reproduce field, so a complete, valid submission could contain nothing reproducible at all. Issue forms cannot require one of two fields, so the requirement is stated where it is read. The library and PHP version were buried in an optional free-text field, on the template whose reports are the most version-sensitive; they are required fields now.

**`agent-task.yml` — labels.** It declared `agent` and `needs-implementation`. Both exist, so nothing was dropped — but they carry one issue each, while the queue this repository works from uses `Agent task` (523) and `Needs implementation` (538). Every issue filed through the template landed outside the working set: labelled, but invisible to the queries that drive it.

**`config.yml` — the blank-issue bypass, and `question.yml` (new).** Every warning and required field the templates carry was one click avoidable. Disabling the blank form costs the maintainer nothing, and the first draft of this change argued the opposite from a figure that did not survive checking: anyone with write access still sees the blank form marked *Maintainers only*, and all 1621 issues in this repository were filed by the owner. The 238 carrying no template label are the maintainer's own backlog, not reports from someone who would be locked out. It closes the easy path, not the path — the REST API still creates an issue with no template, and the comment says so rather than claiming a boundary that is not there.

Disabling it would otherwise strand a real class of report: a documentation error or a question about intended behaviour fits neither defect form, because both require the metadata format and the library and PHP version. 34 issues carry the `Documentation` label, so the class exists. `question.yml` asks for nothing a reporter would have to look up.

The security row is named after the symptom rather than "Report a security vulnerability", because GitHub already renders a generically-worded security row of its own. A reporter holding a file that crashes the parser does not necessarily think of it as a vulnerability, which is the whole point of the entry.

## How it was verified

All six files validated against the official schemas (`json.schemastore.org/github-issue-forms.json`, and the issue-config schema for `config.yml`), with every declared label checked against the live label list, re-run against the tip of this branch:

```
✔ agent-task.yml         labels=['Agent task', 'Needs implementation']  title=(none)
✔ bug_report.yml         labels=['Bug']  title=(none)
✔ config.yml             blank_issues=False  contact_links=1
✔ feature_request.yml    labels=['Enhancement']  title=(none)
✔ parse-error.yml        labels=['Bug', 'parse-error']  title=(none)
✔ question.yml           labels=['Documentation']  title=(none)
```

The checks are written against the **defect class**, not the instance — that distinction caught three of this PR's own regressions:

- Any `title` containing angle brackets is rejected, rather than the one string that was wrong. An earlier revision passed a narrower check while shipping `Bug: <brief description>`.
- A `render:` on a field whose description *asks* for an attachment is rejected, since the two are mutually exclusive. The first version of this check also fired on a field that merely *referenced* the attachment field — a false positive in the check, fixed in the check rather than in the template.
- A template referring to a field it does not define is rejected. An earlier revision told `bug_report.yml` reporters three times to "send the failing structure", a field that existed only on the other form.
- A claim about what is *not* visible must name the case it excludes. An unqualified "never appears" / "cannot see" is rejected unless the sentence scopes it — the check that would have caught the ASCII-column overcorrection a round earlier.
- Every in-repo `blob/main/` link is resolved against the working tree, so a moved or renamed document fails the check rather than 404ing for a reporter.

Every claim about GitHub platform behaviour quoted above was read from the current documentation, and every claim about this library was traced to a named file in `src/`. The commit-to-file mapping was checked as well, after `git reset --soft` silently preserved the index in an earlier rebuild and bundled files into commits whose messages described a different split.

**No check on this PR validates a changed file.** The only required status check is a single PHP build leg over untouched code; the `yamllint` job is invoked without a `paths:` input, so it defaults to `.github/workflows/` and never lints this directory; and nothing validates an issue form against its schema. The green wall attests to nothing here. Tracked in #2325.

## Deliberately not in this PR

- **#2325** — the yamllint gate does not reach `.github/ISSUE_TEMPLATE/**`; scope extended to schema validation, a label-existence assertion, and making the job a required check.
- **#2326** — `agent-task.yml` heads the public chooser and auto-labels reporter issues into the agent queue, while `AGENTS.md` declares issue content authoritative over the agent's own judgement. Reordering the chooser means renaming the file, which `AGENTS.md` references by path.
- **#2327** — reusable workflows pinned to a mutable ref while holding `contents: write`.
- **#2328** — the duplicate `agent` / `Agent task` and `needs-implementation` / `Needs implementation` label pairs.
- **#2329** — `ci.yml` triggers on both unfiltered `push` and `pull_request`, so the only required check runs twice per pull request.

Three review findings were **rejected on evidence** rather than deferred:

- *Add `render:` to the prose fields so pasted identifiers cannot auto-link into unrelated repositories.* Rejected: `render:` also disables Markdown and file attachments, the documented behaviour this PR removed those very keys to avoid. Every field that receives raw metadata bytes already has `render:`; the fenced-code-block instruction covers the rest.
- *Turn the fixture consent line into a required checkbox.* Rejected as written: the substantive point — that owning a photograph's copyright is not authority to publish a third party's name or face — is adopted and stated far more sharply, but an unchecked-by-default box on an optional attachment records nothing the text does not already say.
- *The shared templates declare `bug` / `enhancement` in a casing not every repository uses.* Rejected: the concern cannot manifest. Only repositories without their own `.github/ISSUE_TEMPLATE/` directory consume the shared defaults; all 8 such non-archived, non-fork, issues-enabled repositories were enumerated, and every one spells both labels exactly as declared.
