### PR TITLE
GH-2325: Validate issue templates in CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,37 +1,37 @@
 version: 2
 
 updates:
-    -   package-ecosystem: composer
-        directory: /
-        schedule:
-            interval: weekly
-        open-pull-requests-limit: 5
-        cooldown:
-            default-days: 7
-        groups:
-            composer:
-                patterns:
-                    - "*"
+    - package-ecosystem: composer
+      directory: /
+      schedule:
+          interval: weekly
+      open-pull-requests-limit: 5
+      cooldown:
+          default-days: 7
+      groups:
+          composer:
+              patterns:
+                  - "*"
 
-    -   package-ecosystem: npm
-        directory: /
-        schedule:
-            interval: weekly
-        open-pull-requests-limit: 5
-        cooldown:
-            default-days: 7
-        groups:
-            npm:
-                patterns:
-                    - "*"
+    - package-ecosystem: npm
+      directory: /
+      schedule:
+          interval: weekly
+      open-pull-requests-limit: 5
+      cooldown:
+          default-days: 7
+      groups:
+          npm:
+              patterns:
+                  - "*"
 
-    -   package-ecosystem: github-actions
-        directory: /
-        schedule:
-            interval: weekly
-        cooldown:
-            default-days: 7
-        groups:
-            github-actions:
-                patterns:
-                    - "*"
+    - package-ecosystem: github-actions
+      directory: /
+      schedule:
+          interval: weekly
+      cooldown:
+          default-days: 7
+      groups:
+          github-actions:
+              patterns:
+                  - "*"

--- a/.github/workflows/issue-templates.yml
+++ b/.github/workflows/issue-templates.yml
@@ -30,6 +30,20 @@ jobs:
             - name: Install check-jsonschema
               run: pipx install check-jsonschema
 
+            - name: Fetch the issue-form schemas
+              run: |
+                  set -euo pipefail
+                  # Fetch once, with retries, into local files. A required check
+                  # must not red-fail a good PR on a transient schemastore blip,
+                  # and validating against a local copy removes a network call
+                  # per template.
+                  curl -fsSL --retry 3 --retry-delay 2 \
+                      -o "$RUNNER_TEMP/github-issue-forms.json" \
+                      https://json.schemastore.org/github-issue-forms.json
+                  curl -fsSL --retry 3 --retry-delay 2 \
+                      -o "$RUNNER_TEMP/github-issue-config.json" \
+                      https://json.schemastore.org/github-issue-config.json
+
             - name: Validate issue forms against the schema
               run: |
                   set -euo pipefail
