### PR TITLE
Adopt the shared label sync

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug_report.yml
@@ -1,7 +1,7 @@
 name: "Bug report"
 description: "Report a defect so it can be reproduced and fixed."
 labels:
-    - Bug
+    - bug
 body:
     - type: markdown
       attributes:

--- a/.github/ISSUE_TEMPLATE/2-parse-error.yml
+++ b/.github/ISSUE_TEMPLATE/2-parse-error.yml
@@ -1,7 +1,7 @@
 name: "Parse error report"
 description: "A file cannot be parsed and the parser aborts with an error."
 labels:
-    - Bug
+    - bug
     - parse-error
 body:
     - type: markdown

--- a/.github/ISSUE_TEMPLATE/3-feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/3-feature_request.yml
@@ -1,7 +1,7 @@
 name: "Feature request"
 description: "Suggest a capability, or an improvement to an existing one."
 labels:
-    - Enhancement
+    - enhancement
 body:
     - type: markdown
       attributes:

--- a/.github/ISSUE_TEMPLATE/4-question.yml
+++ b/.github/ISSUE_TEMPLATE/4-question.yml
@@ -1,7 +1,7 @@
 name: "Question or documentation issue"
 description: "Something in the documentation is wrong or missing, or you are not sure how the library is meant to behave."
 labels:
-    - Documentation
+    - documentation
 body:
     - type: markdown
       attributes:

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -1,0 +1,28 @@
+name: Labels
+
+# Apply the canonical magicsunday label set to this repository. The manifest
+# lives in magicsunday/.github; the sync is non-destructive, so labels specific
+# to this repository are preserved.
+on:
+    push:
+        branches: [main]
+        paths: ['.github/workflows/labels.yml']
+    schedule:
+        - cron: '15 4 * * 1'
+    workflow_dispatch:
+
+permissions:
+    contents: read
+
+# Serialise runs so an overlapping schedule/dispatch/push cannot drive two
+# concurrent label mutations; do not cancel an in-flight sync mid-write.
+concurrency:
+    group: ${{ github.workflow }}
+    cancel-in-progress: false
+
+jobs:
+    sync:
+        uses: magicsunday/.github/.github/workflows/label-sync.yml@main
+        permissions:
+            contents: read
+            issues: write


### PR DESCRIPTION
Adopt the shared label sync for this repository.

- Calls the reusable `label-sync.yml` from `magicsunday/.github`, so the label set follows the canonical manifest instead of drifting per repository.
- Triggers: weekly schedule (Mondays 04:15 UTC), manual `workflow_dispatch`, and a `push` trigger scoped to this workflow file so a change to it applies immediately.
- The calling job declares `issues: write` because a reusable workflow's `GITHUB_TOKEN` is capped by the caller's permission ceiling — a job-level grant inside the called workflow alone would not survive the move.
- A `concurrency` group (without `cancel-in-progress`) serialises runs so an overlapping schedule/dispatch/push cannot drive two concurrent label mutations, and no in-flight sync is cancelled mid-write.
- The sync is non-destructive (skip-delete), so labels specific to this repository are preserved.
