### PR TITLE
GH-2329: Run CI once per pull request, not twice

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ name: CI
 
 on:
     push:
+        branches: [main, master]
     pull_request:
 
 permissions:


### PR DESCRIPTION
Closes #2329

## What changes

`ci.yml` triggered on both an unfiltered `push:` and `pull_request:`. For a branch that has an open PR, both fire, so the whole matrix runs twice for the same commit — and `build (8.4)` is the only required status check on `main`, so the one gate that blocks a merge was running twice.

The `push` trigger is now scoped to `[main, master]`, matching `security.yml` in this same repository. A pull request still runs `build (8.4)` through its `pull_request` trigger, so the required check resolves unchanged; a direct push to `main` and the post-merge state stay covered.

This PR is its own proof: it should show a single `build (8.4)` run (via `pull_request`), where before the change a branch push plus the PR produced two.

## How it was verified

`security.yml` already uses `push: branches: [main, master]`, so the pattern is the house one. YAML validated. The required-status-check context on `main` is `build (8.4)`, produced by the `pull_request` trigger — unaffected by narrowing the `push` trigger.