@@ -37,9 +51,9 @@ jobs:
                   status=0
                   for file in .github/ISSUE_TEMPLATE/*.yml; do
                       if [ "$(basename "$file")" = 'config.yml' ]; then
-                          schema='https://json.schemastore.org/github-issue-config.json'
+                          schema="$RUNNER_TEMP/github-issue-config.json"
                       else
-                          schema='https://json.schemastore.org/github-issue-forms.json'
+                          schema="$RUNNER_TEMP/github-issue-forms.json"
                       fi
                       echo "::group::$file"
                       check-jsonschema --schemafile "$schema" "$file" || status=1
@@ -57,12 +71,20 @@ jobs:
                   status=0
                   for file in .github/ISSUE_TEMPLATE/*.yml; do
                       [ "$(basename "$file")" = 'config.yml' ] && continue
+                      # Capture yq first so its exit status is checked — a parse
+                      # failure inside a `< <(…)` process substitution is
+                      # invisible to `set -e` and would skip the file silently.
+                      labels="$(yq -r '.labels[]?' "$file")" || {
+                          echo "::error file=$file::could not parse the labels key"
+                          status=1
+                          continue
+                      }
                       while IFS= read -r label; do
                           [ -z "$label" ] && continue
                           if ! grep -qxF "$label" <<<"$existing"; then
                               echo "::error file=$file::declared label '$label' does not exist in this repository"
                               status=1
                           fi
-                      done < <(yq -r '.labels[]?' "$file")
+                      done <<<"$labels"
                   done
                   exit "$status"

--- a/.github/workflows/issue-templates.yml
+++ b/.github/workflows/issue-templates.yml
@@ -1,0 +1,68 @@
+name: Issue templates
+
+# yamllint (in security.yml) checks the YAML syntax of these files, but not that
+# they are valid GitHub issue forms or that the labels they declare exist. A
+# structurally wrong form is rejected by github.com at render time with no CI
+# signal, and an unresolvable label is dropped silently — so this job validates
+# both. It runs on every push and pull request (no path filter) so it can be a
+# required status check without leaving template-free PRs stuck on a missing one.
+
+on:
+    push:
+        branches: [main, master]
+    pull_request:
+
+permissions:
+    contents: read
+
+jobs:
+    validate:
+        runs-on: ubuntu-latest
+        permissions:
+            contents: read
+            issues: read
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+              with:
+                  persist-credentials: false
+
+            - name: Install check-jsonschema
+              run: pipx install check-jsonschema
+
+            - name: Validate issue forms against the schema
+              run: |
+                  set -euo pipefail
+                  shopt -s nullglob
+                  status=0
+                  for file in .github/ISSUE_TEMPLATE/*.yml; do
+                      if [ "$(basename "$file")" = 'config.yml' ]; then
+                          schema='https://json.schemastore.org/github-issue-config.json'
+                      else
+                          schema='https://json.schemastore.org/github-issue-forms.json'
+                      fi
+                      echo "::group::$file"
+                      check-jsonschema --schemafile "$schema" "$file" || status=1
+                      echo '::endgroup::'
+                  done
+                  exit "$status"
+
+            - name: Assert declared labels exist
+              env:
+                  GH_TOKEN: ${{ github.token }}
+              run: |
+                  set -euo pipefail
+                  shopt -s nullglob
+                  existing="$(gh label list --limit 300 --json name --jq '.[].name')"
+                  status=0
+                  for file in .github/ISSUE_TEMPLATE/*.yml; do
+                      [ "$(basename "$file")" = 'config.yml' ] && continue
+                      while IFS= read -r label; do
+                          [ -z "$label" ] && continue
+                          if ! grep -qxF "$label" <<<"$existing"; then
+                              echo "::error file=$file::declared label '$label' does not exist in this repository"
+                              status=1
+                          fi
+                      done < <(yq -r '.labels[]?' "$file")
+                  done
+                  exit "$status"

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -44,3 +44,5 @@ jobs:
         uses: magicsunday/.github/.github/workflows/yamllint.yml@main
         permissions:
             contents: read
+        with:
+            paths: '.github/workflows/ .github/ISSUE_TEMPLATE/ .github/dependabot.yml .github/zizmor.yml'


### PR DESCRIPTION
Closes #2325

## What changes

No check on this repository validates a changed issue-template file. The `yamllint` job is invoked without a `paths:` input, so it defaults to `.github/workflows/` and never lints `.github/ISSUE_TEMPLATE/`; and nothing validates a form against the issue-form schema or checks that a declared label exists. A structurally wrong form is rejected by github.com at render time with no CI signal, and an unresolvable label is dropped silently on every issue filed through the form — both shipped green on the recent templates work and had to be caught by hand.

Two changes:

- **`security.yml`** passes the shared `yamllint` workflow an explicit `paths:` set (`.github/workflows/ .github/ISSUE_TEMPLATE/ .github/dependabot.yml .github/zizmor.yml`), so their YAML syntax is finally linted.
- **`issue-templates.yml`** (new) validates every `ISSUE_TEMPLATE/*.yml` against the official schema (`github-issue-forms.json`, or `github-issue-config.json` for `config.yml`, routed by filename), and asserts each declared label exists via `gh label list`. It runs on every push and pull request with **no path filter**, so it can become a required check without leaving a template-free PR stuck on a context that never reports.

## How it was verified

The schema-routing logic and the label loop were checked locally: the six current templates all pass the official schema (via the `jsonschema` library), and a deliberately broken form (`type: bogus_type`) is rejected — so the gate discriminates. `check-jsonschema` itself is not installable on the dev host, so **this PR is its own end-to-end test**: `issue-templates.yml` triggers on `pull_request`, so it runs against these very templates here. A green `validate` check is the proof the CI tool agrees with the local `jsonschema` result; a red one would surface any tool-specific difference before merge.

Once green, the `validate` context is added to the branch-protection required checks (the deferred half of #2325), so a future template defect can no longer ship on a green wall.

## Not in this PR

Making the check *required* is a branch-protection change applied after the context name is confirmed from this PR's run — done as a follow-up step, not in the workflow file.