### PR TITLE
Match the issue templates' type labels to the ones that exist

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug_report.yml
@@ -1,7 +1,7 @@
 name: "Bug report"
 description: "Report a defect so it can be reproduced and fixed."
 labels:
-    - Bug
+    - bug
 body:
     - type: markdown
       attributes:

--- a/.github/ISSUE_TEMPLATE/2-parse-error.yml
+++ b/.github/ISSUE_TEMPLATE/2-parse-error.yml
@@ -1,7 +1,7 @@
 name: "Parse error report"
 description: "A file cannot be parsed and the parser aborts with an error."
 labels:
-    - Bug
+    - bug
     - parse-error
 body:
     - type: markdown

--- a/.github/ISSUE_TEMPLATE/3-feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/3-feature_request.yml
@@ -1,7 +1,7 @@
 name: "Feature request"
 description: "Suggest a capability, or an improvement to an existing one."
 labels:
-    - Enhancement
+    - enhancement
 body:
     - type: markdown
       attributes:

--- a/.github/ISSUE_TEMPLATE/4-question.yml
+++ b/.github/ISSUE_TEMPLATE/4-question.yml
@@ -1,7 +1,7 @@
 name: "Question or documentation issue"
 description: "Something in the documentation is wrong or missing, or you are not sure how the library is meant to behave."
 labels:
-    - Documentation
+    - documentation
 body:
     - type: markdown
       attributes:


### PR DESCRIPTION
Four issue templates declared `Bug`, `Enhancement` and `Documentation`. This repository carries GitHub's **default** type labels, which are lower-case — `bug`, `enhancement`, `documentation`. Label resolution is case-sensitive, so none of the three ever matched.

The failure mode is the reason this matters: GitHub **silently drops** a `labels:` entry it cannot resolve rather than reporting it. Every issue opened from those four templates therefore arrived with **no type label at all**, which is exactly what the labelling rule exists to prevent.

`main` is red on the `Issue templates` check until this lands — the `Assert declared labels exist` step is what surfaced it.

Verified against the live label set: all seven declared labels across the five templates now resolve (`bug` ×2, `enhancement`, `documentation`, `Agent task`, `Needs implementation`, `parse-error`), and every template still parses.